### PR TITLE
HHH-20357 Stop reordering primary key columns based on component property order and stop relying on primary key column order for joined subclass keys

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -909,21 +909,6 @@ public class Component extends SimpleValue implements AttributeContainer, MetaAt
 			properties.sort( Comparator.comparing( Property::getName ) );
 			originalPropertyOrder = null;
 		}
-		if ( isKey ) {
-			final var primaryKey = getOwner().getTable().getPrimaryKey();
-			if ( primaryKey != null ) {
-				// We have to re-order the primary key accordingly
-				final var columns = primaryKey.getColumns();
-				columns.clear();
-				for ( var property : properties ) {
-					for ( var selectable : property.getSelectables() ) {
-						if ( selectable instanceof Column column ) {
-							columns.add( column );
-						}
-					}
-				}
-			}
-		}
 		return this.originalPropertyOrder = originalPropertyOrder;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/DependantValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/DependantValue.java
@@ -116,6 +116,7 @@ public class DependantValue extends SimpleValue implements Resolvable, SortableV
 				final int[] originalOrder = sortableValue.sortProperties();
 				if ( originalOrder != null ) {
 					sortColumns( originalOrder );
+					return originalOrder;
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -265,6 +265,15 @@ public abstract sealed class PersistentClass
 		return new JoinedList<>( lists );
 	}
 
+	public List<PersistentClass> getPersistentClassClosure() {
+		final ArrayList<List<PersistentClass>> lists = new ArrayList<>();
+		lists.add( getSuperclassClosure() );
+		for (int j = 0; j < subclasses.size(); j++) {
+			lists.add( subclasses.get(j).getSubclassClosure() );
+		}
+		return new JoinedList<>( lists );
+	}
+
 	public Table getIdentityTable() {
 		return getRootTable();
 	}
@@ -399,6 +408,8 @@ public abstract sealed class PersistentClass
 		return new JoinedList<>( getTableClosure(), subclassTables );
 	}
 
+	public abstract List<PersistentClass> getSuperclassClosure();
+
 	public boolean isClassOrSuperclassJoin(Join join) {
 		return joins.contains( join );
 	}
@@ -436,6 +447,16 @@ public abstract sealed class PersistentClass
 	public void createPrimaryKey() {
 		//Primary key constraint
 		final var table = getTable();
+		// Never overwrite the primary key if there already is an existing one,
+		// because previously created ForeignKey might depend on the order of columns,
+		// which the new PrimaryKey might not have
+		if ( table.getPrimaryKey() == null ) {
+			final var primaryKey = makePrimaryKey( table );
+			table.setPrimaryKey( primaryKey );
+		}
+	}
+
+	PrimaryKey makePrimaryKey(Table table) {
 		final var primaryKey = new PrimaryKey( table );
 		primaryKey.setName( PK_ALIAS.toAliasString( table.getName() ) );
 		primaryKey.addColumns( getKey() );
@@ -446,7 +467,7 @@ public abstract sealed class PersistentClass
 				}
 			}
 		}
-		table.setPrimaryKey( primaryKey );
+		return primaryKey;
 	}
 
 	private boolean addPartitionKeyToPrimaryKey() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import org.hibernate.Internal;
 
