### PR TITLE
HHH-20214 Remove unnecessary `revend_tstmp` optional audit log column

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/Audited.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/Audited.java
@@ -184,16 +184,6 @@ public @interface Audited {
 		 */
 		String invalidatingChangesetIdColumn()
 				default DEFAULT_INVALIDATING_CHANGESET_ID_COLUMN_NAME;
-
-		/**
-		 * The name of the column holding the timestamp of the
-		 * instant at which an audit row was superseded when the
-		 * {@linkplain StateManagementSettings#AUDIT_STRATEGY
-		 * audit strategy} is set to
-		 * {@link org.hibernate.audit.AuditStrategy#VALIDITY}
-		 * and this attribute is set to a nonempty value.
-		 */
-		String invalidationTimestampColumn() default "";
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AuditHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AuditHelper.java
@@ -62,7 +62,6 @@ public final class AuditHelper {
 	public static final String CHANGESET_ID = "changesetId";
 	public static final String MODIFICATION_TYPE = "modificationType";
 	public static final String INVALIDATING_CHANGESET_ID = "invalidatingChangesetId";
-	public static final String INVALIDATION_TIMESTAMP = "invalidationTimestamp";
 
 	private static final String DEFAULT_TABLE_SUFFIX = "_AUD";
 
@@ -707,16 +706,6 @@ public final class AuditHelper {
 		auditTable.addColumn( revEndColumn );
 		holder.addAuxiliaryColumn( INVALIDATING_CHANGESET_ID, revEndColumn );
 		createChangesetForeignKey( auditTable, revEndColumn, context );
-
-		final String revEndTsName = auditTableAnnotation != null
-				? auditTableAnnotation.invalidationTimestampColumn()
-				: "";
-		if ( !isBlank( revEndTsName ) ) {
-			final var revEndTsColumn = createAuditColumn( revEndTsName, Instant.class, auditTable, context );
-			revEndTsColumn.setNullable( true );
-			auditTable.addColumn( revEndTsColumn );
-			holder.addAuxiliaryColumn( INVALIDATION_TIMESTAMP, revEndTsColumn );
-		}
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/AuditMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/AuditMapping.java
@@ -46,13 +46,6 @@ public interface AuditMapping extends AuxiliaryMapping {
 	SelectableMapping getInvalidatingChangesetIdMapping(String originalTableName);
 
 	/**
-	 * Get the invalidation timestamp selectable mapping for the given original table,
-	 * or {@code null} if not configured.
-	 */
-	@Nullable
-	SelectableMapping getInvalidationTimestampMapping(String originalTableName);
-
-	/**
 	 * Get the entity loader for single-entity audit queries.
 	 */
 	AuditEntityLoader getEntityLoader();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AuditMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AuditMappingImpl.java
@@ -79,8 +79,7 @@ public class AuditMappingImpl implements AuditMapping {
 			String auditTableName,
 			SelectableMapping changesetIdMapping,
 			@Nullable SelectableMapping modificationTypeMapping,
-			@Nullable SelectableMapping invalidatingChangesetMapping,
-			@Nullable SelectableMapping invalidationTimestampMapping
+			@Nullable SelectableMapping invalidatingChangesetMapping
 	) {}
 
 	private final Map<String, TableAuditInfo> tableAuditInfoMap;
@@ -169,11 +168,6 @@ public class AuditMappingImpl implements AuditMapping {
 	}
 
 	@Override
-	public SelectableMapping getInvalidationTimestampMapping(String originalTableName) {
-		return resolveInfo( originalTableName ).invalidationTimestampMapping;
-	}
-
-	@Override
 	public List<String> getExtraSelectExpressions() {
 		final var anyInfo = tableAuditInfoMap.values().iterator().next();
 		final var exprs = new ArrayList<>( List.of(
@@ -182,9 +176,6 @@ public class AuditMappingImpl implements AuditMapping {
 		) );
 		if ( anyInfo.invalidatingChangesetMapping != null ) {
 			exprs.add( anyInfo.invalidatingChangesetMapping.getSelectionExpression() );
-		}
-		if ( anyInfo.invalidationTimestampMapping != null ) {
-			exprs.add( anyInfo.invalidationTimestampMapping.getSelectionExpression() );
 		}
 		return exprs;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/AuditCollectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/AuditCollectionHelper.java
@@ -165,13 +165,6 @@ public final class AuditCollectionHelper {
 			updateBuilder.addValueColumn( "?", transactionEndMapping );
 		}
 
-		// SET REVEND_TSTMP = ? (if configured)
-		final var revEndTsMapping = mutationTarget.getTargetPart().getAuditMapping()
-				.getInvalidationTimestampMapping( mutationTarget.getCollectionTableMapping().getTableName() );
-		if ( revEndTsMapping != null ) {
-			updateBuilder.addValueColumn( "?", revEndTsMapping );
-		}
-
 		// WHERE: same identity columns as the INSERT (key + index/identifier + element)
 		attributeMapping.getKeyDescriptor()
 				.getKeyPart()

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/InsertRowsCoordinatorAudit.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/InsertRowsCoordinatorAudit.java
@@ -208,17 +208,6 @@ public class InsertRowsCoordinatorAudit implements InsertRowsCoordinator, Collec
 						ParameterUsage.SET
 				);
 
-				// SET REVEND_TSTMP = :tstmp (if configured)
-				final var revEndTsMapping = auditMapping.getInvalidationTimestampMapping( collectionTableName );
-				if ( revEndTsMapping != null ) {
-					jdbcValueBindings.bindValue(
-							java.time.Instant.now(),
-							tableName,
-							revEndTsMapping.getSelectionExpression(),
-							ParameterUsage.SET
-					);
-				}
-
 				// WHERE: bind key + index/element columns (same as INSERT but RESTRICT)
 				bindings.bindRestrictValues(
 						collection,

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/AbstractAuditCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/AbstractAuditCoordinator.java
@@ -368,16 +368,6 @@ abstract class AbstractAuditCoordinator extends AbstractMutationCoordinator impl
 						ParameterUsage.SET
 				);
 
-				// SET REVEND_TSTMP = :tstmp (if configured)
-				final var revEndTsMapping = auditMapping.getInvalidationTimestampMapping( sourceTableName );
-				if ( revEndTsMapping != null ) {
-					jdbcValueBindings.bindValue(
-							java.time.Instant.now(), tableName,
-							revEndTsMapping.getSelectionExpression(),
-							ParameterUsage.SET
-					);
-				}
-
 				// WHERE id = :id
 				sourceMappings[tableIndex].getKeyMapping().breakDownKeyJdbcValues(
 						id,
@@ -438,12 +428,6 @@ abstract class AbstractAuditCoordinator extends AbstractMutationCoordinator impl
 			}
 			else {
 				updateBuilder.addValueColumn( "?", revEndMapping );
-			}
-
-			// SET REVEND_TSTMP = ? (if configured)
-			final var revEndTsMapping = auditMapping.getInvalidationTimestampMapping( sourceTableName );
-			if ( revEndTsMapping != null ) {
-				updateBuilder.addValueColumn( "?", revEndTsMapping );
 			}
 
 			// WHERE id columns

--- a/hibernate-core/src/main/java/org/hibernate/persister/state/internal/AuditStateManagement.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/state/internal/AuditStateManagement.java
@@ -50,7 +50,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static org.hibernate.boot.model.internal.AuditHelper.MODIFICATION_TYPE;
 import static org.hibernate.boot.model.internal.AuditHelper.INVALIDATING_CHANGESET_ID;
-import static org.hibernate.boot.model.internal.AuditHelper.INVALIDATION_TIMESTAMP;
 import static org.hibernate.boot.model.internal.AuditHelper.CHANGESET_ID;
 import static org.hibernate.metamodel.mapping.internal.MappingModelCreationHelper.getTableIdentifierExpression;
 import static org.hibernate.persister.state.internal.AbstractStateManagement.resolveMutationTarget;
@@ -191,9 +190,6 @@ public class AuditStateManagement implements StateManagement {
 			if ( rootInfo.invalidatingChangesetMapping() != null ) {
 				extras.add( rootInfo.invalidatingChangesetMapping().getSelectionExpression() );
 			}
-			if ( rootInfo.invalidationTimestampMapping() != null ) {
-				extras.add( rootInfo.invalidationTimestampMapping().getSelectionExpression() );
-			}
 			extraColumns = extras;
 		}
 		else {
@@ -268,8 +264,7 @@ public class AuditStateManagement implements StateManagement {
 						auditSubquery,
 						rootInfo.changesetIdMapping(),
 						rootInfo.modificationTypeMapping(),
-						rootInfo.invalidatingChangesetMapping(),
-						rootInfo.invalidationTimestampMapping()
+						rootInfo.invalidatingChangesetMapping()
 				)
 		);
 	}
@@ -317,12 +312,6 @@ public class AuditStateManagement implements StateManagement {
 						auditTableName,
 						holder.getAuxiliaryColumn( INVALIDATING_CHANGESET_ID ),
 						csIdJdbcMapping,
-						creationProcess
-				),
-				toSelectableMapping(
-						auditTableName,
-						holder.getAuxiliaryColumn( INVALIDATION_TIMESTAMP ),
-						resolveJdbcMapping( typeConfiguration, java.time.Instant.class ),
 						creationProcess
 				)
 		);


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

The mapping was originally offered as an alternative for the Envers optional validity strategy's audit log `REVEND_TSTMP`, but it looks like this information is only used in writes and never in read queries, and also duplicates the revision entity's existing timestamp. Removing it from the new core `@Audited` feature.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20214 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20214
<!-- Hibernate GitHub Bot issue links end -->