### PR TITLE
HHH-17558 'select entity.collection' should return a list of collections

### DIFF
--- a/documentation/src/main/asciidoc/querylanguage/Expressions.adoc
+++ b/documentation/src/main/asciidoc/querylanguage/Expressions.adoc
@@ -1049,6 +1049,7 @@ The following functions accept either:
 2. a <<path-expressions,compound path>> that refers to a collection or many-valued association of an entity.
 
 In case 2, application of the function produces an <<implicit-collection-join,implicit join>>.
+It autimatically _flattens_ the collection.
 
 [[collection-functions]]
 [cols="15,20,~,^15"]
@@ -1063,7 +1064,7 @@ In case 2, application of the function produces an <<implicit-collection-join,im
 | `entry()` 💀 | Maps | The whole entry in a map | ✔
 |===
 
-The next group of functions always accept a compound path referring to a collection or many-valued association of an entity.
+The functions in the next group always accept a compound path referring to a collection or many-valued association of an entity.
 They're interpreted as referring to the collection as a whole.
 
 [[collective-collection-functions]]
@@ -1076,14 +1077,26 @@ They're interpreted as referring to the collection as a whole.
 | `keys()` | Maps | The keys of a map, collectively | ✖
 | `values()` | Maps | The values of a map, collectively | ✖
 |===
-Application of one of these functions produces an implicit subquery or implicit join.
 
-This query has an implicit join:
+Application of one of these functions produces an implicit subquery or implicit join.
+It never flattens the collection.
+
+Let's illustrate the difference between the two groups of functions with a simple example.
+
+This query has an implicit join and returns pairs of form `(title, tag)`:
 
 [[elements-join-example]]
 [source, hql]
 ----
 select title, element(tags) from Book
+----
+
+On the other hand, this very similar-looking query returns pairs of form `(title, tags)`, where the tags for a given `Book` are packaged as a detached collection:
+
+[[elements-join-example]]
+[source, hql]
+----
+select title, elements(tags) from Book
 ----
 
 This query has an implicit subquery:
@@ -1156,6 +1169,8 @@ We may use them with:
 - an <<in-predicate,`in`>> or <<exists-predicate,`exists`>> predicate,
 - a <<relational-comparisons-subqueries,relational comparison>>, or
 - an <<aggregate-functions-collections,aggregate function>>.
+
+Alternatively, they may occur directly in the `select` list, in which case the query returns detached collection instances, as we already saw above.
 
 [cols="35,~"]
 |===

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/CustomCollectionTypeSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/CustomCollectionTypeSemantics.java
@@ -4,15 +4,25 @@
  */
 package org.hibernate.collection.internal;
 
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.collection.spi.CollectionSemantics;
-import org.hibernate.collection.spi.InitializerProducerBuilder;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.CollectionClassification;
+import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.spi.NavigablePath;
@@ -20,6 +30,14 @@ import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.type.CollectionType;
+
+import static org.hibernate.collection.spi.InitializerProducerBuilder.createCollectionTypeWrapperInitializerProducer;
+import static org.hibernate.internal.util.collections.CollectionHelper.linkedMap;
+import static org.hibernate.internal.util.collections.CollectionHelper.linkedMapOfSize;
+import static org.hibernate.internal.util.collections.CollectionHelper.linkedSet;
+import static org.hibernate.internal.util.collections.CollectionHelper.linkedSetOfSize;
+import static org.hibernate.internal.util.collections.CollectionHelper.mapOfSize;
+import static org.hibernate.internal.util.collections.CollectionHelper.setOfSize;
 
 /**
  * A collection semantics wrapper for <code>CollectionType</code>.
@@ -53,6 +71,139 @@ public class CustomCollectionTypeSemantics<CE, E> implements CollectionSemantics
 		return (CE) collectionType.instantiate( anticipatedSize );
 	}
 
+	private static <X> @Nullable Comparator<X> getComparator(CollectionPersister collectionDescriptor) {
+		//noinspection unchecked
+		return collectionDescriptor == null ? null
+				: (Comparator<X>) collectionDescriptor.getSortingComparator();
+	}
+
+	@Override
+	public <X> Object instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Collection<? extends X> elements) {
+		final Collection<X> collection =
+				instantiateCollection( anticipatedSize, getCollectionClassification(), collectionDescriptor, elements.size() );
+		collection.addAll( elements );
+		return collection;
+	}
+
+	private static <X> Collection<X> instantiateCollection(
+			int anticipatedSize,
+			CollectionClassification collectionClassification,
+			CollectionPersister collectionDescriptor,
+			int size) {
+		return switch ( collectionClassification ) {
+			case ARRAY, LIST, BAG, ID_BAG -> CollectionHelper.arrayList( anticipatedSize );
+			case SET -> anticipatedSize < 1 ? new HashSet<>() : setOfSize( anticipatedSize );
+			case ORDERED_SET -> anticipatedSize < 1 ? linkedSet() : linkedSetOfSize( anticipatedSize );
+			case SORTED_SET -> new TreeSet<>( getComparator( collectionDescriptor ) );
+			case MAP, ORDERED_MAP, SORTED_MAP -> new LinkedHashSet<>( size );
+		};
+	}
+
+	@Override
+	public <K, V> Map<K, V> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Map<? extends K, ? extends V> entries) {
+		final Map<K, V> map = instantiateMap( anticipatedSize, getCollectionClassification(), collectionDescriptor );
+		map.putAll( entries );
+		return map;
+	}
+
+	private static <K, V> Map<K, V> instantiateMap(
+			int anticipatedSize,
+			CollectionClassification collectionClassification,
+			CollectionPersister collectionDescriptor) {
+		return switch ( collectionClassification ) {
+			case ORDERED_MAP -> anticipatedSize < 1 ? linkedMap() : linkedMapOfSize( anticipatedSize );
+			case SORTED_MAP -> new TreeMap<>( getComparator( collectionDescriptor ) );
+			default -> anticipatedSize < 1 ? CollectionHelper.map() : mapOfSize( anticipatedSize );
+		};
+	}
+
+	@Override
+	public int collectionSize(Object rawCollection) {
+		if ( rawCollection instanceof Collection<?> collection ) {
+			return collection.size();
+		}
+		else if ( rawCollection instanceof Map<?, ?> map ) {
+			return map.size();
+		}
+		else if ( rawCollection == null ) {
+			return 0;
+		}
+		else {
+			int size = 0;
+			final var elements = collectionType.getElementsIterator( rawCollection );
+			while ( elements.hasNext() ) {
+				elements.next();
+				size++;
+			}
+			return size;
+		}
+	}
+
+	@Override
+	public Object copy(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor) {
+		if ( rawCollection instanceof Collection<?> collection ) {
+			return instantiateWithElements( collectionSize( rawCollection ), collectionDescriptor, collection );
+		}
+		else if ( rawCollection instanceof Map<?, ?> map ) {
+			return instantiateWithElements( collectionSize( rawCollection ), collectionDescriptor, map );
+		}
+		else if ( rawCollection == null || getCollectionClassification().isMap() ) {
+			return rawCollection;
+		}
+		else {
+			final int size = collectionSize( rawCollection );
+			final Collection<Object> copy =
+					instantiateCollection( size, getCollectionClassification(), collectionDescriptor, size );
+			final Iterator<?> elements = collectionType.getElementsIterator( rawCollection );
+			while ( elements.hasNext() ) {
+				copy.add( elements.next() );
+			}
+			return copy;
+		}
+	}
+
+	@Override
+	public Set<?> copyPart(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor,
+			CollectionPart.Nature partNature) {
+		final LinkedHashSet<Object> copy = new LinkedHashSet<>();
+		if ( partNature == CollectionPart.Nature.INDEX ) {
+			if ( rawCollection instanceof Map<?, ?> map ) {
+				copy.addAll( map.keySet() );
+			}
+			else {
+				final int listIndexBase =
+						collectionDescriptor.getAttributeMapping()
+								.getIndexMetadata().getListIndexBase();
+				for ( int i = 0; i < collectionSize( rawCollection ); i++ ) {
+					copy.add( listIndexBase + i );
+				}
+			}
+		}
+		else if ( rawCollection instanceof Map<?, ?> map ) {
+			copy.addAll( map.values() );
+		}
+		else if ( rawCollection instanceof Collection<?> collection ) {
+			copy.addAll( collection );
+		}
+		else if ( rawCollection != null ) {
+			final Iterator<?> elements = collectionType.getElementsIterator( rawCollection );
+			while ( elements.hasNext() ) {
+				copy.add( elements.next() );
+			}
+		}
+		return copy;
+	}
+
 	@Override
 	public Iterator<E> getElementIterator(CE rawCollection) {
 		//noinspection unchecked
@@ -74,7 +225,7 @@ public class CustomCollectionTypeSemantics<CE, E> implements CollectionSemantics
 			Fetch indexFetch,
 			Fetch elementFetch,
 			DomainResultCreationState creationState) {
-		return InitializerProducerBuilder.createCollectionTypeWrapperInitializerProducer(
+		return createCollectionTypeWrapperInitializerProducer(
 				navigablePath,
 				attributeMapping,
 				getCollectionClassification(),

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardArraySemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardArraySemantics.java
@@ -5,16 +5,20 @@
 package org.hibernate.collection.internal;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.collection.spi.CollectionSemantics;
-import org.hibernate.collection.spi.InitializerProducerBuilder;
 import org.hibernate.collection.spi.PersistentArrayHolder;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.metamodel.CollectionClassification;
+import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.spi.NavigablePath;
@@ -22,11 +26,18 @@ import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchParent;
 
+import static java.lang.reflect.Array.get;
+import static java.lang.reflect.Array.getLength;
+import static java.lang.reflect.Array.newInstance;
+import static java.lang.reflect.Array.set;
+import static org.hibernate.collection.spi.InitializerProducerBuilder.createArrayInitializerProducer;
+
 /**
  * CollectionSemantics implementation for arrays
  *
  * @author Steve Ebersole
  */
