### PR TITLE
HHH-20384 Exclude interfaces and abstract classes from converter categorization

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -127,8 +127,9 @@ public class DomainModelCategorizationCollector {
 	}
 
 	private static boolean isConverter(ClassDetails classDetails) {
-		return classDetails.getClassName() != null && classDetails.isImplementor( AttributeConverter.class )
-			|| classDetails.getDirectAnnotationUsage( Converter.class ) != null;
+		return classDetails.getClassName() != null && !classDetails.isInterface() && !classDetails.isAbstract()
+			&& ( classDetails.isImplementor( AttributeConverter.class )
+				|| classDetails.getDirectAnnotationUsage( Converter.class ) != null );
 	}
 
 	public static boolean isRootEntity(ClassDetails classInfo) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/ConverterCategorizationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/ConverterCategorizationTest.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.categorization;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.hibernate.boot.models.internal.DomainModelCategorizationCollector;
+import org.hibernate.boot.models.internal.GlobalRegistrationsImpl;
+import org.hibernate.boot.models.spi.ConverterRegistration;
+import org.hibernate.models.spi.ModelsContext;
+import org.hibernate.testing.boot.BootstrapContextImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.boot.models.SourceModelTestHelper.createBuildingContext;
+
+/**
+ * Tests that {@link DomainModelCategorizationCollector} correctly identifies
+ * converter classes and does not treat the {@link AttributeConverter} interface
+ * itself as a converter.
+ */
+public class ConverterCategorizationTest {
+
+	@Test
+	void attributeConverterInterfaceIsNotCategorizedAsConverter() {
+		// Build a context that includes both the converter implementation
+		// and the AttributeConverter interface itself
+		final ModelsContext modelsContext = createBuildingContext(
+				TestConverter.class,
+				AttributeConverter.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			// Apply all known classes, including AttributeConverter itself
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			final Set<ConverterRegistration> converters = globalRegistrations.getJpaConverters();
+
+			// Only the concrete converter should be registered, not the interface
+			assertThat( converters )
+					.extracting( reg -> reg.converterClass().getClassName() )
+					.containsExactly( TestConverter.class.getName() );
+		}
+	}
+
+	@Test
+	void abstractConverterIsNotCategorizedAsConverter() {
+		final ModelsContext modelsContext = createBuildingContext(
+				TestConverter.class,
+				AbstractBaseConverter.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			final Set<ConverterRegistration> converters = globalRegistrations.getJpaConverters();
+
+			assertThat( converters )
+					.extracting( reg -> reg.converterClass().getClassName() )
+					.containsExactly( TestConverter.class.getName() );
+		}
+	}
+
+	public static abstract class AbstractBaseConverter implements AttributeConverter<String, String> {
+	}
+
+	@Converter(autoApply = true)
+	public static class TestConverter extends AbstractBaseConverter {
+		@Override
+		public String convertToDatabaseColumn(String attribute) {
+			return attribute;
+		}
+
+		@Override
+		public String convertToEntityAttribute(String dbData) {
+			return dbData;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `DomainModelCategorizationCollector.isConverter()` was treating the `AttributeConverter` interface itself (and abstract base classes) as converter implementations, because `isImplementor()` is reflexive
- Added `!isInterface()` and `!isAbstract()` checks, and fixed operator precedence in the condition
- Added `ConverterCategorizationTest` covering both interface and abstract class exclusion

Needed for quarkusio/quarkus#48005
Part of https://hibernate.atlassian.net/browse/HHH-20384
This targets 7.3 and will need a forward port to main.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20384 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->