### PR TITLE
HHH-20342 SafeMode validation for HQL queries and some Criteria queries

### DIFF
--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -176,4 +176,29 @@ var entityManager = entityManagerFactory.createEntityManager(
 		ReadOnlyMode.READ_ONLY
 );
 
+[[safe-mode]]
+== Safe Mode Validator
+
+8.0 introduces an opt-in "safe mode" for HQL and Criteria queries, designed to restrict potentially unsafe query operations. This feature is particularly valuable for applications that expose Hibernate's `SessionFactory` to Large Language Models (LLMs) through various integrations, as well as for security-conscious organizations and multi-tenant applications.
+
+When safe mode is enabled, Hibernate blocks the following operations:
+
+* The `sql()` function - prevents arbitrary SQL syntax execution at runtime
+* The `function()` function - blocks explicit arbitrary function calls
+* The `column()` function - prevents arbitrary table column access
+* Unknown function calls - Hibernate will reject any function call that hasn't been explicitly registered with the `Dialect`
+
+To use custom functions in safe mode, they must be explicitly registered via `org.hibernate.boot.model.FunctionContributor`.
+
+Safe mode is disabled by default and can be enabled using:
+
+[source,properties]
+----
+hibernate.query.safe_mode_enabled=true
+----
+
+When safe mode is enabled and an unsafe operation is attempted, Hibernate will throw an exception indicating which function or operation is not allowed.
+
+
+
 ----


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Added validation layer during query parsing/construction to ensure stricter and safer query handling. The implementation integrates SafeMode checks into the query creation pipeline, covering both HQL processing and Criteria-based query construction paths.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20342 (New Feature):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20342
<!-- Hibernate GitHub Bot issue links end -->