### PR TITLE
Add a check that Podman machine on OSX has Rosetta enabled

### DIFF
--- a/db.sh
+++ b/db.sh
@@ -49,6 +49,27 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   DB_COUNT=$(sysctl -n hw.physicalcpu)
   # PostGIS images only support amd64, so we force emulation on macOS
   export POSTGRESQL_PLATFORM="linux/amd64"
+  # On Apple arm with Podman, Rosetta must be enabled to run any x86 images
+  # Since we rely on many such images, let's just fail if we notice that Rosetta is not enabled:
+  if [[ "$IS_PODMAN" == "true" ]]; then
+    PODMAN_MACHINE=$(podman machine ls --format '{{.Name}} {{.Running}}' 2>/dev/null | grep 'true' | head -1 | awk '{print $1}')
+    if [[ -z "$PODMAN_MACHINE" ]]; then
+      echo "ERROR: No running Podman machine was found."
+      echo "Your Podman machine is not running, so the containerized database cannot be started."
+      echo "Start it with: podman machine start"
+      exit 1
+    fi
+    # On Intel Macs the machine runs natively as amd64, so Rosetta is neither needed nor supported
+    if [[ "$(uname -m)" == "arm64" ]]; then
+      ROSETTA=$(podman machine inspect "$PODMAN_MACHINE" --format '{{.Rosetta}}' 2>/dev/null)
+      if [[ "$ROSETTA" != "true" ]]; then
+        echo "WARNING: Rosetta is not enabled in your Podman machine '$PODMAN_MACHINE'."
+        echo "A lot of used database images are x86-only and will fail to start without Rosetta."
+        echo "Recreate your Podman machine with Rosetta enabled."
+      fi
+    fi
+  fi
+
 else
   IS_OSX=false
   DB_COUNT=$(nproc)

--- a/docker_db.sh
+++ b/docker_db.sh
@@ -49,6 +49,19 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   DB_COUNT=$(($(sysctl -n hw.physicalcpu)/2))
   # PostGIS images only support amd64, so we force emulation on macOS
   export POSTGRESQL_PLATFORM="linux/amd64"
+  # On Apple arm with Podman, Rosetta must be enabled to run any x86 images
+  # Since we rely on many such images, let's just fail if we notice that Rosetta is not enabled:
+  if [[ "$IS_PODMAN" == "true" ]]; then
+    PODMAN_MACHINE=$(podman machine ls --format '{{.Name}} {{.Running}}' 2>/dev/null | grep 'true' | head -1 | awk '{print $1}')
+    ROSETTA=$(podman machine inspect ${PODMAN_MACHINE:+"$PODMAN_MACHINE"} --format '{{.Rosetta}}' 2>/dev/null)
+    if [[ "$ROSETTA" != "true" ]]; then
+      echo "ERROR: Rosetta is not enabled in your Podman machine ${PODMAN_MACHINE:+ '$PODMAN_MACHINE'}."
+      echo "A lot of used database images are x86-only and will fail to start without Rosetta."
+      echo "Recreate your Podman machine with Rosetta enabled."
+      exit 1
+    fi
+  fi
+
 else
   IS_OSX=false
   DB_COUNT=$(($(nproc)/2))


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