+@AllowReflection
 public class StandardArraySemantics<E> implements CollectionSemantics<E[], E> {
 	/**
 	 * Singleton access
@@ -57,6 +68,65 @@ public class StandardArraySemantics<E> implements CollectionSemantics<E[], E> {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
+	public <X> Object instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Collection<? extends X> elements) {
+		final Class<?> elementClass =
+				collectionDescriptor == null || collectionDescriptor.getElementClass() == null
+						? Object.class
+						: collectionDescriptor.getElementClass();
+		final Object array = newInstance( elementClass, elements.size() );
+		int i = 0;
+		for ( X element : elements ) {
+			set( array, i++, element );
+		}
+		return array;
+	}
+
+	@Override
+	public int collectionSize(Object rawCollection) {
+		return rawCollection != null && rawCollection.getClass().isArray() ? getLength( rawCollection ) : 0;
+	}
+
+	@Override
+	public Object copy(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor) {
+		if ( rawCollection != null && rawCollection.getClass().isArray() ) {
+			final int length = collectionSize( rawCollection );
+			final Object copy = newInstance( rawCollection.getClass().getComponentType(), length );
+			System.arraycopy( rawCollection, 0, copy, 0, length );
+			return copy;
+		}
+		else {
+			return rawCollection;
+		}
+	}
+
+	@Override
+	public Set<?> copyPart(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor,
+			CollectionPart.Nature partNature) {
+		final LinkedHashSet<Object> copy = new LinkedHashSet<>();
+		final int length = collectionSize( rawCollection );
+		if ( partNature == CollectionPart.Nature.INDEX ) {
+			final int listIndexBase =
+					collectionDescriptor.getAttributeMapping()
+							.getIndexMetadata().getListIndexBase();
+			for ( int i = 0; i < length; i++ ) {
+				copy.add( listIndexBase + i );
+			}
+		}
+		else if ( rawCollection != null && rawCollection.getClass().isArray() ) {
+			for ( int i = 0; i < length; i++ ) {
+				copy.add( get( rawCollection, i ) );
+			}
+		}
+		return copy;
+	}
 
 	@Override
 	public PersistentCollection<E> instantiateWrapper(
@@ -81,12 +151,10 @@ public class StandardArraySemantics<E> implements CollectionSemantics<E[], E> {
 
 	@Override
 	public void visitElements(E[] array, Consumer<? super E> action) {
-		if ( array == null ) {
-			return;
-		}
-
-		for ( E element : array ) {
-			action.accept( element );
+		if ( array != null ) {
+			for ( E element : array ) {
+				action.accept( element );
+			}
 		}
 	}
 
@@ -100,7 +168,7 @@ public class StandardArraySemantics<E> implements CollectionSemantics<E[], E> {
 			Fetch indexFetch,
 			Fetch elementFetch,
 			DomainResultCreationState creationState) {
-		return InitializerProducerBuilder.createArrayInitializerProducer(
+		return createArrayInitializerProducer(
 				navigablePath,
 				attributeMapping,
 				fetchParent,

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardListSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardListSemantics.java
@@ -4,24 +4,29 @@
  */
 package org.hibernate.collection.internal;
 
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.collection.spi.CollectionSemantics;
-import org.hibernate.collection.spi.InitializerProducerBuilder;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.collection.spi.PersistentList;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.CollectionClassification;
+import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+
+import static org.hibernate.collection.spi.InitializerProducerBuilder.createListInitializerProducer;
+import static org.hibernate.internal.util.collections.CollectionHelper.arrayList;
 
 /**
  * Hibernate's standard CollectionSemantics for Lists
@@ -42,8 +47,7 @@ public class StandardListSemantics<E> implements CollectionSemantics<List<E>, E>
 		return CollectionClassification.LIST;
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
+	@Override @SuppressWarnings("rawtypes")
 	public Class<List> getCollectionJavaType() {
 		return List.class;
 	}
@@ -52,7 +56,51 @@ public class StandardListSemantics<E> implements CollectionSemantics<List<E>, E>
 	public List<E> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
-		return CollectionHelper.arrayList( anticipatedSize );
+		return arrayList( anticipatedSize );
+	}
+
+	@Override
+	public <X> List<X> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Collection<? extends X> elements) {
+		final List<X> list = arrayList( anticipatedSize );
+		list.addAll( elements );
+		return list;
+	}
+
+	@Override
+	public int collectionSize(Object rawCollection) {
+		return rawCollection instanceof List<?> list ? list.size() : 0;
+	}
+
+	@Override
+	public Object copy(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor) {
+		return rawCollection instanceof List<?> list
+				? instantiateWithElements( collectionSize( rawCollection ), collectionDescriptor, list )
+				: rawCollection;
+	}
+
+	@Override
+	public Set<?> copyPart(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor,
+			CollectionPart.Nature partNature) {
+		final LinkedHashSet<Object> copy = new LinkedHashSet<>();
+		if ( partNature == CollectionPart.Nature.INDEX ) {
+			final int listIndexBase =
+					collectionDescriptor.getAttributeMapping()
+							.getIndexMetadata().getListIndexBase();
+			for ( int i = 0; i < collectionSize( rawCollection ); i++ ) {
+				copy.add( listIndexBase + i );
+			}
+		}
+		else if ( rawCollection instanceof List<?> list ) {
+			copy.addAll( list );
+		}
+		return copy;
 	}
 
 	@Override
@@ -91,6 +139,14 @@ public class StandardListSemantics<E> implements CollectionSemantics<List<E>, E>
 			Fetch indexFetch,
 			Fetch elementFetch,
 			DomainResultCreationState creationState) {
-		return InitializerProducerBuilder.createListInitializerProducer( navigablePath, attributeMapping, fetchParent, selected, indexFetch, elementFetch, creationState );
+		return createListInitializerProducer(
+				navigablePath,
+				attributeMapping,
+				fetchParent,
+				selected,
+				indexFetch,
+				elementFetch,
+				creationState
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardMapSemantics.java
@@ -41,6 +41,16 @@ public class StandardMapSemantics<K,V> extends AbstractMapSemantics<Map<K,V>,K,V
 	}
 
 	@Override
+	public <KK, VV> Map<KK, VV> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Map<? extends KK, ? extends VV> entries) {
+		final Map<KK, VV> map = CollectionHelper.mapOfSize( anticipatedSize );
+		map.putAll( entries );
+		return map;
+	}
+
+	@Override
 	public PersistentCollection<V> instantiateWrapper(
 			Object key,
 			CollectionPersister collectionDescriptor,

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedMapSemantics.java
@@ -6,6 +6,7 @@ package org.hibernate.collection.internal;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.hibernate.collection.spi.AbstractMapSemantics;
 import org.hibernate.collection.spi.PersistentCollection;
@@ -37,6 +38,18 @@ public class StandardOrderedMapSemantics<K,V> extends AbstractMapSemantics<Linke
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
 		return anticipatedSize < 1 ? CollectionHelper.linkedMap() : CollectionHelper.linkedMapOfSize( anticipatedSize );
+	}
+
+	@Override
+	public <KK, VV> LinkedHashMap<KK, VV> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Map<? extends KK, ? extends VV> entries) {
+		final LinkedHashMap<KK, VV> map = anticipatedSize < 1
+				? CollectionHelper.linkedMap()
+				: CollectionHelper.linkedMapOfSize( anticipatedSize );
+		map.putAll( entries );
+		return map;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedSetSemantics.java
@@ -12,8 +12,9 @@ import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.persister.collection.CollectionPersister;
 
-import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * @author Steve Ebersole
@@ -37,6 +38,18 @@ public class StandardOrderedSetSemantics<E> extends AbstractSetSemantics<LinkedH
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
 		return anticipatedSize < 1 ? CollectionHelper.linkedSet() : CollectionHelper.linkedSetOfSize( anticipatedSize );
+	}
+
+	@Override
+	public <X> LinkedHashSet<X> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Collection<? extends X> elements) {
+		final LinkedHashSet<X> set = anticipatedSize < 1
+				? CollectionHelper.linkedSet()
+				: CollectionHelper.linkedSetOfSize( anticipatedSize );
+		set.addAll( elements );
+		return set;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSetSemantics.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.internal;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -36,6 +37,16 @@ public class StandardSetSemantics<E> extends AbstractSetSemantics<Set<E>,E> {
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
 		return anticipatedSize < 1 ? new HashSet<>() : CollectionHelper.setOfSize( anticipatedSize );
+	}
+
+	@Override
+	public <X> Set<X> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Collection<? extends X> elements) {
+		final Set<X> set = anticipatedSize < 1 ? new HashSet<>() : CollectionHelper.setOfSize( anticipatedSize );
+		set.addAll( elements );
+		return set;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedMapSemantics.java
@@ -5,6 +5,7 @@
 package org.hibernate.collection.internal;
 
 import java.util.Comparator;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -44,6 +45,18 @@ public class StandardSortedMapSemantics<K,V> extends AbstractMapSemantics<Sorted
 		return new TreeMap<K,V>(
 				collectionDescriptor == null ? null : (Comparator) collectionDescriptor.getSortingComparator()
 		);
+	}
+
+	@Override
+	public <KK, VV> SortedMap<KK, VV> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Map<? extends KK, ? extends VV> entries) {
+		final SortedMap<KK, VV> map = new TreeMap<>(
+				collectionDescriptor == null ? null : (Comparator) collectionDescriptor.getSortingComparator()
+		);
+		map.putAll( entries );
+		return map;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedSetSemantics.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.internal;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.SortedSet;
@@ -45,6 +46,18 @@ public class StandardSortedSetSemantics<E> extends AbstractSetSemantics<SortedSe
 		return new TreeSet<E>(
 				collectionDescriptor == null ? null : (Comparator) collectionDescriptor.getSortingComparator()
 		);
+	}
+
+	@Override
+	public <X> SortedSet<X> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Collection<? extends X> elements) {
+		final SortedSet<X> set = new TreeSet<>(
+				collectionDescriptor == null ? null : (Comparator) collectionDescriptor.getSortingComparator()
+		);
+		set.addAll( elements );
+		return set;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractBagSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractBagSemantics.java
@@ -7,9 +7,11 @@ package org.hibernate.collection.spi;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
-import org.hibernate.internal.util.collections.CollectionHelper;
+import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.spi.NavigablePath;
@@ -17,11 +19,14 @@ import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchParent;
 
+import static org.hibernate.collection.spi.InitializerProducerBuilder.createBagInitializerProducer;
+import static org.hibernate.internal.util.collections.CollectionHelper.arrayList;
+
 /**
  * @author Steve Ebersole
  */
 public abstract class AbstractBagSemantics<E> implements BagSemantics<Collection<E>,E> {
-	@Override
+	@Override @SuppressWarnings("rawtypes")
 	public Class<Collection> getCollectionJavaType() {
 		return Collection.class;
 	}
@@ -34,8 +39,55 @@ public abstract class AbstractBagSemantics<E> implements BagSemantics<Collection
 			return new ArrayList<>();
 		}
 		else {
-			return CollectionHelper.arrayList( anticipatedSize );
+			return arrayList( anticipatedSize );
 		}
+	}
+
+	@Override
+	public <X> Collection<X> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Collection<? extends X> elements) {
+		final Collection<X> collection =
+				anticipatedSize < 1
+						? new ArrayList<>()
+						: arrayList( anticipatedSize );
+		collection.addAll( elements );
+		return collection;
+	}
+
+	@Override
+	public int collectionSize(Object rawCollection) {
+		return rawCollection instanceof Collection<?> collection ? collection.size() : 0;
+	}
+
+	@Override
+	public Object copy(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor) {
+		return rawCollection instanceof Collection<?> collection
+				? instantiateWithElements( collectionSize( rawCollection ), collectionDescriptor, collection )
+				: rawCollection;
+	}
+
+	@Override
+	public Set<?> copyPart(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor,
+			CollectionPart.Nature partNature) {
+		final LinkedHashSet<Object> copy = new LinkedHashSet<>();
+		if ( partNature == CollectionPart.Nature.INDEX ) {
+			final int listIndexBase =
+					collectionDescriptor.getAttributeMapping()
+							.getIndexMetadata().getListIndexBase();
+			for ( int i = 0; i < collectionSize( rawCollection ); i++ ) {
+				copy.add( listIndexBase + i );
+			}
+		}
+		else if ( rawCollection instanceof Collection<?> collection ) {
+			copy.addAll( collection );
+		}
+		return copy;
 	}
 
 	@Override
