### PR TITLE
HHH-20336 fix missing call to afterTransactionCompletion when commit fails

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
@@ -14,6 +14,7 @@ import org.hibernate.resource.jdbc.spi.LogicalConnectionImplementor;
 import org.hibernate.resource.jdbc.spi.PhysicalJdbcTransaction;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
+import static org.hibernate.engine.jdbc.JdbcLogging.JDBC_LOGGER;
 import static org.hibernate.resource.jdbc.internal.LogicalConnectionLogging.CONNECTION_LOGGER;
 
 /**
@@ -89,7 +90,19 @@ public abstract class AbstractLogicalConnectionImplementor implements LogicalCon
 			status = TransactionStatus.COMMITTED;
 			CONNECTION_LOGGER.transactionCommittedViaConnectionCommit();
 		}
-		catch( SQLException e ) {
+		catch ( SQLException e ) {
+			// commit failed, the current status of the
+			// transaction is ambiguous; make a last ditch
+			// attempt to roll it back
+			try {
+				getConnectionForTransactionManagement().rollback();
+			}
+			catch ( SQLException e2 ) {
+				e.addSuppressed( e2 );
+				JDBC_LOGGER.encounteredFailureRollingBackFailedCommit( e2 );
+			}
+			// at this point we can't really know for
+			// sure what happened to the transaction
 			status = TransactionStatus.FAILED_COMMIT;
 			throw new TransactionException( "Unable to commit against JDBC Connection", e );
 		}
@@ -128,7 +141,7 @@ public abstract class AbstractLogicalConnectionImplementor implements LogicalCon
 			status = TransactionStatus.ROLLED_BACK;
 			CONNECTION_LOGGER.transactionRolledBackViaConnectionRollback();
 		}
-		catch( SQLException e ) {
+		catch ( SQLException e ) {
 			status = TransactionStatus.FAILED_ROLLBACK;
 			throw new TransactionException( "Unable to rollback against JDBC Connection", e );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
@@ -78,36 +78,41 @@ public abstract class AbstractLogicalConnectionImplementor implements LogicalCon
 
 	@Override
 	public void commit() {
+		if ( isPhysicallyConnected() ) {
+			commitConnection();
+		}
+		else {
+			errorIfClosed();
+			status = TransactionStatus.COMMITTED;
+		}
+		afterCompletion();
+	}
+
+	private void commitConnection() {
 		try {
 			CONNECTION_LOGGER.preparingToCommitViaConnectionCommit();
 			status = TransactionStatus.COMMITTING;
-			if ( isPhysicallyConnected() ) {
-				getConnectionForTransactionManagement().commit();
-			}
-			else {
-				errorIfClosed();
-			}
+			getConnectionForTransactionManagement().commit();
 			status = TransactionStatus.COMMITTED;
 			CONNECTION_LOGGER.transactionCommittedViaConnectionCommit();
 		}
-		catch ( SQLException e ) {
+		catch (SQLException e) {
 			// commit failed, the current status of the
-			// transaction is ambiguous; make a last ditch
-			// attempt to roll it back
+			// transaction is ambiguous
+			status = TransactionStatus.FAILED_COMMIT;
+			// make a last ditch attempt to roll it back
 			try {
 				getConnectionForTransactionManagement().rollback();
+				status = TransactionStatus.ROLLED_BACK;
 			}
-			catch ( SQLException e2 ) {
+			catch (SQLException e2) {
 				e.addSuppressed( e2 );
 				JDBC_LOGGER.encounteredFailureRollingBackFailedCommit( e2 );
+				// at this point we can't really know for
+				// sure what happened to the transaction
 			}
-			// at this point we can't really know for
-			// sure what happened to the transaction
-			status = TransactionStatus.FAILED_COMMIT;
 			throw new TransactionException( "Unable to commit against JDBC Connection", e );
 		}
-
-		afterCompletion();
 	}
 
 	protected void afterCompletion() {

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import jakarta.persistence.RollbackException;
 import jakarta.transaction.Status;
 
+import org.hibernate.resource.transaction.backend.jta.internal.StatusTranslator;
 import org.hibernate.resource.transaction.spi.IsolationDelegate;
 import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.resource.transaction.backend.jdbc.spi.JdbcResourceTransaction;
@@ -178,10 +179,10 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 		}
 	}
 
-	private void afterCompletionCallback(boolean successful) {
+	private void afterCompletionCallback(int status) {
 		JDBC_LOGGER.notifyingResourceLocalObserversAfterCompletion();
-		final int statusToSend = successful ? Status.STATUS_COMMITTED : Status.STATUS_ROLLEDBACK;
-		synchronizationRegistry.notifySynchronizationsAfterTransactionCompletion( statusToSend );
+		synchronizationRegistry.notifySynchronizationsAfterTransactionCompletion( status );
+		final boolean successful = status == Status.STATUS_COMMITTED;
 		transactionCoordinatorOwner.afterTransactionCompletion( successful, false );
 		for ( var transactionObserver : observers() ) {
 			transactionObserver.afterCompletion( successful, false );
@@ -260,7 +261,7 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 					e.addSuppressed( e2 );
 				}
 				try {
-					afterCompletionCallback( false );
+					afterCompletionCallback( StatusTranslator.STATUS_FAILED_ROLLBACK );
 				}
 				catch (RuntimeException e2) {
 					e.addSuppressed( e2 );
@@ -274,7 +275,7 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 			catch (RuntimeException e) {
 				// commit failed
 				try {
-					afterCompletionCallback( false );
+					afterCompletionCallback( StatusTranslator.STATUS_FAILED_COMMIT );
 				}
 				catch (RuntimeException e2) {
 					e.addSuppressed( e2 );
@@ -282,7 +283,7 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 				throw e;
 			}
 			// commit successful
-			afterCompletionCallback( true );
+			afterCompletionCallback( Status.STATUS_COMMITTED );
 		}
 
 		private void commitRollbackOnly() {
@@ -297,7 +298,7 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 		public void rollback() {
 			if ( isActive() ) {
 				jdbcResourceTransaction.rollback();
-				afterCompletionCallback( false );
+				afterCompletionCallback( Status.STATUS_ROLLEDBACK );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
@@ -249,25 +249,30 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 		private void commitNoRollbackOnly() {
 			try {
 				beforeCompletionCallback();
-				jdbcResourceTransaction.commit();
-				afterCompletionCallback( true );
-			}
-			catch (RollbackException e) {
-				afterCompletionCallback( false );
-				throw e;
 			}
 			catch (RuntimeException e) {
-				// something went wrong, so make a last-ditch,
-				// hail-mary attempt to roll back the transaction
+				// error processing before completion callbacks
+				// attempt to roll back the transaction
 				try {
-					rollback();
+					jdbcResourceTransaction.rollback();
 				}
 				catch (RuntimeException e2) {
 					e.addSuppressed( e2 );
-					JDBC_LOGGER.encounteredFailureRollingBackFailedCommit( e2 );
 				}
+				afterCompletionCallback( false );
 				throw e;
 			}
+
+			try {
+				jdbcResourceTransaction.commit();
+			}
+			catch (RuntimeException e) {
+				// commit failed
+				afterCompletionCallback( false );
+				throw e;
+			}
+			// commit successful
+			afterCompletionCallback( true );
 		}
 
 		private void commitRollbackOnly() {

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
@@ -259,7 +259,12 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 				catch (RuntimeException e2) {
 					e.addSuppressed( e2 );
 				}
-				afterCompletionCallback( false );
+				try {
+					afterCompletionCallback( false );
+				}
+				catch (RuntimeException e2) {
+					e.addSuppressed( e2 );
+				}
 				throw e;
 			}
 
@@ -268,7 +273,12 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 			}
 			catch (RuntimeException e) {
 				// commit failed
-				afterCompletionCallback( false );
+				try {
+					afterCompletionCallback( false );
+				}
+				catch (RuntimeException e2) {
+					e.addSuppressed( e2 );
+				}
 				throw e;
 			}
 			// commit successful

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/StatusTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/StatusTranslator.java
@@ -14,17 +14,22 @@ import org.hibernate.resource.transaction.spi.TransactionStatus;
  */
 public class StatusTranslator {
 
+	public static final int STATUS_FAILED_COMMIT = 101;
+	public static final int STATUS_FAILED_ROLLBACK = 102;
+
 	public static TransactionStatus translate(int status) {
 		return switch ( status ) {
-			case Status.STATUS_ACTIVE -> TransactionStatus.ACTIVE;
-			case Status.STATUS_PREPARED -> TransactionStatus.ACTIVE;
-			case Status.STATUS_PREPARING -> TransactionStatus.ACTIVE;
+			case Status.STATUS_ACTIVE,
+				Status.STATUS_PREPARED,
+				Status.STATUS_PREPARING -> TransactionStatus.ACTIVE;
 			case Status.STATUS_COMMITTING -> TransactionStatus.COMMITTING;
 			case Status.STATUS_ROLLING_BACK -> TransactionStatus.ROLLING_BACK;
 			case Status.STATUS_NO_TRANSACTION -> TransactionStatus.NOT_ACTIVE;
 			case Status.STATUS_COMMITTED -> TransactionStatus.COMMITTED;
 			case Status.STATUS_ROLLEDBACK -> TransactionStatus.ROLLED_BACK;
 			case Status.STATUS_MARKED_ROLLBACK -> TransactionStatus.MARKED_ROLLBACK;
+			case STATUS_FAILED_COMMIT -> TransactionStatus.FAILED_COMMIT;
+			case STATUS_FAILED_ROLLBACK -> TransactionStatus.FAILED_ROLLBACK;
 			case Status.STATUS_UNKNOWN -> null;
 			default -> throw new AssertionFailure( "Unknown transaction status code: " + status );
 		};

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/SynchronizationRegistryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/SynchronizationRegistryImplementor.java
@@ -11,21 +11,25 @@ package org.hibernate.resource.transaction.spi;
  */
 public interface SynchronizationRegistryImplementor extends SynchronizationRegistry {
 	/**
-	 * Delegates the {@link jakarta.transaction.Synchronization#beforeCompletion} call to each registered Synchronization
+	 * Delegates the {@link jakarta.transaction.Synchronization#beforeCompletion}
+	 * call to each registered {@code Synchronization}.
 	 */
 	void notifySynchronizationsBeforeTransactionCompletion();
 
 	/**
-	 * Delegates the {@link jakarta.transaction.Synchronization#afterCompletion} call to each registered Synchronization.
-	 * Will also clear the registered {@code Synchronization}s after all have been notified.
+	 * Delegates the {@link jakarta.transaction.Synchronization#afterCompletion}
+	 * call to each registered {@code Synchronization} and clears the registered
+	 * {@code Synchronization}s after all have been notified.
 	 *
-	 * @param status The transaction status, per {@link jakarta.transaction.Status} constants
+	 * @param status The transaction status, per {@link jakarta.transaction.Status}
+	 *               constants
 	 */
 	void notifySynchronizationsAfterTransactionCompletion(int status);
 
 	/**
-	 * Clears all synchronizations from this registry.  Note that synchronizations are automatically cleared during
-	 * after-completion handling; see {@link #notifySynchronizationsAfterTransactionCompletion}
+	 * Clears all synchronizations from this registry.
+	 * The synchronizations are automatically cleared during after-completion
+	 * handling; see {@link #notifySynchronizationsAfterTransactionCompletion}
 	 */
 	void clearSynchronizations();
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionStatus.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionStatus.java
@@ -56,7 +56,7 @@ public enum TransactionStatus {
 	}
 
 	public boolean isOneOf(TransactionStatus... statuses) {
-		for ( TransactionStatus status : statuses ) {
+		for ( var status : statuses ) {
 			if ( this == status ) {
 				return true;
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/CustomAfterCompletionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/CustomAfterCompletionTest.java
@@ -99,11 +99,16 @@ public class CustomAfterCompletionTest {
 			TransactionStatus status;
 			@Override
 			public void accept(SessionImplementor session) {
+
+				// Register a custom after-completion callback before starting the transaction so we can verify
+				// that JDBC commit failures still drive the ActionQueue completion callbacks.
 				session.unwrap( EventSource.class ).getActionQueue()
 						.registerCallback( (success, s) -> successful = success );
 
 				var transaction = session.beginTransaction();
 				transaction.runAfterCompletion( status -> this.status = status );
+				// Closing the connection makes the following commit fail while still exercising the normal
+				// transaction completion path.
 				session.doWork( Connection::close );
 
 				var exception = assertThrows( TransactionException.class, transaction::commit );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/CustomAfterCompletionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/CustomAfterCompletionTest.java
@@ -4,14 +4,20 @@
  */
 package org.hibernate.orm.test.actionqueue;
 
+import java.sql.Connection;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 
 import org.hibernate.HibernateException;
+import org.hibernate.TransactionException;
 
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.event.spi.EventSource;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -24,6 +30,9 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DomainModel(annotatedClasses = {CustomAfterCompletionTest.SimpleEntity.class})
 @SessionFactory
@@ -81,6 +90,33 @@ public class CustomAfterCompletionTest {
 					.uniqueResult();
 			assertEquals( 1L, count );
 		} );
+	}
+
+	@Test
+	public void callbackRunsOnJdbcCommitFailure(SessionFactoryScope scope) {
+		class Work implements Consumer<SessionImplementor> {
+			Boolean successful;
+			TransactionStatus status;
+			@Override
+			public void accept(SessionImplementor session) {
+				session.unwrap( EventSource.class ).getActionQueue()
+						.registerCallback( (success, s) -> successful = success );
+
+				var transaction = session.beginTransaction();
+				transaction.runAfterCompletion( status -> this.status = status );
+				session.doWork( Connection::close );
+
+				var exception = assertThrows( TransactionException.class, transaction::commit );
+				assertThat( exception.getMessage(),
+						containsString( "Unable to commit against JDBC Connection" ) );
+
+				assertNotNull( successful );
+				assertFalse( successful );
+				assertNotNull( status );
+				assertEquals( TransactionStatus.ROLLED_BACK, status );
+			}
+		}
+		scope.inSession( new Work() );
 	}
 
 	@Entity(name = "SimpleEntity")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/CustomAfterCompletionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/CustomAfterCompletionTest.java
@@ -113,7 +113,7 @@ public class CustomAfterCompletionTest {
 				assertNotNull( successful );
 				assertFalse( successful );
 				assertNotNull( status );
-				assertEquals( TransactionStatus.ROLLED_BACK, status );
+				assertEquals( TransactionStatus.FAILED_COMMIT, status );
 			}
 		}
 		scope.inSession( new Work() );


### PR DESCRIPTION
Supersedes #12173.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20336 (Bug):
- [x] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20336
<!-- Hibernate GitHub Bot issue links end -->