### PR TITLE
[6.6] HHH-20378 HHH-20380 HHH-20387 cap_net_raw missing in docker_db.sh for Oracle 23

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -780,6 +780,7 @@ oracle_23() {
     # We need to use the defaults
     # SYSTEM/Oracle18
     $PRIVILEGED_CLI $CONTAINER_CLI run --name oracle -d -p 1521:1521 -e ORACLE_PASSWORD=Oracle18 \
+       --cap-add cap_net_raw \
        --health-cmd healthcheck.sh \
        --health-interval 5s \
        --health-timeout 5s \


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20378
https://hibernate.atlassian.net/browse/HHH-20380
https://hibernate.atlassian.net/browse/HHH-20387

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20380 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->