### PR TITLE
HHH-20423 Relax the strict JPQL compliance and make `select` optional

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -1224,13 +1224,6 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 	}
 
 	protected SqmSelectClause buildInferredSelectClause(SqmFromClause fromClause) {
-		if ( creationOptions.useStrictJpaCompliance() ) {
-			throw new StrictJpaComplianceViolation(
-					"Encountered implicit 'select' clause, but strict JPQL compliance was requested",
-					StrictJpaComplianceViolation.Type.IMPLICIT_SELECT
-			);
-		}
-
 		if ( fromClause.getNumberOfRoots() == 0 ) {
 			throw new SemanticException( "query has no 'select' clause, and no root entities"
 					+ " (every selection query must have an explicit 'select', an explicit 'from', or an explicit entity result type)",

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/OptionalSelectClauseWithJPAQLStrictComplinceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/OptionalSelectClauseWithJPAQLStrictComplinceTest.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.compliance;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Jpa(
+		annotatedClasses = {
+				OptionalSelectClauseWithJPAQLStrictComplinceTest.QueryBook.class
+		},
+		properties = @Setting(name = AvailableSettings.JPAQL_STRICT_COMPLIANCE, value = "true")
+)
+@JiraKey("HHH-20423")
+public class OptionalSelectClauseWithJPAQLStrictComplinceTest {
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					QueryBook book1 = new QueryBook( 1, "Book 1" );
+					QueryBook book2 = new QueryBook( 2, "Book 2" );
+					QueryBook book3 = new QueryBook( 3, "Book 3" );
+					entityManager.persist( book1 );
+					entityManager.persist( book2 );
+					entityManager.persist( book3 );
+				}
+		);
+	}
+
+	@Test
+	public void optionalSelectClausesTest(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					List<QueryBook> books = entityManager
+							.createQuery( "FROM QueryBook WHERE title = :title", QueryBook.class )
+							.setParameter( "title", "Book 1" )
+							.getResultList();
+					assertThat( books.size() ).isEqualTo( 1 );
+					assertThat( books.get( 0 ).getId() ).isEqualTo( 1 );
+				}
+		);
+
+	}
+
+	@Entity(name = "QueryBook")
+	public static class QueryBook {
+
+		@Id
+		private Integer id;
+
+		private String title;
+
+
+		public QueryBook() {
+		}
+
+		public QueryBook(Integer id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20423

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20423 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->