### PR TITLE
HHH-20396: Re-enable the failing Ant tests in the wip/jpa4 branch

### DIFF
--- a/tooling/hibernate-ant/src/legacyTest/java/org/hibernate/tool/ant/EJB3Configuration/TestCase.java
+++ b/tooling/hibernate-ant/src/legacyTest/java/org/hibernate/tool/ant/EJB3Configuration/TestCase.java
@@ -10,7 +10,6 @@ import org.hibernate.tool.ant.test.utils.JdbcUtil;
 import org.hibernate.tool.ant.test.utils.ResourceUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -43,7 +42,6 @@ public class TestCase {
 	}
 
 	@Test
-	@Disabled
 	public void testEJB3ConfigurationFailureExpected() {
 
 		String[] resources = new String[] {"build.xml", "hibernate.cfg.xml", "persistence.xml"};

--- a/tooling/hibernate-ant/src/legacyTest/java/org/hibernate/tool/ant/JPAPUnit/TestCase.java
+++ b/tooling/hibernate-ant/src/legacyTest/java/org/hibernate/tool/ant/JPAPUnit/TestCase.java
@@ -10,7 +10,6 @@ import org.hibernate.tool.ant.test.utils.JdbcUtil;
 import org.hibernate.tool.ant.test.utils.ResourceUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -43,7 +42,6 @@ public class TestCase {
 	}
 
 	@Test
-	@Disabled
 	public void testJPAPUnit() {
 
 		String[] resources = new String[] {"build.xml", "hibernate.cfg.xml", "persistence.xml"};

--- a/tooling/hibernate-ant/src/legacyTest/resources/org/hibernate/tool/ant/EJB3Configuration/persistence.xml
+++ b/tooling/hibernate-ant/src/legacyTest/resources/org/hibernate/tool/ant/EJB3Configuration/persistence.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright 2004 - 2025 Red Hat, Inc.
   ~
@@ -14,15 +13,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<!-- example of reference to a cfg.xml file -->
-<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
-   version="1.0">
+   xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_1.xsd"
+   version="3.1">
    <persistence-unit name="ejb3test" transaction-type="RESOURCE_LOCAL">
       <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+      <class>VerySimpleTable</class>
       <properties>
-         <property name="hibernate.ejb.cfgfile" value="/hibernate.cfg.xml"/>
       </properties>
    </persistence-unit>
 </persistence>

--- a/tooling/hibernate-ant/src/legacyTest/resources/org/hibernate/tool/ant/JPAPUnit/persistence.xml
+++ b/tooling/hibernate-ant/src/legacyTest/resources/org/hibernate/tool/ant/JPAPUnit/persistence.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright 2004 - 2025 Red Hat, Inc.
   ~
@@ -14,15 +13,14 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<!-- example of reference to a cfg.xml file -->
-<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
-   version="1.0">
+   xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_1.xsd"
+   version="3.1">
    <persistence-unit name="ejb3test" transaction-type="RESOURCE_LOCAL">
       <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+      <class>VerySimpleTable</class>
       <properties>
-         <property name="hibernate.ejb.cfgfile" value="/hibernate.cfg.xml"/>
-       </properties>
+      </properties>
    </persistence-unit>
 </persistence>


### PR DESCRIPTION
- Update to to Jakarta Persistence 3.1 namespace
 - Add explicit <class>VerySimpleTable</class>
 - Remove obsolete 'hibernate.ejb.cfgfile' property

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20396 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20396
<!-- Hibernate GitHub Bot issue links end -->