### PR TITLE
HHH-20265 Resolve type variables to bounds when no concrete type is given

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/GenericsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/GenericsHelper.java
@@ -50,12 +50,22 @@ public final class GenericsHelper {
 	private static Map<TypeVariable<?>, Type> collectTypeArguments(
 			Class<?> subclass, Member superMember) {
 		final var superclass = superMember.getDeclaringClass();
-		final var typeArguments = typeArguments( superclass, subclass );
 		final var typeParameters = superclass.getTypeParameters();
 		final Map<TypeVariable<?>, Type> typeMap =
 				new HashMap<>( typeParameters.length );
-		for ( int i = 0; i < typeParameters.length; i++ ) {
-			typeMap.put( typeParameters[i], typeArguments[i] );
+
+		// There is no context to resolve the type variables if the subclass is the same as the superclass,
+		// so just take the type parameter bounds instead
+		if ( subclass == superclass ) {
+			for ( var typeParameter : typeParameters ) {
+				typeMap.put( typeParameter, typeParameter.getBounds()[0] );
+			}
+		}
+		else {
+			final var typeArguments = typeArguments( superclass, subclass );
+			for ( int i = 0; i < typeParameters.length; i++ ) {
+				typeMap.put( typeParameters[i], typeArguments[i] );
+			}
 		}
 		return typeMap;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/internal/util/GenericsHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/internal/util/GenericsHelperTest.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.internal.util;
+
+import org.hibernate.testing.orm.junit.Jira;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import jakarta.persistence.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericsHelperTest {
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-20265")
+	public void testChainedTypeVariable() throws Exception {
+		Type t = GenericsHelper.actualInheritedMemberType(
+				BaseLibraryEntity.class,
+				BaseLibraryEntity.class.getDeclaredField( "processed" )
+		);
+
+		assertThat(t).isEqualTo(boolean.class);
+	}
+
+	@MappedSuperclass
+	static abstract class BaseEntity<T> {
+	}
+
+	@MappedSuperclass
+	static abstract class BaseReadableEntity<T> extends BaseEntity<T> {
+	}
+
+	@MappedSuperclass
+	static abstract class BaseLibraryEntity<T> extends BaseReadableEntity<T> {
+		private boolean processed;
+	}
+
+	@Entity
+	static class Book extends BaseLibraryEntity<String> {
+		@Id
+		private String id;
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/12181
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20265 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20265
<!-- Hibernate GitHub Bot issue links end -->