### PR TITLE
Disable caching for JARs in URLConnection to avoid s390x errors

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/PackagedEntityManagerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/PackagedEntityManagerTest.java
@@ -459,16 +459,17 @@ public class PackagedEntityManagerTest extends PackagingTestCase {
 	public void testClasspathResources() throws Exception {
 		File externalJar = buildExternalJar2();
 		File testPackage = buildExplicitPar2();
-		final URLClassLoader urlClassLoader = new URLClassLoader( new URL[] {externalJar.toURL(), testPackage.toURL()} );
+		try (final URLClassLoader urlClassLoader = new URLClassLoader( new URL[] {externalJar.toURL(), testPackage.toURL()} )) {
+			final Enumeration<URL> gotten = urlClassLoader.getResources( "META-INF/orm.xml" );
+			while ( gotten.hasMoreElements() ) {
+				System.out.println( "Got META-INF/orm.xml: " + gotten.nextElement() );
+			}
 
-		final Enumeration<URL> gotten = urlClassLoader.getResources( "META-INF/orm.xml" );
-		while ( gotten.hasMoreElements() ) {
-			System.out.println( "Got META-INF/orm.xml: " + gotten.nextElement() );
-		}
-
-		final Enumeration<URL> gottenTccl = Thread.currentThread().getContextClassLoader().getResources( "META-INF/orm.xml" );
-		while ( gottenTccl.hasMoreElements() ) {
-			System.out.println( "Got META-INF/orm.xml (tccl): " + gottenTccl.nextElement() );
+			final Enumeration<URL> gottenTccl = Thread.currentThread().getContextClassLoader()
+					.getResources( "META-INF/orm.xml" );
+			while ( gottenTccl.hasMoreElements() ) {
+				System.out.println( "Got META-INF/orm.xml (tccl): " + gottenTccl.nextElement() );
+			}
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/PackagingTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/PackagingTestCase.java
@@ -119,6 +119,16 @@ public abstract class PackagingTestCase extends BaseSessionFactoryFunctionalTest
 	@AfterEach
 	public void resetTCCL() {
 		// reset the classloader
+		final ClassLoader contextClassLoader = thread.getContextClassLoader();
+		if ( contextClassLoader instanceof URLClassLoader urlClassLoader
+			&& urlClassLoader != bundleClassLoader ) {
+			try {
+				urlClassLoader.close();
+			}
+			catch (IOException e) {
+				// Ignore
+			}
+		}
 		thread.setContextClassLoader( originalClassLoader );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/PackagingTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/PackagingTestCase.java
@@ -39,7 +39,9 @@ import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
@@ -47,11 +49,13 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 /**
@@ -59,10 +63,10 @@ import static org.junit.Assert.fail;
  * @author Brett Meyer
  */
 public abstract class PackagingTestCase extends BaseSessionFactoryFunctionalTest {
-	protected static ClassLoader originalClassLoader;
-	private static Thread thread;
+	protected final static ClassLoader originalClassLoader;
+	private final static Thread thread;
 
-	protected static ClassLoader bundleClassLoader;
+	protected final static ClassLoader bundleClassLoader;
 	protected static File packageTargetDir;
 
 	static {
@@ -104,14 +108,29 @@ public abstract class PackagingTestCase extends BaseSessionFactoryFunctionalTest
 			bundleClassLoader = new URLClassLoader( new URL[] { testPackagesDir.toURL() }, originalClassLoader );
 		}
 		catch ( MalformedURLException e ) {
-			fail( "Unable to build custom class loader" );
+			throw new AssertionError( "Unable to build custom class loader" );
 		}
 		packageTargetDir = new File( baseDir, "target/packages" );
 		packageTargetDir.mkdirs();
 	}
 
+	// Ensure no JAR files are being cached to avoid file deletion issues on Windows
+	private static boolean jarDefaultUseCaches;
+
+	@BeforeAll
+	public static void setup() {
+		jarDefaultUseCaches = URLConnection.getDefaultUseCaches( "jar" );
+		URLConnection.setDefaultUseCaches( "jar", false );
+	}
+
+	@AfterAll
+	public static void cleanup() {
+		URLConnection.setDefaultUseCaches( "jar", jarDefaultUseCaches );
+	}
+
 	@BeforeEach
 	public void prepareTCCL() {
+		assertSame( thread, Thread.currentThread() );
 		// add the bundle class loader in order for ShrinkWrap to build the test package
 		thread.setContextClassLoader( bundleClassLoader );
 	}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
