### PR TITLE
HHH-20182 OracleLegacyDialect try to deploy an unknown time type

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -808,7 +808,7 @@ public class OracleLegacyDialect extends Dialect {
 			case DATE:
 				return "date";
 			case TIME:
-				return getVersion().isBefore( 9 ) ? "date" : super.columnType( sqlTypeCode );
+				return getVersion().isBefore( 9 ) ? "date" : "timestamp($p)";
 			case TIMESTAMP:
 				// the only difference between date and timestamp
 				// on Oracle is that date has no fractional seconds


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

The legacy dialect for Oracle try to deploy a time type, who is still not supported by Oracle, instead of the timestamp fallback type

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20182 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20182
<!-- Hibernate GitHub Bot issue links end -->