### PR TITLE
HHH-20276 IllegalArgumentException "X is not a subtype of X" when using `@ConverterRegistration` with a generic entity

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/GenericsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/GenericsHelper.java
@@ -182,9 +182,20 @@ public final class GenericsHelper {
 			return null;
 		}
 
-		if ( clazz == genericType
-				&& base instanceof ParameterizedType result ) {
-			return result;
+		if ( clazz == genericType ) {
+			if ( base instanceof ParameterizedType result ) {
+				return result;
+			}
+			// raw type used as-is (e.g. member declared directly on a generic class)
+			// resolve type parameters to their upper bounds (erasure)
+			final var typeParameters = clazz.getTypeParameters();
+			if ( typeParameters.length > 0 ) {
+				final var bounds = new Type[typeParameters.length];
+				for ( int i = 0; i < typeParameters.length; i++ ) {
+					bounds[i] = typeParameters[i].getBounds()[0];
+				}
+				return new SimpleParameterizedType( clazz, bounds, null );
+			}
 		}
 
 		final var superclass = clazz.getGenericSuperclass();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/registrations/genericentity/ConverterRegistrationWithGenericEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/registrations/genericentity/ConverterRegistrationWithGenericEntityTest.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.converted.converter.registrations.genericentity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test that {@link org.hibernate.annotations.ConverterRegistration} works
+ * correctly when an entity has a generic type parameter bounded by another
+ * class (e.g. {@code Book<T extends Person>}).
+ *
+ * @author Vincent Bouthinon
+ * @author Marco Belladelli
+ */
+@DomainModel(
+		annotatedClasses = {
+				ConverterRegistrationWithGenericEntityTest.Book.class,
+				ConverterRegistrationWithGenericEntityTest.Novel.class,
+		},
+		annotatedPackageNames = "org.hibernate.orm.test.mapping.converted.converter.registrations.genericentity"
+)
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-20276")
+class ConverterRegistrationWithGenericEntityTest {
+
+	@BeforeAll
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var book = new Book<>();
+			book.setTitle( "Dune" );
+			session.persist( book );
+			final var novel = new Novel();
+			novel.setTitle( "Neuromancer" );
+			novel.setGenre( "Cyberpunk" );
+			session.persist( novel );
+		} );
+	}
+
+	@Test
+	void testConverter(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var book = session.createSelectionQuery( "from Book where title = 'Dune'", Book.class )
+					.getSingleResult();
+			assertThat( book.getTitle() ).isEqualTo( "Dune" );
+			final var novel = session.createSelectionQuery( "from Novel", Novel.class ).getSingleResult();
+			assertThat( novel.getTitle() ).isEqualTo( "Neuromancer" );
+			assertThat( novel.getGenre() ).isEqualTo( "Cyberpunk" );
+		} );
+	}
+
+	@AfterAll
+	void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	public static class Person {
+	}
+
+	@Entity(name = "Book")
+	public static class Book<T extends Person> {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String title;
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+	}
+
+	@Entity(name = "Novel")
+	public static class Novel extends Book<Person> {
+		private String genre;
+
+		public String getGenre() {
+			return genre;
+		}
+
+		public void setGenre(String genre) {
+			this.genre = genre;
+		}
+	}
+
+	@Converter(autoApply = true)
+	public static class StringConverter implements AttributeConverter<String, String> {
+
+		@Override
+		public String convertToDatabaseColumn(String attribute) {
+			return attribute == null ? null : "[" + attribute + "]";
+		}
+
+		@Override
+		public String convertToEntityAttribute(String dbData) {
+			return dbData == null || dbData.length() < 2 ? dbData : dbData.substring( 1, dbData.length() - 1 );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/registrations/genericentity/package-info.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/registrations/genericentity/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+@ConverterRegistration(converter = ConverterRegistrationWithGenericEntityTest.StringConverter.class)
+package org.hibernate.orm.test.mapping.converted.converter.registrations.genericentity;
+
+import org.hibernate.annotations.ConverterRegistration;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-20276

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20276 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->