### PR TITLE
HHH-20435 Sync the updates from Jakarta Persistence 4 XSDs to corresponding ORM extended equivalents

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/mapping/spi/JaxbLifecycleCallbackContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/mapping/spi/JaxbLifecycleCallbackContainer.java
@@ -20,24 +20,45 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Steve Ebersole
  */
 public interface JaxbLifecycleCallbackContainer {
-	@Nullable JaxbPrePersistImpl getPrePersist();
-	void setPrePersist(@Nullable JaxbPrePersistImpl value);
+	@Nullable JaxbLifecycleCallbackImpl getPreMerge();
+	void setPreMerge(@Nullable JaxbLifecycleCallbackImpl value);
 
-	@Nullable JaxbPostPersistImpl getPostPersist();
-	void setPostPersist(@Nullable JaxbPostPersistImpl value);
+	@Nullable JaxbLifecycleCallbackImpl getPrePersist();
+	void setPrePersist(@Nullable JaxbLifecycleCallbackImpl value);
 
-	@Nullable JaxbPreRemoveImpl getPreRemove();
-	void setPreRemove(@Nullable JaxbPreRemoveImpl value);
+	@Nullable JaxbLifecycleCallbackImpl getPostPersist();
+	void setPostPersist(@Nullable JaxbLifecycleCallbackImpl value);
 
-	@Nullable JaxbPostRemoveImpl getPostRemove();
-	void setPostRemove(@Nullable JaxbPostRemoveImpl value);
+	@Nullable JaxbLifecycleCallbackImpl getPreRemove();
+	void setPreRemove(@Nullable JaxbLifecycleCallbackImpl value);
 
-	@Nullable JaxbPreUpdateImpl getPreUpdate();
-	void setPreUpdate(@Nullable JaxbPreUpdateImpl value);
+	@Nullable JaxbLifecycleCallbackImpl getPostRemove();
+	void setPostRemove(@Nullable JaxbLifecycleCallbackImpl value);
 
-	@Nullable JaxbPostUpdateImpl getPostUpdate();
-	void setPostUpdate(@Nullable JaxbPostUpdateImpl value);
+	@Nullable JaxbLifecycleCallbackImpl getPreUpdate();
+	void setPreUpdate(@Nullable JaxbLifecycleCallbackImpl value);
 
-	@Nullable JaxbPostLoadImpl getPostLoad();
-	void setPostLoad(@Nullable JaxbPostLoadImpl value);
+	@Nullable JaxbLifecycleCallbackImpl getPostUpdate();
+	void setPostUpdate(@Nullable JaxbLifecycleCallbackImpl value);
+
+	@Nullable JaxbLifecycleCallbackImpl getPreUpsert();
+	void setPreUpsert(@Nullable JaxbLifecycleCallbackImpl value);
+
+	@Nullable JaxbLifecycleCallbackImpl getPostUpsert();
+	void setPostUpsert(@Nullable JaxbLifecycleCallbackImpl value);
+
+	@Nullable JaxbLifecycleCallbackImpl getPreInsert();
+	void setPreInsert(@Nullable JaxbLifecycleCallbackImpl value);
+
+	@Nullable JaxbLifecycleCallbackImpl getPostInsert();
+	void setPostInsert(@Nullable JaxbLifecycleCallbackImpl value);
+
+	@Nullable JaxbLifecycleCallbackImpl getPreDelete();
+	void setPreDelete(@Nullable JaxbLifecycleCallbackImpl value);
+
+	@Nullable JaxbLifecycleCallbackImpl getPostDelete();
+	void setPostDelete(@Nullable JaxbLifecycleCallbackImpl value);
+
+	@Nullable JaxbLifecycleCallbackImpl getPostLoad();
+	void setPostLoad(@Nullable JaxbLifecycleCallbackImpl value);
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/xsd/ConfigXsdSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/xsd/ConfigXsdSupport.java
@@ -37,11 +37,12 @@ public class ConfigXsdSupport {
 	 * 7: Jakarta Persistence 3.1
 	 * 8: Jakarta Persistence 3.2
 	 * 9: configurationXML 8.0 (JPA 4.0)
+	 * 10: Jakarta Persistence 4.0
 	 */
-	private static final XsdDescriptor[] xsdCache = new XsdDescriptor[10];
+	private static final XsdDescriptor[] xsdCache = new XsdDescriptor[11];
 
 	public XsdDescriptor latestJpaDescriptor() {
-		return getJPA31();
+		return getJPA40();
 	}
 
 	public static boolean shouldBeMappedToLatestJpaDescriptor(String uri) {
@@ -76,6 +77,9 @@ public class ConfigXsdSupport {
 			case "3.2": {
 				return getJPA32();
 			}
+			case "4.0": {
+				return getJPA40();
+			}
 			default: {
 				throw new IllegalArgumentException( "Unrecognized JPA persistence.xml XSD version : `" + version + "`" );
 			}
@@ -104,8 +108,8 @@ public class ConfigXsdSupport {
 			XsdDescriptor cfgXml = xsdCache[index];
 			if ( cfgXml == null ) {
 				cfgXml = LocalXsdResolver.buildXsdDescriptor(
-						"org/hibernate/xsd/cfg/configuration-3.2.0.xsd",
-						"3.2.0" ,
+						"org/hibernate/xsd/cfg/configuration-8.0.xsd",
+						"8.0" ,
 						"http://www.hibernate.org/xsd/orm/configuration"
 				);
 				xsdCache[index] = cfgXml;
@@ -223,6 +227,22 @@ public class ConfigXsdSupport {
 				xsdCache[index] = jpa32;
 			}
 			return jpa32;
+		}
+	}
+
+	public static XsdDescriptor getJPA40() {
+		final int index = 10;
+		synchronized ( xsdCache ) {
+			XsdDescriptor jpa40 = xsdCache[index];
+			if ( jpa40 == null ) {
+				jpa40 = LocalXsdResolver.buildXsdDescriptor(
+						"org/hibernate/jpa/persistence_4_0.xsd",
+						"4.0",
+						"https://jakarta.ee/xml/ns/persistence"
+				);
+				xsdCache[index] = jpa40;
+			}
+			return jpa40;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/xsd/LocalXsdResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/xsd/LocalXsdResolver.java
@@ -28,12 +28,12 @@ import static org.hibernate.boot.jaxb.JaxbLogger.JAXB_LOGGER;
 public class LocalXsdResolver {
 
 	public static String latestJpaVerison() {
-		return "3.2";
+		return "4.0";
 	}
 
 	public static boolean isValidJpaVersion(String version) {
 		return switch ( version ) {
-			case "1.0", "2.0", "2.1", "2.2", "3.0", "3.1", "3.2" -> true;
+			case "1.0", "2.0", "2.1", "2.2", "3.0", "3.1", "3.2", "4.0" -> true;
 			default -> false;
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/xsd/MappingXsdSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/xsd/MappingXsdSupport.java
@@ -81,6 +81,12 @@ public class MappingXsdSupport {
 			"https://jakarta.ee/xml/ns/persistence/orm"
 	);
 
+	public static final XsdDescriptor jpa40 = LocalXsdResolver.buildXsdDescriptor(
+			"org/hibernate/jpa/orm_4_0.xsd",
+			"4.0",
+			"https://jakarta.ee/xml/ns/persistence/orm"
+	);
+
 	public static final XsdDescriptor hbmXml = LocalXsdResolver.buildXsdDescriptor(
 			"org/hibernate/xsd/mapping/legacy-mapping-4.0.xsd",
 			"4.0",
@@ -102,7 +108,7 @@ public class MappingXsdSupport {
 	}
 
 	public static XsdDescriptor latestJpaDescriptor() {
-		return jpa32;
+		return jpa40;
 	}
 
 	public XsdDescriptor jpaXsd(String version) {
@@ -127,6 +133,9 @@ public class MappingXsdSupport {
 			}
 			case "3.2:": {
 				return jpa32;
+			}
+			case "4.0": {
+				return jpa40;
 			}
 			default: {
 				throw new IllegalArgumentException( "Unrecognized JPA orm.xml XSD version : `" + version + "`" );

--- a/hibernate-core/src/main/resources/org/hibernate/jpa/orm_4_0.xsd
+++ b/hibernate-core/src/main/resources/org/hibernate/jpa/orm_4_0.xsd
@@ -1,0 +1,2883 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<!-- Jakarta Persistence API object/relational mapping file schema -->
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/persistence/orm"
+            xmlns:orm="https://jakarta.ee/xml/ns/persistence/orm"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="4.0">
+  <xsd:annotation>
+    <xsd:documentation><![CDATA[
+
+       This is the XML Schema for the persistence object/relational mapping file.
+       The file may be named "META-INF/orm.xml" in the persistence
+       archive or it may be named some other name which would be
+       used to locate the file as resource on the classpath.
+
+       Object/relational mapping files must indicate the object/relational
+       mapping file schema by using the persistence namespace:
+
+       https://jakarta.ee/xml/ns/persistence/orm
+
+       and indicate the version of the schema by
+       using the version element as shown below:
+
+      <entity-mappings xmlns="https://jakarta.ee/xml/ns/persistence/orm"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm
+          https://jakarta.ee/xml/ns/persistence/orm/orm_4_0.xsd"
+        version="4.0">
+          ...
+      </entity-mappings>
+
+
+     ]]></xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:complexType name="emptyType"/>
+
+  <xsd:simpleType name="versionType">
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="[0-9]+(\.[0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:element name="entity-mappings">
+    <xsd:complexType>
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The entity-mappings element is the root element of a mapping
+          file. It contains the following four types of elements:
+
+          1. The persistence-unit-metadata element contains metadata
+          for the entire persistence unit. It is undefined if this element
+          occurs in multiple mapping files within the same persistence unit.
+
+          2. The package, schema, catalog and access elements apply to all of
+          the entity, mapped-superclass and embeddable elements defined in
+          the same file in which they occur.
+
+          3. The sequence-generator, table-generator, converter, named-query,
+          named-native-query, named-stored-procedure-query, and
+          sql-result-set-mapping elements are global to the persistence
+          unit. It is undefined to have more than one sequence-generator
+          or table-generator of the same name in the same or different
+          mapping files in a persistence unit. It is undefined to have
+          more than one named-query, named-native-query, sql-result-set-mapping,
+          or named-stored-procedure-query of the same name in the same
+          or different mapping files in a persistence unit.  It is also
+          undefined to have more than one converter for the same target
+          type in the same or different mapping files in a persistence unit.
+
+          4. The entity, mapped-superclass and embeddable elements each define
+          the mapping information for a managed persistent class. The mapping
+          information contained in these elements may be complete or it may
+          be partial.
+
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence>
+        <xsd:element name="description" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="persistence-unit-metadata"
+                     type="orm:persistence-unit-metadata"
+                     minOccurs="0"/>
+        <xsd:element name="package" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="schema" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="catalog" type="xsd:string"
+                     minOccurs="0"/>
+        <xsd:element name="access" type="orm:access-type"
+                     minOccurs="0"/>
+        <xsd:element name="sequence-generator" type="orm:sequence-generator"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="table-generator" type="orm:table-generator"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="named-query" type="orm:named-query"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="named-native-query" type="orm:named-native-query"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="named-statement" type="orm:named-statement"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="named-native-statement" type="orm:named-native-statement"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="named-stored-procedure-query"
+                     type="orm:named-stored-procedure-query"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="sql-result-set-mapping"
+                     type="orm:sql-result-set-mapping"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="mapped-superclass" type="orm:mapped-superclass"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="entity" type="orm:entity"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="embeddable" type="orm:embeddable"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="converter" type="orm:converter"
+                     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="version" type="orm:versionType"
+                     fixed="4.0" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-unit-metadata">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Metadata that applies to the persistence unit and not just to
+        the mapping file in which it is contained.
+
+        If the xml-mapping-metadata-complete element is specified,
+        the complete set of mapping metadata for the persistence unit
+        is contained in the XML mapping files for the persistence unit.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="xml-mapping-metadata-complete" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-unit-defaults"
+                   type="orm:persistence-unit-defaults"
+                   minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-unit-defaults">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        These defaults are applied to the persistence unit as a whole
+        unless they are overridden by local annotation or XML
+        element settings.
+
+        schema - Used as the schema for all tables, secondary tables, join
+        tables, collection tables, sequence generators, and table
+        generators that apply to the persistence unit
+        catalog - Used as the catalog for all tables, secondary tables, join
+        tables, collection tables, sequence generators, and table
+        generators that apply to the persistence unit
+        delimited-identifiers - Used to treat database identifiers as
+        delimited identifiers.
+        access - Used as the access type for all managed classes in
+        the persistence unit
+        cascade-persist - Adds cascade-persist to the set of cascade options
+        in all entity relationships of the persistence unit
+        entity-listeners - List of default entity listeners to be invoked
+        on each entity in the persistence unit.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="schema" type="xsd:string"
+                   minOccurs="0"/>
+      <xsd:element name="catalog" type="xsd:string"
+                   minOccurs="0"/>
+      <xsd:element name="delimited-identifiers" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="access" type="orm:access-type"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-persist" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="entity-listeners" type="orm:entity-listeners"
+                   minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="entity">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the settings and mappings for an entity. Is allowed to be
+        sparsely populated and used in conjunction with the annotations.
+        Alternatively, the metadata-complete attribute can be used to
+        indicate that no annotations on the entity class (and its fields
+        or properties) are to be processed. If this is the case then
+        the defaulting rules for the entity and its subelements will
+        be recursively applied.
+
+        @Target(TYPE) @Retention(RUNTIME)
+        public @interface Entity {
+        String name() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="table" type="orm:table"
+                   minOccurs="0"/>
+      <xsd:element name="secondary-table" type="orm:secondary-table"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:sequence>
+        <xsd:element name="primary-key-join-column"
+                     type="orm:primary-key-join-column"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="primary-key-foreign-key"
+                     type="orm:foreign-key"
+                     minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:element name="id-class" type="orm:id-class" minOccurs="0"/>
+      <xsd:element name="inheritance" type="orm:inheritance" minOccurs="0"/>
+      <xsd:element name="discriminator-value" type="orm:discriminator-value"
+                   minOccurs="0"/>
+      <xsd:element name="discriminator-column"
+                   type="orm:discriminator-column"
+                   minOccurs="0"/>
+      <xsd:element name="sequence-generator" type="orm:sequence-generator"
+                   minOccurs="0"/>
+      <xsd:element name="table-generator" type="orm:table-generator"
+                   minOccurs="0"/>
+      <xsd:element name="named-query" type="orm:named-query"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="named-native-query" type="orm:named-native-query"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="named-statement" type="orm:named-statement"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="named-native-statement" type="orm:named-native-statement"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="named-stored-procedure-query"
+                   type="orm:named-stored-procedure-query"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="sql-result-set-mapping"
+                   type="orm:sql-result-set-mapping"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="exclude-default-listeners" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="exclude-superclass-listeners" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="entity-listeners" type="orm:entity-listeners"
+                   minOccurs="0"/>
+      <xsd:element name="pre-merge" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreMerge {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-persist" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PrePersist {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-persist" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostPersist {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-remove" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreRemove {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-remove" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostRemove {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-update" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreUpdate {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-update" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostUpdate {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-upsert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreUpsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-upsert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostUpsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-insert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreInsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-insert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostInsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-delete" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreDelete {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-delete" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostDelete {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-load" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostLoad {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute-override" type="orm:attribute-override"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="association-override"
+                   type="orm:association-override"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="convert" type="orm:convert"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="named-entity-graph" type="orm:named-entity-graph"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="attributes" type="orm:attributes" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="cacheable" type="xsd:boolean"/>
+    <xsd:attribute name="metadata-complete" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="access-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element determines how the persistence provider accesses the
+        state of an entity or embedded object.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="PROPERTY"/>
+      <xsd:enumeration value="FIELD"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="association-override">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(AssociationOverrides.class)
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface AssociationOverride {
+        String name();
+        JoinColumn[] joinColumns() default{};
+        ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
+        JoinTable joinTable() default @JoinTable;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:choice>
+        <xsd:sequence>
+          <xsd:element name="join-column" type="orm:join-column"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="foreign-key" type="orm:foreign-key"
+                       minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:element name="join-table" type="orm:join-table"
+                     minOccurs="0"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="attribute-override">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(AttributeOverrides.class)
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface AttributeOverride {
+        String name();
+        Column column();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="column" type="orm:column"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="attributes">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element contains the entity field or property mappings.
+        It may be sparsely populated to include only a subset of the
+        fields or properties. If metadata-complete for the entity is true
+        then the remainder of the attributes will be defaulted according
+        to the default rules.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:choice>
+        <xsd:element name="id" type="orm:id"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="embedded-id" type="orm:embedded-id"
+                     minOccurs="0"/>
+      </xsd:choice>
+      <xsd:element name="basic" type="orm:basic"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="version" type="orm:version"
+                   minOccurs="0"/>
+      <xsd:element name="many-to-one" type="orm:many-to-one"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="one-to-many" type="orm:one-to-many"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="one-to-one" type="orm:one-to-one"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="many-to-many" type="orm:many-to-many"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="element-collection" type="orm:element-collection"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="embedded" type="orm:embedded"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="excluded-from-versioning"
+                   type="orm:excluded-from-versioning"
+                   minOccurs="0"/>
+      <xsd:element name="transient" type="orm:transient"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="basic">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Basic {
+        FetchType fetch() default FetchType.EAGER;
+        boolean optional() default true;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column" type="orm:column" minOccurs="0"/>
+      <xsd:choice>
+        <xsd:element name="lob" type="orm:lob" minOccurs="0"/>
+        <xsd:element name="temporal" type="orm:temporal" minOccurs="0"/>
+        <xsd:element name="enumerated" type="orm:enumerated" minOccurs="0"/>
+        <xsd:element name="convert" type="orm:convert" minOccurs="0"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="optional" type="xsd:boolean"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="cascade-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum CascadeType { ALL, PERSIST, MERGE, REMOVE, REFRESH, DETACH }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="cascade-all" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-persist" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-merge" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-remove" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-refresh" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="cascade-detach" type="orm:emptyType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="check-constraint">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface CheckConstraint {
+        String name() default "";
+        String constraint();
+        String options() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="constraint" type="xsd:string" use="required"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="collection-table">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface CollectionTable {
+        String name() default "";
+        String catalog() default "";
+        String schema() default "";
+        JoinColumn[] joinColumns() default {};
+        ForeignKey foreignKey() default @ForeignKey(ConstraintMode.PROVIDER_DEFAULT);
+        UniqueConstraint[] uniqueConstraints() default {};
+        Index[] indexes() default {};
+        CheckConstraint[] check() default {};
+        String comment() default "";
+        String type() default "";
+        String options() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:sequence>
+        <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+        <xsd:element name="join-column" type="orm:join-column"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="foreign-key" type="orm:foreign-key"
+                     minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:element name="unique-constraint" type="orm:unique-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="index" type="orm:index"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+    <xsd:attribute name="type" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Column {
+        String name() default "";
+        boolean unique() default false;
+        boolean nullable() default true;
+        boolean insertable() default true;
+        boolean updatable() default true;
+        String columnDefinition() default "";
+        String options() default "";
+        String table() default "";
+        int length() default 255;
+        int precision() default 0; // decimal precision
+        int scale() default 0; // decimal scale
+        int secondPrecision() default -1; //fractional second precision
+        CheckConstraint[] check() default {};
+        String comment() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+    <xsd:attribute name="length" type="xsd:int"/>
+    <xsd:attribute name="precision" type="xsd:int"/>
+    <xsd:attribute name="scale" type="xsd:int"/>
+    <xsd:attribute name="second-precision" type="xsd:int"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="column-result">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target(METHOD) @Retention(RUNTIME)
+        public @interface ColumnResult {
+          String name();
+          Class<?> type() default void.class;
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="class" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="constraint-mode">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum ConstraintMode { CONSTRAINT, NO_CONSTRAINT, PROVIDER_DEFAULT }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="CONSTRAINT"/>
+      <xsd:enumeration value="NO_CONSTRAINT"/>
+      <xsd:enumeration value="PROVIDER_DEFAULT"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+
+  <xsd:complexType name="constructor-result">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target(METHOD) @Retention(RUNTIME)
+        public @interface ConstructorResult {
+          Class<?> targetClass();
+          ColumnResult[] columns() default {};
+          EntityResult[] entities() default {};
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column" type="orm:column-result"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="entity" type="orm:entity-result"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="target-class" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="convert">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Repeatable(Converts.class)
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Convert {
+          Class<? extends AttributeConverter> converter() default AttributeConverter.class;
+          String attributeName() default "";
+          boolean disableConversion() default false;
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="converter" type="xsd:string"/>
+    <xsd:attribute name="attribute-name" type="xsd:string"/>
+    <xsd:attribute name="disable-conversion" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="converter">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface Converter {
+        boolean autoApply() default false;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="auto-apply" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="discriminator-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface DiscriminatorColumn {
+        String name() default "DTYPE";
+        DiscriminatorType discriminatorType() default STRING;
+        String columnDefinition() default "";
+        String options() default "";
+        int length() default 31;
+        String comment() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="discriminator-type" type="orm:discriminator-type"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+    <xsd:attribute name="length" type="xsd:int"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="discriminator-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum DiscriminatorType { STRING, CHAR, INTEGER }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="STRING"/>
+      <xsd:enumeration value="CHAR"/>
+      <xsd:enumeration value="INTEGER"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="discriminator-value">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface DiscriminatorValue {
+        String value();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="element-collection">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface ElementCollection {
+          Class<?> targetClass() default void.class;
+          FetchType fetch() default FetchType.LAZY;
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="order-by" type="orm:order-by"
+                     minOccurs="0"/>
+        <xsd:element name="order-column" type="orm:order-column"
+                     minOccurs="0"/>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:element name="map-key" type="orm:map-key"
+                     minOccurs="0"/>
+        <xsd:sequence>
+          <xsd:element name="map-key-class" type="orm:map-key-class"
+                       minOccurs="0"/>
+          <xsd:choice>
+            <xsd:element name="map-key-temporal"
+                         type="orm:temporal"
+                         minOccurs="0"/>
+            <xsd:element name="map-key-enumerated"
+                         type="orm:enumerated"
+                         minOccurs="0"/>
+            <xsd:sequence>
+              <xsd:element name="map-key-attribute-override"
+                           type="orm:attribute-override"
+                           minOccurs="0" maxOccurs="unbounded"/>
+              <xsd:element name="map-key-convert" type="orm:convert"
+                           minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+          </xsd:choice>
+          <xsd:choice>
+            <xsd:element name="map-key-column"
+                         type="orm:map-key-column"
+                         minOccurs="0"/>
+            <xsd:sequence>
+              <xsd:element name="map-key-join-column"
+                           type="orm:map-key-join-column"
+                           minOccurs="0" maxOccurs="unbounded"/>
+              <xsd:element name="map-key-foreign-key"
+                           type="orm:foreign-key"
+                           minOccurs="0"/>
+            </xsd:sequence>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:sequence>
+          <xsd:element name="column" type="orm:column" minOccurs="0"/>
+          <xsd:choice>
+            <xsd:element name="temporal"
+                         type="orm:temporal"
+                         minOccurs="0"/>
+            <xsd:element name="enumerated"
+                         type="orm:enumerated"
+                         minOccurs="0"/>
+            <xsd:element name="lob"
+                         type="orm:lob"
+                         minOccurs="0"/>
+          </xsd:choice>
+        </xsd:sequence>
+        <xsd:sequence>
+          <xsd:element name="attribute-override"
+                       type="orm:attribute-override"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="association-override"
+                       type="orm:association-override"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="convert" type="orm:convert"
+                       minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="collection-table" type="orm:collection-table"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-class" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="embeddable">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the settings and mappings for embeddable objects. Is
+        allowed to be sparsely populated and used in conjunction with
+        the annotations. Alternatively, the metadata-complete attribute
+        can be used to indicate that no annotations are to be processed
+        in the class. If this is the case then the defaulting rules will
+        be recursively applied.
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface Embeddable {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="attributes" type="orm:embeddable-attributes"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="metadata-complete" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="embeddable-attributes">
+    <xsd:sequence>
+      <xsd:element name="basic" type="orm:basic"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="many-to-one" type="orm:many-to-one"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="one-to-many" type="orm:one-to-many"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="one-to-one" type="orm:one-to-one"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="many-to-many" type="orm:many-to-many"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="element-collection" type="orm:element-collection"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="embedded" type="orm:embedded"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="transient" type="orm:transient"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="embedded">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Embedded {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="attribute-override" type="orm:attribute-override"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="association-override"
+                   type="orm:association-override"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="convert" type="orm:convert"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="embedded-id">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface EmbeddedId {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="attribute-override" type="orm:attribute-override"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="entity-listener">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines an entity listener to be invoked at lifecycle events
+        for the entities that list this listener.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="pre-merge" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreMerge {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-persist" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PrePersist {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-persist" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostPersist {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-remove" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreRemove {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-remove" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostRemove {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-update" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreUpdate {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-update" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostUpdate {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-upsert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreUpsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-upsert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostUpsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-insert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreInsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-insert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostInsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-delete" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreDelete {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-delete" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostDelete {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-load" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostLoad {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="entity-listeners">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface EntityListeners {
+          Class<?>[] value();
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="entity-listener" type="orm:entity-listener"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="entity-result">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target(METHOD) @Retention(RUNTIME)
+        public @interface EntityResult {
+          Class<?> entityClass();
+          LockModeType lockMode() default LockModeType.NONE;
+          FieldResult[] fields() default {};
+          String discriminatorColumn() default "";
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="lock-mode" type="orm:lock-mode-type" minOccurs="0"/>
+      <xsd:element name="field-result" type="orm:field-result"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="entity-class" type="xsd:string" use="required"/>
+    <xsd:attribute name="discriminator-column" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="enum-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum EnumType { ORDINAL, STRING }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="ORDINAL"/>
+      <xsd:enumeration value="STRING"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="enumerated">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Enumerated {
+        EnumType value() default ORDINAL;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="orm:enum-type"/>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="fetch-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum FetchType { LAZY, EAGER }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="LAZY"/>
+      <xsd:enumeration value="EAGER"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="field-result">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface FieldResult {
+        String name();
+        String column();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="column" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="foreign-key">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface ForeignKey {
+        String name() default "";
+        ConstraintMode value() default CONSTRAINT;
+        String foreign-key-definition() default "";
+        String options() default "";
+        }
+
+        Note that the elements that embed the use of the annotation
+        default this use as @ForeignKey(PROVIDER_DEFAULT).
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="constraint-mode" type="orm:constraint-mode"/>
+    <xsd:attribute name="foreign-key-definition" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="generated-value">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface GeneratedValue {
+        GenerationType strategy() default AUTO;
+        String generator() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="strategy" type="orm:generation-type"/>
+    <xsd:attribute name="generator" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="generation-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum GenerationType { TABLE, SEQUENCE, IDENTITY, UUID, AUTO }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="TABLE"/>
+      <xsd:enumeration value="SEQUENCE"/>
+      <xsd:enumeration value="IDENTITY"/>
+      <xsd:enumeration value="UUID"/>
+      <xsd:enumeration value="AUTO"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="id">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Id {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column" type="orm:column"
+                   minOccurs="0"/>
+      <xsd:element name="generated-value" type="orm:generated-value"
+                   minOccurs="0"/>
+      <xsd:element name="temporal" type="orm:temporal"
+                   minOccurs="0"/>
+      <xsd:element name="table-generator" type="orm:table-generator"
+                   minOccurs="0"/>
+      <xsd:element name="sequence-generator" type="orm:sequence-generator"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="id-class">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface IdClass {
+          Class<?> value();
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="index">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface Index {
+        String name() default "";
+        String columnList();
+        boolean unique() default false;
+        String type() default "";
+        String using() default "";
+        String options() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="column-list" type="xsd:string" use="required"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+    <xsd:attribute name="type" type="xsd:string"/>
+    <xsd:attribute name="using" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="inheritance">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface Inheritance {
+        InheritanceType strategy() default InheritanceType.SINGLE_TABLE;
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="strategy" type="orm:inheritance-type"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="inheritance-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum InheritanceType { SINGLE_TABLE, TABLE_PER_CLASS, JOINED }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="SINGLE_TABLE"/>
+      <xsd:enumeration value="JOINED"/>
+      <xsd:enumeration value="TABLE_PER_CLASS"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="join-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(JoinColumns.class)
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface JoinColumn {
+        String name() default "";
+        String referencedColumnName() default "";
+        boolean unique() default false;
+        boolean nullable() default true;
+        boolean insertable() default true;
+        boolean updatable() default true;
+        String columnDefinition() default "";
+        String options() default "";
+        String table() default "";
+        ForeignKey foreignKey() default @ForeignKey();
+        CheckConstraint[] check() default {};
+        String comment() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+      <xsd:element name="foreign-key" type="orm:foreign-key"
+                   minOccurs="0"/>
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="referenced-column-name" type="xsd:string"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="join-table">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface JoinTable {
+        String name() default "";
+        String catalog() default "";
+        String schema() default "";
+        JoinColumn[] joinColumns() default {};
+        JoinColumn[] inverseJoinColumns() default {};
+        ForeignKey foreignKey() default @ForeignKey(ConstraintMode.PROVIDER_DEFAULT);
+        ForeignKey inverseForeignKey() default @ForeignKey(ConstraintMode.PROVIDER_DEFAULT);
+        UniqueConstraint[] uniqueConstraints() default {};
+        Index[] indexes() default {};
+        CheckConstraint[] check() default {};
+        String comment() default "";
+        String type() default "";
+        String options() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+      <xsd:sequence>
+        <xsd:element name="join-column" type="orm:join-column"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="foreign-key" type="orm:foreign-key"
+                     minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:sequence>
+        <xsd:element name="inverse-join-column" type="orm:join-column"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="inverse-foreign-key" type="orm:foreign-key"
+                     minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:element name="unique-constraint" type="orm:unique-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="index" type="orm:index"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+    <xsd:attribute name="type" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="lob">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Lob {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="lock-mode-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum LockModeType implements FindOption, RefreshOption { READ, WRITE, OPTIMISTIC, OPTIMISTIC_FORCE_INCREMENT, PESSIMISTIC_READ, PESSIMISTIC_WRITE, PESSIMISTIC_FORCE_INCREMENT, NONE}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="READ"/>
+      <xsd:enumeration value="WRITE"/>
+      <xsd:enumeration value="OPTIMISTIC"/>
+      <xsd:enumeration value="OPTIMISTIC_FORCE_INCREMENT"/>
+      <xsd:enumeration value="PESSIMISTIC_READ"/>
+      <xsd:enumeration value="PESSIMISTIC_WRITE"/>
+      <xsd:enumeration value="PESSIMISTIC_FORCE_INCREMENT"/>
+      <xsd:enumeration value="NONE"/>
+
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="pessimistic-lock-scope">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum PessimisticLockScope implements FindOption, RefreshOption, LockOption { NORMAL, EXTENDED, FETCHED }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="NORMAL"/>
+      <xsd:enumeration value="EXTENDED"/>
+      <xsd:enumeration value="FETCHED"/>
+
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="many-to-many">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface ManyToMany {
+          Class<?> targetEntity() default void.class;
+          CascadeType[] cascade() default {};
+          FetchType fetch() default FetchType.LAZY;
+          String mappedBy() default "";
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="order-by" type="orm:order-by"
+                     minOccurs="0"/>
+        <xsd:element name="order-column" type="orm:order-column"
+                     minOccurs="0"/>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:element name="map-key" type="orm:map-key"
+                     minOccurs="0"/>
+        <xsd:sequence>
+          <xsd:element name="map-key-class" type="orm:map-key-class"
+                       minOccurs="0"/>
+          <xsd:choice>
+            <xsd:element name="map-key-temporal"
+                         type="orm:temporal"
+                         minOccurs="0"/>
+            <xsd:element name="map-key-enumerated"
+                         type="orm:enumerated"
+                         minOccurs="0"/>
+            <xsd:sequence>
+              <xsd:element name="map-key-attribute-override"
+                           type="orm:attribute-override"
+                           minOccurs="0" maxOccurs="unbounded"/>
+              <xsd:element name="map-key-convert" type="orm:convert"
+                           minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+          </xsd:choice>
+          <xsd:choice>
+            <xsd:element name="map-key-column" type="orm:map-key-column"
+                         minOccurs="0"/>
+            <xsd:sequence>
+              <xsd:element name="map-key-join-column"
+                           type="orm:map-key-join-column"
+                           minOccurs="0" maxOccurs="unbounded"/>
+              <xsd:element name="map-key-foreign-key"
+                           type="orm:foreign-key"
+                           minOccurs="0"/>
+            </xsd:sequence>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="join-table" type="orm:join-table"
+                   minOccurs="0"/>
+      <xsd:element name="cascade" type="orm:cascade-type"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-entity" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="mapped-by" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="many-to-one">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface ManyToOne {
+          Class<?> targetEntity() default void.class;
+          CascadeType[] cascade() default {};
+          FetchType fetch() default FetchType.EAGER;
+          boolean optional() default true;
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:sequence>
+          <xsd:element name="join-column" type="orm:join-column"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="foreign-key" type="orm:foreign-key"
+                       minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:element name="join-table" type="orm:join-table"
+                     minOccurs="0"/>
+      </xsd:choice>
+      <xsd:element name="cascade" type="orm:cascade-type"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-entity" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="optional" type="xsd:boolean"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="maps-id" type="xsd:string"/>
+    <xsd:attribute name="id" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="map-key">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface MapKey {
+        String value() default "";
+        @Deprecated
+        String name() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <!-- no need to reflect annotation member name change here -->
+    <xsd:attribute name="name" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="map-key-class">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface MapKeyClass {
+          Class<?> value();
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="map-key-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface MapKeyColumn {
+        String name() default "";
+        boolean unique() default false;
+        boolean nullable() default false;
+        boolean insertable() default true;
+        boolean updatable() default true;
+        String columnDefinition() default "";
+        String options() default "";
+        String table() default "";
+        int length() default 255;
+        int precision() default 0; // decimal precision
+        int scale() default 0; // decimal scale
+        CheckConstraint[] check() default {};
+        String comment() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+    <xsd:attribute name="length" type="xsd:int"/>
+    <xsd:attribute name="precision" type="xsd:int"/>
+    <xsd:attribute name="scale" type="xsd:int"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="map-key-join-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(MapKeyJoinColumns.class)
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface MapKeyJoinColumn {
+        String name() default "";
+        String referencedColumnName() default "";
+        boolean unique() default false;
+        boolean nullable() default false;
+        boolean insertable() default true;
+        boolean updatable() default true;
+        String columnDefinition() default "";
+        String options() default "";
+        String table() default "";
+        ForeignKey foreignKey() default @ForeignKey(ConstraintMode.PROVIDER_DEFAULT);
+        CheckConstraint[] check() default {};
+        String comment() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+      <xsd:element name="foreign-key" type="orm:foreign-key"
+                   minOccurs="0"/>
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="referenced-column-name" type="xsd:string"/>
+    <xsd:attribute name="unique" type="xsd:boolean"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="mapped-superclass">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the settings and mappings for a mapped superclass. Is
+        allowed to be sparsely populated and used in conjunction with
+        the annotations. Alternatively, the metadata-complete attribute
+        can be used to indicate that no annotations are to be processed
+        If this is the case then the defaulting rules will be recursively
+        applied.
+
+        @Target(TYPE) @Retention(RUNTIME)
+        public @interface MappedSuperclass {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="id-class" type="orm:id-class" minOccurs="0"/>
+      <xsd:element name="exclude-default-listeners" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="exclude-superclass-listeners" type="orm:emptyType"
+                   minOccurs="0"/>
+      <xsd:element name="entity-listeners" type="orm:entity-listeners"
+                   minOccurs="0"/>
+      <xsd:element name="pre-merge" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreMerge {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-persist" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PrePersist {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-persist" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostPersist {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-remove" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreRemove {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-remove" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostRemove {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-update" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreUpdate {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-update" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostUpdate {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-upsert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreUpsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-upsert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostUpsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-insert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreInsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-insert" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostInsert {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="pre-delete" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PreDelete {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-delete" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostDelete {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="post-load" type="orm:lifecycle-callback" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            @Target({METHOD}) @Retention(RUNTIME)
+            public @interface PostLoad {}
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attributes" type="orm:attributes" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="metadata-complete" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="named-attribute-node">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface NamedAttributeNode {
+        String value();
+        String subgraph() default "";
+        String keySubgraph() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="subgraph" type="xsd:string"/>
+    <xsd:attribute name="key-subgraph" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="named-entity-graph">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(NamedEntityGraphs.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedEntityGraph {
+        String name() default "";
+        NamedAttributeNode[] attributeNodes() default {};
+        boolean includeAllAttributes() default false;
+        NamedSubgraph[] subgraphs() default {};
+        NamedSubGraph[] subclassSubgraphs() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="named-attribute-node"
+                   type="orm:named-attribute-node"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="subgraph"
+                   type="orm:named-subgraph"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="subclass-subgraph"
+                   type="orm:named-subgraph"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="include-all-attributes" type="xsd:boolean"/>
+  </xsd:complexType>
+
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="named-native-query">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Repeatable(NamedNativeQueries.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedNativeQuery {
+          String name();
+          String query();
+          QueryHint[] hints() default {};
+          Class<?> resultClass() default void.class;
+          String resultSetMapping() default ""; //named SqlResultSetMapping
+          EntityResult[] entities() default {};
+          ConstructorResult[] classes() default {};
+          ColumnResult[] columns() default {};
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="query" type="xsd:string"/>
+      <xsd:element name="hint" type="orm:query-hint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="entity-result" type="orm:entity-result"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="constructor-result" type="orm:constructor-result"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="column-result" type="orm:column-result"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="result-class" type="xsd:string"/>
+    <xsd:attribute name="result-set-mapping" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="named-query">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Repeatable(NamedQueries.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedQuery {
+          String name();
+          String query();
+          Class<?> resultClass() default void.class;
+          LockModeType lockMode() default LockModeType.NONE;
+          PessimisticLockScope lockScope() default PessimisticLockScope.NORMAL;
+          QueryHint[] hints() default {};
+          String entityGraph() default "";
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="query" type="xsd:string"/>
+      <xsd:element name="lock-mode" type="orm:lock-mode-type" minOccurs="0"/>
+      <xsd:element name="lock-scope" type="orm:pessimistic-lock-scope" minOccurs="0"/>
+      <xsd:element name="hint" type="orm:query-hint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="entity-graph" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="result-class" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="named-native-statement">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Repeatable(NamedNativeStatements.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedNativeStatement {
+          String name();
+          String statement();
+          QueryHint[] hints() default {};
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="statement" type="xsd:string"/>
+      <xsd:element name="hint" type="orm:query-hint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="named-statement">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Repeatable(NamedStatements.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedStatement {
+          String name();
+          String statement();
+          QueryHint[] hints() default {};
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="statement" type="xsd:string"/>
+      <xsd:element name="hint" type="orm:query-hint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="named-stored-procedure-query">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(NamedStoredProcedureQueries.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedStoredProcedureQuery {
+        String name();
+        String procedureName();
+        StoredProcedureParameter[] parameters() default {};
+        Class[] resultClasses() default {};
+        String[] resultSetMappings() default{};
+        QueryHint[] hints() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="parameter"
+                   type="orm:stored-procedure-parameter"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="result-class" type="xsd:string"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="result-set-mapping" type="xsd:string"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="hint" type="orm:query-hint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="procedure-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="named-subgraph">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface NamedSubgraph {
+          String name();
+          Class<?> type() default void.class;
+          NamedAttributeNode[] attributeNodes();
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="named-attribute-node"
+                   type="orm:named-attribute-node"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="class" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="one-to-many">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface OneToMany {
+          Class<?> targetEntity() default void.class;
+          CascadeType[] cascade() default {};
+          FetchType fetch() default FetchType.LAZY;
+          String mappedBy() default "";
+          boolean orphanRemoval() default false;
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="order-by" type="orm:order-by"
+                     minOccurs="0"/>
+        <xsd:element name="order-column" type="orm:order-column"
+                     minOccurs="0"/>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:element name="map-key" type="orm:map-key"
+                     minOccurs="0"/>
+        <xsd:sequence>
+          <xsd:element name="map-key-class" type="orm:map-key-class"
+                       minOccurs="0"/>
+          <xsd:choice>
+            <xsd:element name="map-key-temporal"
+                         type="orm:temporal"
+                         minOccurs="0"/>
+            <xsd:element name="map-key-enumerated"
+                         type="orm:enumerated"
+                         minOccurs="0"/>
+            <xsd:sequence>
+              <xsd:element name="map-key-attribute-override"
+                           type="orm:attribute-override"
+                           minOccurs="0" maxOccurs="unbounded"/>
+              <xsd:element name="map-key-convert" type="orm:convert"
+                           minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+          </xsd:choice>
+          <xsd:choice>
+            <xsd:element name="map-key-column" type="orm:map-key-column"
+                         minOccurs="0"/>
+            <xsd:sequence>
+              <xsd:element name="map-key-join-column"
+                           type="orm:map-key-join-column"
+                           minOccurs="0" maxOccurs="unbounded"/>
+              <xsd:element name="map-key-foreign-key"
+                           type="orm:foreign-key"
+                           minOccurs="0"/>
+            </xsd:sequence>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:choice>
+        <xsd:element name="join-table" type="orm:join-table"
+                     minOccurs="0"/>
+        <xsd:sequence>
+          <xsd:element name="join-column" type="orm:join-column"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="foreign-key" type="orm:foreign-key"
+                       minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="cascade" type="orm:cascade-type"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-entity" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="mapped-by" type="xsd:string"/>
+    <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="one-to-one">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface OneToOne {
+          Class<?> targetEntity() default void.class;
+          CascadeType[] cascade() default {};
+          FetchType fetch() default FetchType.EAGER;
+          boolean optional() default true;
+          String mappedBy() default "";
+          boolean orphanRemoval() default false;
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:sequence>
+          <xsd:element name="primary-key-join-column"
+                       type="orm:primary-key-join-column"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="primary-key-foreign-key"
+                       type="orm:foreign-key"
+                       minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:sequence>
+          <xsd:element name="join-column" type="orm:join-column"
+                       minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element name="foreign-key" type="orm:foreign-key"
+                       minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:element name="join-table" type="orm:join-table"
+                     minOccurs="0"/>
+      </xsd:choice>
+      <xsd:element name="cascade" type="orm:cascade-type"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="target-entity" type="xsd:string"/>
+    <xsd:attribute name="fetch" type="orm:fetch-type"/>
+    <xsd:attribute name="optional" type="xsd:boolean"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+    <xsd:attribute name="mapped-by" type="xsd:string"/>
+    <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
+    <xsd:attribute name="maps-id" type="xsd:string"/>
+    <xsd:attribute name="id" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="order-by">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface OrderBy {
+        String value() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="order-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface OrderColumn {
+        String name() default "";
+        boolean nullable() default true;
+        boolean insertable() default true;
+        boolean updatable() default true;
+        String columnDefinition() default "";
+        String options() default "";
+        String comment() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="nullable" type="xsd:boolean"/>
+    <xsd:attribute name="insertable" type="xsd:boolean"/>
+    <xsd:attribute name="updatable" type="xsd:boolean"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="parameter-mode">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum ParameterMode { IN, INOUT, OUT, REF_CURSOR }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="IN"/>
+      <xsd:enumeration value="INOUT"/>
+      <xsd:enumeration value="OUT"/>
+      <xsd:enumeration value="REF_CURSOR"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="lifecycle-callback">
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="method-name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="primary-key-join-column">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(PrimaryKeyJoinColumns.class)
+        @Target({TYPE, METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface PrimaryKeyJoinColumn {
+        String name() default "";
+        String referencedColumnName() default "";
+        String columnDefinition() default "";
+        String options() default "";
+        ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
+        CheckConstraint[] check() default {};
+        String comment() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+      <xsd:element name="foreign-key" type="orm:foreign-key"
+                   minOccurs="0"/>
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="referenced-column-name" type="xsd:string"/>
+    <xsd:attribute name="column-definition" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="query-hint">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface QueryHint {
+        String name();
+        String value();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="value" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="secondary-table">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(SecondaryTables.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface SecondaryTable {
+        String name();
+        String catalog() default "";
+        String schema() default "";
+        PrimaryKeyJoinColumn[] pkJoinColumns() default {};
+        ForeignKey foreignKey() default @ForeignKey(ConstraintMode.PROVIDER_DEFAULT);
+        UniqueConstraint[] uniqueConstraints() default {};
+        Index[] indexes() default {};
+        CheckConstraint[] check() default {};
+        String comment() default "";
+        String type() default "";
+        String options() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:sequence>
+        <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+        <xsd:element name="primary-key-join-column"
+                     type="orm:primary-key-join-column"
+                     minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="primary-key-foreign-key"
+                     type="orm:foreign-key"
+                     minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:element name="unique-constraint" type="orm:unique-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="index" type="orm:index"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="foreign-key" type="orm:foreign-key"
+                   minOccurs="0"/>
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+    <xsd:attribute name="type" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="sequence-generator">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(SequenceGenerators.class)
+        @Target({TYPE, METHOD, FIELD, PACKAGE}) @Retention(RUNTIME)
+        public @interface SequenceGenerator {
+        String name() default "";
+        String sequenceName() default "";
+        String catalog() default "";
+        String schema() default "";
+        int initialValue() default 1;
+        int allocationSize() default 50;
+        String options() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="sequence-name" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+    <xsd:attribute name="initial-value" type="xsd:int"/>
+    <xsd:attribute name="allocation-size" type="xsd:int"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="sql-result-set-mapping">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(SqlResultSetMappings.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface SqlResultSetMapping {
+        String name();
+        EntityResult[] entities() default {};
+        ConstructorResult[] classes() default{};
+        ColumnResult[] columns() default {};
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="entity-result" type="orm:entity-result"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="constructor-result" type="orm:constructor-result"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="column-result" type="orm:column-result"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="stored-procedure-parameter">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface StoredProcedureParameter {
+          String name() default "";
+          ParameterMode mode() default ParameterMode.IN;
+          Class<?> type();
+        }
+
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="class" type="xsd:string" use="required"/>
+    <xsd:attribute name="mode" type="orm:parameter-mode"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="table">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface Table {
+        String name() default "";
+        String catalog() default "";
+        String schema() default "";
+        UniqueConstraint[] uniqueConstraints() default {};
+        Index[] indexes() default {};
+        CheckConstraint[] check() default {};
+        String comment() default "";
+        String type() default "";
+        String options() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+      <xsd:element name="unique-constraint" type="orm:unique-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="index" type="orm:index"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+    <xsd:attribute name="type" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="table-generator">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Repeatable(TableGenerators.class)
+        @Target({TYPE, METHOD, FIELD, PACKAGE}) @Retention(RUNTIME)
+        public @interface TableGenerator {
+        String name() default "";
+        String table() default "";
+        String catalog() default "";
+        String schema() default "";
+        String pkColumnName() default "";
+        String valueColumnName() default "";
+        String pkColumnValue() default "";
+        int initialValue() default 0;
+        int allocationSize() default 50;
+        UniqueConstraint[] uniqueConstraints() default {};
+        Indexes[] indexes() default {};
+        String options() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="unique-constraint" type="orm:unique-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="index" type="orm:index"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="check-constraint" type="orm:check-constraint"
+                   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="table" type="xsd:string"/>
+    <xsd:attribute name="catalog" type="xsd:string"/>
+    <xsd:attribute name="schema" type="xsd:string"/>
+    <xsd:attribute name="pk-column-name" type="xsd:string"/>
+    <xsd:attribute name="value-column-name" type="xsd:string"/>
+    <xsd:attribute name="pk-column-value" type="xsd:string"/>
+    <xsd:attribute name="initial-value" type="xsd:int"/>
+    <xsd:attribute name="allocation-size" type="xsd:int"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="temporal">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Temporal {
+        TemporalType value();
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="orm:temporal-type"/>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="temporal-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Deprecated(since = "3.2")
+        public enum TemporalType {
+        DATE, // java.sql.Date
+        TIME, // java.sql.Time
+        TIMESTAMP // java.sql.Timestamp
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="DATE"/>
+      <xsd:enumeration value="TIME"/>
+      <xsd:enumeration value="TIMESTAMP"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="excluded-from-versioning">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD})
+        @Retention(RUNTIME)
+        public @interface ExcludedFromVersioning {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="transient">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Transient {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="unique-constraint">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({}) @Retention(RUNTIME)
+        public @interface UniqueConstraint {
+        String name() default "";
+        String[] columnNames();
+        String options() default "";
+        }
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column-name" type="xsd:string"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="options" type="xsd:string"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="version">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        @Target({METHOD, FIELD}) @Retention(RUNTIME)
+        public @interface Version {}
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="column" type="orm:column" minOccurs="0"/>
+      <xsd:element name="temporal" type="orm:temporal" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="access" type="orm:access-type"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/hibernate-core/src/main/resources/org/hibernate/jpa/persistence_4_0.xsd
+++ b/hibernate-core/src/main/resources/org/hibernate/jpa/persistence_4_0.xsd
@@ -1,0 +1,416 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2008, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<!-- persistence.xml schema -->
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/persistence"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:persistence="https://jakarta.ee/xml/ns/persistence"
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified"
+  version="4.0">
+
+   <xsd:annotation>
+     <xsd:documentation><![CDATA[
+
+     This is the XML Schema for the persistence configuration file.
+     The file must be named "META-INF/persistence.xml" in the
+     persistence archive.
+
+     Persistence configuration files must indicate
+     the persistence schema by using the persistence namespace:
+
+     https://jakarta.ee/xml/ns/persistence
+
+     and indicate the version of the schema by
+     using the version element as shown below:
+
+      <persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+          https://jakarta.ee/xml/ns/persistence/persistence_4_0.xsd"
+        version="4.0">
+          ...
+      </persistence>
+
+    ]]></xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:simpleType name="versionType">
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="[0-9]+(\.[0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:element name="persistence">
+    <xsd:complexType>
+      <xsd:sequence>
+
+        <!-- **************************************************** -->
+
+        <xsd:element name="persistence-unit"
+                     minOccurs="1" maxOccurs="unbounded">
+          <xsd:complexType>
+            <xsd:annotation>
+              <xsd:documentation>
+
+                Configuration of a persistence unit.
+
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:sequence>
+
+            <!-- **************************************************** -->
+
+              <xsd:element name="description" type="xsd:string"
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Description of this persistence unit.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="provider" type="xsd:string"
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Provider class that supplies EntityManagers for this
+                    persistence unit.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="qualifier" type="xsd:string"
+                           minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Qualifier annotation class used for dependency injection.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="scope" type="xsd:string"
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Scope annotation class used for dependency injection.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="jta-data-source" type="xsd:string"
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    The container-specific name of the JTA datasource to use.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="non-jta-data-source" type="xsd:string"
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    The container-specific name of a non-JTA datasource to use.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="mapping-file" type="xsd:string"
+                           minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    File containing mapping information. Loaded as a resource
+                    by the persistence provider.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="jar-file" type="xsd:string"
+                           minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Jar file that is to be scanned for managed classes.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="class" type="xsd:string"
+                           minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Managed class to be included in the persistence unit and
+                    to scan for annotations.  It should be annotated
+                    with either @Entity, @Embeddable or @MappedSuperclass.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="exclude-unlisted-classes" type="xsd:boolean"
+                           default="true" minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    When set to true then only listed classes and jars will
+                    be scanned for persistent classes, otherwise the
+                    enclosing jar or directory will also be scanned.
+                    Not applicable to Java SE persistence units.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="default-to-one-fetch-type"
+                           type="persistence:persistence-unit-default-to-one-fetch-type"
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    The default fetch type for one-to-one and many-to-one associations.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="shared-cache-mode"
+                           type="persistence:persistence-unit-caching-type"
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Defines whether caching is enabled for the
+                    persistence unit if caching is supported by the
+                    persistence provider. When set to ALL, all entities
+                    will be cached. When set to NONE, no entities will
+                    be cached. When set to ENABLE_SELECTIVE, only entities
+                    specified as cacheable will be cached. When set to
+                    DISABLE_SELECTIVE, entities specified as not cacheable
+                    will not be cached. When not specified or when set to
+                    UNSPECIFIED, provider defaults may apply.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="validation-mode"
+                           type="persistence:persistence-unit-validation-mode-type"
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    The validation mode to be used for the persistence unit.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="properties" minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    A list of standard and vendor-specific properties
+                    and hints.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+                <xsd:complexType>
+                  <xsd:sequence>
+                    <xsd:element name="property"
+                                 minOccurs="0" maxOccurs="unbounded">
+                      <xsd:annotation>
+                        <xsd:documentation>
+                          A name-value pair.
+                        </xsd:documentation>
+                      </xsd:annotation>
+                      <xsd:complexType>
+                        <xsd:attribute name="name" type="xsd:string"
+                                       use="required"/>
+                        <xsd:attribute name="value" type="xsd:string"
+                                       use="required"/>
+                      </xsd:complexType>
+                    </xsd:element>
+                  </xsd:sequence>
+                </xsd:complexType>
+              </xsd:element>
+
+              <xsd:any namespace="##other" processContents="lax"
+                       minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    An extension point for integration related configuration, e.g. cdi:
+                    <!--
+                    <persistence-unit name="my-unit" xmlns:cdi="https://jakarta.ee/xml/ns/persistence-cdi">
+                      ...
+                      <cdi:scope>com.example.jpa.ACustomScope</cdi:scope>
+                      <cdi:qualifier>com.example.jpa.CustomQualifier</cdi:qualifier>
+                    </persistence-unit>
+                    -->
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:any>
+            </xsd:sequence>
+
+            <!-- **************************************************** -->
+
+            <xsd:attribute name="name" type="xsd:string" use="required">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  Name used in code to reference this persistence unit.
+
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:attribute>
+
+            <!-- **************************************************** -->
+
+            <xsd:attribute name="transaction-type"
+                           type="persistence:persistence-unit-transaction-type">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  Type of transactions used by EntityManagers from this
+                  persistence unit.
+
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:attribute>
+
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="version" type="persistence:versionType"
+                     fixed="4.0" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="persistence-unit-transaction-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum PersistenceUnitTransactionType {JTA, RESOURCE_LOCAL};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="JTA"/>
+      <xsd:enumeration value="RESOURCE_LOCAL"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="persistence-unit-default-to-one-fetch-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum FetchType { LAZY, EAGER, DEFAULT };
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="LAZY"/>
+      <xsd:enumeration value="EAGER"/>
+      <!-- no DEFAULT -->
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="persistence-unit-caching-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum SharedCacheMode { ALL, NONE, ENABLE_SELECTIVE, DISABLE_SELECTIVE, UNSPECIFIED};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="ALL"/>
+      <xsd:enumeration value="NONE"/>
+      <xsd:enumeration value="ENABLE_SELECTIVE"/>
+      <xsd:enumeration value="DISABLE_SELECTIVE"/>
+      <xsd:enumeration value="UNSPECIFIED"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="persistence-unit-validation-mode-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum ValidationMode { AUTO, CALLBACK, NONE };
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="AUTO"/>
+      <xsd:enumeration value="CALLBACK"/>
+      <xsd:enumeration value="NONE"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/mapping-8.0.xsd
+++ b/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/mapping-8.0.xsd
@@ -18,7 +18,7 @@
 
         <entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                version="7.0">
+                version="8.0">
             ...
         </entity-mappings>
         ]]></xsd:documentation>
@@ -159,6 +159,7 @@
             <xsd:enumeration value="3.0" />
             <xsd:enumeration value="3.1" />
             <xsd:enumeration value="3.2" />
+            <xsd:enumeration value="4.0" />
 
             <!-- Hibernate versions -->
             <xsd:enumeration value="7.0" />
@@ -376,6 +377,10 @@
                          minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="named-native-query" type="orm:named-native-query"
                          minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="named-statement" type="orm:named-statement"
+                         minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="named-native-statement" type="orm:named-native-statement"
+                         minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="named-stored-procedure-query"
                          type="orm:named-stored-procedure-query"
                          minOccurs="0" maxOccurs="unbounded"/>
@@ -389,14 +394,146 @@
                          minOccurs="0"/>
             <xsd:element name="entity-listeners" type="orm:entity-listeners"
                          minOccurs="0"/>
-            <xsd:element name="pre-persist" type="orm:pre-persist" minOccurs="0"/>
-            <xsd:element name="post-persist" type="orm:post-persist"
-                         minOccurs="0"/>
-            <xsd:element name="pre-remove" type="orm:pre-remove" minOccurs="0"/>
-            <xsd:element name="post-remove" type="orm:post-remove" minOccurs="0"/>
-            <xsd:element name="pre-update" type="orm:pre-update" minOccurs="0"/>
-            <xsd:element name="post-update" type="orm:post-update" minOccurs="0"/>
-            <xsd:element name="post-load" type="orm:post-load" minOccurs="0"/>
+            <xsd:element name="pre-merge" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreMerge {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-persist" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PrePersist {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-persist" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostPersist {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-remove" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreRemove {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-remove" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostRemove {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-update" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreUpdate {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-update" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostUpdate {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-upsert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreUpsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-upsert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostUpsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-insert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreInsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-insert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostInsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-delete" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreDelete {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-delete" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostDelete {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-load" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostLoad {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
 
             <xsd:element name="attribute-override" type="orm:attribute-override"
                          minOccurs="0" maxOccurs="unbounded"/>
@@ -548,6 +685,9 @@
                          minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="embedded" type="orm:embedded"
                          minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="excluded-from-versioning"
+                         type="orm:excluded-from-versioning"
+                         minOccurs="0"/>
             <xsd:element name="transient" type="orm:transient"
                          minOccurs="0" maxOccurs="unbounded"/>
             <!-- hbm: discriminated association mapping -->
@@ -734,6 +874,9 @@
                 ForeignKey foreignKey() default @ForeignKey(ConstraintMode.PROVIDER_DEFAULT);
                 UniqueConstraint[] uniqueConstraints() default {};
                 Index[] indexes() default {};
+                CheckConstraint[] check() default {};
+                String comment() default "";
+                String type() default "";
                 String options() default "";
                 }
 
@@ -751,12 +894,11 @@
                          minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="index" type="orm:index"
                          minOccurs="0" maxOccurs="unbounded"/>
-            <xsd:element name="check" type="orm:check-constraint"
-                         minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string"/>
         <xsd:attribute name="catalog" type="xsd:string"/>
         <xsd:attribute name="schema" type="xsd:string"/>
+        <xsd:attribute name="type" type="xsd:string"/>
         <xsd:attribute name="options" type="xsd:string"/>
     </xsd:complexType>
 
@@ -853,7 +995,7 @@
         <xsd:sequence>
             <xsd:element name="column" type="orm:column-result"
                          maxOccurs="unbounded"/>
-            <xsd:element name="entities" type="orm:entity-result"
+            <xsd:element name="entity" type="orm:entity-result"
                          maxOccurs="unbounded"/>
         </xsd:sequence>
         <xsd:attribute name="target-class" type="xsd:string" use="required"/>
@@ -1160,14 +1302,146 @@
         </xsd:annotation>
         <xsd:sequence>
             <xsd:element name="description" type="xsd:string" minOccurs="0"/>
-            <xsd:element name="pre-persist" type="orm:pre-persist" minOccurs="0"/>
-            <xsd:element name="post-persist" type="orm:post-persist"
-                         minOccurs="0"/>
-            <xsd:element name="pre-remove" type="orm:pre-remove" minOccurs="0"/>
-            <xsd:element name="post-remove" type="orm:post-remove" minOccurs="0"/>
-            <xsd:element name="pre-update" type="orm:pre-update" minOccurs="0"/>
-            <xsd:element name="post-update" type="orm:post-update" minOccurs="0"/>
-            <xsd:element name="post-load" type="orm:post-load" minOccurs="0"/>
+            <xsd:element name="pre-merge" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreMerge {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-persist" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PrePersist {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-persist" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostPersist {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-remove" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreRemove {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-remove" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostRemove {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-update" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreUpdate {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-update" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostUpdate {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-upsert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreUpsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-upsert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostUpsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-insert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreInsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-insert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostInsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-delete" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreDelete {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-delete" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostDelete {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-load" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostLoad {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
         </xsd:sequence>
         <xsd:attribute name="class" type="xsd:string" use="required"/>
     </xsd:complexType>
@@ -1405,6 +1679,8 @@
                 String name() default "";
                 String columnList();
                 boolean unique() default false;
+                String type() default "";
+                String using() default "";
                 String options() default "";
                 }
 
@@ -1416,6 +1692,8 @@
         <xsd:attribute name="name" type="xsd:string"/>
         <xsd:attribute name="column-list" type="xsd:string" use="required"/>
         <xsd:attribute name="unique" type="xsd:boolean"/>
+        <xsd:attribute name="type" type="xsd:string"/>
+        <xsd:attribute name="using" type="xsd:string"/>
         <xsd:attribute name="options" type="xsd:string"/>
     </xsd:complexType>
 
@@ -1514,6 +1792,7 @@
                 Index[] indexes() default {};
                 CheckConstraint[] check() default {};
                 String comment() default "";
+                String type() default "";
                 String options() default "";
                 }
 
@@ -1542,6 +1821,7 @@
         <xsd:attribute name="name" type="xsd:string"/>
         <xsd:attribute name="catalog" type="xsd:string"/>
         <xsd:attribute name="schema" type="xsd:string"/>
+        <xsd:attribute name="type" type="xsd:string"/>
         <xsd:attribute name="options" type="xsd:string"/>
     </xsd:complexType>
 
@@ -1754,10 +2034,17 @@
                 int length() default 255;
                 int precision() default 0; // decimal precision
                 int scale() default 0; // decimal scale
+                CheckConstraint[] check() default {};
+                String comment() default "";
                 }
 
             </xsd:documentation>
         </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="comment" type="xsd:string" minOccurs="0" />
+            <xsd:element name="check-constraint" type="orm:check-constraint"
+                         minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string"/>
         <xsd:attribute name="unique" type="xsd:boolean"/>
         <xsd:attribute name="nullable" type="xsd:boolean"/>
@@ -1792,6 +2079,7 @@
                     String table() default "";
                     ForeignKey foreignKey() default @ForeignKey(ConstraintMode.PROVIDER_DEFAULT);
                     CheckConstraint[] check() default {}
+                    String comment() default "";
                 }
 
             </xsd:documentation>
@@ -1800,7 +2088,7 @@
             <xsd:element name="comment" type="xsd:string" minOccurs="0"/>
             <xsd:element name="foreign-key" type="orm:foreign-key"
                          minOccurs="0"/>
-            <xsd:element name="check" type="orm:check-constraint"
+            <xsd:element name="check-constraint" type="orm:check-constraint"
                          minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string"/>
@@ -1842,14 +2130,146 @@
                          minOccurs="0"/>
             <xsd:element name="entity-listeners" type="orm:entity-listeners"
                          minOccurs="0"/>
-            <xsd:element name="pre-persist" type="orm:pre-persist" minOccurs="0"/>
-            <xsd:element name="post-persist" type="orm:post-persist"
-                         minOccurs="0"/>
-            <xsd:element name="pre-remove" type="orm:pre-remove" minOccurs="0"/>
-            <xsd:element name="post-remove" type="orm:post-remove" minOccurs="0"/>
-            <xsd:element name="pre-update" type="orm:pre-update" minOccurs="0"/>
-            <xsd:element name="post-update" type="orm:post-update" minOccurs="0"/>
-            <xsd:element name="post-load" type="orm:post-load" minOccurs="0"/>
+            <xsd:element name="pre-merge" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreMerge {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-persist" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PrePersist {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-persist" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostPersist {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-remove" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreRemove {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-remove" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostRemove {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-update" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreUpdate {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-update" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostUpdate {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-upsert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreUpsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-upsert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostUpsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-insert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreInsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-insert" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostInsert {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="pre-delete" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PreDelete {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-delete" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostDelete {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="post-load" type="orm:lifecycle-callback" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+
+                        @Target({METHOD}) @Retention(RUNTIME)
+                        public @interface PostLoad {}
+
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
             <xsd:element name="attributes" type="orm:attributes" minOccurs="0"/>
         </xsd:sequence>
         <xsd:attribute name="class" type="xsd:string" use="required"/>
@@ -1958,31 +2378,81 @@
 
     <xsd:complexType name="named-query">
         <xsd:annotation>
-            <xsd:documentation>
+            <xsd:documentation><![CDATA[
 
                 @Repeatable(NamedQueries.class)
                 @Target({TYPE}) @Retention(RUNTIME)
                     public @interface NamedQuery {
                     String name();
                     String query();
-                    Class resultClass();
+                    Class<?> resultClass() default void.class;
                     String entityGraph();
                     LockModeType lockMode() default LockModeType.NONE;
                     PessimisticLockScope lockScope() default NORMAL;
                     QueryHint[] hints() default {};
                 }
 
-            </xsd:documentation>
+            ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
             <xsd:element name="description" type="xsd:string" minOccurs="0"/>
             <xsd:element name="query" type="xsd:string"/>
-            <xsd:element name="result-class" type="xsd:string"/>
             <xsd:element name="entity-graph" type="xsd:string"/>
             <xsd:element name="lock-mode" type="orm:lock-mode-type" minOccurs="0"/>
             <xsd:element name="lock-scope" type="orm:pessimistic-lock-scope" minOccurs="0"/>
             <xsd:element name="hint" type="orm:query-hint" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:group ref="orm:hbm-common-named-query-elements"/>
+        </xsd:sequence>
+        <xsd:attribute name="result-class" type="xsd:string"/>
+        <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+
+    <!-- **************************************************** -->
+
+    <xsd:complexType name="named-native-statement">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[
+
+        @Repeatable(NamedNativeStatements.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedNativeStatement {
+          String name();
+          String statement();
+          QueryHint[] hints() default {};
+        }
+
+      ]]></xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="statement" type="xsd:string"/>
+            <xsd:element name="hint" type="orm:query-hint"
+                         minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+        <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+
+    <!-- **************************************************** -->
+
+    <xsd:complexType name="named-statement">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[
+
+        @Repeatable(NamedStatements.class)
+        @Target({TYPE}) @Retention(RUNTIME)
+        public @interface NamedStatement {
+          String name();
+          String statement();
+          QueryHint[] hints() default {};
+        }
+
+      ]]></xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="statement" type="xsd:string"/>
+            <xsd:element name="hint" type="orm:query-hint"
+                         minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="required"/>
     </xsd:complexType>
@@ -2222,117 +2692,7 @@
 
     <!-- **************************************************** -->
 
-    <xsd:complexType name="post-load">
-        <xsd:annotation>
-            <xsd:documentation>
-
-                @Target({METHOD}) @Retention(RUNTIME)
-                public @interface PostLoad {}
-
-            </xsd:documentation>
-        </xsd:annotation>
-        <xsd:sequence>
-            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
-        </xsd:sequence>
-        <xsd:attribute name="method-name" type="xsd:string" use="required"/>
-    </xsd:complexType>
-
-    <!-- **************************************************** -->
-
-    <xsd:complexType name="post-persist">
-        <xsd:annotation>
-            <xsd:documentation>
-
-                @Target({METHOD}) @Retention(RUNTIME)
-                public @interface PostPersist {}
-
-            </xsd:documentation>
-        </xsd:annotation>
-        <xsd:sequence>
-            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
-        </xsd:sequence>
-        <xsd:attribute name="method-name" type="xsd:string" use="required"/>
-    </xsd:complexType>
-
-    <!-- **************************************************** -->
-
-    <xsd:complexType name="post-remove">
-        <xsd:annotation>
-            <xsd:documentation>
-
-                @Target({METHOD}) @Retention(RUNTIME)
-                public @interface PostRemove {}
-
-            </xsd:documentation>
-        </xsd:annotation>
-        <xsd:sequence>
-            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
-        </xsd:sequence>
-        <xsd:attribute name="method-name" type="xsd:string" use="required"/>
-    </xsd:complexType>
-
-    <!-- **************************************************** -->
-
-    <xsd:complexType name="post-update">
-        <xsd:annotation>
-            <xsd:documentation>
-
-                @Target({METHOD}) @Retention(RUNTIME)
-                public @interface PostUpdate {}
-
-            </xsd:documentation>
-        </xsd:annotation>
-        <xsd:sequence>
-            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
-        </xsd:sequence>
-        <xsd:attribute name="method-name" type="xsd:string" use="required"/>
-    </xsd:complexType>
-
-    <!-- **************************************************** -->
-
-    <xsd:complexType name="pre-persist">
-        <xsd:annotation>
-            <xsd:documentation>
-
-                @Target({METHOD}) @Retention(RUNTIME)
-                public @interface PrePersist {}
-
-            </xsd:documentation>
-        </xsd:annotation>
-        <xsd:sequence>
-            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
-        </xsd:sequence>
-        <xsd:attribute name="method-name" type="xsd:string" use="required"/>
-    </xsd:complexType>
-
-    <!-- **************************************************** -->
-
-    <xsd:complexType name="pre-remove">
-        <xsd:annotation>
-            <xsd:documentation>
-
-                @Target({METHOD}) @Retention(RUNTIME)
-                public @interface PreRemove {}
-
-            </xsd:documentation>
-        </xsd:annotation>
-        <xsd:sequence>
-            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
-        </xsd:sequence>
-        <xsd:attribute name="method-name" type="xsd:string" use="required"/>
-    </xsd:complexType>
-
-    <!-- **************************************************** -->
-
-    <xsd:complexType name="pre-update">
-        <xsd:annotation>
-            <xsd:documentation>
-
-                @Target({METHOD}) @Retention(RUNTIME)
-                public @interface PreUpdate {}
-
-            </xsd:documentation>
-        </xsd:annotation>
+    <xsd:complexType name="lifecycle-callback">
         <xsd:sequence>
             <xsd:element name="description" type="xsd:string" minOccurs="0"/>
         </xsd:sequence>
@@ -2353,13 +2713,18 @@
                 String columnDefinition() default "";
                 String options() default "";
                 ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
+                CheckConstraint[] check() default {};
+                String comment() default "";
                 }
 
             </xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
+            <xsd:element name="comment" type="xsd:string" minOccurs="0" />
             <xsd:element name="foreign-key" type="orm:foreign-key"
                          minOccurs="0"/>
+            <xsd:element name="check-constraint" type="orm:check-constraint"
+                         minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string"/>
         <xsd:attribute name="referenced-column-name" type="xsd:string"/>
@@ -2420,6 +2785,7 @@
         <!-- hbm: Hibernate allows controlling whether the joined rows for this secondary table are required (inner join) or optional (outer join)-->
         <xsd:attribute name="optional" type="xsd:boolean"/>
         <xsd:attribute name="owned" type="xsd:boolean"/>
+        <xsd:attribute name="type" type="xsd:string"/>
         <xsd:attribute name="options" type="xsd:string"/>
     </xsd:complexType>
 
@@ -2524,6 +2890,7 @@
                 Index[] indexes() default {};
                 CheckConstraint[] check() default {};
                 String comment() default "";
+                String type() default "";
                 String options() default "";
                 }
 
@@ -2539,6 +2906,7 @@
         <xsd:attribute name="name" type="xsd:string"/>
         <xsd:attribute name="catalog" type="xsd:string"/>
         <xsd:attribute name="schema" type="xsd:string"/>
+        <xsd:attribute name="type" type="xsd:string"/>
         <xsd:attribute name="options" type="xsd:string"/>
     </xsd:complexType>
 
@@ -2625,6 +2993,21 @@
             <xsd:enumeration value="TIMESTAMP"/>
         </xsd:restriction>
     </xsd:simpleType>
+
+    <!-- **************************************************** -->
+
+    <xsd:complexType name="excluded-from-versioning">
+        <xsd:annotation>
+            <xsd:documentation>
+
+                @Target({METHOD, FIELD})
+                @Retention(RUNTIME)
+                public @interface ExcludedFromVersioning {}
+
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
 
     <!-- **************************************************** -->
 

--- a/hibernate-core/src/main/xjb/mapping-bindings.xjb
+++ b/hibernate-core/src/main/xjb/mapping-bindings.xjb
@@ -428,6 +428,9 @@
             <bindings node=".//xsd:element[@name='column']">
                 <property name="columns"/>
             </bindings>
+            <bindings node=".//xsd:element[@name='entity']">
+                <property name="entities"/>
+            </bindings>
         </bindings>
 
         <bindings node="//xsd:group[@name='collection-structure-group']">
@@ -570,25 +573,7 @@
             <inheritance:implements>org.hibernate.boot.jaxb.mapping.spi.JaxbLifecycleCallbackContainer</inheritance:implements>
         </bindings>
 
-        <bindings node="//xsd:complexType[@name='pre-persist']">
-            <inheritance:implements>org.hibernate.boot.jaxb.mapping.spi.JaxbLifecycleCallback</inheritance:implements>
-        </bindings>
-        <bindings node="//xsd:complexType[@name='pre-remove']">
-            <inheritance:implements>org.hibernate.boot.jaxb.mapping.spi.JaxbLifecycleCallback</inheritance:implements>
-        </bindings>
-        <bindings node="//xsd:complexType[@name='pre-update']">
-            <inheritance:implements>org.hibernate.boot.jaxb.mapping.spi.JaxbLifecycleCallback</inheritance:implements>
-        </bindings>
-        <bindings node="//xsd:complexType[@name='post-load']">
-            <inheritance:implements>org.hibernate.boot.jaxb.mapping.spi.JaxbLifecycleCallback</inheritance:implements>
-        </bindings>
-        <bindings node="//xsd:complexType[@name='post-remove']">
-            <inheritance:implements>org.hibernate.boot.jaxb.mapping.spi.JaxbLifecycleCallback</inheritance:implements>
-        </bindings>
-        <bindings node="//xsd:complexType[@name='post-update']">
-            <inheritance:implements>org.hibernate.boot.jaxb.mapping.spi.JaxbLifecycleCallback</inheritance:implements>
-        </bindings>
-        <bindings node="//xsd:complexType[@name='post-persist']">
+        <bindings node="//xsd:complexType[@name='lifecycle-callback']">
             <inheritance:implements>org.hibernate.boot.jaxb.mapping.spi.JaxbLifecycleCallback</inheritance:implements>
         </bindings>
 


### PR DESCRIPTION
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20435 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20435
<!-- Hibernate GitHub Bot issue links end -->