-import static java.util.Arrays.asList;
 import static org.hibernate.internal.util.StringHelper.qualify;
 
 /**
@@ -44,18 +43,6 @@ public class PrimaryKey extends Constraint {
 	@Override
 	public String getExportIdentifier() {
 		return qualify( getTable().getExportIdentifier(), "PK-" + getName() );
-	}
-
-	public List<Column> getColumnsInOriginalOrder() {
-		final var columns = getColumns();
-		if ( originalOrder == null ) {
-			return columns;
-		}
-		final var columnsInOriginalOrder = new Column[columns.size()];
-		for ( int i = 0; i < columnsInOriginalOrder.length; i++ ) {
-			columnsInOriginalOrder[originalOrder[i]] = columns.get( i );
-		}
-		return asList( columnsInOriginalOrder );
 	}
 
 	public void setOrderingUniqueKey(UniqueKey uniqueKey) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
@@ -158,6 +158,11 @@ public final class RootClass extends PersistentClass implements TableOwner, Soft
 	}
 
 	@Override
+	public List<PersistentClass> getSuperclassClosure() {
+		return List.of( this );
+	}
+
+	@Override
 	public Property getVersion() {
 		return version;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
@@ -178,6 +178,11 @@ public sealed class Subclass extends PersistentClass
 	}
 
 	@Override
+	public List<PersistentClass> getSuperclassClosure() {
+		return new JoinedList<>( superclass.getSuperclassClosure(), List.of( this ) );
+	}
+
+	@Override
 	public boolean isVersioned() {
 		return getSuperclass().isVersioned();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -281,13 +281,14 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		final ArrayList<Boolean> isNullables = new ArrayList<>();
 
 		final ArrayList<String[]> allKeyColumns = new ArrayList<>();
-		for ( var table : persistentClass.getSubclassTableClosure() ) {
+		for ( var persistentSubclass : persistentClass.getPersistentClassClosure() ) {
+			final Table table = persistentSubclass.getTable();
 			isConcretes.add( persistentClass.isClassOrSuperclassTable( table ) );
 			isNullables.add( false );
 			final String tableName = determineTableName( table );
 			subclassTableNames.add( tableName );
 			final String[] key = new String[idColumnSpan];
-			final var columns = table.getPrimaryKey().getColumnsInOriginalOrder();
+			final var columns = persistentSubclass.getKey().getColumns();
 			for ( int k = 0; k < idColumnSpan; k++ ) {
 				key[k] = columns.get(k).getQuotedName( dialect );
 			}
@@ -302,7 +303,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			final String joinTableName = determineTableName( joinTable );
 			subclassTableNames.add( joinTableName );
 			final String[] key = new String[idColumnSpan];
-			final var columns = joinTable.getPrimaryKey().getColumnsInOriginalOrder();
+			final var columns = join.getKey().getColumns();
 			for ( int k = 0; k < idColumnSpan; k++ ) {
 				key[k] = columns.get(k).getQuotedName( dialect );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -25,6 +25,7 @@ import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.id.IdentityGenerator;
+import org.hibernate.mapping.Table;
 import org.hibernate.persister.filter.FilterAliasGenerator;
 import org.hibernate.persister.filter.internal.StaticFilterAliasGenerator;
 import org.hibernate.internal.util.collections.JoinedList;
@@ -170,11 +171,12 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 			final int idColumnSpan = getIdentifierColumnSpan();
 			final ArrayList<String> tableNames = new ArrayList<>();
 			final ArrayList<String[]> keyColumns = new ArrayList<>();
-			for ( var table : persistentClass.getSubclassTableClosure() ) {
+			for ( var persistentSubclass : persistentClass.getPersistentClassClosure() ) {
+				final Table table = persistentSubclass.getTable();
 				if ( !table.isAbstractUnionTable() ) {
 					tableNames.add( determineTableName( table ) );
 					final String[] key = new String[idColumnSpan];
-					final List<Column> columns = table.getPrimaryKey().getColumnsInOriginalOrder();
+					final List<Column> columns = persistentSubclass.getKey().getColumns();
 					for ( int k = 0; k < idColumnSpan; k++ ) {
 						key[k] = columns.get(k).getQuotedName( dialect );
 					}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/joined/JoinedInheritanceAuditTableReadOrderingTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/joined/JoinedInheritanceAuditTableReadOrderingTest.java
@@ -1,0 +1,246 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.inheritance.joined;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.Immutable;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.testing.envers.junit.EnversTest;
+import org.hibernate.testing.orm.junit.BeforeClassTemplate;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Jira("https://hibernate.atlassian.net/browse/HHH-20357")
+@EnversTest
+@Jpa(annotatedClasses = {
+		JoinedInheritanceAuditTableReadOrderingTest.PartyEntity.class,
+		JoinedInheritanceAuditTableReadOrderingTest.PersonEntity.class,
+		JoinedInheritanceAuditTableReadOrderingTest.PartyAuditView.class,
+		JoinedInheritanceAuditTableReadOrderingTest.PersonAuditView.class
+})
+public class JoinedInheritanceAuditTableReadOrderingTest {
+
+	@BeforeClassTemplate
+	public void initData(EntityManagerFactoryScope scope) {
+		Long id = scope.fromTransaction( em -> {
+			PersonEntity person = new PersonEntity();
+			person.setId( 1L );
+			person.setFullName( "fullName.1" );
+			person.setFirstName( "firstName.1" );
+			person.setLastName( "lastName.1" );
+			em.persist( person );
+
+			return person.getId();
+		} );
+
+		scope.inTransaction( em -> {
+			PersonEntity person = em.find( PersonEntity.class, id );
+			person.setFullName( "fullName.2" );
+			person.setFirstName( "firstName.2" );
+			person.setLastName( "lastName.2" );
+		} );
+
+		scope.inTransaction( em -> {
+			PersonEntity person = em.find( PersonEntity.class, id );
+			person.setFullName( "fullName.3" );
+			person.setFirstName( "firstName.3" );
+			person.setLastName( "lastName.3" );
+		} );
+	}
+
+	@Test
+	public void testAuditRowsExist(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			var auditReader = AuditReaderFactory.get( em );
+			assertEquals( Arrays.asList( 1, 2, 3 ), auditReader.getRevisions( PersonEntity.class, 1L ) );
+		} );
+	}
+
+	@Test
+	public void testJoinedAuditTableReadReturnsAllRowsEnvers(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			PersonEntity person1 = AuditReaderFactory.get( em ).find( PersonEntity.class, 1L, 1 );
+			PersonEntity person2 = AuditReaderFactory.get( em ).find( PersonEntity.class, 1L, 2 );
+			PersonEntity person3 = AuditReaderFactory.get( em ).find( PersonEntity.class, 1L, 3 );
+
+			assertEquals( "firstName.1", person1.getFirstName() );
+			assertEquals( "firstName.2", person2.getFirstName() );
+			assertEquals( "firstName.3", person3.getFirstName() );
+		} );
+	}
+
+	@Test
+	public void testJoinedAuditTableReadReturnsAllRowsCustom(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			List<PersonAuditView> audits = em.createQuery(
+					"select p from PersonAuditView p order by p.revisionId",
+					PersonAuditView.class
+			).getResultList();
+
+			assertEquals( 3, audits.size() );
+			assertEquals( "firstName.1", audits.get( 0 ).getFirstName() );
+			assertEquals( "firstName.2", audits.get( 1 ).getFirstName() );
+			assertEquals( "firstName.3", audits.get( 2 ).getFirstName() );
+		} );
+	}
+
+
+	public static class AuditId implements Serializable {
+		private Long entityId;
+		private Integer revisionId;
+
+		public AuditId() {
+		}
+
+		public AuditId(Long entityId, Integer revisionId) {
+			this.entityId = entityId;
+			this.revisionId = revisionId;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( !( o instanceof AuditId ) ) {
+				return false;
+			}
+			AuditId auditId = (AuditId) o;
+			return Objects.equals( entityId, auditId.entityId ) && Objects.equals( revisionId, auditId.revisionId );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( entityId, revisionId );
+		}
+	}
+
+	@Entity(name = "PartyEntity")
+	@Table(name = "PARTY")
+	@Audited
+	@Inheritance(strategy = InheritanceType.JOINED)
+	public abstract static class PartyEntity {
+		@Id
+		@Column(name = "PTY_ID")
+		private Long id;
+
+		@Column(name = "FULL_NAME")
+		private String fullName;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getFullName() {
+			return fullName;
+		}
+
+		public void setFullName(String fullName) {
+			this.fullName = fullName;
+		}
+	}
+
+	@Entity(name = "PersonEntity")
+	@Table(name = "PERSON")
+	@Audited
+	public static class PersonEntity extends PartyEntity {
+		@Column(name = "FIRST_NAME")
+		private String firstName;
+
+		@Column(name = "LAST_NAME")
+		private String lastName;
+
+		public String getFirstName() {
+			return firstName;
+		}
+
+		public void setFirstName(String firstName) {
+			this.firstName = firstName;
+		}
+
+		public String getLastName() {
+			return lastName;
+		}
+
+		public void setLastName(String lastName) {
+			this.lastName = lastName;
+		}
+	}
+
+	@MappedSuperclass
+	@IdClass(AuditId.class)
+	public abstract static class BaseAuditView {
+		@Id
+		@Column(name = "PTY_ID")
+		private Long entityId;
+
+		@Id
+		@Column(name = "REV")
+		private Integer revisionId;
+
+		public Long getEntityId() {
+			return entityId;
+		}
+
+		public Integer getRevisionId() {
+			return revisionId;
+		}
+	}
+
+	@Entity(name = "PartyAuditView")
+	@Table(name = "PARTY_AUD")
+	@Immutable
+	@Inheritance(strategy = InheritanceType.JOINED)
+	@AttributeOverride(name = "entityId", column = @Column(name = "PTY_ID"))
+	public abstract static class PartyAuditView extends BaseAuditView {
+		@Column(name = "FULL_NAME")
+		private String fullName;
+
+		public String getFullName() {
+			return fullName;
+		}
+	}
+
+	@Entity(name = "PersonAuditView")
+	@Table(name = "PERSON_AUD")
+	public static class PersonAuditView extends PartyAuditView {
+		@Column(name = "FIRST_NAME")
+		private String firstName;
+
+		@Column(name = "LAST_NAME")
+		private String lastName;
+
+		public String getFirstName() {
+			return firstName;
+		}
+
+		public String getLastName() {
+			return lastName;
+		}
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/12365

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20357 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20357
<!-- Hibernate GitHub Bot issue links end -->