### PR TITLE
HHH-20384 Collect enum and java.* types in DomainModelCategorizationCollector

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -11,6 +11,7 @@ import org.hibernate.boot.models.spi.GlobalRegistrations;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ModelsContext;
+import org.hibernate.models.spi.TypeDetails;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,6 +34,8 @@ public class DomainModelCategorizationCollector {
 	private final Set<ClassDetails> rootEntities = new HashSet<>();
 	private final Map<String,ClassDetails> mappedSuperclasses = new HashMap<>();
 	private final Map<String,ClassDetails> embeddables = new HashMap<>();
+	private final Set<String> enumTypes = new HashSet<>();
+	private final Set<String> javaTypes = new HashSet<>();
 
 	public DomainModelCategorizationCollector(
 			GlobalRegistrations globalRegistrations,
@@ -55,6 +58,14 @@ public class DomainModelCategorizationCollector {
 
 	public Map<String, ClassDetails> getEmbeddables() {
 		return embeddables;
+	}
+
+	public Set<String> getEnumTypes() {
+		return enumTypes;
+	}
+
+	public Set<String> getJavaTypes() {
+		return javaTypes;
 	}
 
 	public void apply(JaxbEntityMappingsImpl jaxbRoot, XmlDocumentContext xmlDocumentContext) {
@@ -109,16 +120,22 @@ public class DomainModelCategorizationCollector {
 			if ( classDetails.getClassName() != null ) {
 				mappedSuperclasses.put( classDetails.getClassName(), classDetails );
 			}
+			collectFieldEnumTypes( classDetails );
+			collectClassHierarchyJavaTypes( classDetails );
 		}
 		else if ( isEntity( classDetails ) ) {
 			if ( isRootEntity( classDetails ) ) {
 				rootEntities.add( classDetails );
 			}
+			collectFieldEnumTypes( classDetails );
+			collectClassHierarchyJavaTypes( classDetails );
 		}
 		else if ( isEmbeddable( classDetails ) ) {
 			if ( classDetails.getClassName() != null ) {
 				embeddables.put( classDetails.getClassName(), classDetails );
 			}
+			collectFieldEnumTypes( classDetails );
+			collectClassHierarchyJavaTypes( classDetails );
 		}
 
 		if ( isConverter( classDetails ) ) {
@@ -129,6 +146,44 @@ public class DomainModelCategorizationCollector {
 	private static boolean isConverter(ClassDetails classDetails) {
 		return classDetails.getClassName() != null && classDetails.isImplementor( AttributeConverter.class )
 			|| classDetails.getDirectAnnotationUsage( Converter.class ) != null;
+	}
+
+	private void collectFieldEnumTypes(ClassDetails classDetails) {
+		classDetails.forEachField( (index, fieldDetails) -> {
+			final TypeDetails type = fieldDetails.getType();
+			if ( type == null || type.getTypeKind() != TypeDetails.Kind.CLASS ) {
+				return;
+			}
+			final ClassDetails fieldTypeClass = type.determineRawClass();
+			if ( fieldTypeClass != null && fieldTypeClass.isEnum() ) {
+				enumTypes.add( fieldTypeClass.getClassName() );
+			}
+		} );
+	}
+
+	private void collectClassHierarchyJavaTypes(ClassDetails classDetails) {
+		collectClassHierarchyJavaTypes( classDetails, new HashSet<>() );
+	}
+
+	private void collectClassHierarchyJavaTypes(ClassDetails classDetails, Set<String> visited) {
+		if ( classDetails == null ) {
+			return;
+		}
+		final String className = classDetails.getClassName();
+		if ( className == null || !visited.add( className ) ) {
+			return;
+		}
+		if ( "java.lang.Object".equals( className ) ) {
+			return;
+		}
+		if ( className.startsWith( "java." ) ) {
+			javaTypes.add( className );
+			return;
+		}
+		collectClassHierarchyJavaTypes( classDetails.getSuperClass(), visited );
+		for ( TypeDetails iface : classDetails.getImplementedInterfaces() ) {
+			collectClassHierarchyJavaTypes( iface.determineRawClass(), visited );
+		}
 	}
 
 	public static boolean isRootEntity(ClassDetails classInfo) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -176,7 +176,7 @@ public class DomainModelCategorizationCollector {
 		if ( "java.lang.Object".equals( className ) ) {
 			return;
 		}
-		if ( className.startsWith( "java." ) ) {
+		if ( !isEntity( classDetails ) && !isEmbeddable( classDetails ) ) {
 			javaTypes.add( className );
 			return;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/EnumAndJavaTypeCategorizationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/EnumAndJavaTypeCategorizationTest.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.categorization;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.boot.models.internal.DomainModelCategorizationCollector;
+import org.hibernate.boot.models.internal.GlobalRegistrationsImpl;
+import org.hibernate.models.spi.ModelsContext;
+import org.hibernate.testing.boot.BootstrapContextImpl;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.boot.models.SourceModelTestHelper.createBuildingContext;
+
+/**
+ * Tests that {@link DomainModelCategorizationCollector} correctly collects
+ * enum types from entity fields and java.* types from class hierarchies.
+ */
+public class EnumAndJavaTypeCategorizationTest {
+
+	enum MyStatus {
+		ACTIVE,
+		INACTIVE
+	}
+
+	@Entity
+	public static class EntityWithEnum {
+		@Id
+		private Long id;
+		private MyStatus status;
+	}
+
+	@Entity
+	public static class SerializableEntity implements Serializable {
+		@Id
+		private Long id;
+	}
+
+	@Entity
+	public static class SimpleEntity {
+		@Id
+		private Long id;
+	}
+
+	@MappedSuperclass
+	public static class MappedSuperclassWithEnum {
+		@Id
+		private Long id;
+		private MyStatus status;
+	}
+
+	@Entity
+	public static class ChildEntity extends MappedSuperclassWithEnum {
+		private String name;
+	}
+
+	@Embeddable
+	public static class EmbeddableWithEnum {
+		private MyStatus status;
+	}
+
+	@Entity
+	public static class EntityWithEmbeddedEnum {
+		@Id
+		private Long id;
+		@Embedded
+		private EmbeddableWithEnum embedded;
+	}
+
+	@Test
+	void enumFieldOnEntityIsCollected() {
+		final ModelsContext modelsContext = createBuildingContext(
+				MyStatus.class,
+				EntityWithEnum.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getEnumTypes() )
+					.contains( MyStatus.class.getName() );
+		}
+	}
+
+	@Test
+	void enumFieldOnMappedSuperclassIsCollected() {
+		final ModelsContext modelsContext = createBuildingContext(
+				MyStatus.class,
+				MappedSuperclassWithEnum.class,
+				ChildEntity.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getEnumTypes() )
+					.contains( MyStatus.class.getName() );
+		}
+	}
+
+	@Test
+	void enumFieldOnEmbeddableIsCollected() {
+		final ModelsContext modelsContext = createBuildingContext(
+				MyStatus.class,
+				EmbeddableWithEnum.class,
+				EntityWithEmbeddedEnum.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getEnumTypes() )
+					.contains( MyStatus.class.getName() );
+		}
+	}
+
+	@Test
+	void entityWithoutEnumHasEmptyEnumTypes() {
+		final ModelsContext modelsContext = createBuildingContext(
+				SimpleEntity.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getEnumTypes() ).isEmpty();
+		}
+	}
+
+	@Test
+	void javaInterfaceOnEntityIsCollected() {
+		final ModelsContext modelsContext = createBuildingContext(
+				SerializableEntity.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getJavaTypes() )
+					.contains( Serializable.class.getName() );
+		}
+	}
+
+	@Test
+	void simpleEntityHasEmptyJavaTypes() {
+		final ModelsContext modelsContext = createBuildingContext(
+				SimpleEntity.class
+		);
+
+		try (BootstrapContextImpl bootstrapContext = new BootstrapContextImpl()) {
+			final GlobalRegistrationsImpl globalRegistrations =
+					new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+			final DomainModelCategorizationCollector collector =
+					new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+
+			modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+
+			assertThat( collector.getJavaTypes() ).isEmpty();
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Collect enum types used as field types on entities, mapped superclasses, and embeddables during categorization
- Collect `java.*` types from class hierarchies (superclasses and interfaces) of managed types
- Quarkus needs these for reflection registration in native image builds
- Added `EnumAndJavaTypeCategorizationTest`

Needed for quarkusio/quarkus#48005
Part of https://hibernate.atlassian.net/browse/HHH-20384
This targets 7.3 and will need a forward port to main.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20384 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->