### PR TITLE
HHH-20384 Extract HBM component classes as embeddables in XmlPreprocessor

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/XmlPreprocessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/XmlPreprocessor.java
@@ -4,18 +4,25 @@
  */
 package org.hibernate.boot.jaxb.hbm.transform;
 
+import java.io.Serializable;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.hibernate.boot.jaxb.hbm.spi.EntityInfo;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDiscriminatorSubclassEntityType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmJoinedSubclassEntityType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmRootEntityType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnionSubclassEntityType;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
 import org.hibernate.boot.jaxb.spi.Binding;
+
+import static org.hibernate.internal.util.StringHelper.isNotEmpty;
 
 import static org.hibernate.internal.util.collections.CollectionHelper.arrayList;
 
@@ -51,39 +58,42 @@ public class XmlPreprocessor {
 		) );
 		mappingBindings.add( new Binding<>( mappingRoot, origin ) );
 
+		final Set<String> seenEmbeddableClasses = new HashSet<>();
+
 		hbmRoot.getTypedef().forEach( hbmTypeDef ->
 				transformationState.getTypeDefMap().put( hbmTypeDef.getName(), hbmTypeDef ) );
 
 		hbmRoot.getClazz().forEach( hbmRootEntity ->
-				preProcessRooEntity( hbmRootEntity, hbmRoot, mappingRoot, transformationState ) );
+				preProcessRooEntity( hbmRootEntity, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 
 		hbmRoot.getSubclass().forEach( hbmSubclass ->
-				preProcessSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState ) );
+				preProcessSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 
 		hbmRoot.getJoinedSubclass().forEach( hbmSubclass ->
-				preProcessJoinedSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState ) );
+				preProcessJoinedSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 
 		hbmRoot.getUnionSubclass().forEach( hbmSubclass ->
-				preProcessUnionSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState ) );
+				preProcessUnionSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 	}
 
 	private static void preProcessRooEntity(
 			JaxbHbmRootEntityType hbmRootEntity,
 			JaxbHbmHibernateMapping hbmRoot,
 			JaxbEntityMappingsImpl mappingRoot,
-			TransformationState transformationState) {
+			TransformationState transformationState,
+			Set<String> seenEmbeddableClasses) {
 		final var mappingEntity = new JaxbEntityImpl();
 		mappingRoot.getEntities().add( mappingEntity );
-		commonEntityPreprocessing( hbmRootEntity, hbmRoot, mappingRoot, transformationState, mappingEntity );
+		commonEntityPreprocessing( hbmRootEntity, hbmRoot, mappingRoot, transformationState, mappingEntity, seenEmbeddableClasses );
 
 		hbmRootEntity.getSubclass().forEach( hbmSubclass ->
-				preProcessSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState ) );
+				preProcessSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 
 		hbmRootEntity.getJoinedSubclass().forEach( hbmSubclass ->
-				preProcessJoinedSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState ) );
+				preProcessJoinedSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 
 		hbmRootEntity.getUnionSubclass().forEach( hbmSubclass ->
-				preProcessUnionSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState ) );
+				preProcessUnionSubclass( hbmSubclass, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 	}
 
 	private static void commonEntityPreprocessing(
@@ -91,7 +101,8 @@ public class XmlPreprocessor {
 			JaxbHbmHibernateMapping hbmRoot,
 			JaxbEntityMappingsImpl mappingRoot,
 			TransformationState transformationState,
-			JaxbEntityImpl mappingEntity) {
+			JaxbEntityImpl mappingEntity,
+			Set<String> seenEmbeddableClasses) {
 		// apply some basic info to the mapping.xsd entity
 		TransformationHelper.transfer( hbmEntity::getEntityName, mappingEntity::setName );
 		TransformationHelper.transfer( hbmEntity::getName, mappingEntity::setClazz );
@@ -102,42 +113,61 @@ public class XmlPreprocessor {
 		transformationState.getHbmEntityByName().put( entityName, hbmEntity );
 		transformationState.getMappingEntityByName().put( entityName, mappingEntity );
 
-		// todo (7.0) : walk attributes looking for components
+		//noinspection unchecked
+		collectComponentTypes( hbmEntity.getAttributes(), mappingRoot, seenEmbeddableClasses );
+	}
+
+	private static void collectComponentTypes(List<Serializable> attributes, JaxbEntityMappingsImpl mappingRoot,
+			Set<String> seenEmbeddableClasses) {
+		for ( Object attribute : attributes ) {
+			if ( attribute instanceof JaxbHbmCompositeAttributeType compositeAttribute ) {
+				final String className = compositeAttribute.getClazz();
+				if ( isNotEmpty( className ) && seenEmbeddableClasses.add( className ) ) {
+					final var embeddable = new JaxbEmbeddableImpl();
+					embeddable.setClazz( className );
+					mappingRoot.getEmbeddables().add( embeddable );
+				}
+				collectComponentTypes( compositeAttribute.getAttributes(), mappingRoot, seenEmbeddableClasses );
+			}
+		}
 	}
 
 	private static void preProcessSubclass(
 			JaxbHbmDiscriminatorSubclassEntityType hbmSubclass,
 			JaxbHbmHibernateMapping hbmRoot,
 			JaxbEntityMappingsImpl mappingRoot,
-			TransformationState transformationState) {
+			TransformationState transformationState,
+			Set<String> seenEmbeddableClasses) {
 		final var mappingEntity = new JaxbEntityImpl();
 		mappingRoot.getEntities().add( mappingEntity );
-		commonEntityPreprocessing( hbmSubclass, hbmRoot, mappingRoot, transformationState, mappingEntity );
+		commonEntityPreprocessing( hbmSubclass, hbmRoot, mappingRoot, transformationState, mappingEntity, seenEmbeddableClasses );
 		hbmSubclass.getSubclass().forEach( hbmSubclassSubclass ->
-				preProcessSubclass( hbmSubclassSubclass, hbmRoot, mappingRoot, transformationState ) );
+				preProcessSubclass( hbmSubclassSubclass, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 	}
 
 	private static void preProcessJoinedSubclass(
 			JaxbHbmJoinedSubclassEntityType hbmSubclass,
 			JaxbHbmHibernateMapping hbmRoot,
 			JaxbEntityMappingsImpl mappingRoot,
-			TransformationState transformationState) {
+			TransformationState transformationState,
+			Set<String> seenEmbeddableClasses) {
 		final var mappingEntity = new JaxbEntityImpl();
 		mappingRoot.getEntities().add( mappingEntity );
-		commonEntityPreprocessing( hbmSubclass, hbmRoot, mappingRoot, transformationState, mappingEntity );
+		commonEntityPreprocessing( hbmSubclass, hbmRoot, mappingRoot, transformationState, mappingEntity, seenEmbeddableClasses );
 		hbmSubclass.getJoinedSubclass().forEach( hbmSubclassSubclass ->
-				preProcessJoinedSubclass( hbmSubclassSubclass, hbmRoot, mappingRoot, transformationState ) );
+				preProcessJoinedSubclass( hbmSubclassSubclass, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 	}
 
 	private static void preProcessUnionSubclass(
 			JaxbHbmUnionSubclassEntityType hbmSubclass,
 			JaxbHbmHibernateMapping hbmRoot,
 			JaxbEntityMappingsImpl mappingRoot,
-			TransformationState transformationState) {
+			TransformationState transformationState,
+			Set<String> seenEmbeddableClasses) {
 		final var mappingEntity = new JaxbEntityImpl();
 		mappingRoot.getEntities().add( mappingEntity );
-		commonEntityPreprocessing( hbmSubclass, hbmRoot, mappingRoot, transformationState, mappingEntity );
+		commonEntityPreprocessing( hbmSubclass, hbmRoot, mappingRoot, transformationState, mappingEntity, seenEmbeddableClasses );
 		hbmSubclass.getUnionSubclass().forEach( hbmSubclassSubclass ->
-				preProcessUnionSubclass( hbmSubclassSubclass, hbmRoot, mappingRoot, transformationState ) );
+				preProcessUnionSubclass( hbmSubclassSubclass, hbmRoot, mappingRoot, transformationState, seenEmbeddableClasses ) );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/hbm/transform/XmlPreprocessorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/hbm/transform/XmlPreprocessorTest.java
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.hbm.transform;
+
+import java.util.List;
+
+import org.hibernate.boot.jaxb.Origin;
+import org.hibernate.boot.jaxb.SourceType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDiscriminatorSubclassEntityType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmRootEntityType;
+import org.hibernate.boot.jaxb.hbm.transform.TransformationState;
+import org.hibernate.boot.jaxb.hbm.transform.XmlPreprocessor;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
+import org.hibernate.boot.jaxb.spi.Binding;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XmlPreprocessorTest {
+
+	@Test
+	void componentIsPreprocessedAsEmbeddable() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType entity = new JaxbHbmRootEntityType();
+		entity.setName( "MyEntity" );
+
+		JaxbHbmCompositeAttributeType component = new JaxbHbmCompositeAttributeType();
+		component.setName( "address" );
+		component.setClazz( "com.example.Address" );
+		entity.getAttributes().add( component );
+
+		hbmMapping.getClazz().add( entity );
+
+		List<Binding<JaxbEntityMappingsImpl>> result = XmlPreprocessor.preprocessHbmXml(
+				List.of( new Binding<>( hbmMapping, new Origin( SourceType.OTHER, "test" ) ) ),
+				new TransformationState()
+		);
+
+		JaxbEntityMappingsImpl mappingRoot = result.get( 0 ).getRoot();
+		assertThat( mappingRoot.getEntities() ).hasSize( 1 );
+		assertThat( mappingRoot.getEmbeddables() ).hasSize( 1 );
+		assertThat( mappingRoot.getEmbeddables().get( 0 ).getClazz() ).isEqualTo( "com.example.Address" );
+	}
+
+	@Test
+	void nestedComponentIsPreprocessedAsEmbeddable() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType entity = new JaxbHbmRootEntityType();
+		entity.setName( "MyEntity" );
+
+		JaxbHbmCompositeAttributeType innerComponent = new JaxbHbmCompositeAttributeType();
+		innerComponent.setName( "city" );
+		innerComponent.setClazz( "com.example.City" );
+
+		JaxbHbmCompositeAttributeType outerComponent = new JaxbHbmCompositeAttributeType();
+		outerComponent.setName( "address" );
+		outerComponent.setClazz( "com.example.Address" );
+		outerComponent.getAttributes().add( innerComponent );
+
+		entity.getAttributes().add( outerComponent );
+		hbmMapping.getClazz().add( entity );
+
+		List<Binding<JaxbEntityMappingsImpl>> result = XmlPreprocessor.preprocessHbmXml(
+				List.of( new Binding<>( hbmMapping, new Origin( SourceType.OTHER, "test" ) ) ),
+				new TransformationState()
+		);
+
+		JaxbEntityMappingsImpl mappingRoot = result.get( 0 ).getRoot();
+		assertThat( mappingRoot.getEmbeddables() )
+				.hasSize( 2 )
+				.extracting( e -> e.getClazz() )
+				.containsExactlyInAnyOrder( "com.example.Address", "com.example.City" );
+	}
+
+	@Test
+	void subclassComponentIsPreprocessedAsEmbeddable() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType rootEntity = new JaxbHbmRootEntityType();
+		rootEntity.setName( "ParentEntity" );
+
+		JaxbHbmDiscriminatorSubclassEntityType subclass = new JaxbHbmDiscriminatorSubclassEntityType();
+		subclass.setName( "ChildEntity" );
+
+		JaxbHbmCompositeAttributeType component = new JaxbHbmCompositeAttributeType();
+		component.setName( "address" );
+		component.setClazz( "com.example.Address" );
+		subclass.getAttributes().add( component );
+
+		rootEntity.getSubclass().add( subclass );
+		hbmMapping.getClazz().add( rootEntity );
+
+		List<Binding<JaxbEntityMappingsImpl>> result = XmlPreprocessor.preprocessHbmXml(
+				List.of( new Binding<>( hbmMapping, new Origin( SourceType.OTHER, "test" ) ) ),
+				new TransformationState()
+		);
+
+		JaxbEntityMappingsImpl mappingRoot = result.get( 0 ).getRoot();
+		assertThat( mappingRoot.getEmbeddables() )
+				.hasSize( 1 )
+				.extracting( e -> e.getClazz() )
+				.containsExactly( "com.example.Address" );
+	}
+
+	@Test
+	void sameComponentInRootAndSubclassIsNotDuplicated() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType rootEntity = new JaxbHbmRootEntityType();
+		rootEntity.setName( "ParentEntity" );
+
+		JaxbHbmCompositeAttributeType rootComponent = new JaxbHbmCompositeAttributeType();
+		rootComponent.setName( "address" );
+		rootComponent.setClazz( "com.example.Address" );
+		rootEntity.getAttributes().add( rootComponent );
+
+		JaxbHbmDiscriminatorSubclassEntityType subclass = new JaxbHbmDiscriminatorSubclassEntityType();
+		subclass.setName( "ChildEntity" );
+
+		JaxbHbmCompositeAttributeType subclassComponent = new JaxbHbmCompositeAttributeType();
+		subclassComponent.setName( "shippingAddress" );
+		subclassComponent.setClazz( "com.example.Address" );
+		subclass.getAttributes().add( subclassComponent );
+
+		rootEntity.getSubclass().add( subclass );
+		hbmMapping.getClazz().add( rootEntity );
+
+		List<Binding<JaxbEntityMappingsImpl>> result = XmlPreprocessor.preprocessHbmXml(
+				List.of( new Binding<>( hbmMapping, new Origin( SourceType.OTHER, "test" ) ) ),
+				new TransformationState()
+		);
+
+		JaxbEntityMappingsImpl mappingRoot = result.get( 0 ).getRoot();
+		assertThat( mappingRoot.getEmbeddables() )
+				.extracting( e -> e.getClazz() )
+				.containsExactly( "com.example.Address" );
+	}
+
+	@Test
+	void entityWithoutComponentHasNoEmbeddables() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType entity = new JaxbHbmRootEntityType();
+		entity.setName( "SimpleEntity" );
+		hbmMapping.getClazz().add( entity );
+
+		List<Binding<JaxbEntityMappingsImpl>> result = XmlPreprocessor.preprocessHbmXml(
+				List.of( new Binding<>( hbmMapping, new Origin( SourceType.OTHER, "test" ) ) ),
+				new TransformationState()
+		);
+
+		JaxbEntityMappingsImpl mappingRoot = result.get( 0 ).getRoot();
+		assertThat( mappingRoot.getEntities() ).hasSize( 1 );
+		assertThat( mappingRoot.getEmbeddables() ).isEmpty();
+	}
+}


### PR DESCRIPTION
## Summary
- `XmlPreprocessor` had a TODO to walk entity attributes looking for components
- Implemented: when preprocessing HBM XML, collect `JaxbHbmCompositeAttributeType` (component) elements and add them as embeddables to the converted `JaxbEntityMappingsImpl`
- Handles nested components recursively
- Added `XmlPreprocessorTest` with 3 test cases: basic component, nested components, and entity without components

Needed for quarkusio/quarkus#48005
Part of https://hibernate.atlassian.net/browse/HHH-20384
This targets 7.3 and will need a forward port to main.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20384 (Improvement):
- [x] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->