### PR TITLE
HHH-13010 Align the metamodel generator's default access type inference with core

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/AccessTypeInformation.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/AccessTypeInformation.java
@@ -26,7 +26,7 @@ public class AccessTypeInformation {
 	 */
 	private @Nullable AccessType defaultAccessType;
 
-	static final AccessType DEFAULT_ACCESS_TYPE = AccessType.FIELD;
+	static final AccessType DEFAULT_ACCESS_TYPE = AccessType.PROPERTY;
 
 	public AccessTypeInformation(
 			String fullyQualifiedName,

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.hibernate.processor.util.Constants.MANY_TO_ANY;
+import static org.hibernate.processor.util.Constants.TRANSIENT;
 import static org.hibernate.processor.util.StringUtil.decapitalize;
 import static java.util.stream.Stream.concat;
 import static org.hibernate.internal.util.StringHelper.split;
@@ -321,41 +322,22 @@ public final class TypeUtils {
 		}
 		else {
 			// check for explicit access type
-			final var forcedAccessType = determineAnnotationSpecifiedAccessType( searchedElement) ;
+			final var forcedAccessType = determineAnnotationSpecifiedAccessType( searchedElement );
+
+			final var defaultAccessType = determineDefaultAccessType( searchedElement, context );
+
 			if ( forcedAccessType != null ) {
 				context.logMessage(
 						Diagnostic.Kind.OTHER,
 						"Explicit access type on " + searchedElement + ":" + forcedAccessType
 				);
-				final var newAccessTypeInfo =
-						new AccessTypeInformation( qualifiedName, forcedAccessType, null );
-				context.addAccessTypeInformation( qualifiedName, newAccessTypeInfo );
-				updateEmbeddableAccessType( searchedElement, context, forcedAccessType );
 			}
-			else {
-				// need to find the default access type for this class
-				// let's check first if this entity is the root of the class hierarchy and defines an id. If so the
-				// placement of the id annotation determines the access type
-				final var defaultAccessType = getAccessTypeInCaseElementIsRoot( searchedElement, context );
-				if ( defaultAccessType != null ) {
-					final var newAccessTypeInfo =
-							new AccessTypeInformation(qualifiedName, null, defaultAccessType);
-					context.addAccessTypeInformation( qualifiedName, newAccessTypeInfo );
-					updateEmbeddableAccessType( searchedElement, context, defaultAccessType );
-					setDefaultAccessTypeForMappedSuperclassesInHierarchy( searchedElement, defaultAccessType, context );
-				}
-				else {
-					// if we end up here we need to recursively look for superclasses
-					var newDefaultAccessType = getDefaultAccessForHierarchy( searchedElement, context );
-					if ( newDefaultAccessType == null ) {
-						newDefaultAccessType = DEFAULT_ACCESS_TYPE;
-					}
-					final var newAccessTypeInfo =
-							new AccessTypeInformation( qualifiedName, null, newDefaultAccessType );
-					context.addAccessTypeInformation( qualifiedName, newAccessTypeInfo );
-					updateEmbeddableAccessType( searchedElement, context, newDefaultAccessType );
-				}
-			}
+
+			final var newAccessTypeInfo =
+					new AccessTypeInformation( qualifiedName, forcedAccessType, defaultAccessType );
+			context.addAccessTypeInformation( qualifiedName, newAccessTypeInfo );
+			updateEmbeddableAccessType( searchedElement, context, newAccessTypeInfo.getAccessType() );
+			setDefaultAccessTypeForMappedSuperclassesInHierarchy( searchedElement, defaultAccessType, context );
 		}
 	}
 
@@ -426,15 +408,15 @@ public final class TypeUtils {
 		do {
 			superClass = getSuperclassTypeElement( superClass );
 			if ( superClass != null ) {
-				final var qualifiedName = superClass.getQualifiedName().toString();
-				final var accessTypeInfo = context.getAccessTypeInfo( qualifiedName );
-				if ( accessTypeInfo != null && accessTypeInfo.getDefaultAccessType() != null ) {
-					return accessTypeInfo.getDefaultAccessType();
-				}
 				if ( containsAnnotation( superClass, ENTITY, MAPPED_SUPERCLASS ) ) {
+					final var qualifiedName = superClass.getQualifiedName().toString();
+					final var accessTypeInfo = context.getAccessTypeInfo( qualifiedName );
+					if ( accessTypeInfo != null && accessTypeInfo.getDefaultAccessType() != null ) {
+						return accessTypeInfo.getDefaultAccessType();
+					}
 					defaultAccessType = getAccessTypeInCaseElementIsRoot( superClass, context );
 					if ( defaultAccessType != null ) {
-						final AccessTypeInformation newAccessTypeInfo
+						final var newAccessTypeInfo
 								= new AccessTypeInformation( qualifiedName, null, defaultAccessType );
 						context.addAccessTypeInformation( qualifiedName, newAccessTypeInfo );
 
@@ -478,22 +460,86 @@ public final class TypeUtils {
 		while ( superClass != null );
 	}
 
+	private static AccessType determineDefaultAccessType(TypeElement searchedElement, Context context) {
+
+		// do not check for `@Access` to determine the default access type of the hierarchy
+
+		final var idAccessType = determineAccessTypeFromId( searchedElement, context );
+		if ( idAccessType != null ) {
+			return idAccessType;
+		}
+
+		// next consider the current class
+
+		final var memberAccessType = determineAccessTypeFromMembers( searchedElement );
+		if ( memberAccessType != null ) {
+			return memberAccessType;
+		}
+
+		// next consider the root class of the hierarchy
+
+		final var rootEntity = getRootEntity( searchedElement );
+		if ( rootEntity != null ) {
+			final var rootMemberAccessType = determineAccessTypeFromMembers( rootEntity );
+			if ( rootMemberAccessType != null ) {
+				return rootMemberAccessType;
+			}
+		}
+
+		// as an absolute last resort, fall back to looking at mapped superclasses
+
+		for ( var candidate = getSuperclassTypeElement( searchedElement );
+			candidate != null;
+			candidate = getSuperclassTypeElement( candidate ) ) {
+			if ( containsAnnotation( candidate, MAPPED_SUPERCLASS ) ) {
+				final var accessType = determineAccessTypeFromMembers( candidate );
+				if ( accessType != null ) {
+					return accessType;
+				}
+			}
+		}
+
+		return DEFAULT_ACCESS_TYPE;
+	}
+
+	private static @Nullable AccessType determineAccessTypeFromId(TypeElement searchedElement, Context context) {
+		final var idAccessType = getAccessTypeInCaseElementIsRoot( searchedElement, context );
+		if ( idAccessType != null ) {
+			return idAccessType;
+		}
+		return getDefaultAccessForHierarchy( searchedElement, context );
+	}
+
+	private static @Nullable TypeElement getRootEntity(TypeElement element) {
+		TypeElement rootEntity = null;
+		for ( var candidate = element; candidate != null; candidate = getSuperclassTypeElement( candidate ) ) {
+			if ( containsAnnotation( candidate, ENTITY ) ) {
+				rootEntity = candidate;
+			}
+		}
+		return rootEntity;
+	}
+
 	/**
-	 * Iterates all elements of a type to check whether they contain the id annotation. If so the placement of this
-	 * annotation determines the access type
+	 * Infers the access type from the placement of {@code @Id} or {@code @EmbeddedId}.
+	 * Returns {@code null} if the class itself has an explicit {@code @Access}, or if
+	 * no member qualifies (members with their own {@code @Access} or {@code @Transient}
+	 * are skipped).
 	 *
-	 * @param searchedElement the type to be searched
-	 * @param context The global execution context
+	 * @param searchedElement the type to inspect
+	 * @param context the global execution context
 	 *
-	 * @return returns the access type of the element annotated with the id annotation. If no element is annotated
-	 *         {@code null} is returned.
+	 * @return the inferred {@link jakarta.persistence.AccessType}, or {@code null}
 	 */
 	private static @Nullable AccessType getAccessTypeInCaseElementIsRoot(TypeElement searchedElement, Context context) {
-		for ( var subElement : searchedElement.getEnclosedElements() ) {
-			for ( var entityAnnotation :
-					context.getElementUtils().getAllAnnotationMirrors( subElement ) ) {
-				if ( isIdAnnotation( entityAnnotation ) ) {
-					return getAccessTypeOfIdAnnotation( subElement );
+		if ( !hasAnnotation( searchedElement, ACCESS ) ) {
+			for ( var subElement : searchedElement.getEnclosedElements() ) {
+				if ( !canBeUsedToInferAccessType( subElement ) ) continue;
+				for ( var entityAnnotation :
+						context.getElementUtils().getAllAnnotationMirrors( subElement ) ) {
+					if ( isIdAnnotation( entityAnnotation ) ) {
+						return getAccessTypeOfIdAnnotation( subElement );
+					}
 				}
 			}
 		}
@@ -512,6 +558,51 @@ public final class TypeUtils {
 		return isAnnotationMirrorOfType( annotationMirror, ID )
 			|| isAnnotationMirrorOfType( annotationMirror, EMBEDDED_ID );
 	}
+
+	private static @Nullable AccessType determineAccessTypeFromMembers(TypeElement element) {
+		for ( var field : ElementFilter.fieldsIn( element.getEnclosedElements() ) ) {
+			if ( canBeUsedToInferAccessType( field )
+				&& hasMappingAnnotation( field ) ) {
+				return AccessType.FIELD;
+			}
+		}
+		for ( var method : ElementFilter.methodsIn( element.getEnclosedElements() ) ) {
+			if ( isPropertyGetter( (ExecutableType) method.asType(), method )
+				&& canBeUsedToInferAccessType( method )
+				&& hasMappingAnnotation( method ) ) {
+				return AccessType.PROPERTY;
+			}
+		}
+		return null;
+	}
+
+	private static boolean canBeUsedToInferAccessType(Element element) {
+		return !hasAnnotation( element, ACCESS, TRANSIENT );
+	}
+
+	private static boolean hasMappingAnnotation(Element element) {
+		for ( var mirror : element.getAnnotationMirrors() ) {
+			final var qualifiedName = ((TypeElement) mirror.getAnnotationType().asElement())
+					.getQualifiedName().toString();
+			if ( qualifiedName.startsWith( "jakarta.persistence." )
+				&& !IGNORED_PERSISTENCE_ANNOTATIONS.contains( qualifiedName ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static final Set<String> IGNORED_PERSISTENCE_ANNOTATIONS = Set.of(
+			"jakarta.persistence.PostLoad",
+			"jakarta.persistence.PostPersist",
+			"jakarta.persistence.PostRemove",
+			"jakarta.persistence.PostUpdate",
+			"jakarta.persistence.PrePersist",
+			"jakarta.persistence.PreRemove",
+			"jakarta.persistence.PreUpdate",
+			"jakarta.persistence.Transient",
+			"jakarta.persistence.Access"
+	);
 
 	public static @Nullable AccessType determineAnnotationSpecifiedAccessType(Element element) {
 		final var mirror = getAnnotationMirror( element, ACCESS );

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/AccessTypeTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/AccessTypeTest.java
@@ -42,7 +42,13 @@ import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfFieldIn
 		Product.class,
 		Room.class,
 		Shop.class,
-		User.class
+		User.class,
+		Depth1Entity.class,
+		Depth2Entity.class,
+		Depth3Root.class,
+		Depth3Sub.class,
+		Depth4Base.class,
+		Depth4Entity.class
 })
 @WithMappingFiles("orm.xml")
 class AccessTypeTest {
@@ -114,5 +120,56 @@ class AccessTypeTest {
 	void testMemberAccessType() {
 		assertPresenceOfFieldInMetamodelFor( Customer.class, "goodPayer", "access type overriding" );
 		assertAttributeTypeInMetaModelFor( Customer.class, "goodPayer", Boolean.class, "access type overriding" );
+	}
+
+	// test for default access type inference
+	@Test
+	@TestForIssue(jiraKey = "HHH-13010")
+	void depth1IdPlacement() {
+		// step 1: field-placed @Id → FIELD access → plain field is a persistent attribute
+		assertPresenceOfFieldInMetamodelFor(
+				Depth1Entity.class, "probe",
+				"field-placed @Id resolves to FIELD access, which includes plain fields"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13010")
+	void depth2CurrentClassMembers() {
+		// step 2: the @Id is excluded from id inference by its member-level @Access, so access
+		// comes from a mapping annotation on a member of the current class. The @Column is on a
+		// getter, giving PROPERTY — never the FIELD the @Id field would yield.
+		assertPresenceOfFieldInMetamodelFor(
+				Depth2Entity.class, "value",
+				"the @Column getter property is a persistent attribute"
+		);
+		assertAbsenceOfFieldInMetamodelFor(
+				Depth2Entity.class, "probe",
+				"step 2 resolves to PROPERTY (from the getter), which excludes the plain field"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13010")
+	void depth3RootEntityMembers() {
+		// step 3: empty subclass inherits access from the root entity's members.
+		// The root's FIELD signal is a @Column field (its @Id is a PROPERTY getter, excluded from inference)
+		// so FIELD can only come from a member scan — never from @Id placement.
+		assertPresenceOfFieldInMetamodelFor(
+				Depth3Sub.class, "probe",
+				"access inherited from the root entity's @Column field resolves to FIELD, which includes plain fields"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13010")
+	void depth4MappedSuperclassMembers() {
+		// step 4: entity inherits access from the mapped superclass's members. The mapped
+		// superclass's FIELD signal is a @Column field (its @Id is a PROPERTY getter, excluded
+		// from inference), so FIELD can only come from a member scan — never from @Id placement.
+		assertPresenceOfFieldInMetamodelFor(
+				Depth4Entity.class, "probe",
+				"access inherited from the mapped superclass's @Column field resolves to FIELD, which includes plain fields"
+		);
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth1Entity.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth1Entity.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.accesstype;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Depth1Entity {
+
+	@Id
+	Long id;
+
+	String probe;
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth2Entity.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth2Entity.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.accesstype;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Depth2Entity {
+
+	@Id
+	@Access(AccessType.FIELD)
+	Long id;
+
+	String value;
+
+	String probe;
+
+	@Column
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth3Root.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth3Root.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.accesstype;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+@Access(AccessType.FIELD)
+public class Depth3Root {
+
+	Long id;
+
+	@Column
+	String label;
+
+	@Id
+	@Access(AccessType.PROPERTY)
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth3Sub.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth3Sub.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.accesstype;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Depth3Sub extends Depth3Root {
+
+	String probe;
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth4Base.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth4Base.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.accesstype;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+@Access(AccessType.FIELD)
+public class Depth4Base {
+
+	Long id;
+
+	@Column
+	String label;
+
+	@Id
+	@Access(AccessType.PROPERTY)
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth4Entity.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/accesstype/Depth4Entity.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.accesstype;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Depth4Entity extends Depth4Base {
+
+	String probe;
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

## Issue

This aligns the annotation processor's access-type inference with core, following the Jakarta Persistence specification.

**Jakarta Persistence 4.0, Section 2.3.1:**
> The default access type of an entity hierarchy is determined by the placement of mapping annotations on the attributes of the entity classes and mapped superclasses of the entity hierarchy which do not explicitly specify an access type.

## New fix (commit 51c6ac5)

### 1. Infer the default access type even when an explicit access type is present
Like core (`InheritanceState#getElementsToProcess`), 
the processor (`TypeUtils#determineAccessTypeForHierarchy`) now infers the default access type 
regardless of whether an explicit access type is present, 
and populates both fields of `AccessTypeInformation` (explicit + default). 
Previously it skipped default inference entirely when a class-level `@Access` was found, leaving the default field `null`.

### 2. Align the default access-type inference steps
Like core (`InheritanceState#determineDefaultAccessType`), 
the processor now applies the same five-step resolution (`TypeUtils#determineDefaultAccessType`):

1. The placement of `@Id`/`@EmbeddedId` on the current and ancestor entities; a class with an explicit `@Access` is skipped.
2. Mapping annotations on the current entity's members.
3. Mapping annotations on the root entity's members.
4. Mapping annotations on the mapped-superclass chain's members.
5. Otherwise, return the default access type.

### 3. Change the default access type to `PROPERTY`
Core's default access type is `PROPERTY`:
```java
// org.hibernate.boot.model.internal.PropertyContainer
if ( defaultClassLevelAccessType == AccessType.DEFAULT ) {
    // this is effectively what the old code did when AccessType.DEFAULT was passed in
    // to getProperties(AccessType) from AnnotationBinder and InheritanceState
    defaultClassLevelAccessType = AccessType.PROPERTY;
}
```
The processor's `DEFAULT_ACCESS_TYPE` is changed from `FIELD` to `PROPERTY` to match.

## Old fix (commit 187292df)
The earlier commit aligned only steps 1–2, 5 of core's inference; nothing else was aligned.

1. The placement of `@Id`/`@EmbeddedId` on the current and ancestor entities; a class with an explicit `@Access` is skipped.
2. Mapping annotations on the current entity's members.
3. Otherwise, return the default access type.

---

https://hibernate.atlassian.net/browse/HHH-13010

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-13010 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->