### PR TITLE
HHH-20298 Update Spanner emulator to 1.5.53 and enable supported features

### DIFF
--- a/docker-compose/latest/spanner.yml
+++ b/docker-compose/latest/spanner.yml
@@ -1,6 +1,6 @@
 services:
   spanner:
-    image: ${SPANNER_EMULATOR:-gcr.io/cloud-spanner-emulator/emulator:1.5.52@sha256:350fa0e504aff363c386a237ef4755f3332deca6f6aa3335664c5b8245495e9c}
+    image: ${SPANNER_EMULATOR:-gcr.io/cloud-spanner-emulator/emulator:1.5.53@sha256:2c3a9be05e1f36476ec2d07dae0544e1c91c46bc170c22807436f11c496f5f06}
     container_name: ${SPANNER_CONTAINER_NAME:-spanner}
     ports:
       - "${SPANNER_GRPC_PORT:-9011}:9010"

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaBuilderNonStandardFunctionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaBuilderNonStandardFunctionsTest.java
@@ -489,7 +489,6 @@ public class CriteriaBuilderNonStandardFunctionsTest {
 	@Test
 	@JiraKey("HHH-16130")
 	@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsDateTimeTruncation.class )
-	@SkipForDialect( dialectClass = SpannerPostgreSQLDialect.class, reason = "Emulator bug in date_trunc")
 	public void testDateTruncFunction(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			HibernateCriteriaBuilder cb = session.getCriteriaBuilder();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -594,7 +594,6 @@ public class FunctionTests {
 
 	@Test
 	@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsDateTimeTruncation.class )
-	@SkipForDialect( dialectClass = SpannerPostgreSQLDialect.class, reason = "Emulator bug with date_trunc")
 	public void testDateTruncFunction(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -623,7 +622,6 @@ public class FunctionTests {
 
 	@Test
 	@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsDateTimeTruncation.class )
-	@SkipForDialect(dialectClass = SpannerPostgreSQLDialect.class, reason = "Emulator bug")
 	public void testDateTruncWithOffsetFunction(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -644,7 +642,6 @@ public class FunctionTests {
 	}
 
 	@Test
-	@SkipForDialect(dialectClass = SpannerPostgreSQLDialect.class, reason = "Emulator bug with extract epoch from date in non-UTC timezones")
 	public void testDateTruncWithLocalDatetimeMinusLocalDate(SessionFactoryScope scope) {
 		scope.inTransaction( session ->
 				assertThat( session.createQuery( "select trunc(local datetime, day) - local date", Duration.class )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/TruncConvertedDatetimeAttributeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/TruncConvertedDatetimeAttributeTest.java
@@ -13,14 +13,12 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import org.hibernate.dialect.SpannerPostgreSQLDialect;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -55,7 +53,6 @@ public class TruncConvertedDatetimeAttributeTest {
 	}
 
 	@Test
-	@SkipForDialect( dialectClass = SpannerPostgreSQLDialect.class, reason = "Emulator bug with date_trunc")
 	public void testTruncSelection(SessionFactoryScope scope) {
 		scope.inSession( session -> {
 			assertThat( session.createQuery(

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -1035,10 +1035,6 @@ abstract public class DialectFeatureChecks {
 
 	public static class SupportsGenerateSeries implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
-			if (dialect instanceof SpannerPostgreSQLDialect) {
-				// TODO(spanner): Current limitation of Spanner
-				return false;
-			}
 			return definesSetReturningFunction( dialect, "generate_series" );
 		}
 	}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

- Update Spanner emulator version to 1.5.53 in docker-compose/latest/spanner.yml.

- Unskip tests for date_trunc in CriteriaBuilderNonStandardFunctionsTest, FunctionTests, and TruncConvertedDatetimeAttributeTest as they are now supported by the emulator.

- Enable generate_series support for SpannerPostgreSQLDialect in DialectFeatureChecks and verify with GenerateSeriesTest.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20298 (Sub-task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20298
<!-- Hibernate GitHub Bot issue links end -->