### PR TITLE
[7.1] HHH-20394 Cascade profile causes LAZY associations to be eagerly fetched even if they won't be affected

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -826,6 +826,7 @@ public class LoaderSelectBuilder {
 
 			final boolean isFetchablePluralAttributeMapping = isABag || isPluralAttributeMapping( fetchable );
 			final Integer maximumFetchDepth = creationContext.getMaximumFetchDepth();
+			boolean cascadeReachable = false;
 
 			if ( !( fetchable instanceof CollectionPart ) ) {
 				// 'entity graph' takes precedence over 'fetch profile'
@@ -866,6 +867,7 @@ public class LoaderSelectBuilder {
 						fetchTiming = FetchTiming.IMMEDIATE;
 						// In 5.x the CascadeEntityJoinWalker only join fetched the first collection fetch
 						joined = !isFetchablePluralAttributeMapping || rowCardinality == RowCardinality.SINGLE;
+						cascadeReachable = true;
 					}
 				}
 			}
@@ -878,9 +880,16 @@ public class LoaderSelectBuilder {
 				};
 			}
 
+			// Disable the cascade profile for non-cascaded fetchables so sub-fetches aren't eagerly loaded
+			final var originalCascadingFetchProfile = !cascadeReachable
+					? loadQueryInfluencers.getEnabledCascadingFetchProfile()
+					: null;
 			try {
 				if ( fetchable.incrementFetchDepth() ) {
 					fetchDepth++;
+				}
+				if ( originalCascadingFetchProfile != null ) {
+					loadQueryInfluencers.setEnabledCascadingFetchProfile( null );
 				}
 
 				// There is no need to check for circular fetches if this is an explicit fetch
@@ -932,6 +941,9 @@ public class LoaderSelectBuilder {
 				}
 				if ( entityGraphTraversalState != null && traversalResult != null ) {
 					entityGraphTraversalState.backtrack( traversalResult );
+				}
+				if ( originalCascadingFetchProfile != null ) {
+					loadQueryInfluencers.setEnabledCascadingFetchProfile( originalCascadingFetchProfile );
 				}
 			}
 		};

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/merge/MergeCascadingFetchProfileTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/merge/MergeCascadingFetchProfileTest.java
@@ -1,0 +1,208 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.merge;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.hibernate.Hibernate;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code CascadingFetchProfile.MERGE} only eagerly loads
+ * associations reachable through a cascade-eligible path.
+ * <p>
+ * The model has a {@code Root} entity with two {@link ManyToOne} associations
+ * to {@code Parent}: one with {@code cascade=ALL} and one without.
+ * Each {@code Parent} owns a lazy {@code cascade=MERGE} collection of {@code Child}.
+ * When merging {@code Root}, only the cascade-reachable parent's children
+ * should be eagerly initialized.
+ *
+ * @author Marco Belladelli
+ */
+@DomainModel(annotatedClasses = {
+		MergeCascadingFetchProfileTest.Root.class,
+		MergeCascadingFetchProfileTest.Parent.class,
+		MergeCascadingFetchProfileTest.Child.class,
+})
+@SessionFactory(useCollectingStatementInspector = true)
+@Jira("https://hibernate.atlassian.net/browse/HHH-20394")
+public class MergeCascadingFetchProfileTest {
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			var cascadeParent = new Parent( 1L, "cascadeParent" );
+			var noCascadeParent = new Parent( 2L, "noCascadeParent" );
+			session.persist( cascadeParent );
+			session.persist( noCascadeParent );
+			for ( int i = 0; i < 5; i++ ) {
+				session.persist( new Child( (long) (i + 1), cascadeParent, "c_" + i ) );
+				session.persist( new Child( (long) (i + 6), noCascadeParent, "nc_" + i ) );
+			}
+			session.persist( new Root( 1L, cascadeParent, noCascadeParent ) );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	public void testMergeCascadeLoads(SessionFactoryScope scope) {
+		final var inspector = scope.getCollectingStatementInspector();
+		inspector.clear();
+
+		final var detached = new Root( 1L, new Parent( 1L, "cascadeParent" ), new Parent( 2L, "noCascadeParent" ) );
+
+		scope.inTransaction( session -> {
+			final var merged = session.merge( detached );
+
+			// cascadeParent.children should be initialized because the entire
+			// path Root -> cascadeParent (cascade=ALL) -> children (cascade=ALL) is cascade-reachable
+			assertThat( Hibernate.isInitialized( merged.getCascadeParent().getChildren() ) )
+					.as( "cascadeParent.children should be initialized "
+						+ "because the entire path has cascade=ALL" )
+					.isTrue();
+
+			// noCascadeParent is loaded (eager ManyToOne), but its children
+			// should NOT be initialized: no cascade path from Root
+			assertThat( Hibernate.isInitialized( merged.getNoCascadeParent().getChildren() ) )
+					.as( "noCascadeParent.children should not be initialized "
+						+ "because Root.noCascadeParent has no cascade" )
+					.isFalse();
+
+			// Root + cascadeParent + 5 cascade children + noCascadeParent = 8
+			final var entityCount = session
+					.getPersistenceContextInternal()
+					.getNumberOfManagedEntities();
+			assertThat( entityCount )
+					.as( "Only Root, both Parents, and the cascade-reachable children should be managed" )
+					.isEqualTo( 8 );
+		} );
+
+		// 1 SELECT for the initial merge load, no additional lazy-loading or update queries
+		inspector.assertExecutedCount( 1 );
+		inspector.assertIsSelect( 0 );
+	}
+
+	@Test
+	public void testMergeCascadeChanges(SessionFactoryScope scope) {
+		final var inspector = scope.getCollectingStatementInspector();
+		inspector.clear();
+
+		// Build a detached Root with a modified child on the cascade-reachable parent,
+		// and a sneaky new child on the non-cascade parent
+		final var detachedCascade = new Parent( 1L, "cascadeParent" );
+		detachedCascade.getChildren().add( new Child( 1L, detachedCascade, "modified_label" ) );
+		final var detachedNoCascade = new Parent( 2L, "noCascadeParent" );
+		detachedNoCascade.getChildren().add( new Child( 99L, detachedNoCascade, "sneaky" ) );
+		final var detached = new Root( 1L, detachedCascade, detachedNoCascade );
+
+		scope.inTransaction( session -> session.merge( detached ) );
+
+		// 1 SELECT for the initial load + 1 UPDATE for the modified child, no additional lazy-loading queries
+		inspector.assertExecutedCount( 2 );
+		inspector.assertIsSelect( 0 );
+		inspector.assertIsUpdate( 1 );
+
+		scope.inSession( session -> {
+			// Verify the modified label was actually persisted through the cascade path
+			assertThat( session.find( Child.class, 1L ).getLabel() ).isEqualTo( "modified_label" );
+			// Verify the sneaky child was NOT persisted through the non-cascade path
+			assertThat( session.find( Child.class, 99L ) ).isNull();
+		} );
+	}
+
+	@Entity(name = "MergeRoot")
+	public static class Root {
+		@Id
+		private Long id;
+
+		@ManyToOne(cascade = CascadeType.ALL)
+		private Parent cascadeParent;
+
+		@ManyToOne
+		private Parent noCascadeParent;
+
+		public Root() {
+		}
+
+		public Root(Long id, Parent cascadeParent, Parent noCascadeParent) {
+			this.id = id;
+			this.cascadeParent = cascadeParent;
+			this.noCascadeParent = noCascadeParent;
+		}
+
+		public Parent getCascadeParent() {
+			return cascadeParent;
+		}
+
+		public Parent getNoCascadeParent() {
+			return noCascadeParent;
+		}
+	}
+
+	@Entity(name = "MergeParent")
+	public static class Parent {
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany(mappedBy = "parent", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
+		private List<Child> children = new ArrayList<>();
+
+		public Parent() {
+		}
+
+		public Parent(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public List<Child> getChildren() {
+			return children;
+		}
+	}
+
+	@Entity(name = "MergeChild")
+	public static class Child {
+		@Id
+		private Long id;
+
+		@ManyToOne
+		private Parent parent;
+
+		private String label;
+
+		public Child() {
+		}
+
+		public Child(Long id, Parent parent, String label) {
+			this.id = id;
+			this.parent = parent;
+			this.label = label;
+		}
+
+		public String getLabel() {
+			return label;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/12385

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20394 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20394
<!-- Hibernate GitHub Bot issue links end -->