### PR TITLE
HHH-20298 Document migration and support of SpannerPostgreSQLDialect

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Configuration.adoc
+++ b/documentation/src/main/asciidoc/introduction/Configuration.adoc
@@ -311,6 +311,8 @@ If we're using programmatic configuration, but we don't want to put certain conf
 ----
 # PostgreSQL
 jakarta.persistence.jdbc.url=jdbc:postgresql://localhost/example
+# Google Cloud Spanner (PostgreSQL dialect)
+jakarta.persistence.jdbc.url=jdbc:cloudspanner:/projects/my-project/instances/my-instance/databases/my-db?dialect=postgresql;defaultsequencekind=bit_reversed_positive
 # Credentials
 jakarta.persistence.jdbc.user=hibernate
 jakarta.persistence.jdbc.password=zAh7mY$2MNshzAQ5

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -103,6 +103,12 @@ are mapped. This is the correct behavior, but it means that applications which h
 `import.sql` file on the classpath by accident may now see it executed when it was
 previously ignored.
 
+=== Migration of Spanner PostgreSQL Dialect to core
+
+The `SpannerPostgreSQLDialect`, which was previously part of the `hibernate-community-dialects` artifact under the package name `org.hibernate.community.dialect`, has been migrated to the `hibernate-core` artifact and package name `org.hibernate.dialect`.
+
+Users currently using the community dialect must update their dialect configuration to use `org.hibernate.dialect.SpannerPostgreSQLDialect` (or rely on Hibernate's automatic dialect resolution).
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // DDL changes
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -115,3 +115,8 @@ The `@Nationalized` annotation may now be placed on a package descriptor, acting
 == New Services
 
 The SPI interfaces `BatchBuilder`, `StatisticsFactory`, `MutationExecutorService`, and `SchemaManagementTool` are now Java services, allowing customization via the service loader mechanism.
+
+[[spanner-postgres-dialect]]
+== Support for Google Cloud Spanner PostgreSQL-compatible Dialect
+
+The dialect for Google Cloud Spanner's PostgreSQL-compatible interface (`SpannerPostgreSQLDialect`) is now fully integrated into Hibernate ORM Core, and is officially tested and supported out of the box.


### PR DESCRIPTION
- Update Configuration.adoc to include a JDBC URL example for Google Cloud Spanner (PostgreSQL dialect).
- Document the migration of SpannerPostgreSQLDialect from hibernate-community-dialects to hibernate-core in migration-guide.adoc.
- Highlight official support and testing of SpannerPostgreSQLDialect in whats-new.adoc.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20298 (Sub-task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20298
<!-- Hibernate GitHub Bot issue links end -->