### PR TITLE
HHH-20384 Collect @IdClass, entity listener, and package-info classes in DomainModelCategorizationCollector

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -6,6 +6,14 @@ package org.hibernate.boot.models.internal;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.PostRemove;
+import jakarta.persistence.PostUpdate;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreRemove;
+import jakarta.persistence.PreUpdate;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
 import org.hibernate.boot.models.spi.GlobalRegistrations;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
@@ -33,6 +41,9 @@ public class DomainModelCategorizationCollector {
 	private final Set<ClassDetails> rootEntities = new HashSet<>();
 	private final Map<String,ClassDetails> mappedSuperclasses = new HashMap<>();
 	private final Map<String,ClassDetails> embeddables = new HashMap<>();
+	private final Set<String> idClasses = new HashSet<>();
+	private final Set<ClassDetails> entityListenerClasses = new HashSet<>();
+	private final Set<String> packageNames = new HashSet<>();
 
 	public DomainModelCategorizationCollector(
 			GlobalRegistrations globalRegistrations,
@@ -55,6 +66,30 @@ public class DomainModelCategorizationCollector {
 
 	public Map<String, ClassDetails> getEmbeddables() {
 		return embeddables;
+	}
+
+	public Set<String> getIdClasses() {
+		return idClasses;
+	}
+
+	/**
+	 * Classes that have methods annotated with JPA lifecycle callback annotations
+	 * ({@code @PrePersist}, {@code @PostPersist}, {@code @PreRemove}, {@code @PostRemove},
+	 * {@code @PreUpdate}, {@code @PostUpdate}, {@code @PostLoad}).
+	 * <p>
+	 * These are classes that act as entity listeners (either standalone listener classes
+	 * referenced via {@code @EntityListeners} or entity classes with callback methods).
+	 */
+	public Set<ClassDetails> getEntityListenerClasses() {
+		return entityListenerClasses;
+	}
+
+	/**
+	 * Package names discovered from {@code package-info} classes encountered
+	 * during categorization.
+	 */
+	public Set<String> getPackageNames() {
+		return packageNames;
 	}
 
 	public void apply(JaxbEntityMappingsImpl jaxbRoot, XmlDocumentContext xmlDocumentContext) {
@@ -121,9 +156,42 @@ public class DomainModelCategorizationCollector {
 			}
 		}
 
+		if ( hasIdClass( classDetails ) ) {
+			idClasses.add( classDetails.getDirectAnnotationUsage( IdClass.class ).value().getName() );
+		}
+
 		if ( isConverter( classDetails ) ) {
 			globalRegistrations.collectConverter( classDetails );
 		}
+
+		if ( hasJpaLifecycleCallbackMethods( classDetails ) ) {
+			entityListenerClasses.add( classDetails );
+		}
+
+		if ( isPackageInfo( classDetails ) ) {
+			String className = classDetails.getClassName();
+			packageNames.add( className.substring( 0, className.lastIndexOf( '.' ) ) );
+		}
+	}
+
+	private static boolean hasJpaLifecycleCallbackMethods(ClassDetails classDetails) {
+		return classDetails.getMethods().stream().anyMatch( method ->
+				method.hasDirectAnnotationUsage( PrePersist.class )
+				|| method.hasDirectAnnotationUsage( PostPersist.class )
+				|| method.hasDirectAnnotationUsage( PreRemove.class )
+				|| method.hasDirectAnnotationUsage( PostRemove.class )
+				|| method.hasDirectAnnotationUsage( PreUpdate.class )
+				|| method.hasDirectAnnotationUsage( PostUpdate.class )
+				|| method.hasDirectAnnotationUsage( PostLoad.class ) );
+	}
+
+	private static boolean hasIdClass(ClassDetails classDetails) {
+		return classDetails.getDirectAnnotationUsage( IdClass.class ) != null;
+	}
+
+	private static boolean isPackageInfo(ClassDetails classDetails) {
+		String className = classDetails.getClassName();
+		return className != null && className.endsWith( ".package-info" );
 	}
 
 	private static boolean isConverter(ClassDetails classDetails) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -186,7 +186,7 @@ public class DomainModelCategorizationCollector {
 	}
 
 	private static boolean hasIdClass(ClassDetails classDetails) {
-		return classDetails.getDirectAnnotationUsage( IdClass.class ) != null;
+		return classDetails.hasDirectAnnotationUsage( IdClass.class );
 	}
 
 	private static boolean isPackageInfo(ClassDetails classDetails) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/IdClassCategorizationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/IdClassCategorizationTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.categorization;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import org.hibernate.boot.models.internal.DomainModelCategorizationCollector;
+import org.hibernate.boot.models.internal.GlobalRegistrationsImpl;
+import org.hibernate.models.spi.ModelsContext;
+import org.hibernate.testing.boot.BootstrapContextImpl;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.boot.models.SourceModelTestHelper.createBuildingContext;
+
+/**
+ * Tests that {@link DomainModelCategorizationCollector} correctly collects
+ * {@link IdClass} references from entities.
+ */
+public class IdClassCategorizationTest {
+
+	@Test
+	void idClassIsCollected() {
+		final ModelsContext modelsContext = createBuildingContext(
+				MyIdClass.class,
+				EntityWithIdClass.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getIdClasses() )
+					.containsExactly( MyIdClass.class.getName() );
+		}
+	}
+
+	@Test
+	void entityWithoutIdClassHasEmptyIdClasses() {
+		final ModelsContext modelsContext = createBuildingContext(
+				SimpleEntity.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getIdClasses() ).isEmpty();
+		}
+	}
+
+	public static class MyIdClass implements Serializable {
+		private Long key1;
+		private Long key2;
+	}
+
+	@Entity
+	@IdClass(MyIdClass.class)
+	public static class EntityWithIdClass {
+		@Id
+		private Long key1;
+		@Id
+		private Long key2;
+	}
+
+	@Entity
+	public static class SimpleEntity {
+		@Id
+		private Long id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/PackageCategorizationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/PackageCategorizationTest.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.categorization;
+
+import org.hibernate.boot.models.internal.DomainModelCategorizationCollector;
+import org.hibernate.boot.models.internal.GlobalRegistrationsImpl;
+import org.hibernate.models.spi.ModelsContext;
+import org.hibernate.testing.boot.BootstrapContextImpl;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.boot.models.SourceModelTestHelper.createBuildingContext;
+
+/**
+ * Tests that {@link DomainModelCategorizationCollector} correctly collects
+ * package names from {@code package-info} classes.
+ */
+public class PackageCategorizationTest {
+
+	@Test
+	void packageInfoClassIsCollected() {
+		// The package-info class in pkgannotated has @FilterDef
+		final Class<?> packageInfoClass;
+		try {
+			packageInfoClass = Class.forName(
+					"org.hibernate.orm.test.boot.models.categorization.pkgannotated.package-info" );
+		}
+		catch (ClassNotFoundException e) {
+			throw new RuntimeException( e );
+		}
+
+		final ModelsContext modelsContext = createBuildingContext( packageInfoClass );
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getPackageNames() )
+					.contains( "org.hibernate.orm.test.boot.models.categorization.pkgannotated" );
+		}
+	}
+
+	@Test
+	void regularClassDoesNotProducePackageName() {
+		final ModelsContext modelsContext = createBuildingContext( SimpleEntity.class );
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getPackageNames() ).isEmpty();
+		}
+	}
+
+	@Entity
+	public static class SimpleEntity {
+		@Id
+		private Long id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/pkgannotated/package-info.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/pkgannotated/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+@FilterDef(name = "testFilter")
+package org.hibernate.orm.test.boot.models.categorization.pkgannotated;
+
+import org.hibernate.annotations.FilterDef;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/globals/AnnotatedEntityListener.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/globals/AnnotatedEntityListener.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.globals;
+
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.PreRemove;
+
+/**
+ * Annotated JPA entity listener (not declared via XML)
+ */
+public class AnnotatedEntityListener {
+	@PostPersist
+	public void entityCreated(Object entity) {
+	}
+
+	@PreRemove
+	public void entityRemoved(Object entity) {
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/globals/EntityListenerCategorizationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/globals/EntityListenerCategorizationTests.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.globals;
+
+import org.hibernate.boot.models.internal.DomainModelCategorizationCollector;
+import org.hibernate.boot.models.internal.GlobalRegistrationsImpl;
+import org.hibernate.models.spi.ClassDetails;
+import org.hibernate.models.spi.ModelsContext;
+import org.hibernate.orm.test.boot.models.SourceModelTestHelper;
+import org.hibernate.testing.boot.BootstrapContextImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that {@link DomainModelCategorizationCollector} discovers classes
+ * with JPA lifecycle callback annotations.
+ */
+public class EntityListenerCategorizationTests {
+
+	@Test
+	void testAnnotatedListenerClassIsDiscovered() {
+		final ModelsContext modelsContext = SourceModelTestHelper.createBuildingContext(
+				AnnotatedEntityListener.class
+		);
+
+		final DomainModelCategorizationCollector collector = new DomainModelCategorizationCollector(
+				new GlobalRegistrationsImpl( modelsContext, new BootstrapContextImpl() ),
+				modelsContext
+		);
+
+		collector.apply( modelsContext.getClassDetailsRegistry().resolveClassDetails( AnnotatedEntityListener.class.getName() ) );
+
+		final Set<String> listenerClassNames = collector.getEntityListenerClasses().stream()
+				.map( ClassDetails::getClassName )
+				.collect( Collectors.toSet() );
+
+		assertThat( listenerClassNames ).containsExactly( AnnotatedEntityListener.class.getName() );
+	}
+
+	@Test
+	void testEntityWithCallbackIsDiscovered() {
+		final ModelsContext modelsContext = SourceModelTestHelper.createBuildingContext(
+				EntityWithCallback.class
+		);
+
+		final DomainModelCategorizationCollector collector = new DomainModelCategorizationCollector(
+				new GlobalRegistrationsImpl( modelsContext, new BootstrapContextImpl() ),
+				modelsContext
+		);
+
+		collector.apply( modelsContext.getClassDetailsRegistry().resolveClassDetails( EntityWithCallback.class.getName() ) );
+
+		final Set<String> listenerClassNames = collector.getEntityListenerClasses().stream()
+				.map( ClassDetails::getClassName )
+				.collect( Collectors.toSet() );
+
+		assertThat( listenerClassNames ).containsExactly( EntityWithCallback.class.getName() );
+	}
+
+	@Test
+	void testPlainEntityIsNotDiscovered() {
+		final ModelsContext modelsContext = SourceModelTestHelper.createBuildingContext(
+				PlainEntity.class
+		);
+
+		final DomainModelCategorizationCollector collector = new DomainModelCategorizationCollector(
+				new GlobalRegistrationsImpl( modelsContext, new BootstrapContextImpl() ),
+				modelsContext
+		);
+
+		collector.apply( modelsContext.getClassDetailsRegistry().resolveClassDetails( PlainEntity.class.getName() ) );
+
+		assertThat( collector.getEntityListenerClasses() ).isEmpty();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/globals/EntityWithCallback.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/globals/EntityWithCallback.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.globals;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+
+/**
+ * Entity with a JPA lifecycle callback method directly on the entity class
+ */
+@Entity
+public class EntityWithCallback {
+	@Id
+	private Integer id;
+
+	private String name;
+
+	@PrePersist
+	public void prePersist() {
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/globals/PlainEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/globals/PlainEntity.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.globals;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Entity without any JPA lifecycle callback methods
+ */
+@Entity
+public class PlainEntity {
+	@Id
+	private Integer id;
+
+	private String name;
+}


### PR DESCRIPTION
## Summary
- Expand `DomainModelCategorizationCollector` to discover additional class types needed by Quarkus for Jandex indexing at build time:
  - `@IdClass` references from entities
  - Classes with JPA lifecycle callback annotations (`@PrePersist`, `@PostPersist`, `@PreRemove`, `@PostRemove`, `@PreUpdate`, `@PostUpdate`, `@PostLoad`)
  - Package names from `package-info` classes
- Added tests for all three: `IdClassCategorizationTest`, `EntityListenerCategorizationTests`, `PackageCategorizationTest`

Needed for quarkusio/quarkus#48005
Part of https://hibernate.atlassian.net/browse/HHH-20384
This targets 7.3 and will need a forward port to main.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20384 (Improvement):
- [x] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->