@@ -63,7 +115,7 @@ public abstract class AbstractBagSemantics<E> implements BagSemantics<Collection
 			Fetch indexFetch,
 			Fetch elementFetch,
 			DomainResultCreationState creationState) {
-		return InitializerProducerBuilder.createBagInitializerProducer(
+		return createBagInitializerProducer(
 				navigablePath,
 				attributeMapping,
 				fetchParent,

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractMapSemantics.java
@@ -4,34 +4,72 @@
  */
 package org.hibernate.collection.spi;
 
-import java.util.Collections;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
+import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchParent;
+
+import static java.util.Collections.emptyIterator;
+import static org.hibernate.collection.spi.InitializerProducerBuilder.createMapInitializerProducer;
 
 /**
  * @author Steve Ebersole
  */
 public abstract class AbstractMapSemantics<MKV extends Map<K,V>, K, V> implements MapSemantics<MKV,K,V> {
 	@Override
+	public <X> Collection<X> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Collection<? extends X> elements) {
+		return new LinkedHashSet<>( elements );
+	}
+
+	@Override
+	public int collectionSize(Object rawCollection) {
+		return rawCollection instanceof Map<?, ?> map ? map.size() : 0;
+	}
+
+	@Override
+	public Object copy(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor) {
+		return rawCollection instanceof Map<?, ?> map
+				? instantiateWithElements( collectionSize( rawCollection ), collectionDescriptor, map )
+				: rawCollection;
+	}
+
+	@Override
+	public Set<?> copyPart(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor,
+			CollectionPart.Nature partNature) {
+		final LinkedHashSet<Object> copy = new LinkedHashSet<>();
+		if ( rawCollection instanceof Map<?, ?> map ) {
+			copy.addAll( partNature == CollectionPart.Nature.INDEX ? map.keySet() : map.values() );
+		}
+		return copy;
+	}
+
+	@Override @SuppressWarnings("rawtypes")
 	public Class<? extends Map> getCollectionJavaType() {
 		return Map.class;
 	}
 
 	@Override
 	public Iterator<K> getKeyIterator(MKV rawMap) {
-		if ( rawMap == null ) {
-			return null;
-		}
+		return rawMap == null ? null : rawMap.keySet().iterator();
 
-		return rawMap.keySet().iterator();
 	}
 
 	@Override
@@ -51,11 +89,8 @@ public abstract class AbstractMapSemantics<MKV extends Map<K,V>, K, V> implement
 
 	@Override
 	public Iterator<V> getElementIterator(MKV rawMap) {
-		if ( rawMap == null ) {
-			return Collections.emptyIterator();
-		}
+		return rawMap == null ? emptyIterator() : rawMap.values().iterator();
 
-		return rawMap.values().iterator();
 	}
 
 	@Override
@@ -75,7 +110,7 @@ public abstract class AbstractMapSemantics<MKV extends Map<K,V>, K, V> implement
 			Fetch indexFetch,
 			Fetch elementFetch,
 			DomainResultCreationState creationState) {
-		return InitializerProducerBuilder.createMapInitializerProducer(
+		return createMapInitializerProducer(
 				navigablePath,
 				attributeMapping,
 				fetchParent,

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractSetSemantics.java
@@ -5,14 +5,19 @@
 package org.hibernate.collection.spi;
 
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
+import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+
+import static org.hibernate.collection.spi.InitializerProducerBuilder.createSetInitializerProducer;
 
 /**
  * @author Steve Ebersole
@@ -25,10 +30,7 @@ public abstract class AbstractSetSemantics<SE extends Set<E>,E> implements Colle
 
 	@Override
 	public Iterator<E> getElementIterator(SE rawCollection) {
-		if ( rawCollection == null ) {
-			return null;
-		}
-		return rawCollection.iterator();
+		return rawCollection == null ? null : rawCollection.iterator();
 	}
 
 	@Override
@@ -36,6 +38,40 @@ public abstract class AbstractSetSemantics<SE extends Set<E>,E> implements Colle
 		if ( rawCollection != null ) {
 			rawCollection.forEach( action );
 		}
+	}
+
+	@Override
+	public int collectionSize(Object rawCollection) {
+		return rawCollection instanceof Set<?> set ? set.size() : 0;
+	}
+
+	@Override
+	public Object copy(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor) {
+		return rawCollection instanceof Set<?> set
+				? instantiateWithElements( collectionSize( rawCollection ), collectionDescriptor, set )
+				: rawCollection;
+	}
+
+	@Override
+	public Set<?> copyPart(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor,
+			CollectionPart.Nature partNature) {
+		final LinkedHashSet<Object> copy = new LinkedHashSet<>();
+		if ( partNature == CollectionPart.Nature.INDEX ) {
+			final int listIndexBase =
+					collectionDescriptor.getAttributeMapping()
+							.getIndexMetadata().getListIndexBase();
+			for ( int i = 0; i < collectionSize( rawCollection ); i++ ) {
+				copy.add( listIndexBase + i );
+			}
+		}
+		else if ( rawCollection instanceof Set<?> set ) {
+			copy.addAll( set );
+		}
+		return copy;
 	}
 
 	@Override
@@ -49,7 +85,7 @@ public abstract class AbstractSetSemantics<SE extends Set<E>,E> implements Colle
 			Fetch elementFetch,
 			DomainResultCreationState creationState) {
 		assert indexFetch == null;
-		return InitializerProducerBuilder.createSetInitializerProducer(
+		return createSetInitializerProducer(
 				navigablePath,
 				attributeMapping,
 				fetchParent,

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionSemantics.java
@@ -4,12 +4,18 @@
  */
 package org.hibernate.collection.spi;
 
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.CollectionClassification;
+import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.spi.NavigablePath;
@@ -51,6 +57,48 @@ public interface CollectionSemantics<CE, E> {
 	CE instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor);
+
+	/**
+	 * Create a raw (unwrapped) version of the collection and populate it
+	 * with the given elements.
+	 */
+	default <X> Object instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Collection<? extends X> elements) {
+		return new LinkedHashSet<>( elements );
+	}
+
+	/**
+	 * Create a raw (unwrapped) version of the collection and populate it
+	 * with the given map entries.
+	 */
+	default <K, V> Map<K, V> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Map<? extends K, ? extends V> entries) {
+		return new LinkedHashMap<>( entries );
+	}
+
+	/**
+	 * Determine the size of the given raw collection.
+	 */
+	int collectionSize(Object rawCollection);
+
+	/**
+	 * Create a raw (unwrapped) copy of the given collection.
+	 */
+	Object copy(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor);
+
+	/**
+	 * Create a detached copy of a collection part.
+	 */
+	Set<?> copyPart(
+			Object rawCollection,
+			CollectionPersister collectionDescriptor,
+			CollectionPart.Nature partNature);
 
 	/**
 	 * Create a wrapper for the collection

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/MapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/MapSemantics.java
@@ -9,12 +9,23 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import org.hibernate.persister.collection.CollectionPersister;
+
 /**
  * Extension of {@link CollectionSemantics} for Maps
  *
  * @author Steve Ebersole
  */
 public interface MapSemantics<MKV extends Map<K,V>,K,V> extends CollectionSemantics<MKV,V> {
+	/**
+	 * Create a raw (unwrapped) version of the map and populate it
+	 * with the given entries.
+	 */
+	<KK, VV> Map<KK, VV> instantiateWithElements(
+			int anticipatedSize,
+			CollectionPersister collectionDescriptor,
+			Map<? extends KK, ? extends VV> entries);
+
 	Iterator<K> getKeyIterator(MKV rawMap);
 
 	void visitKeys(MKV rawMap, Consumer<? super K> action);

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -128,6 +128,7 @@ import org.hibernate.query.sqm.tree.domain.SqmListJoin;
 import org.hibernate.query.sqm.tree.domain.SqmMapEntryReference;
 import org.hibernate.query.sqm.tree.domain.SqmMapJoin;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
+import org.hibernate.query.sqm.tree.domain.SqmPluralPartSelectionPath;
 import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmPolymorphicRootDescriptor;
 import org.hibernate.query.sqm.tree.expression.*;
@@ -211,10 +212,12 @@ import static org.hibernate.grammars.hql.HqlParser.ELEMENTS;
 import static org.hibernate.grammars.hql.HqlParser.EXCEPT;
 import static org.hibernate.grammars.hql.HqlParser.INDICES;
 import static org.hibernate.grammars.hql.HqlParser.INTERSECT;
+import static org.hibernate.grammars.hql.HqlParser.KEYS;
 import static org.hibernate.grammars.hql.HqlParser.ListaggFunctionContext;
 import static org.hibernate.grammars.hql.HqlParser.PLUS;
 import static org.hibernate.grammars.hql.HqlParser.QUOTED_IDENTIFIER;
 import static org.hibernate.grammars.hql.HqlParser.UNION;
+import static org.hibernate.grammars.hql.HqlParser.VALUES;
 import static org.hibernate.internal.util.QuotingHelper.unquoteIdentifier;
 import static org.hibernate.internal.util.QuotingHelper.unquoteJavaStringLiteral;
 import static org.hibernate.internal.util.QuotingHelper.unquoteStringLiteral;
@@ -1381,29 +1384,90 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 	private SqmSelectableNode<?> visitSelectableNode(HqlParser.SelectionContext ctx) {
 		final var expressionOrPredicate = ctx.selectExpression().expressionOrPredicate();
 		if ( expressionOrPredicate != null ) {
-			final var sqmExpression = (SqmExpression<?>) expressionOrPredicate.accept( this );
-			if ( sqmExpression instanceof SqmPath<?> sqmPath
-					&& sqmPath.getReferencedPathSource() instanceof PluralPersistentAttribute ) {
-				// for plural-attribute selections, use the element path as the selection
-				//		- this is not strictly JPA compliant
-				if ( creationOptions.useStrictJpaCompliance() ) {
-					SqmTreeCreationLogger.LOGGER.debugf(
-							"Raw selection of plural attribute not supported by JPA."
-								+ " Use 'value(%s)' or 'key(%s)' to indicate what part of the collection to select",
-							sqmPath.getAlias(),
-							sqmPath.getAlias()
-					);
-				}
-				final var elementPath =
-						sqmPath.resolvePathPart( CollectionPart.Nature.ELEMENT.getName(), true, this );
-				processingStateStack.getCurrent().getPathRegistry().register( elementPath );
-				return elementPath;
-			}
-			return sqmExpression;
+			final var pluralCollectionFunctionSelection =
+					visitPluralCollectionFunctionSelection( expressionOrPredicate );
+			return pluralCollectionFunctionSelection == null
+					? pluralPathSelection( (SqmSelectableNode<?>) expressionOrPredicate.accept( this ) )
+					: pluralCollectionFunctionSelection;
 		}
 		else {
 			return (SqmSelectableNode<?>) ctx.selectExpression().accept( this );
 		}
+	}
+
+	private SqmSelectableNode<?> pluralPathSelection(SqmSelectableNode<?> selectableNode) {
+		if ( selectableNode instanceof SqmPluralValuedSimplePath<?> pluralPath ) {
+			// Raw plural-attribute selections are not strictly JPA compliant.
+			if ( creationOptions.useStrictJpaCompliance() ) {
+				SqmTreeCreationLogger.LOGGER.debugf(
+						"Raw selection of plural attribute not supported by JPA."
+							+ " Use 'value(%s)' or 'key(%s)' to indicate what part of the collection to select",
+						pluralPath.getAlias(),
+						pluralPath.getAlias()
+				);
+			}
+			return new SqmPluralPartSelectionPath<>( pluralPath, null );
+		}
+		else if ( selectableNode instanceof SqmPath<?> sqmPath
+				&& sqmPath.getReferencedPathSource() instanceof PluralPersistentAttribute ) {
+			// for plural-join selections, use the element path as the selection
+			//		- this is not strictly JPA compliant
+			if ( creationOptions.useStrictJpaCompliance() ) {
+				SqmTreeCreationLogger.LOGGER.debugf(
+						"Raw selection of plural attribute not supported by JPA."
+							+ " Use 'value(%s)' or 'key(%s)' to indicate what part of the collection to select",
+						sqmPath.getAlias(),
+						sqmPath.getAlias()
+				);
+			}
+			final var elementPath =
+					sqmPath.resolvePathPart( CollectionPart.Nature.ELEMENT.getName(), true, this );
+			processingStateStack.getCurrent().getPathRegistry().register( elementPath );
+			return elementPath;
+		}
+		return selectableNode;
+	}
+
+	private SqmSelectableNode<?> visitPluralCollectionFunctionSelection(
+			HqlParser.ExpressionOrPredicateContext expressionOrPredicate) {
+		if ( expressionOrPredicate.expression()
+					instanceof HqlParser.BarePrimaryExpressionContext barePrimaryExpression
+				&& barePrimaryExpression.primaryExpression()
+						instanceof HqlParser.FunctionExpressionContext functionExpression
+				&& functionExpression.pathContinuation() == null
+				&& functionExpression.slicedPathAccessFragment() == null
+				&& functionExpression.indexedPathAccessFragment() == null ) {
+			final var collectionFunctionMisuse = functionExpression.function().collectionFunctionMisuse();
+			if ( collectionFunctionMisuse != null ) {
+				return visitCollectionFunctionSelection( collectionFunctionMisuse );
+			}
+		}
+		return null;
+	}
+
+	private SqmPluralPartSelectionPath<?> visitCollectionFunctionSelection(
+			HqlParser.CollectionFunctionMisuseContext ctx) {
+		if ( getCreationOptions().useStrictJpaCompliance() ) {
+			throw new StrictJpaComplianceViolation( StrictJpaComplianceViolation.Type.HQL_COLLECTION_FUNCTION );
+		}
+
+		final var pluralAttributePath = consumeDomainPath( ctx.path() );
+		final var firstNode = (TerminalNode) ctx.getChild( 0 ).getChild( 0 );
+
+		if ( !( pluralAttributePath.getReferencedPathSource() instanceof PluralPersistentAttribute<?, ?, ?> ) ) {
+			throw new FunctionArgumentException(
+					String.format(
+							"Argument '%s' of '%s()' function is not a plural path ",
+							pluralAttributePath.getNavigablePath(),
+							firstNode.getSymbol().getText()
+					)
+			);
+		}
+
+		return new SqmPluralPartSelectionPath<>(
+				(SqmPluralValuedSimplePath<?>) pluralAttributePath,
+				collectionFunctionNature( firstNode )
+		);
 	}
 
 	@Override
@@ -1466,7 +1530,14 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 	public SqmDynamicInstantiationArgument<?> visitInstantiationArgument(HqlParser.InstantiationArgumentContext ctx) {
 		final var variable = ctx.variable();
 		final String alias = variable == null ? null : extractAlias( variable );
-		final var argExpression = (SqmSelectableNode<?>) ctx.instantiationArgumentExpression().accept( this );
+		final var expressionOrPredicate = ctx.instantiationArgumentExpression().expressionOrPredicate();
+		final var collectionFunctionSelection =
+				expressionOrPredicate == null
+						? null
+						: visitPluralCollectionFunctionSelection( expressionOrPredicate );
+		final var argExpression = collectionFunctionSelection == null
+				? pluralPathSelection( (SqmSelectableNode<?>) ctx.instantiationArgumentExpression().accept( this ) )
+				: collectionFunctionSelection;
 		final var argument = new SqmDynamicInstantiationArgument<>( argExpression, alias, nodeBuilder() );
 		if ( !(argExpression instanceof SqmDynamicInstantiation) ) {
 			processingStateStack.getCurrent().getPathRegistry().register( argument );
@@ -5513,13 +5584,15 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 			);
 		}
 
-		final var nature = switch ( firstNode.getSymbol().getType() ) {
-			case ELEMENTS -> CollectionPart.Nature.ELEMENT;
-			case INDICES -> CollectionPart.Nature.INDEX;
+		return pluralAttributePath.resolvePathPart( collectionFunctionNature( firstNode ).getName(), true, this );
+	}
+
+	private CollectionPart.Nature collectionFunctionNature(TerminalNode firstNode) {
+		return switch ( firstNode.getSymbol().getType() ) {
+			case ELEMENTS, VALUES -> CollectionPart.Nature.ELEMENT;
+			case INDICES, KEYS -> CollectionPart.Nature.INDEX;
 			default -> throw new ParsingException( "Impossible symbol" );
 		};
-
-		return pluralAttributePath.resolvePathPart( nature.getName(), true, this );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -4197,36 +4197,47 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 				selectionPath instanceof AbstractSqmSpecificPluralPartPath<?>
 						? selectionPath.getLhs().getLhs()
 						: selectionPath;
-		final var fromClauseIndex = getFromClauseIndex();
-		final var tableGroup = fromClauseIndex.findTableGroupForGetOrCreate( path.getNavigablePath() );
-		if ( tableGroup == null ) {
-			prepareReusablePath( path, () -> null );
-			if ( path.getLhs() != null && !( path instanceof SqmEntityValuedSimplePath<?>
-					|| path instanceof SqmEmbeddedValuedSimplePath<?>
-					|| path instanceof SqmAnyValuedSimplePath<?>
-					|| path instanceof SqmTreatedPath<?, ?> ) ) {
-				// Since this is a selection, we must create a table group for the path as a DomainResult will be created
-				// But only create it for paths that are not handled by #prepareReusablePath anyway
-				final var createdTableGroup = createTableGroup(
-						getActualTableGroup( fromClauseIndex.getTableGroup( path.getLhs().getNavigablePath() ), path ),
-						path,
-						false
-				);
-				if ( createdTableGroup != null ) {
-					registerEntityNameProjectionUsage( path, createdTableGroup );
+		final var lhs = path.getLhs();
+		if ( path instanceof SqmPluralValuedSimplePath<?> ) {
+			prepareReusablePath( lhs, () -> null );
+			registerEntityNameProjectionUsage( lhs,
+					getFromClauseIndex().findTableGroup( lhs.getNavigablePath() ) );
+		}
+		else {
+			final var fromClauseIndex = getFromClauseIndex();
+			final var tableGroup = fromClauseIndex.findTableGroupForGetOrCreate( path.getNavigablePath() );
+			if ( tableGroup == null ) {
+				prepareReusablePath( path, () -> null );
+				if ( lhs != null
+					&& !(path instanceof SqmEntityValuedSimplePath<?>
+							|| path instanceof SqmEmbeddedValuedSimplePath<?>
+							|| path instanceof SqmAnyValuedSimplePath<?>
+							|| path instanceof SqmTreatedPath<?, ?>) ) {
+					// Since this is a selection, we must create a table group for the path as a DomainResult will be created
+					// But only create it for paths that are not handled by #prepareReusablePath anyway
+					final var createdTableGroup = createTableGroup(
+							getActualTableGroup( fromClauseIndex.getTableGroup( lhs.getNavigablePath() ), path ),
+							path,
+							false
+					);
+					if ( createdTableGroup != null ) {
+						registerEntityNameProjectionUsage( path, createdTableGroup );
+					}
+				}
+				else {
+					registerEntityNameProjectionUsage( path,
+							fromClauseIndex.findTableGroup( path.getNavigablePath() ) );
 				}
 			}
 			else {
-				registerEntityNameProjectionUsage( path, fromClauseIndex.findTableGroup( path.getNavigablePath() ) );
-			}
-		}
-		else {
-			registerEntityNameProjectionUsage( path, tableGroup );
-			if ( path instanceof SqmSimplePath<?> && CollectionPart.Nature.fromName( path.getNavigablePath().getLocalName() ) == null ) {
-				// If a table group for a selection already exists, we must make sure that the join type is INNER
-				fromClauseIndex.findTableGroup( path.getNavigablePath().getParent() )
-						.findTableGroupJoin( tableGroup )
-						.setJoinType( SqlAstJoinType.INNER );
+				registerEntityNameProjectionUsage( path, tableGroup );
+				if ( path instanceof SqmSimplePath<?>
+						&& CollectionPart.Nature.fromName( path.getNavigablePath().getLocalName() ) == null ) {
+					// If a table group for a selection already exists, we must make sure that the join type is INNER
+					fromClauseIndex.findTableGroup( path.getNavigablePath().getParent() )
+							.findTableGroupJoin( tableGroup )
+							.setJoinType( SqlAstJoinType.INNER );
+				}
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/PluralValuedSimplePathInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/PluralValuedSimplePathInterpretation.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.sql.internal;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.query.sqm.sql.SqmToSqlAstConverter;
+import org.hibernate.query.sqm.tree.domain.SqmPluralPartSelectionPath;
 import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.SqlAstWalker;
@@ -14,6 +15,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.collection.internal.DetachedCollectionDomainResult;
 
 /**
  * @author Andrea Boriero
@@ -33,19 +35,25 @@ public class PluralValuedSimplePathInterpretation<T> extends AbstractSqmPathInte
 				null,
 				sqmPath.getNavigablePath(),
 				mapping,
-				tableGroup
+				tableGroup,
+				sqmPath instanceof SqmPluralPartSelectionPath<?> pluralPartSelectionPath
+						? pluralPartSelectionPath.getSelectedPartNature()
+						: null
 		);
 	}
 
 	private final Expression sqlExpression;
+	private final CollectionPart.Nature selectedPartNature;
 
 	private PluralValuedSimplePathInterpretation(
 			Expression sqlExpression,
 			NavigablePath navigablePath,
 			PluralAttributeMapping mapping,
-			TableGroup tableGroup) {
+			TableGroup tableGroup,
+			CollectionPart.Nature selectedPartNature) {
 		super( navigablePath, mapping, tableGroup );
 		this.sqlExpression = sqlExpression;
+		this.selectedPartNature = selectedPartNature;
 	}
 
 	@Override
@@ -55,12 +63,12 @@ public class PluralValuedSimplePathInterpretation<T> extends AbstractSqmPathInte
 
 	@Override
 	public DomainResult<T> createDomainResult(String resultVariable, DomainResultCreationState creationState) {
-		// This is only invoked when a plural attribute is a top level select, order by or group by item
-		// in which case we have to produce results for the element
-		return ( (PluralAttributeMapping) getExpressionType() ).getElementDescriptor().createDomainResult(
-				getNavigablePath().append( CollectionPart.Nature.ELEMENT.getName() ),
-				getTableGroup(),
+		return new DetachedCollectionDomainResult<>(
+				getNavigablePath(),
+				(PluralAttributeMapping) getExpressionType(),
 				resultVariable,
+				getTableGroup(),
+				selectedPartNature,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPluralPartSelectionPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPluralPartSelectionPath.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.query.sqm.tree.domain;
+
+import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.metamodel.mapping.CollectionPart;
+import org.hibernate.query.sqm.NodeBuilder;
+import org.hibernate.query.sqm.SqmBindableType;
+import org.hibernate.query.sqm.tree.SqmCopyContext;
+import org.hibernate.query.sqm.tree.SqmRenderContext;
+import org.hibernate.spi.NavigablePath;
+import org.hibernate.type.descriptor.java.JavaType;
+
+/**
+ * A plural-valued path selection produced by the plural collection functions
+ * {@code elements()}, {@code values()}, {@code indices()}, and {@code keys()}.
+ *
+ * @author Gavin King
+ */
+public class SqmPluralPartSelectionPath<C> extends SqmPluralValuedSimplePath<C> {
+	private final CollectionPart.@Nullable Nature selectedPartNature;
+	private final JavaType<C> javaType;
+	private final SqmBindableType<C> selectionType;
+
+	@SuppressWarnings("unchecked")
+	public SqmPluralPartSelectionPath(
+			SqmPluralValuedSimplePath<C> pluralPath,
+			CollectionPart.@Nullable Nature selectedPartNature) {
+		this(
+				pluralPath.getNavigablePath(),
+				(SqmPluralPersistentAttribute<?, C, ?>) pluralPath.getModel(),
+				pluralPath.getLhs(),
+				pluralPath.getExplicitAlias(),
+				pluralPath.nodeBuilder(),
+				selectedPartNature
+		);
+	}
+
+	@SuppressWarnings("unchecked")
+	private SqmPluralPartSelectionPath(
+			NavigablePath navigablePath,
+			SqmPluralPersistentAttribute<?, C, ?> referencedNavigable,
+			SqmPath<?> lhs,
+			@Nullable String explicitAlias,
+			NodeBuilder nodeBuilder,
+			CollectionPart.@Nullable Nature selectedPartNature) {
+		super( navigablePath, referencedNavigable, lhs, explicitAlias, nodeBuilder );
+		this.selectedPartNature = selectedPartNature;
+		this.javaType = selectedPartNature == null
+				? referencedNavigable.getAttributeJavaType()
+				: (JavaType<C>) nodeBuilder.getTypeConfiguration()
+						.getJavaTypeRegistry()
+						.resolveDescriptor( Set.class );
+		this.selectionType = new PluralAttributeCollectionType<>( javaType );
+	}
+
+	public CollectionPart.@Nullable Nature getSelectedPartNature() {
+		return selectedPartNature;
+	}
+
+	@Override
+	public SqmPluralPartSelectionPath<C> copy(SqmCopyContext context) {
+		final var existing = context.getCopy( this );
+		if ( existing != null ) {
+			return existing;
+		}
+
+		final SqmPath<?> lhsCopy = getLhs().copy( context );
+		final var path = context.registerCopy(
+				this,
+				new SqmPluralPartSelectionPath<>(
+						getNavigablePathCopy( lhsCopy ),
+						(SqmPluralPersistentAttribute<?, C, ?>) getModel(),
+						lhsCopy,
+						getExplicitAlias(),
+						nodeBuilder(),
+						selectedPartNature
+				)
+		);
+		copyTo( path, context );
+		return path;
+	}
+
+	@Override
+	public @NonNull JavaType<C> getJavaTypeDescriptor() {
+		return javaType;
+	}
+
+	@Override
+	public @NonNull JavaType<C> getNodeJavaType() {
+		return javaType;
+	}
+
+	@Override
+	public @NonNull SqmBindableType<C> getExpressible() {
+		return selectionType;
+	}
+
+	@Override
+	public @NonNull SqmBindableType<C> getNodeType() {
+		return selectionType;
+	}
+
+	@Override
+	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
+		if ( selectedPartNature == null ) {
+			super.appendHqlString( hql, context );
+		}
+		else {
+			hql.append( selectedPartNature == CollectionPart.Nature.INDEX ? "indices(" : "elements(" );
+			getLhs().appendHqlString( hql, context );
+			hql.append( '.' ).append( getReferencedPathSource().getPathName() );
+			hql.append( ')' );
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPluralValuedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPluralValuedSimplePath.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.tree.domain;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.NumericExpression;
 import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.metamodel.Type.PersistenceType;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.metamodel.mapping.CollectionPart;
@@ -19,6 +20,7 @@ import org.hibernate.query.PathException;
 import org.hibernate.query.hql.spi.SqmCreationState;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SemanticQueryWalker;
+import org.hibernate.query.sqm.SqmBindableType;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmJoinType;
@@ -223,5 +225,33 @@ public class SqmPluralValuedSimplePath<C> extends AbstractSqmSimplePath<C> imple
 	@Override
 	public Predicate contains(Expression elem) {
 		throw new UnsupportedOperationException( "Not implemented yet" );
+	}
+
+	protected static class PluralAttributeCollectionType<C> implements SqmBindableType<C> {
+		private final JavaType<C> javaType;
+
+		public PluralAttributeCollectionType(JavaType<C> javaType) {
+			this.javaType = javaType;
+		}
+
+		@Override
+		public PersistenceType getPersistenceType() {
+			return PersistenceType.BASIC;
+		}
+
+		@Override
+		public JavaType<C> getExpressibleJavaType() {
+			return javaType;
+		}
+
+		@Override
+		public Class<C> getJavaType() {
+			return javaType.getJavaTypeClass();
+		}
+
+		@Override
+		public @Nullable SqmDomainType<C> getSqmType() {
+			return null;
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
@@ -34,8 +34,6 @@ import org.hibernate.query.sqm.tree.SqmCacheable;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmNode;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
-import org.hibernate.query.sqm.tree.domain.SqmDomainType;
-import org.hibernate.query.sqm.tree.domain.SqmEmbeddedValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmEntityValuedSimplePath;
 import org.hibernate.query.sqm.tree.expression.SqmAliasedNodeRef;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
@@ -52,7 +50,6 @@ import org.hibernate.spi.NavigablePath;
 
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.metamodel.SingularAttribute;
 
 import static org.hibernate.internal.util.NullnessUtil.castNonNull;
 
@@ -565,12 +562,6 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 				collectSelectedFromSet( selectedFromSet, (SqmFrom<?, ?>) castNonNull( path.getLhs() ) );
 			}
 		}
-		else if ( selectableNode instanceof SqmEmbeddedValuedSimplePath<?> path ) {
-			final SqmDomainType<?> sqmType = path.getSqmType();
-			if ( sqmType != null ) {
-				assertEmbeddableCollections( path.getNavigablePath(), (EmbeddableDomainType<?>) sqmType );
-			}
-		}
 	}
 
 	private void collectSelectedFromSet(Set<SqmFrom<?, ?>> selectedFromSet, SqmFrom<?, ?> sqmFrom) {
@@ -616,22 +607,6 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 							"of the fetched association was not present in the select list " +
 							"[" + fetchJoin.asLoggableText() + "]"
 			);
-		}
-	}
-
-	private void assertEmbeddableCollections(NavigablePath navigablePath, EmbeddableDomainType<?> embeddableType) {
-		if ( !embeddableType.getPluralAttributes().isEmpty() ) {
-			throw new SemanticException( String.format(
-					"Explicit selection of an embeddable containing associated collections is not supported: %s",
-					navigablePath
-			) );
-		}
-		else {
-			for ( SingularAttribute<?, ?> attribute : embeddableType.getSingularAttributes() ) {
-				if ( attribute.getType() instanceof EmbeddableDomainType<?> ) {
-					assertEmbeddableCollections( navigablePath, (EmbeddableDomainType<?>) attribute.getType() );
-				}
-			}
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DetachedCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DetachedCollectionAssembler.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.sql.results.graph.collection.internal;
+
+import org.hibernate.metamodel.mapping.CollectionPart;
+import org.hibernate.metamodel.mapping.PluralAttributeMapping;
+import org.hibernate.sql.results.graph.DomainResultAssembler;
+import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
+import org.hibernate.type.descriptor.java.JavaType;
+
+/**
+ * @author Gavin King
+ */
+public class DetachedCollectionAssembler<T> implements DomainResultAssembler<T> {
+	private final PluralAttributeMapping collectionAttribute;
+	private final CollectionPart.Nature selectedPartNature;
+	private final DomainResultAssembler<?> collectionKeyAssembler;
+	private final JavaType<?> resultJavaType;
+
+	public DetachedCollectionAssembler(
+			PluralAttributeMapping collectionAttribute,
+			CollectionPart.Nature selectedPartNature,
+			DomainResultAssembler<?> collectionKeyAssembler,
+			JavaType<?> resultJavaType) {
+		this.collectionAttribute = collectionAttribute;
+		this.selectedPartNature = selectedPartNature;
+		this.collectionKeyAssembler = collectionKeyAssembler;
+		this.resultJavaType = resultJavaType;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public T assemble(RowProcessingState rowProcessingState) {
+		final Object collectionKey = collectionKeyAssembler.assemble( rowProcessingState );
+		return (T) DetachedCollectionHelper.loadAndCopy(
+				collectionAttribute,
+				collectionKey,
+				rowProcessingState.getSession(),
+				selectedPartNature
+		);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public JavaType<T> getAssembledJavaType() {
+		return (JavaType<T>) resultJavaType;
+	}
+
+	@Override
+	public void resolveState(RowProcessingState rowProcessingState) {
+		collectionKeyAssembler.resolveState( rowProcessingState );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DetachedCollectionDomainResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DetachedCollectionDomainResult.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.sql.results.graph.collection.internal;
+
+import java.util.BitSet;
+import java.util.Set;
+
+import org.hibernate.metamodel.mapping.CollectionPart;
+import org.hibernate.metamodel.mapping.PluralAttributeMapping;
+import org.hibernate.spi.NavigablePath;
+import org.hibernate.sql.ast.tree.from.TableGroup;
+import org.hibernate.sql.results.graph.AssemblerCreationState;
+import org.hibernate.sql.results.graph.DomainResult;
+import org.hibernate.sql.results.graph.DomainResultAssembler;
+import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetch;
+import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
+import org.hibernate.sql.results.graph.FetchableContainer;
+import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.InitializerParent;
+import org.hibernate.sql.results.graph.internal.ImmutableFetchList;
+import org.hibernate.type.descriptor.java.JavaType;
+
+/**
+ * A collection-valued domain result that preserves the cardinality of the owning row.
+ *
+ * @author Gavin King
+ */
+public class DetachedCollectionDomainResult<T> implements DomainResult<T>, FetchParent {
+	private final NavigablePath loadingPath;
+	private final PluralAttributeMapping loadingAttribute;
+	private final String resultVariable;
+	private final CollectionPart.Nature selectedPartNature;
+	private final JavaType<?> resultJavaType;
+	private final DomainResult<?> collectionKeyResult;
+
+	public DetachedCollectionDomainResult(
+			NavigablePath loadingPath,
+			PluralAttributeMapping loadingAttribute,
+			String resultVariable,
+			TableGroup ownerTableGroup,
+			CollectionPart.Nature selectedPartNature,
+			DomainResultCreationState creationState) {
+		this.loadingPath = loadingPath;
+		this.loadingAttribute = loadingAttribute;
+		this.resultVariable = resultVariable;
+		this.selectedPartNature = selectedPartNature;
+		this.resultJavaType = selectedPartNature == null
+				? loadingAttribute.getJavaType()
+				: creationState.getSqlAstCreationState()
+						.getCreationContext()
+						.getTypeConfiguration()
+						.getJavaTypeRegistry()
+						.resolveDescriptor( Set.class );
+		this.collectionKeyResult = loadingAttribute.getKeyDescriptor().createTargetDomainResult(
+				ownerTableGroup.getNavigablePath().append( loadingAttribute.getPartName() ),
+				ownerTableGroup,
+				this,
+				creationState
+		);
+	}
+
+	@Override
+	public String getResultVariable() {
+		return resultVariable;
+	}
+
+	@Override
+	public boolean containsAnyNonScalarResults() {
+		return true;
+	}
+
+	@Override
+	public JavaType<?> getResultJavaType() {
+		return resultJavaType;
+	}
+
+	@Override
+	public NavigablePath getNavigablePath() {
+		return loadingPath;
+	}
+
+	@Override
+	public DomainResultAssembler<T> createResultAssembler(
+			InitializerParent<?> parent,
+			AssemblerCreationState creationState) {
+		return new DetachedCollectionAssembler<>(
+				loadingAttribute,
+				selectedPartNature,
+				collectionKeyResult.createResultAssembler( parent, creationState ),
+				resultJavaType
+		);
+	}
+
+	@Override
+	public void collectValueIndexesToCache(BitSet valueIndexes) {
+		collectionKeyResult.collectValueIndexesToCache( valueIndexes );
+	}
+
+	@Override
+	public FetchableContainer getReferencedMappingContainer() {
+		return loadingAttribute;
+	}
+
+	@Override
+	public FetchableContainer getReferencedMappingType() {
+		return loadingAttribute;
+	}
+
+	@Override
+	public ImmutableFetchList getFetches() {
+		return ImmutableFetchList.EMPTY;
+	}
+
+	@Override
+	public Fetch findFetch(Fetchable fetchable) {
+		return null;
+	}
+
+	@Override
+	public boolean hasJoinFetches() {
+		return false;
+	}
+
+	@Override
+	public boolean containsCollectionFetches() {
+		return false;
+	}
+
+	@Override
+	public Initializer<?> createInitializer(InitializerParent<?> parent, AssemblerCreationState creationState) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DetachedCollectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DetachedCollectionHelper.java
@@ -4,27 +4,19 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import java.lang.reflect.Array;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
-import org.hibernate.persister.collection.CollectionPersister;
 
 /**
  * Helper for producing plain Java collection values for collection-valued query results.
  *
  * @author Gavin King
+ *
+ * @since 8.0
  */
 public final class DetachedCollectionHelper {
-	private DetachedCollectionHelper() {
-	}
-
 	public static Object loadAndCopy(
 			PluralAttributeMapping attributeMapping,
 			Object collectionKey,
@@ -33,107 +25,25 @@ public final class DetachedCollectionHelper {
 		if ( collectionKey == null ) {
 			return null;
 		}
-
-		final CollectionPersister collectionDescriptor = attributeMapping.getCollectionDescriptor();
-		final Object collection = collectionDescriptor.getCollectionType()
-				.getCollection( collectionKey, session, null, Boolean.TRUE );
-		if ( collection instanceof PersistentCollection<?> persistentCollection ) {
-			session.initializeCollection( persistentCollection, false );
-		}
-		return copy( attributeMapping, collection, selectedPartNature );
-	}
-
-	public static Object copy(
-			PluralAttributeMapping attributeMapping,
-			Object collection,
-			CollectionPart.Nature selectedPartNature) {
-		if ( collection == null ) {
-			return null;
-		}
-		if ( selectedPartNature != null ) {
-			return copyPart( attributeMapping, collection, selectedPartNature );
-		}
-		if ( collection instanceof Map<?, ?> map ) {
-			final Map<Object, Object> copy = instantiateMap( attributeMapping, map.size() );
-			copy.putAll( map );
-			return copy;
-		}
-		if ( collection instanceof Collection<?> collectionValue ) {
-			final Collection<Object> copy = instantiateCollection( attributeMapping, collectionValue.size() );
-			copy.addAll( collectionValue );
-			return copy;
-		}
-		if ( collection.getClass().isArray() ) {
-			final int length = Array.getLength( collection );
-			final Object copy = Array.newInstance( collection.getClass().getComponentType(), length );
-			System.arraycopy( collection, 0, copy, 0, length );
-			return copy;
-		}
-		return collection;
-	}
-
-	private static LinkedHashSet<Object> copyPart(
-			PluralAttributeMapping attributeMapping,
-			Object collection,
-			CollectionPart.Nature selectedPartNature) {
-		final LinkedHashSet<Object> copy = new LinkedHashSet<>();
-		if ( selectedPartNature == CollectionPart.Nature.INDEX ) {
-			if ( collection instanceof Map<?, ?> map ) {
-				copy.addAll( map.keySet() );
+		else {
+			final var collectionDescriptor = attributeMapping.getCollectionDescriptor();
+			final Object collection =
+					collectionDescriptor.getCollectionType()
+							.getCollection( collectionKey, session, null, true );
+			if ( collection instanceof PersistentCollection<?> persistentCollection ) {
+				session.initializeCollection( persistentCollection, false );
+			}
+			if ( collection == null ) {
+				return null;
+			}
+			else if ( selectedPartNature != null ) {
+				return collectionDescriptor.getCollectionSemantics()
+						.copyPart( collection, collectionDescriptor, selectedPartNature );
 			}
 			else {
-				final int size = collectionSize( collection );
-				final int listIndexBase = attributeMapping.getIndexMetadata().getListIndexBase();
-				for ( int i = 0; i < size; i++ ) {
-					copy.add( listIndexBase + i );
-				}
+				return collectionDescriptor.getCollectionSemantics()
+						.copy( collection, collectionDescriptor );
 			}
 		}
-		else if ( collection instanceof Map<?, ?> map ) {
-			copy.addAll( map.values() );
-		}
-		else if ( collection instanceof Collection<?> collectionValue ) {
-			copy.addAll( collectionValue );
-		}
-		else if ( collection.getClass().isArray() ) {
-			final int length = Array.getLength( collection );
-			for ( int i = 0; i < length; i++ ) {
-				copy.add( Array.get( collection, i ) );
-			}
-		}
-		return copy;
-	}
-
-	@SuppressWarnings("unchecked")
-	private static Map<Object, Object> instantiateMap(PluralAttributeMapping attributeMapping, int size) {
-		final Object rawCollection = attributeMapping.getCollectionDescriptor()
-				.getCollectionSemantics()
-				.instantiateRaw( size, attributeMapping.getCollectionDescriptor() );
-		return rawCollection instanceof Map<?, ?>
-				? (Map<Object, Object>) rawCollection
-				: new LinkedHashMap<>( size );
-	}
-
-	@SuppressWarnings("unchecked")
-	private static Collection<Object> instantiateCollection(PluralAttributeMapping attributeMapping, int size) {
-		final Object rawCollection = attributeMapping.getCollectionDescriptor()
-				.getCollectionSemantics()
-				.instantiateRaw( size, attributeMapping.getCollectionDescriptor() );
-		return rawCollection instanceof Collection<?>
-				? (Collection<Object>) rawCollection
-				: new LinkedHashSet<>( size );
-	}
-
-	private static int collectionSize(Object collection) {
-		if ( collection instanceof Map<?, ?> map ) {
-			return map.size();
-		}
-		if ( collection instanceof Collection<?> collectionValue ) {
-			return collectionValue.size();
-		}
-		if ( collection.getClass().isArray() ) {
-			return Array.getLength( collection );
-		}
-		return 0;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DetachedCollectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DetachedCollectionHelper.java
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.sql.results.graph.collection.internal;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.metamodel.mapping.CollectionPart;
+import org.hibernate.metamodel.mapping.PluralAttributeMapping;
+import org.hibernate.persister.collection.CollectionPersister;
+
+/**
+ * Helper for producing plain Java collection values for collection-valued query results.
+ *
+ * @author Gavin King
+ */
+public final class DetachedCollectionHelper {
+	private DetachedCollectionHelper() {
+	}
+
+	public static Object loadAndCopy(
+			PluralAttributeMapping attributeMapping,
+			Object collectionKey,
+			SharedSessionContractImplementor session,
+			CollectionPart.Nature selectedPartNature) {
+		if ( collectionKey == null ) {
+			return null;
+		}
+
+		final CollectionPersister collectionDescriptor = attributeMapping.getCollectionDescriptor();
+		final Object collection = collectionDescriptor.getCollectionType()
+				.getCollection( collectionKey, session, null, Boolean.TRUE );
+		if ( collection instanceof PersistentCollection<?> persistentCollection ) {
+			session.initializeCollection( persistentCollection, false );
+		}
+		return copy( attributeMapping, collection, selectedPartNature );
+	}
+
+	public static Object copy(
+			PluralAttributeMapping attributeMapping,
+			Object collection,
+			CollectionPart.Nature selectedPartNature) {
+		if ( collection == null ) {
+			return null;
+		}
+		if ( selectedPartNature != null ) {
+			return copyPart( attributeMapping, collection, selectedPartNature );
+		}
+		if ( collection instanceof Map<?, ?> map ) {
+			final Map<Object, Object> copy = instantiateMap( attributeMapping, map.size() );
+			copy.putAll( map );
+			return copy;
+		}
+		if ( collection instanceof Collection<?> collectionValue ) {
+			final Collection<Object> copy = instantiateCollection( attributeMapping, collectionValue.size() );
+			copy.addAll( collectionValue );
+			return copy;
+		}
+		if ( collection.getClass().isArray() ) {
+			final int length = Array.getLength( collection );
+			final Object copy = Array.newInstance( collection.getClass().getComponentType(), length );
+			System.arraycopy( collection, 0, copy, 0, length );
+			return copy;
+		}
+		return collection;
+	}
+
+	private static LinkedHashSet<Object> copyPart(
+			PluralAttributeMapping attributeMapping,
+			Object collection,
+			CollectionPart.Nature selectedPartNature) {
+		final LinkedHashSet<Object> copy = new LinkedHashSet<>();
+		if ( selectedPartNature == CollectionPart.Nature.INDEX ) {
+			if ( collection instanceof Map<?, ?> map ) {
+				copy.addAll( map.keySet() );
+			}
+			else {
+				final int size = collectionSize( collection );
+				final int listIndexBase = attributeMapping.getIndexMetadata().getListIndexBase();
+				for ( int i = 0; i < size; i++ ) {
+					copy.add( listIndexBase + i );
+				}
+			}
+		}
+		else if ( collection instanceof Map<?, ?> map ) {
+			copy.addAll( map.values() );
+		}
+		else if ( collection instanceof Collection<?> collectionValue ) {
+			copy.addAll( collectionValue );
+		}
+		else if ( collection.getClass().isArray() ) {
+			final int length = Array.getLength( collection );
+			for ( int i = 0; i < length; i++ ) {
+				copy.add( Array.get( collection, i ) );
+			}
+		}
+		return copy;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<Object, Object> instantiateMap(PluralAttributeMapping attributeMapping, int size) {
+		final Object rawCollection = attributeMapping.getCollectionDescriptor()
+				.getCollectionSemantics()
+				.instantiateRaw( size, attributeMapping.getCollectionDescriptor() );
+		return rawCollection instanceof Map<?, ?>
+				? (Map<Object, Object>) rawCollection
+				: new LinkedHashMap<>( size );
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Collection<Object> instantiateCollection(PluralAttributeMapping attributeMapping, int size) {
+		final Object rawCollection = attributeMapping.getCollectionDescriptor()
+				.getCollectionSemantics()
+				.instantiateRaw( size, attributeMapping.getCollectionDescriptor() );
+		return rawCollection instanceof Collection<?>
+				? (Collection<Object>) rawCollection
+				: new LinkedHashSet<>( size );
+	}
+
+	private static int collectionSize(Object collection) {
+		if ( collection instanceof Map<?, ?> map ) {
+			return map.size();
+		}
+		if ( collection instanceof Collection<?> collectionValue ) {
+			return collectionValue.size();
+		}
+		if ( collection.getClass().isArray() ) {
+			return Array.getLength( collection );
+		}
+		return 0;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableAssembler.java
@@ -6,10 +6,12 @@ package org.hibernate.sql.results.graph.embeddable.internal;
 
 import java.util.function.BiConsumer;
 
+import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.graph.InitializerData;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableInitializer;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
+import org.hibernate.sql.results.graph.collection.internal.DetachedCollectionHelper;
 import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 import org.hibernate.type.descriptor.java.JavaType;
 
@@ -17,10 +19,18 @@ import org.hibernate.type.descriptor.java.JavaType;
  * @author Steve Ebersole
  */
 public class EmbeddableAssembler implements DomainResultAssembler {
+	private static final CollectionLoader[] NO_COLLECTION_LOADERS = new CollectionLoader[0];
+
 	protected final EmbeddableInitializer<InitializerData> initializer;
+	private final CollectionLoader[] collectionLoaders;
 
 	public EmbeddableAssembler(EmbeddableInitializer<?> initializer) {
+		this( initializer, NO_COLLECTION_LOADERS );
+	}
+
+	public EmbeddableAssembler(EmbeddableInitializer<?> initializer, CollectionLoader[] collectionLoaders) {
 		this.initializer = (EmbeddableInitializer<InitializerData>) initializer;
+		this.collectionLoaders = collectionLoaders;
 	}
 
 	@Override
@@ -38,7 +48,11 @@ public class EmbeddableAssembler implements DomainResultAssembler {
 		if ( state == Initializer.State.KEY_RESOLVED ) {
 			initializer.resolveInstance( data );
 		}
-		return initializer.getResolvedInstance( data );
+		final Object instance = initializer.getResolvedInstance( data );
+		for ( CollectionLoader collectionLoader : collectionLoaders ) {
+			collectionLoader.load( instance, rowProcessingState );
+		}
+		return instance;
 	}
 
 	@Override
@@ -46,6 +60,9 @@ public class EmbeddableAssembler implements DomainResultAssembler {
 		// use resolveState instead of initialize instance to avoid
 		// unneeded embeddable instantiation and injection
 		initializer.resolveState( rowProcessingState );
+		for ( var collectionLoader : collectionLoaders ) {
+			collectionLoader.resolveState( rowProcessingState );
+		}
 	}
 
 	@Override
@@ -57,6 +74,36 @@ public class EmbeddableAssembler implements DomainResultAssembler {
 	public void forEachResultAssembler(BiConsumer consumer, Object arg) {
 		if ( initializer.isResultInitializer() ) {
 			consumer.accept( initializer, arg );
+		}
+	}
+
+	public static class CollectionLoader {
+		private final PluralAttributeMapping collectionAttribute;
+		private final DomainResultAssembler<?> collectionKeyAssembler;
+
+		public CollectionLoader(
+				PluralAttributeMapping collectionAttribute,
+				DomainResultAssembler<?> collectionKeyAssembler) {
+			this.collectionAttribute = collectionAttribute;
+			this.collectionKeyAssembler = collectionKeyAssembler;
+		}
+
+		public void load(Object embeddable, RowProcessingState rowProcessingState) {
+			if ( embeddable != null ) {
+				collectionAttribute.setValue(
+						embeddable,
+						DetachedCollectionHelper.loadAndCopy(
+								collectionAttribute,
+								collectionKeyAssembler.assemble( rowProcessingState ),
+								rowProcessingState.getSession(),
+								null
+						)
+				);
+			}
+		}
+
+		public void resolveState(RowProcessingState rowProcessingState) {
+			collectionKeyAssembler.resolveState( rowProcessingState );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableResultImpl.java
@@ -4,10 +4,14 @@
  */
 package org.hibernate.sql.results.graph.embeddable.internal;
 
+import java.util.ArrayList;
+import java.util.BitSet;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.internal.util.NullnessUtil;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
+import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.SqlAstJoinType;
 import org.hibernate.sql.ast.spi.SqlAstCreationState;
@@ -25,6 +29,7 @@ import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableResult;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableResultGraphNode;
 import org.hibernate.sql.results.graph.internal.ImmutableFetchList;
+import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
@@ -34,11 +39,15 @@ public class EmbeddableResultImpl<T> extends AbstractFetchParent implements Embe
 		DomainResult<T>,
 		EmbeddableResult<T>,
 		InitializerProducer<EmbeddableResultImpl<T>> {
+
+	private static final CollectionLoadingAttribute[] NO_COLLECTION_LOADING_ATTRIBUTES = new CollectionLoadingAttribute[0];
+
 	private final String resultVariable;
 	private final boolean containsAnyNonScalars;
 	private final EmbeddableMappingType fetchContainer;
 	private final BasicFetch<?> discriminatorFetch;
 	private final @Nullable DomainResult<Boolean> nullIndicatorResult;
+	private final CollectionLoadingAttribute[] collectionLoadingAttributes;
 
 	public EmbeddableResultImpl(
 			NavigablePath navigablePath,
@@ -60,31 +69,99 @@ public class EmbeddableResultImpl<T> extends AbstractFetchParent implements Embe
 		final var embeddableTableGroup = fromClauseAccess.resolveTableGroup(
 				getNavigablePath(),
 				np -> {
-					final var embeddedValueMapping = modelPart.getEmbeddableTypeDescriptor().getEmbeddedValueMapping();
 					final var tableGroup =
 							fromClauseAccess.findTableGroup( NullnessUtil.castNonNull( np.getParent() ).getParent() );
-					final var tableGroupJoin = embeddedValueMapping.createTableGroupJoin(
-							np,
-							tableGroup,
-							resultVariable,
-							null,
-							SqlAstJoinType.INNER,
-							true,
-							false,
-							sqlAstCreationState
-					);
+					final var tableGroupJoin =
+							modelPart.getEmbeddableTypeDescriptor()
+									.getEmbeddedValueMapping()
+									.createTableGroupJoin(
+											np,
+											tableGroup,
+											resultVariable,
+											null,
+											SqlAstJoinType.INNER,
+											true,
+											false,
+											sqlAstCreationState
+									);
 					tableGroup.addTableGroupJoin( tableGroupJoin );
 					return tableGroupJoin.getJoinedGroup();
 				}
 		);
 
 		discriminatorFetch = creationState.visitEmbeddableDiscriminatorFetch( this, false );
-		nullIndicatorResult = nullIndicatorResult( creationState, embeddableTableGroup, sqlAstCreationState );
+		final TableGroup ownerTableGroup =
+				fromClauseAccess.findTableGroup( NullnessUtil.castNonNull( navigablePath.getParent() ) );
+		collectionLoadingAttributes = collectionLoadingAttributes(
+				modelPart,
+				ownerTableGroup,
+				creationState
+		);
+		final var aggregateNullIndicatorResult =
+				nullIndicatorResult( creationState, embeddableTableGroup, sqlAstCreationState );
+		nullIndicatorResult = aggregateNullIndicatorResult == null && collectionLoadingAttributes.length > 0
+				? new CollectionKeyNullIndicatorResult(
+						collectionLoadingAttributes[0].collectionKeyResult(),
+						sqlAstCreationState.getCreationContext()
+								.getTypeConfiguration()
+								.getBasicTypeForJavaType( Boolean.class )
+								.getJavaTypeDescriptor()
+				)
+				: aggregateNullIndicatorResult;
 
-		afterInitialize( this, creationState );
+		resetFetches( withoutCollectionFetches( creationState.visitFetches( this ) ) );
 
 		// after-after-initialize :D
 		containsAnyNonScalars = determineIfContainedAnyScalars( getFetches() );
+	}
+
+	private CollectionLoadingAttribute[] collectionLoadingAttributes(
+			EmbeddableValuedModelPart modelPart,
+			TableGroup ownerTableGroup,
+			DomainResultCreationState creationState) {
+		if ( ownerTableGroup == null ) {
+			return NO_COLLECTION_LOADING_ATTRIBUTES;
+		}
+		else {
+			final var collectionLoadingAttributes = new ArrayList<CollectionLoadingAttribute>();
+			try {
+				modelPart.getEmbeddableTypeDescriptor().forEachAttributeMapping(
+						attributeMapping -> {
+							if ( attributeMapping instanceof PluralAttributeMapping pluralAttributeMapping ) {
+								collectionLoadingAttributes.add(
+										new CollectionLoadingAttribute(
+												pluralAttributeMapping,
+												pluralAttributeMapping.getKeyDescriptor().createTargetDomainResult(
+														ownerTableGroup.getNavigablePath()
+																.append( pluralAttributeMapping.getPartName() ),
+														ownerTableGroup,
+														this,
+														creationState
+												)
+										)
+								);
+							}
+						}
+				);
+			}
+			catch (UnsupportedOperationException ignored) {
+				return NO_COLLECTION_LOADING_ATTRIBUTES;
+			}
+			return collectionLoadingAttributes.toArray( CollectionLoadingAttribute[]::new );
+		}
+	}
+
+	private ImmutableFetchList withoutCollectionFetches(ImmutableFetchList fetches) {
+		if ( collectionLoadingAttributes.length == 0 ) {
+			return fetches;
+		}
+		final var builder = new ImmutableFetchList.Builder( fetchContainer );
+		for ( var fetch : fetches ) {
+			if ( !( fetch.getFetchedMapping() instanceof PluralAttributeMapping ) ) {
+				builder.add( fetch );
+			}
+		}
+		return builder.build();
 	}
 
 	private DomainResult<Boolean> nullIndicatorResult(
@@ -153,8 +230,21 @@ public class EmbeddableResultImpl<T> extends AbstractFetchParent implements Embe
 	public DomainResultAssembler<T> createResultAssembler(
 			InitializerParent<?> parent,
 			AssemblerCreationState creationState) {
+		final var collectionLoaders = new EmbeddableAssembler.CollectionLoader[collectionLoadingAttributes.length];
+		for ( int i = 0; i < collectionLoadingAttributes.length; i++ ) {
+			final var collectionLoadingAttribute = collectionLoadingAttributes[i];
+			collectionLoaders[i] = new EmbeddableAssembler.CollectionLoader(
+					collectionLoadingAttribute.collectionAttribute(),
+					collectionLoadingAttribute.collectionKeyResult()
+							.createResultAssembler( parent, creationState )
+			);
+		}
 		//noinspection unchecked
-		return new EmbeddableAssembler( creationState.resolveInitializer( this, parent, this ).asEmbeddableInitializer() );
+		return new EmbeddableAssembler(
+				creationState.resolveInitializer( this, parent, this )
+						.asEmbeddableInitializer(),
+				collectionLoaders
+		);
 	}
 
 	@Override
@@ -168,5 +258,54 @@ public class EmbeddableResultImpl<T> extends AbstractFetchParent implements Embe
 	@Override
 	public Initializer<?> createInitializer(InitializerParent<?> parent, AssemblerCreationState creationState) {
 		return new EmbeddableInitializerImpl( this, discriminatorFetch, nullIndicatorResult, parent, creationState, true );
+	}
+
+	private record CollectionLoadingAttribute(
+			PluralAttributeMapping collectionAttribute,
+			DomainResult<?> collectionKeyResult) {
+	}
+
+	private record CollectionKeyNullIndicatorResult
+			(DomainResult<?> collectionKeyResult, JavaType<Boolean> javaType)
+			implements DomainResult<Boolean> {
+
+		@Override
+		public String getResultVariable() {
+			return null;
+		}
+
+		@Override
+		public JavaType<?> getResultJavaType() {
+			return javaType;
+		}
+
+		@Override
+		public DomainResultAssembler<Boolean> createResultAssembler(
+				InitializerParent<?> parent,
+				AssemblerCreationState creationState) {
+			final var collectionKeyAssembler =
+					collectionKeyResult.createResultAssembler( parent, creationState );
+			return new DomainResultAssembler<>() {
+				@Override
+				public Boolean assemble(RowProcessingState rowProcessingState) {
+					return collectionKeyAssembler.assemble( rowProcessingState ) == null;
+				}
+
+				@Override
+				public JavaType<Boolean> getAssembledJavaType() {
+					return javaType;
+				}
+
+				@Override
+				public void resolveState(RowProcessingState rowProcessingState) {
+					collectionKeyAssembler.resolveState( rowProcessingState );
+				}
+			};
+		}
+
+		@Override
+		public void collectValueIndexesToCache(BitSet valueIndexes) {
+			collectionKeyResult.collectValueIndexesToCache( valueIndexes );
+		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/OneToManyInEmbeddedQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/OneToManyInEmbeddedQueryTest.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.query.SemanticException;
+import org.hibernate.collection.spi.PersistentCollection;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
@@ -33,7 +33,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 @DomainModel( annotatedClasses = {
 		OneToManyInEmbeddedQueryTest.EntityA.class,
@@ -88,23 +87,17 @@ public class OneToManyInEmbeddedQueryTest {
 	}
 
 	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-17558" )
 	public void testSelectEmbedded(SessionFactoryScope scope) {
-		scope.inTransaction( session -> {
-			try {
-				session.createQuery(
+		final EmbeddedValue embedded = scope.fromTransaction(
+				session -> session.createQuery(
 						"select a.embedded from EntityA a where a.id = 2",
 						EmbeddedValue.class
-				).getSingleResult();
-				fail( "Should throw SemanticException" );
-			}
-			catch (Exception e) {
-				final Throwable cause = e.getCause();
-				assertThat( cause ).isInstanceOf( SemanticException.class );
-				assertThat( cause.getMessage() ).contains(
-						"selection of an embeddable containing associated collections is not supported"
-				);
-			}
-		} );
+				).getSingleResult()
+		);
+
+		assertThat( embedded.getEntityCList() ).isNotInstanceOf( PersistentCollection.class );
+		assertThat( embedded.getEntityCList().stream().map( EntityC::getName ) ).containsOnly( "entityc_3" );
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/IndicesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/IndicesTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,10 +56,20 @@ public class IndicesTest {
 	}
 
 	@Test
+	public void testSelectIndes(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			List<?> result = session.createQuery("select index(p.roles) from Person p", Project.class ).list();
+			assertThat( result ).hasSize( 1 );
+		} );
+	}
+
+	@Test
 	public void testSelectIndices(SessionFactoryScope factoryScope) {
 		factoryScope.inTransaction( (session) -> {
-			List<?> result = session.createQuery("select indices(p.roles) from Person p", Project.class ).list();
+			Class<Collection<Project>> type = (Class) Collection.class;
+			List<Collection<Project>> result = session.createQuery( "select indices(p.roles) from Person p", type ).list();
 			assertThat( result ).hasSize( 1 );
+			assertThat( result.get( 0 ) ).hasSize( 1 );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/embeddable/EmbeddableInheritanceAssciationsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/embeddable/EmbeddableInheritanceAssciationsTest.java
@@ -108,7 +108,7 @@ public class EmbeddableInheritanceAssciationsTest {
 		scope.inTransaction( session -> {
 			// queries
 			final List<AssociatedEntity> resultList = session.createQuery(
-					"select embeddable.manyToMany from TestEntity",
+					"select element(embeddable.manyToMany) from TestEntity",
 					AssociatedEntity.class
 			).getResultList();
 			final Integer size = session.createQuery(
@@ -155,7 +155,7 @@ public class EmbeddableInheritanceAssciationsTest {
 		scope.inTransaction( session -> {
 			// queries
 			final List<AssociatedEntity> resultList = session.createQuery(
-					"select embeddable.oneToMany from TestEntity",
+					"select element(embeddable.oneToMany) from TestEntity",
 					AssociatedEntity.class
 			).getResultList();
 			final Integer size = session.createQuery(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/EntitySuperclassCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/EntitySuperclassCollectionTest.java
@@ -21,6 +21,7 @@ import org.hibernate.testing.orm.junit.Jpa;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,13 +54,20 @@ public class EntitySuperclassCollectionTest {
 				person.id,
 				"addresses"
 		);
-		assertEquals( 1, results.size() );
+		final Address selectedAddress = singleSelectedAddress( results );
 
 		assertEquals(
 				person.addresses.get( 0 ).id,
-				((Address) results.get( 0 )).id
+				selectedAddress.id
 		);
-		assertEquals( address, ((Address) results.get( 0 )).name );
+		assertEquals( address, selectedAddress.name );
+	}
+
+	private Address singleSelectedAddress(List<Object> results) {
+		assertEquals( 1, results.size() );
+		final Collection<?> addresses = (Collection<?>) results.get( 0 );
+		assertEquals( 1, addresses.size() );
+		return (Address) addresses.iterator().next();
 	}
 
 	private PersonBase createPerson(EntityManagerFactoryScope scope, PersonBase person, String address) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/SuperclassCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/SuperclassCollectionTest.java
@@ -5,6 +5,7 @@
 package org.hibernate.orm.test.jpa.criteria;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -71,18 +72,25 @@ public class SuperclassCollectionTest {
 
 	private void assertAddress(EntityManagerFactoryScope scope, PersonBaseBase person, String address, String localAddress) {
 		List<Object> results = find( scope, person.getClass(), person.id, "addresses" );
-		assertEquals( 1, results.size() );
+		final Address selectedAddress = singleSelectedAddress( results );
 
-		assertEquals( person.addresses.get( 0 ).id, ( (Address) results.get( 0 ) ).id );
-		assertEquals( address, ( (Address) results.get( 0 ) ).name );
+		assertEquals( person.addresses.get( 0 ).id, selectedAddress.id );
+		assertEquals( address, selectedAddress.name );
 
 
 		results = find( scope, person.getClass(), person.id, "localAddresses" );
+		final Address selectedLocalAddress = singleSelectedAddress( results );
+
+		assertEquals( person.getLocalAddresses().get( 0 ).id, selectedLocalAddress.id );
+		assertEquals( localAddress, selectedLocalAddress.name );
+
+	}
+
+	private Address singleSelectedAddress(List<Object> results) {
 		assertEquals( 1, results.size() );
-
-		assertEquals( person.getLocalAddresses().get( 0 ).id, ( (Address) results.get( 0 ) ).id );
-		assertEquals( localAddress, ( (Address) results.get( 0 ) ).name );
-
+		final Collection<?> addresses = (Collection<?>) results.get( 0 );
+		assertEquals( 1, addresses.size() );
+		return (Address) addresses.iterator().next();
 	}
 
 	private PersonBaseBase createPerson(EntityManagerFactoryScope scope, PersonBaseBase person, String address, String localAddress) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/graphs/EntityGraphAttributeResolutionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/graphs/EntityGraphAttributeResolutionTest.java
@@ -67,9 +67,10 @@ public class EntityGraphAttributeResolutionTest {
 	@Test
 	public void fetchAssocWithNamedFetchGraph(EntityManagerFactoryScope scope) {
 		scope.inTransaction( entityManager -> {
-			List result = entityManager.createQuery( "SELECT u.groups FROM User u WHERE u.id = ?1" )
+			List result = entityManager.createQuery( "SELECT element(u.groups) FROM User u WHERE u.id = ?1" )
 					.setParameter(1, u.getId() )
-					.setHint( GraphSemantic.FETCH.getJakartaHintName(), entityManager.getEntityGraph( Group.ENTITY_GRAPH ) )
+					.setHint( GraphSemantic.FETCH.getJakartaHintName(),
+							entityManager.getEntityGraph( Group.ENTITY_GRAPH ) )
 					.getResultList();
 
 			assertThat( result ).containsExactlyInAnyOrder( g1, g2 );
@@ -81,7 +82,8 @@ public class EntityGraphAttributeResolutionTest {
 		scope.inTransaction( entityManager -> {
 			List result = entityManager.createQuery( "SELECT g FROM User u JOIN u.groups g WHERE u.id = ?1" )
 					.setParameter( 1, u.getId() )
-					.setHint( GraphSemantic.FETCH.getJakartaHintName(), entityManager.getEntityGraph( Group.ENTITY_GRAPH ) )
+					.setHint( GraphSemantic.FETCH.getJakartaHintName(),
+							entityManager.getEntityGraph( Group.ENTITY_GRAPH ) )
 					.getResultList();
 
 			assertThat( result ).containsExactlyInAnyOrder( g1, g2 );
@@ -94,7 +96,7 @@ public class EntityGraphAttributeResolutionTest {
 			EntityGraph<Group> eg = entityManager.createEntityGraph( Group.class );
 			eg.addAttributeNodes( "permissions" );
 
-			List result = entityManager.createQuery( "SELECT u.groups FROM User u WHERE u.id = ?1" )
+			List result = entityManager.createQuery( "SELECT element(u.groups) FROM User u WHERE u.id = ?1" )
 					.setParameter(1, u.getId() )
 					.setHint( GraphSemantic.FETCH.getJakartaHintName(), eg )
 					.getResultList();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/HqlDetachedCollectionSelectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/HqlDetachedCollectionSelectionTest.java
@@ -1,0 +1,342 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.hql;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.collection.spi.PersistentCollection;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Gavin King
+ */
+@DomainModel( annotatedClasses = {
+		HqlDetachedCollectionSelectionTest.Author.class,
+		HqlDetachedCollectionSelectionTest.Book.class,
+		HqlDetachedCollectionSelectionTest.CatalogItem.class,
+		HqlDetachedCollectionSelectionTest.Shelf.class,
+} )
+@SessionFactory
+@JiraKey( "HHH-17558" )
+public class HqlDetachedCollectionSelectionTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Author gavin = new Author( 1, "Gavin King" );
+			final Author steve = new Author( 2, "Steve Ebersole" );
+			session.persist( gavin );
+			session.persist( steve );
+
+			final Book book = new Book( 1, "Hibernate ORM" );
+			book.getAuthors().add( gavin );
+			book.getAuthors().add( steve );
+			book.getTags().add( "hql" );
+			book.getTags().add( "orm" );
+			book.getTranslations().put( "de", "Hibernate ORM auf Deutsch" );
+			book.getTranslations().put( "fr", "Hibernate ORM en francais" );
+			session.persist( book );
+
+			final CatalogItem first = new CatalogItem( 1, "First pick" );
+			final CatalogItem second = new CatalogItem( 2, "Second pick" );
+			final Catalog catalog = new Catalog( "Recommended" );
+			catalog.getItems().add( first );
+			catalog.getItems().add( second );
+			session.persist( new Shelf( 1, catalog ) );
+		} );
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	public void testPluralAttributeSelectionReturnsDetachedCollection(SessionFactoryScope scope) {
+		final Collection<Author> authors =
+				scope.fromTransaction(
+						session -> session.createSelectionQuery( "select book.authors from Hhh17558Book book",
+								collectionType( Author.class ) ).getSingleResult()
+				);
+
+		assertDetachedSet( authors );
+		assertThat( authors )
+				.extracting( Author::getName )
+				.containsExactlyInAnyOrder( "Gavin King", "Steve Ebersole" );
+	}
+
+	@Test
+	public void testElementsFunctionReturnsDetachedCollection(SessionFactoryScope scope) {
+		final Collection<Author> authors =
+				scope.fromTransaction(
+						session1 -> session1.createSelectionQuery(
+								"select elements(book.authors) from Hhh17558Book book",
+								collectionType( Author.class ) ).getSingleResult()
+				);
+		final Collection<String> tags =
+				scope.fromTransaction(
+						session -> session.createSelectionQuery( "select elements(book.tags) from Hhh17558Book book",
+								collectionType( String.class ) ).getSingleResult()
+				);
+
+		assertDetachedSet( authors );
+		assertThat( authors )
+				.extracting( Author::getName )
+				.containsExactlyInAnyOrder( "Gavin King", "Steve Ebersole" );
+		assertDetachedSet( tags );
+		assertThat( tags ).containsExactlyInAnyOrder( "hql", "orm" );
+	}
+
+	@Test
+	public void testElementFunctionStillFlattensCollection(SessionFactoryScope scope) {
+		final Collection<String> authorNames = scope.fromTransaction(
+				session -> session.createSelectionQuery(
+						"select element(book.authors).name from Hhh17558Book book",
+						String.class
+				).getResultList()
+		);
+		final Collection<String> tags = scope.fromTransaction(
+				session -> session.createSelectionQuery(
+						"select element(book.tags) from Hhh17558Book book",
+						String.class
+				).getResultList()
+		);
+
+		assertThat( authorNames ).containsExactlyInAnyOrder( "Gavin King", "Steve Ebersole" );
+		assertThat( tags ).containsExactlyInAnyOrder( "hql", "orm" );
+	}
+
+	@Test
+	public void testKeysAndValuesFunctionsReturnDetachedCollections(SessionFactoryScope scope) {
+		final Collection<String> locales =
+				scope.fromTransaction(
+						session1 -> session1.createSelectionQuery(
+								"select keys(book.translations) from Hhh17558Book book",
+								collectionType( String.class ) ).getSingleResult()
+				);
+		final Collection<String> translations =
+				scope.fromTransaction(
+						session -> session.createSelectionQuery(
+								"select values(book.translations) from Hhh17558Book book",
+								collectionType( String.class ) ).getSingleResult()
+				);
+
+		assertDetachedSet( locales );
+		assertThat( locales ).containsExactlyInAnyOrder( "de", "fr" );
+		assertDetachedSet( translations );
+		assertThat( translations ).containsExactlyInAnyOrder(
+				"Hibernate ORM auf Deutsch",
+				"Hibernate ORM en francais"
+		);
+	}
+
+	@Test
+	public void testKeyAndValueFunctionsStillFlattenMap(SessionFactoryScope scope) {
+		final Collection<String> locales = scope.fromTransaction(
+				session -> session.createSelectionQuery(
+						"select key(book.translations) from Hhh17558Book book",
+						String.class
+				).getResultList()
+		);
+		final Collection<String> translations = scope.fromTransaction(
+				session -> session.createSelectionQuery(
+						"select value(book.translations) from Hhh17558Book book",
+						String.class
+				).getResultList()
+		);
+
+		assertThat( locales ).containsExactlyInAnyOrder( "de", "fr" );
+		assertThat( translations ).containsExactlyInAnyOrder(
+				"Hibernate ORM auf Deutsch",
+				"Hibernate ORM en francais"
+		);
+	}
+
+	@Test
+	public void testEmbeddableSelectionReturnsDetachedCollection(SessionFactoryScope scope) {
+		final Catalog catalog = scope.fromTransaction(
+				session -> session.createSelectionQuery(
+						"select shelf.catalog from Hhh17558Shelf shelf",
+						Catalog.class
+				).getSingleResult()
+		);
+
+		assertThat( catalog.getName() ).isEqualTo( "Recommended" );
+		assertDetachedSet( catalog.getItems() );
+		assertThat( catalog.getItems() )
+				.extracting( CatalogItem::getName )
+				.containsExactlyInAnyOrder( "First pick", "Second pick" );
+	}
+
+	@SuppressWarnings("unchecked")
+	private static @NonNull <T> Class<Collection<T>> collectionType(Class<T> elementType) {
+		return (Class<Collection<T>>) (Class) Collection.class;
+	}
+
+	private static void assertDetachedSet(Collection<?> collection) {
+		assertThat( collection ).isInstanceOf( Set.class );
+		assertThat( collection ).isNotInstanceOf( PersistentCollection.class );
+	}
+
+	@Entity( name = "Hhh17558Author" )
+	@Table( name = "hhh17558_author" )
+	public static class Author {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		protected Author() {
+		}
+
+		private Author(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Entity( name = "Hhh17558Book" )
+	@Table( name = "hhh17558_book" )
+	public static class Book {
+		@Id
+		private Integer id;
+
+		private String title;
+
+		@ManyToMany
+		@JoinTable( name = "hhh17558_book_author",
+				joinColumns = @JoinColumn( name = "book_id" ),
+				inverseJoinColumns = @JoinColumn( name = "author_id" ) )
+		private Set<Author> authors = new HashSet<>();
+
+		@ElementCollection
+		@CollectionTable( name = "hhh17558_book_tag", joinColumns = @JoinColumn( name = "book_id" ) )
+		@Column( name = "tag" )
+		private Set<String> tags = new HashSet<>();
+
+		@ElementCollection
+		@CollectionTable( name = "hhh17558_book_translation", joinColumns = @JoinColumn( name = "book_id" ) )
+		@MapKeyColumn( name = "locale" )
+		@Column( name = "translation" )
+		private Map<String, String> translations = new HashMap<>();
+
+		protected Book() {
+		}
+
+		private Book(Integer id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		public Set<Author> getAuthors() {
+			return authors;
+		}
+
+		public Set<String> getTags() {
+			return tags;
+		}
+
+		public Map<String, String> getTranslations() {
+			return translations;
+		}
+	}
+
+	@Entity( name = "Hhh17558Shelf" )
+	@Table( name = "hhh17558_shelf" )
+	public static class Shelf {
+		@Id
+		private Integer id;
+
+		@Embedded
+		private Catalog catalog;
+
+		protected Shelf() {
+		}
+
+		private Shelf(Integer id, Catalog catalog) {
+			this.id = id;
+			this.catalog = catalog;
+		}
+	}
+
+	@Embeddable
+	public static class Catalog {
+		private String name;
+
+		@OneToMany( cascade = CascadeType.PERSIST, fetch = FetchType.LAZY )
+		@JoinColumn( name = "shelf_id" )
+		private Set<CatalogItem> items = new HashSet<>();
+
+		protected Catalog() {
+		}
+
+		private Catalog(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Set<CatalogItem> getItems() {
+			return items;
+		}
+	}
+
+	@Entity( name = "Hhh17558CatalogItem" )
+	@Table( name = "hhh17558_catalog_item" )
+	public static class CatalogItem {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		protected CatalogItem() {
+		}
+
+		private CatalogItem(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/HqlDetachedCollectionSelectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/HqlDetachedCollectionSelectionTest.java
@@ -4,9 +4,11 @@
  */
 package org.hibernate.orm.test.query.hql;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,6 +37,7 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,6 +68,8 @@ public class HqlDetachedCollectionSelectionTest {
 			book.getAuthors().add( steve );
 			book.getTags().add( "hql" );
 			book.getTags().add( "orm" );
+			book.getChapters().add( "Introduction" );
+			book.getChapters().add( "Query Language" );
 			book.getTranslations().put( "de", "Hibernate ORM auf Deutsch" );
 			book.getTranslations().put( "fr", "Hibernate ORM en francais" );
 			session.persist( book );
@@ -95,6 +100,23 @@ public class HqlDetachedCollectionSelectionTest {
 		assertThat( authors )
 				.extracting( Author::getName )
 				.containsExactlyInAnyOrder( "Gavin King", "Steve Ebersole" );
+	}
+
+	@Test
+	public void testMapPluralAttributeSelectionReturnsDetachedMap(SessionFactoryScope scope) {
+		final Map<String, String> translations =
+				scope.fromTransaction(
+						session -> session.createSelectionQuery(
+								"select book.translations from Hhh17558Book book",
+								mapType( String.class, String.class )
+						).getSingleResult()
+				);
+
+		assertDetachedMap( translations );
+		assertThat( translations )
+				.containsEntry( "de", "Hibernate ORM auf Deutsch" )
+				.containsEntry( "fr", "Hibernate ORM en francais" )
+				.hasSize( 2 );
 	}
 
 	@Test
@@ -163,6 +185,20 @@ public class HqlDetachedCollectionSelectionTest {
 	}
 
 	@Test
+	public void testIndicesFunctionReturnsListIndexes(SessionFactoryScope scope) {
+		final Collection<Integer> indexes =
+				scope.fromTransaction(
+						session -> session.createSelectionQuery(
+								"select indices(book.chapters) from Hhh17558Book book",
+								collectionType( Integer.class )
+						).getSingleResult()
+				);
+
+		assertDetachedSet( indexes );
+		assertThat( indexes ).containsExactly( 0, 1 );
+	}
+
+	@Test
 	public void testKeyAndValueFunctionsStillFlattenMap(SessionFactoryScope scope) {
 		final Collection<String> locales = scope.fromTransaction(
 				session -> session.createSelectionQuery(
@@ -205,9 +241,19 @@ public class HqlDetachedCollectionSelectionTest {
 		return (Class<Collection<T>>) (Class) Collection.class;
 	}
 
+	@SuppressWarnings("unchecked")
+	private static @NonNull <K, V> Class<Map<K, V>> mapType(Class<K> keyType, Class<V> valueType) {
+		return (Class<Map<K, V>>) (Class) Map.class;
+	}
+
 	private static void assertDetachedSet(Collection<?> collection) {
 		assertThat( collection ).isInstanceOf( Set.class );
 		assertThat( collection ).isNotInstanceOf( PersistentCollection.class );
+	}
+
+	private static void assertDetachedMap(Map<?, ?> map) {
+		assertThat( map ).isInstanceOf( Map.class );
+		assertThat( map ).isNotInstanceOf( PersistentCollection.class );
 	}
 
 	@Entity( name = "Hhh17558Author" )
@@ -251,6 +297,12 @@ public class HqlDetachedCollectionSelectionTest {
 		private Set<String> tags = new HashSet<>();
 
 		@ElementCollection
+		@CollectionTable( name = "hhh17558_book_chapter", joinColumns = @JoinColumn( name = "book_id" ) )
+		@OrderColumn( name = "chapter_index" )
+		@Column( name = "chapter" )
+		private List<String> chapters = new ArrayList<>();
+
+		@ElementCollection
 		@CollectionTable( name = "hhh17558_book_translation", joinColumns = @JoinColumn( name = "book_id" ) )
 		@MapKeyColumn( name = "locale" )
 		@Column( name = "translation" )
@@ -270,6 +322,10 @@ public class HqlDetachedCollectionSelectionTest {
 
 		public Set<String> getTags() {
 			return tags;
+		}
+
+		public List<String> getChapters() {
+			return chapters;
 		}
 
 		public Map<String, String> getTranslations() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/HqlDetachedCollectionSelectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/HqlDetachedCollectionSelectionTest.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 		HqlDetachedCollectionSelectionTest.Author.class,
 		HqlDetachedCollectionSelectionTest.Book.class,
 		HqlDetachedCollectionSelectionTest.CatalogItem.class,
+		HqlDetachedCollectionSelectionTest.CatalogArchive.class,
 		HqlDetachedCollectionSelectionTest.Shelf.class,
 } )
 @SessionFactory
@@ -76,10 +77,20 @@ public class HqlDetachedCollectionSelectionTest {
 
 			final CatalogItem first = new CatalogItem( 1, "First pick" );
 			final CatalogItem second = new CatalogItem( 2, "Second pick" );
-			final Catalog catalog = new Catalog( "Recommended" );
+			final CatalogWithItems catalog = new CatalogWithItems( "Recommended" );
 			catalog.getItems().add( first );
 			catalog.getItems().add( second );
 			session.persist( new Shelf( 1, catalog ) );
+
+			final CatalogArchive catalogArchive = new CatalogArchive( 1 );
+			catalogArchive.getCatalogs().add( new Catalog( "Seasonal" ) );
+			catalogArchive.getCatalogs().add( new Catalog( "Clearance" ) );
+			session.persist( catalogArchive );
+
+			final CatalogArchive otherCatalogArchive = new CatalogArchive( 2 );
+			otherCatalogArchive.getCatalogs().add( new Catalog( "Reference" ) );
+			otherCatalogArchive.getCatalogs().add( new Catalog( "Backlist" ) );
+			session.persist( otherCatalogArchive );
 		} );
 	}
 
@@ -222,13 +233,78 @@ public class HqlDetachedCollectionSelectionTest {
 
 	@Test
 	public void testEmbeddableSelectionReturnsDetachedCollection(SessionFactoryScope scope) {
-		final Catalog catalog = scope.fromTransaction(
+		final CatalogWithItems catalog = scope.fromTransaction(
 				session -> session.createSelectionQuery(
 						"select shelf.catalog from Hhh17558Shelf shelf",
-						Catalog.class
+						CatalogWithItems.class
 				).getSingleResult()
 		);
 
+		assertCatalogWithItems( catalog );
+	}
+
+	@Test
+	public void testUntypedEmbeddableSelectionReturnsDetachedCollection(SessionFactoryScope scope) {
+		final Object result = scope.fromTransaction(
+				session -> session.createSelectionQuery(
+						"select shelf.catalog from Hhh17558Shelf shelf",
+						Object.class
+				).getSingleResult()
+		);
+
+		assertThat( result ).isInstanceOf( CatalogWithItems.class );
+		assertCatalogWithItems( (CatalogWithItems) result );
+	}
+
+	@Test
+	public void testTupleEmbeddableSelectionReturnsDetachedCollection(SessionFactoryScope scope) {
+		final Object[] result = scope.fromTransaction(
+				session -> session.createSelectionQuery(
+						"select shelf.id, shelf.catalog from Hhh17558Shelf shelf",
+						Object[].class
+				).getSingleResult()
+		);
+
+		assertThat( result[0] ).isEqualTo( 1 );
+		assertCatalogWithItems( (CatalogWithItems) result[1] );
+	}
+
+	@Test
+	public void testElementCollectionOfCatalogsSelectionReturnsDetachedCollection(SessionFactoryScope scope) {
+		final Collection<Catalog> catalogs = scope.fromTransaction(
+				session -> session.createSelectionQuery(
+						"select archive.catalogs from Hhh17558CatalogArchive archive where archive.id = 1",
+						collectionType( Catalog.class )
+				).getSingleResult()
+		);
+
+		assertDetachedList( catalogs );
+		assertThat( catalogs )
+				.extracting( Catalog::getName )
+				.containsExactly( "Seasonal", "Clearance" );
+	}
+
+	@Test
+	public void testElementCollectionOfCatalogsSelectionReturnsMultipleDetachedCollections(SessionFactoryScope scope) {
+		final List<Collection<Catalog>> catalogLists = scope.fromTransaction(
+				session -> session.createSelectionQuery(
+						"select archive.catalogs from Hhh17558CatalogArchive archive order by archive.id",
+						collectionType( Catalog.class )
+				).getResultList()
+		);
+
+		assertThat( catalogLists ).hasSize( 2 );
+		assertDetachedList( catalogLists.get( 0 ) );
+		assertThat( catalogLists.get( 0 ) )
+				.extracting( Catalog::getName )
+				.containsExactly( "Seasonal", "Clearance" );
+		assertDetachedList( catalogLists.get( 1 ) );
+		assertThat( catalogLists.get( 1 ) )
+				.extracting( Catalog::getName )
+				.containsExactly( "Reference", "Backlist" );
+	}
+
+	private static void assertCatalogWithItems(CatalogWithItems catalog) {
 		assertThat( catalog.getName() ).isEqualTo( "Recommended" );
 		assertDetachedSet( catalog.getItems() );
 		assertThat( catalog.getItems() )
@@ -248,6 +324,11 @@ public class HqlDetachedCollectionSelectionTest {
 
 	private static void assertDetachedSet(Collection<?> collection) {
 		assertThat( collection ).isInstanceOf( Set.class );
+		assertThat( collection ).isNotInstanceOf( PersistentCollection.class );
+	}
+
+	private static void assertDetachedList(Collection<?> collection) {
+		assertThat( collection ).isInstanceOf( List.class );
 		assertThat( collection ).isNotInstanceOf( PersistentCollection.class );
 	}
 
@@ -340,24 +421,44 @@ public class HqlDetachedCollectionSelectionTest {
 		private Integer id;
 
 		@Embedded
-		private Catalog catalog;
+		private CatalogWithItems catalog;
 
 		protected Shelf() {
 		}
 
-		private Shelf(Integer id, Catalog catalog) {
+		private Shelf(Integer id, CatalogWithItems catalog) {
 			this.id = id;
 			this.catalog = catalog;
 		}
 	}
 
 	@Embeddable
-	public static class Catalog {
+	public static class CatalogWithItems {
 		private String name;
 
 		@OneToMany( cascade = CascadeType.PERSIST, fetch = FetchType.LAZY )
 		@JoinColumn( name = "shelf_id" )
 		private Set<CatalogItem> items = new HashSet<>();
+
+		protected CatalogWithItems() {
+		}
+
+		private CatalogWithItems(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Set<CatalogItem> getItems() {
+			return items;
+		}
+	}
+
+	@Embeddable
+	public static class Catalog {
+		private String name;
 
 		protected Catalog() {
 		}
@@ -369,9 +470,28 @@ public class HqlDetachedCollectionSelectionTest {
 		public String getName() {
 			return name;
 		}
+	}
 
-		public Set<CatalogItem> getItems() {
-			return items;
+	@Entity( name = "Hhh17558CatalogArchive" )
+	@Table( name = "hhh17558_catalog_archive" )
+	public static class CatalogArchive {
+		@Id
+		private Integer id;
+
+		@ElementCollection
+		@CollectionTable( name = "hhh17558_catalog_archive_catalog", joinColumns = @JoinColumn( name = "archive_id" ) )
+		@OrderColumn( name = "catalog_index" )
+		private List<Catalog> catalogs = new ArrayList<>();
+
+		protected CatalogArchive() {
+		}
+
+		private CatalogArchive(Integer id) {
+			this.id = id;
+		}
+
+		public List<Catalog> getCatalogs() {
+			return catalogs;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/InstantiationWithCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/InstantiationWithCollectionTest.java
@@ -4,22 +4,27 @@
  */
 package org.hibernate.orm.test.query.hql.instantiation;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.collection.spi.PersistentCollection;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.SessionFactory;
-import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -36,11 +41,10 @@ public class InstantiationWithCollectionTest {
 		scope.inTransaction(s -> s.persist(entity));
 
 		List<Object[]> tuples =
-				// this kind of query is currently not documented to work, but it does, and I guess I don't see why it's terrible
 				scope.fromSession(s -> s.createSelectionQuery("select id, names from Entity", Object[].class).getResultList());
-		assertEquals(2, tuples.size());
-		tuples.forEach(tuple -> assertNotNull(tuple[0]));
-		tuples.forEach(tuple -> assertNotNull(tuple[1]));
+		assertEquals(1, tuples.size());
+		assertNotNull(tuples.get(0)[0]);
+		assertThat( assertDetachedSet( tuples.get(0)[1] ) ).containsExactlyInAnyOrder("hello", "world");
 
 		List<Object[]> tuples2 =
 				scope.fromSession(s -> s.createSelectionQuery("select id, element(names) from Entity", Object[].class).getResultList());
@@ -48,13 +52,12 @@ public class InstantiationWithCollectionTest {
 		tuples2.forEach(tuple -> assertNotNull(tuple[0]));
 		tuples2.forEach(tuple -> assertNotNull(tuple[1]));
 
-		List<EntityCopy> copies =
-				// this kind of query is currently not documented to work, but it does, and I guess I don't see why it's terrible
-				scope.fromSession(s -> s.createSelectionQuery("select id, names from Entity", EntityCopy.class).getResultList());
-		assertEquals(2, copies.size());
+		List<EntityNamesCopy> copies =
+				scope.fromSession(s -> s.createSelectionQuery("select id, names from Entity", EntityNamesCopy.class).getResultList());
+		assertEquals(1, copies.size());
 		copies.forEach(Assertions::assertNotNull);
 		copies.forEach(copy -> assertNotNull(copy.id));
-		copies.forEach(copy -> assertNotNull(copy.name));
+		copies.forEach(copy -> assertThat( assertDetachedSet( copy.names ) ).containsExactlyInAnyOrder("hello", "world"));
 
 		List<EntityCopy> copies2 =
 				scope.fromSession(s -> s.createSelectionQuery("select id, element(names) from Entity", EntityCopy.class).getResultList());
@@ -63,17 +66,16 @@ public class InstantiationWithCollectionTest {
 		copies2.forEach(copy -> assertNotNull(copy.id));
 		copies2.forEach(copy -> assertNotNull(copy.name));
 
-		List<EntityCopy> newCopies =
-				// this kind of query is currently not documented to work, but it does, and I guess I don't see why it's terrible
-				scope.fromSession(s -> s.createSelectionQuery("select new EntityCopy(id, names) from Entity", EntityCopy.class).getResultList());
-		assertEquals(2, newCopies.size());
+		List<EntityNamesCopy> newCopies =
+				scope.fromSession(s -> s.createSelectionQuery("select new EntityNamesCopy(id, names) from Entity", EntityNamesCopy.class).getResultList());
+		assertEquals(1, newCopies.size());
 		newCopies.forEach(Assertions::assertNotNull);
 		newCopies.forEach(copy -> assertNotNull(copy.id));
-		newCopies.forEach(copy -> assertNotNull(copy.name));
+		newCopies.forEach(copy -> assertThat( assertDetachedSet( copy.names ) ).containsExactlyInAnyOrder("hello", "world"));
 
 		List<EntityCopy> newCopies2 =
 				scope.fromSession(s -> s.createSelectionQuery("select new EntityCopy(id, element(names)) from Entity", EntityCopy.class).getResultList());
-		assertEquals(2, newCopies.size());
+		assertEquals(2, newCopies2.size());
 		newCopies2.forEach(Assertions::assertNotNull);
 		newCopies2.forEach(copy -> assertNotNull(copy.id));
 		newCopies2.forEach(copy -> assertNotNull(copy.name));
@@ -89,11 +91,12 @@ public class InstantiationWithCollectionTest {
 		scope.inTransaction(s -> s.persist(entity));
 
 		List<Object[]> tuples =
-				// this kind of query is currently not documented to work, but it does, and I guess I don't see why it's terrible
 				scope.fromSession(s -> s.createSelectionQuery("select id, children from Entity", Object[].class).getResultList());
-		assertEquals(2, tuples.size());
-		tuples.forEach(tuple -> assertNotNull(tuple[0]));
-		tuples.forEach(tuple -> assertNotNull(tuple[1]));
+		assertEquals(1, tuples.size());
+		assertNotNull(tuples.get(0)[0]);
+		assertThat( InstantiationWithCollectionTest.<ChildEntity>assertDetachedSet( tuples.get(0)[1] ) )
+				.extracting( ChildEntity::getName )
+				.containsExactlyInAnyOrder("goodbye", "gavin");
 
 		List<Object[]> tuples2 =
 				scope.fromSession(s -> s.createSelectionQuery("select id, element(children) from Entity", Object[].class).getResultList());
@@ -114,12 +117,37 @@ public class InstantiationWithCollectionTest {
 		copies.forEach(copy -> assertNotNull(copy.id));
 		copies.forEach(copy -> assertNotNull(copy.name));
 
+		List<EntityChildrenCopy> collectionCopies =
+				scope.fromSession(s -> s.createSelectionQuery("select id, children from Entity", EntityChildrenCopy.class).getResultList());
+		assertEquals(1, collectionCopies.size());
+		collectionCopies.forEach(Assertions::assertNotNull);
+		collectionCopies.forEach(copy -> assertNotNull(copy.id));
+		collectionCopies.forEach(copy -> assertThat( InstantiationWithCollectionTest.<ChildEntity>assertDetachedSet( copy.children ) )
+				.extracting( ChildEntity::getName )
+				.containsExactlyInAnyOrder("goodbye", "gavin"));
+
 		List<EntityCopy> newCopies =
 				scope.fromSession(s -> s.createSelectionQuery("select new EntityCopy(id, element(children).name) from Entity", EntityCopy.class).getResultList());
 		assertEquals(2, newCopies.size());
 		newCopies.forEach(Assertions::assertNotNull);
 		newCopies.forEach(copy -> assertNotNull(copy.id));
 		newCopies.forEach(copy -> assertNotNull(copy.name));
+
+		List<EntityChildrenCopy> newCollectionCopies =
+				scope.fromSession(s -> s.createSelectionQuery("select new EntityChildrenCopy(id, children) from Entity", EntityChildrenCopy.class).getResultList());
+		assertEquals(1, newCollectionCopies.size());
+		newCollectionCopies.forEach(Assertions::assertNotNull);
+		newCollectionCopies.forEach(copy -> assertNotNull(copy.id));
+		newCollectionCopies.forEach(copy -> assertThat( InstantiationWithCollectionTest.<ChildEntity>assertDetachedSet( copy.children ) )
+				.extracting( ChildEntity::getName )
+				.containsExactlyInAnyOrder("goodbye", "gavin"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> Set<T> assertDetachedSet(Object collection) {
+		assertThat( collection ).isInstanceOf( Set.class );
+		assertThat( collection ).isNotInstanceOf( PersistentCollection.class );
+		return (Set<T>) collection;
 	}
 
 	static class EntityCopy {
@@ -129,6 +157,26 @@ public class InstantiationWithCollectionTest {
 		public EntityCopy(Long id, String name) {
 			this.id = id;
 			this.name = name;
+		}
+	}
+
+	static class EntityNamesCopy {
+		Long id;
+		Set<String> names;
+
+		public EntityNamesCopy(Long id, Set<String> names) {
+			this.id = id;
+			this.names = names;
+		}
+	}
+
+	static class EntityChildrenCopy {
+		Long id;
+		Set<ChildEntity> children;
+
+		public EntityChildrenCopy(Long id, Set<ChildEntity> children) {
+			this.id = id;
+			this.children = children;
 		}
 	}
 
@@ -164,6 +212,10 @@ public class InstantiationWithCollectionTest {
 		}
 
 		ChildEntity() {
+		}
+
+		public String getName() {
+			return name;
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/InstantiationWithCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/InstantiationWithCollectionTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @SessionFactory
 @DomainModel(annotatedClasses = {InstantiationWithCollectionTest.Entity.class,
 		InstantiationWithCollectionTest.ChildEntity.class})
+@JiraKey("HHH-17558")
 public class InstantiationWithCollectionTest {
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/readonly/ReadOnlySessionLazyNonLazyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/readonly/ReadOnlySessionLazyNonLazyTest.java
@@ -850,7 +850,9 @@ public class ReadOnlySessionLazyNonLazyTest extends AbstractReadOnlyTest {
 		s = openSession(scope);
 		t = s.beginTransaction();
 		assertFalse( s.isDefaultReadOnly() );
-		var dp = s.createQuery(DataPoint.class, "select c.lazyDataPoints from Container c join c.lazyDataPoints where c.id=" + cOrig.getId() )
+		var dp = s.createQuery(DataPoint.class,
+						"select element(c.lazyDataPoints) from Container c join c.lazyDataPoints where c.id="
+						+ cOrig.getId() )
 				.setReadOnly( true ).uniqueResult();
 		assertTrue( s.isReadOnly( dp ) );
 		t.commit();

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -188,7 +188,33 @@ bootstrapping and supply the root and/or non-root URLs.
 
 This section describes changes in behavior that applications should be aware of.
 
+[[detached-collection-queries]]
+=== Queries Returning Detached Collections
+
+A HQL query like:
+
+[source,sql]
+select items from Order /* each query result is a collection */
+
+[source,sql]
+select elements(items) from Order /* each query result is a collection */
+
+[source,sql]
+select indices(items) from Order /* each query result is a collection */
+
+now returns a detached collection without flattening.
+
+In previous versions of Hibernate, such queries were accepted, and due to an undocumented and unsupported behavior, resulted in an implicit join and flattening of the collection.
+To recover this previous undocumented behavior, the singular form of the functions may be used:
+
+[source,sql]
+select element(items) from Order /* flatten the items collection */
+
+[source,sql]
+select indice(items) from Order /* flatten the items collection */
+
 [[procedure-results]]
+=== Procedure Results
 
 The behavior of Hibernate's handling for creating a `ProcedureCall` / `StoredProcedureQuery` with multiple result set mappings has been changed to fix a https://hibernate.atlassian.net/browse/HHH-9912[long-standing bug] and comply with the Jakarta Persistence specification.
 Hibernate now interprets the multiple mappings as one per result available from the procedure.  E.g.

--- a/tooling/hibernate-assistant/src/test/java/org/hibernate/tool/language/ResultsJsonSerializerTest.java
+++ b/tooling/hibernate-assistant/src/test/java/org/hibernate/tool/language/ResultsJsonSerializerTest.java
@@ -274,7 +274,7 @@ public class ResultsJsonSerializerTest {
 	public void testSelectCollection(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			final SelectionQuery<Employee> q = query(
-					"select c.employees from Company c where c.id = 1",
+					"select element(c.employees) from Company c where c.id = 1",
 					Employee.class,
 					session
 			);


### PR DESCRIPTION
This works restores the semantics that HQL was always really intended to have,

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-17558 (Proposal):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17558
<!-- Hibernate GitHub Bot issue links end -->