### PR TITLE
HHH-13284 Additional tests showing trouble with session refresh

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/refresh/CascadeRefreshToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/refresh/CascadeRefreshToManyTest.java
@@ -7,10 +7,12 @@ package org.hibernate.orm.test.refresh;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.CacheMode;
 import org.hibernate.Hibernate;
 
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -112,6 +114,32 @@ public class CascadeRefreshToManyTest {
 			session.refresh( owner );
 
 			assertThat( target.getName() ).isEqualTo( "updated target" );
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+		} );
+	}
+
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-13284")
+	public void refreshCollectionViaQuery(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		scope.inTransaction( session -> {
+			final Parent parent = session.find( Parent.class, 1L );
+			Hibernate.initialize( parent.getChildren() );
+			assertThat( parent.getChildren() ).hasSize( 2 );
+
+			session.createMutationQuery( "update RefreshChild c set c.name = 'updated 1' where c.id = 1" )
+					.executeUpdate();
+			session.createMutationQuery( "update RefreshChild c set c.name = 'updated 2' where c.id = 2" )
+					.executeUpdate();
+
+			statementInspector.clear();
+			session.createSelectionQuery( "from RefreshParent p left join fetch p.children", Parent.class )
+							.setCacheMode( CacheMode.REFRESH_SESSION )
+							.getResultList();
+
+			assertThat( parent.getChildren() )
+					.extracting( Child::getName )
+					.containsExactlyInAnyOrder( "updated 1", "updated 2" );
 			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
 		} );
 	}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-13284
<!-- Hibernate GitHub Bot issue links end -->

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-13284 (New Feature):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->