### PR TITLE
HHH-19742 Define optional imports for packages that are optionally loaded in the code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,28 @@ jobs:
           POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
           DEVELOCITY_ACCESS_KEY: "${{ secrets.DEVELOCITY_ACCESS_KEY }}"
 
+      - name: Check OSGi optional imports
+        run: ./gradlew
+          :hibernate-core:checkOptionalImports
+          :hibernate-vector:checkOptionalImports
+          :hibernate-agroal:checkOptionalImports
+          :hibernate-ant:checkOptionalImports
+          :hibernate-c3p0:checkOptionalImports
+          :hibernate-community-dialects:checkOptionalImports
+          :hibernate-envers:checkOptionalImports
+          :hibernate-graalvm:checkOptionalImports
+          :hibernate-hikaricp:checkOptionalImports
+          :hibernate-jcache:checkOptionalImports
+          :hibernate-jfr:checkOptionalImports
+          :hibernate-micrometer:checkOptionalImports
+          :hibernate-processor:checkOptionalImports
+          :hibernate-scan-jandex:checkOptionalImports
+          :hibernate-spatial:checkOptionalImports
+          :hibernate-testing:checkOptionalImports
+        env:
+          POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
+          DEVELOCITY_ACCESS_KEY: "${{ secrets.DEVELOCITY_ACCESS_KEY }}"
+
       # For jobs running on 'pull_request', upload build scan data.
       # The actual publishing must be done in a separate job (see ci-report.yml).
       # We don't write to the remote cache as that would be unsafe.

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -103,7 +103,34 @@ dependencies {
 jar {
     manifest {
         attributes(
-                'Main-Class': 'org.hibernate.Version'
+                'Main-Class': 'org.hibernate.Version',
+                // Override the base Import-Package to mark optional dependencies as resolution:=optional.
+                // These packages are referenced in the compiled bytecode but only loaded conditionally
+                // at runtime (guarded by Class.forName / classForName availability checks), so OSGi
+                // containers must not require them to be present.
+                'Import-Package': [
+                        // Temporarily support JTA 1.1 (see base plugin comment)
+                        'javax.transaction;version="[1.1,2)"',
+                        // Oracle JDBC / OSON: loaded conditionally via OracleJdbcHelper.isUsable()
+                        // and JacksonIntegration.ableToLoadJacksonOSONFactory()
+                        'oracle.*;resolution:=optional',
+                        // Jackson 2.x (core, databind, dataformat-xml): loaded conditionally via
+                        // JacksonIntegration.ableToLoadJackson*Mapper()
+                        'com.fasterxml.jackson.*;resolution:=optional',
+                        // Jackson 3 (tools.jackson): loaded conditionally via
+                        // JacksonIntegration.ableToLoadJackson3*Mapper()
+                        'tools.jackson.*;resolution:=optional',
+                        // Bean Validation API: integrated only when a provider is present
+                        'jakarta.validation.*;resolution:=optional',
+                        // CDI API: integrated only when a BeanManager is present
+                        'jakarta.enterprise.*;resolution:=optional',
+                        // JSON-B API: loaded conditionally in JsonBJsonFormatMapper
+                        'jakarta.json.bind.*;resolution:=optional',
+                        // PostgreSQL driver types: used only when running against PostgreSQL
+                        'org.postgresql.*;resolution:=optional',
+                        // All other referenced packages are required
+                        '*'
+                ].join(',')
         )
     }
 }

--- a/hibernate-graalvm/hibernate-graalvm.gradle
+++ b/hibernate-graalvm/hibernate-graalvm.gradle
@@ -10,6 +10,19 @@ plugins {
 
 description = "Experimental extension to make it easier to compile applications into a GraalVM native image"
 
+jar {
+    manifest {
+        attributes(
+                'Import-Package': [
+                        // GraalVM Native Image API: only present when building native images
+                        'org.graalvm.nativeimage.*;resolution:=optional',
+                        // All other referenced packages are required
+                        '*'
+                ].join(',')
+        )
+    }
+}
+
 dependencies {
     //No need for transitive dependencies: this is all just metadata to be used as companion jar.
     compileOnly project( ':hibernate-core' )

--- a/hibernate-spatial/hibernate-spatial.gradle
+++ b/hibernate-spatial/hibernate-spatial.gradle
@@ -10,6 +10,19 @@ plugins {
 
 description = 'Integrate support for Spatial/GIS data into Hibernate O/RM'
 
+jar {
+	manifest {
+		attributes(
+				'Import-Package': [
+						// PostgreSQL JDBC spatial types: used only when running against PostgreSQL
+						'org.postgresql.*;resolution:=optional',
+						// All other referenced packages are required
+						'*'
+				].join(',')
+		)
+	}
+}
+
 dependencies {
 	api project( ':hibernate-core' )
 	api libs.geolatte

--- a/hibernate-testing/hibernate-testing.gradle
+++ b/hibernate-testing/hibernate-testing.gradle
@@ -10,6 +10,25 @@ plugins {
 
 description = 'Support for testing Hibernate ORM functionality'
 
+jar {
+    manifest {
+        attributes(
+                'Import-Package': [
+                        // Temporarily support JTA 1.1 (see base plugin comment)
+                        'javax.transaction;version="[1.1,2)"',
+                        // JDBC driver packages: loaded dynamically via Class.forName() in
+                        // SharedDriverManagerConnectionProvider and BaseCoreFunctionalTestCase
+                        'oracle.*;resolution:=optional',
+                        'com.edb.*;resolution:=optional',
+                        'org.postgresql.*;resolution:=optional',
+                        'org.h2.*;resolution:=optional',
+                        // All other referenced packages are required
+                        '*'
+                ].join(',')
+        )
+    }
+}
+
 dependencies {
     api project( ':hibernate-core' )
     api project( ':hibernate-community-dialects' )

--- a/hibernate-vector/hibernate-vector.gradle
+++ b/hibernate-vector/hibernate-vector.gradle
@@ -10,6 +10,21 @@ plugins {
 
 description = 'Hibernate\'s extensions for vector support'
 
+jar {
+    manifest {
+        attributes(
+                'Import-Package': [
+                        // Oracle JDBC Vector type: used only when running against Oracle
+                        'oracle.*;resolution:=optional',
+                        // MS SQL Server JDBC Vector type: used only when running against SQL Server
+                        'microsoft.*;resolution:=optional',
+                        // All other referenced packages are required
+                        '*'
+                ].join(',')
+        )
+    }
+}
+
 dependencies {
     api project( ':hibernate-core' )
 

--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -377,3 +377,166 @@ configurations.configureEach {
         }
     }
 }
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// OSGi optional import helpers
+
+// Lists packages from compileOnly deps that are statically imported in main
+// sources — these need resolution:=optional in the Import-Package header.
+// Run whenever a compileOnly dependency is added or changed.
+//   ./gradlew :<module>:findOptionalImports
+tasks.register('findOptionalImports') {
+    description = 'Lists packages from compileOnly deps that are statically imported in main sources (need resolution:=optional in Import-Package)'
+    group = 'help'
+
+    doLast {
+        // 'compileOnly' is declarable-only in Gradle 9+, so we derive the compileOnly
+        // artifacts by subtracting runtimeClasspath files from compileClasspath files —
+        // both configurations are resolvable.
+        def runtimeFiles = configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts
+                .collect { it.file } as Set
+        def compileOnlyPackages = [] as Set
+        configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts
+                .findAll { !(it.file in runtimeFiles) }
+                .each { artifact ->
+                    if (artifact.file.name.endsWith('.jar')) {
+                        new java.util.jar.JarFile(artifact.file).entries().each { entry ->
+                            if (entry.name.endsWith('.class') && entry.name.contains('/')) {
+                                compileOnlyPackages << entry.name.replaceAll('/[^/]+\\.class$', '').replace('/', '.')
+                            }
+                        }
+                    }
+                }
+
+        def usedOptional = [] as SortedSet
+        sourceSets.main.java.srcDirs.each { srcDir ->
+            if (!srcDir.exists()) return
+            srcDir.eachFileRecurse { file ->
+                if (!file.name.endsWith('.java')) return
+                file.eachLine { line ->
+                    def m = line =~ /^import\s+(?:static\s+)?([a-z][a-zA-Z0-9.]+)\.[A-Z]/
+                    if (m) {
+                        def importedPkg = m[0][1]
+                        if (compileOnlyPackages.any { cp -> importedPkg == cp || importedPkg.startsWith(cp + '.') }) {
+                            usedOptional << importedPkg.replaceAll('\\.[a-z][^.]*$', '')
+                        }
+                    }
+                }
+            }
+        }
+
+        println "\nPackages from compileOnly deps referenced in main source (need resolution:=optional):"
+        usedOptional.each { println "  '${it}.*;resolution:=optional'," }
+    }
+}
+
+// Verifies that every Import-Package entry in the built jar is satisfiable from
+// the runtimeClasspath, and reports any that are missing and not already marked
+// resolution:=optional.  Wire this into CI alongside the jar task.
+//   ./gradlew :<module>:checkOptionalImports
+tasks.register('checkOptionalImports') {
+    description = 'Checks that all Import-Package entries in the built jar are either satisfiable at runtime or already marked resolution:=optional'
+    group = 'verification'
+    dependsOn jar
+
+    doLast {
+        def runtimePkgs = [] as Set
+
+        // Packages from runtime dependency jars
+        configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            if (artifact.file.name.endsWith('.jar')) {
+                new java.util.jar.JarFile(artifact.file).entries().each { entry ->
+                    if (entry.name.endsWith('.class') && entry.name.contains('/'))
+                        runtimePkgs << entry.name.replaceAll('/[^/]+\\.class$', '').replace('/', '.')
+                }
+            }
+        }
+
+        // Packages from JDK built-in modules (not present as jars on the classpath in Java 9+)
+        ModuleLayer.boot().modules().each { module ->
+            runtimePkgs.addAll(module.packages)
+        }
+
+        // The project's own packages: BND exports these via -exportcontents so it won't
+        // emit them as imports, but the bytecode scan still sees them as references.
+        sourceSets.main.output.classesDirs.each { classesDir ->
+            if (!classesDir.exists()) return
+            classesDir.eachFileRecurse { file ->
+                if (file.name.endsWith('.class') && file.parentFile != classesDir) {
+                    def pkg = classesDir.toPath().relativize(file.parentFile.toPath()).toString().replace(File.separator, '.')
+                    if (pkg) runtimePkgs << pkg
+                }
+            }
+        }
+
+        // Packages from compileOnly *project* dependencies: these are provided by other OSGi
+        // bundles at runtime (e.g. hibernate-core for hibernate-graalvm), so they are required
+        // imports — not missing ones.  Only compileOnly *external* artifacts are truly absent.
+        // Note: project artifacts resolve to a classes *directory*, not a jar file.
+        def runtimeFileSet = configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts
+                .collect { it.file } as Set
+        configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts
+                .findAll { !(it.file in runtimeFileSet) }
+                .findAll { it.id.componentIdentifier instanceof org.gradle.api.artifacts.component.ProjectComponentIdentifier }
+                .each { artifact ->
+                    if (artifact.file.name.endsWith('.jar')) {
+                        new java.util.jar.JarFile(artifact.file).entries().each { entry ->
+                            if (entry.name.endsWith('.class') && entry.name.contains('/'))
+                                runtimePkgs << entry.name.replaceAll('/[^/]+\\.class$', '').replace('/', '.')
+                        }
+                    } else if (artifact.file.isDirectory()) {
+                        artifact.file.eachFileRecurse { file ->
+                            if (file.name.endsWith('.class') && file.parentFile != artifact.file) {
+                                def pkg = artifact.file.toPath().relativize(file.parentFile.toPath()).toString().replace(File.separator, '.')
+                                if (pkg) runtimePkgs << pkg
+                            }
+                        }
+                    }
+                }
+
+        // Packages explicitly listed in the Import-Package *instruction* (before BND
+        // expands '*') are intentional required imports — e.g. javax.transaction for
+        // JTA 1.1 compatibility in Karaf — even if they're absent from runtimeClasspath.
+        // Only BND-auto-discovered packages (from '*') should be verified here.
+        def splitOnUnquotedCommas = { String s ->
+            def result = []
+            def cur = new StringBuilder()
+            def inQuote = false
+            s.each { ch ->
+                if (ch == '"') { inQuote = !inQuote; cur.append(ch) }
+                else if (ch == ',' && !inQuote) { result << cur.toString().trim(); cur = new StringBuilder() }
+                else { cur.append(ch) }
+            }
+            if (cur.length() > 0) result << cur.toString().trim()
+            result
+        }
+
+        def instruction = tasks.jar.manifest.attributes['Import-Package'] ?: ''
+        def explicitImports = splitOnUnquotedCommas(instruction)
+                .collect { it.replaceAll(';.*', '').trim() }
+                .findAll { it != '*' }
+                .toSet()
+
+        def builtJar = tasks.jar.archiveFile.get().asFile
+        def importPkg = new java.util.jar.JarFile(builtJar).manifest.mainAttributes.getValue('Import-Package') ?: ''
+
+        def missing = []
+        splitOnUnquotedCommas(importPkg).each { entry ->
+            def pkg = entry.replaceAll(';.*', '')
+            if (pkg == '*' || entry.contains('resolution:=optional')) return
+            if (explicitImports.contains(pkg)) return   // intentional explicit import
+            if (!runtimePkgs.contains(pkg)) missing << pkg
+        }
+
+        if (missing) {
+            throw new GradleException(
+                "The following Import-Package entries are absent from runtimeClasspath and not marked resolution:=optional.\n" +
+                "Add them to the Import-Package list in ${project.name}.gradle with ';resolution:=optional':\n" +
+                missing.collect { "  $it" }.join('\n')
+            )
+        }
+        else {
+            println "checkOptionalImports: all Import-Package entries are satisfiable at runtime."
+        }
+    }
+}

--- a/tooling/hibernate-ant/hibernate-ant.gradle
+++ b/tooling/hibernate-ant/hibernate-ant.gradle
@@ -7,6 +7,19 @@ plugins {
 
 description = 'Annotation Processor to generate JPA 2 static metamodel classes'
 
+jar {
+    manifest {
+        attributes(
+                'Import-Package': [
+                        // Apache Ant: used directly but Ant is an optional runtime dep
+                        'org.apache.tools.ant.*;resolution:=optional',
+                        // All other referenced packages are required
+                        '*'
+                ].join(',')
+        )
+    }
+}
+
 sourceSets {
     legacyTest {
         compileClasspath += sourceSets.main.output


### PR DESCRIPTION
Hibernate core has many optional dependencies which are discovered at runtime by dynamically loading some specific classes.
However, the packages are not listed as optional dependency in the META-INF/MANIFEST.MF file.
This means that in an OSGI environment the dependencies (like for example the oracle driver) is required.

The BND tool is used to build the import-package section in the manifest file, however, BND works on compiled byte code and cannot see that some packages are guarded by dynamic loading, like using Class.forName().
The compileOnly distinction is a Gradle concept. BND doesn't know or care that Gradle marked the dependency as compile-only — it just sees a resolvable package reference and generates a required import for it

The developer knows which packages are  optional, so declaring these in the build file makes sense.

The fix is to specify optional packages according to the logic in the code.

Additionally, there are 2 new tasks: one to list the optional packages for a module and one to check if the optional imports are ok.

I have added the checking task to the ci build script as a separate step.

Note that the changes are made with assistance of AI tooling.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19742 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19742
<!-- Hibernate GitHub Bot issue links end -->