### PR TITLE
HHH-20386 Fix raw type generated for SingularAttribute with generic collection fields

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OptimisticLockException;
 import jakarta.persistence.Version;
-import org.hibernate.StaleStateException;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.testing.orm.junit.DomainModel;

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/MetaAttributeGenerationVisitor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/MetaAttributeGenerationVisitor.java
@@ -114,7 +114,8 @@ public class MetaAttributeGenerationVisitor extends SimpleTypeVisitor8<@Nullable
 			}
 		}
 		else {
-			final String type = targetEntity != null ? targetEntity : returnedElement.getQualifiedName().toString();
+			final String type = targetEntity != null ? targetEntity
+					: extractClosestRealTypeAsString( declaredType, context );
 			return targetEntity != null || isManagedType( returnedElement )
 					? new AnnotationMetaSingleAttribute( entity, element, type )
 					: singleAttribute( element, declaredType, type );

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/arraytype/ArrayTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/arraytype/ArrayTest.java
@@ -10,6 +10,9 @@ import org.hibernate.processor.test.util.WithClasses;
 import org.junit.jupiter.api.Test;
 
 import static org.hibernate.processor.test.util.TestUtil.assertAttributeTypeInMetaModelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Hardy Ferentschik
@@ -30,6 +33,34 @@ class ArrayTest {
 	void testIntegerArray() {
 		assertAttributeTypeInMetaModelFor(
 				TemperatureSamples.class, "samples", Integer[].class, "Wrong type for field."
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-20386")
+	@WithClasses(JdbcTypeCodeArrayEntity.class)
+	void testJdbcTypeCodeArrayPreservesGenericTypeWithAnnotation() {
+		// SingularAttribute<JdbcTypeCodeArrayEntity, Set<String>> expected — NOT raw Set
+		String source = getMetaModelSourceAsString( JdbcTypeCodeArrayEntity.class );
+		assertTrue(
+				source.contains( "SingularAttribute<JdbcTypeCodeArrayEntity, Set<String>>" ),
+				"Expected SingularAttribute with generic type Set<String> for @JdbcTypeCode(ARRAY) field, but got:\n" + source
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-20386")
+	@WithClasses(JdbcTypeCodeArrayEntity.class)
+	void testSetFieldWithoutJdbcTypeCodeAnnotationPreservesGenericType() {
+		// Same fix must apply to Set<String> fields without @JdbcTypeCode as well
+		String source = getMetaModelSourceAsString( JdbcTypeCodeArrayEntity.class );
+		long count = source.lines()
+				.filter( line -> line.contains( "SingularAttribute<JdbcTypeCodeArrayEntity, Set<String>>" ) )
+				.count();
+		assertEquals(
+				2,
+				count,
+				"Expected at least 2 fields with SingularAttribute<JdbcTypeCodeArrayEntity, Set<String>>, but got:\n" + source
 		);
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/arraytype/JdbcTypeCodeArrayEntity.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/arraytype/JdbcTypeCodeArrayEntity.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.arraytype;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Test entity for HHH-20386: Set<&lt;>String&gt; with {@code @JdbcTypeCode(SqlTypes.ARRAY)}
+ * should generate {@code SingularAttribute<JdbcTypeCodeArrayEntity, Set<String>>}
+ * (not the raw type {@code SingularAttribute<JdbcTypeCodeArrayEntity, Set>}).
+ */
+@Entity
+public class JdbcTypeCodeArrayEntity {
+	@Id
+	private Long id;
+
+	@Column
+	@JdbcTypeCode(SqlTypes.ARRAY)
+	private Set<String> tags = new HashSet<>();
+
+	@Column
+	private Set<String> tagsWithoutAnnotation = new HashSet<>();
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public Set<String> getTags() {
+		return tags;
+	}
+
+	public void setTags(Set<String> tags) {
+		this.tags = tags;
+	}
+
+	public Set<String> getTagsWithoutAnnotation() {
+		return tagsWithoutAnnotation;
+	}
+
+	public void setTagsWithoutAnnotation(Set<String> tagsWithoutAnnotation) {
+		this.tagsWithoutAnnotation = tagsWithoutAnnotation;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

In `MetaAttributeGenerationVisitor.visitDeclared`, singular attributes
(those without `@ElementCollection`/`@OneToMany` etc.) had their type
resolved via r`eturnedElement.getQualifiedName().toString()`, which
returns the raw erased type (e.g. `java.util.Set`) without any
generic type arguments.

Replace with `extractClosestRealTypeAsString(declaredType, context)`
which recursively preserves generic type parameters, so that a field
like `Set<String>` now correctly produces:

  `SingularAttribute<Entity, Set<String>>`

instead of the raw:

  `SingularAttribute<Entity, Set>`

Add ArrayTest test cases covering both the `@JdbcTypeCode(SqlTypes.ARRAY)`
variant and the plain (unannotated) `Set<String>` singular field variant.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20386 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20386
<!-- Hibernate GitHub Bot issue links end -->