### PR TITLE
HHH-20439: enable ci for spanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           - rdbms: mariadb
           - rdbms: postgresql
           - rdbms: spannerpgsql
+          - rdbms: spanner
           - rdbms: edb
           - rdbms: oracle
           - rdbms: db2

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -113,6 +113,8 @@ elif [ "$RDBMS" == "informix" ]; then
   goal="-Pdb=informix"
 elif [ "$RDBMS" == "spannerpgsql" ]; then
   goal="-Pdb=spannerpgsql"
+elif [ "$RDBMS" == "spanner" ]; then
+  goal="-Pdb=spanner"
 else
   echo "Invalid value for RDBMS: $RDBMS"
   exit 1

--- a/ci/database-start.sh
+++ b/ci/database-start.sh
@@ -14,6 +14,8 @@ elif [ "$RDBMS" == 'edb' ]; then
   bash $DIR/../docker_db.sh edb
 elif [ "$RDBMS" == 'spannerpgsql' ]; then
   bash $DIR/../docker_db.sh spanner_pg
+elif [ "$RDBMS" == 'spanner' ]; then
+  bash $DIR/../docker_db.sh spanner
 elif [ "$RDBMS" == 'db2' ]; then
   bash $DIR/../docker_db.sh db2
 elif [ "$RDBMS" == 'oracle' ]; then

--- a/hibernate-core/src/main/java/org/hibernate/dialect/sql/ast/SpannerSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/sql/ast/SpannerSqlAstTranslator.java
@@ -6,16 +6,10 @@ package org.hibernate.dialect.sql.ast;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.jdbc.Expectation;
-import org.hibernate.metamodel.mapping.TableDetails;
-import org.hibernate.query.IllegalQueryOperationException;
 import org.hibernate.query.sqm.ComparisonOperator;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
@@ -37,7 +31,6 @@ import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.insert.ConflictClause;
-import org.hibernate.sql.ast.tree.insert.InsertSelectStatement;
 import org.hibernate.sql.ast.tree.predicate.InArrayPredicate;
 import org.hibernate.sql.ast.tree.predicate.LikePredicate;
 import org.hibernate.sql.ast.tree.select.QueryPart;
@@ -47,13 +40,9 @@ import org.hibernate.sql.ast.tree.expression.Any;
 import org.hibernate.sql.ast.tree.expression.Every;
 import org.hibernate.sql.ast.tree.expression.ModifiedSubQueryExpression;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
-import org.hibernate.sql.ast.tree.update.Assignable;
-import org.hibernate.sql.ast.tree.update.Assignment;
 import org.hibernate.sql.ast.tree.update.UpdateStatement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.sql.model.MutationOperation;
-import org.hibernate.sql.model.MutationTarget;
-import org.hibernate.sql.model.TableMapping;
 import org.hibernate.sql.model.ast.ColumnValueBinding;
 import org.hibernate.sql.model.ast.LogicalTableUpdate;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
@@ -440,140 +429,8 @@ public class SpannerSqlAstTranslator<T extends JdbcOperation> extends AbstractSq
 	}
 
 	@Override
-	protected void renderInsertCommand(InsertSelectStatement statement) {
-		final ConflictClause conflictClause = statement.getConflictClause();
-		if ( conflictClause == null ) {
-			appendSql( "insert into " );
-			return;
-		}
-		if ( conflictClause.getConstraintName() != null ) {
-			throw new IllegalQueryOperationException(
-					"Spanner does not support named constraints in conflict clauses" );
-		}
-		if ( conflictClause.getPredicate() != null ) {
-			throw new IllegalQueryOperationException(
-					"Spanner does not support predicates (WHERE clause) in conflict clauses" );
-		}
-		Set<String> pkColumns = resolvePrimaryKeyColumns( statement );
-		if ( conflictClause.getConstraintColumnNames() != null && !conflictClause.getConstraintColumnNames()
-				.isEmpty() ) {
-			if ( pkColumns.isEmpty() ) {
-				throw new IllegalQueryOperationException(
-						"Spanner implicitly targets the Primary Key in conflict clauses. " +
-						"Explicit conflict columns are not supported here because the table metadata could not be resolved."
-				);
-			}
-			Set<String> conflictTargetCols = new HashSet<>( conflictClause.getConstraintColumnNames() );
-			if ( pkColumns.size() != conflictTargetCols.size() || !pkColumns.containsAll( conflictTargetCols ) ) {
-				throw new IllegalQueryOperationException(
-						String.format(
-								"Spanner only supports conflict resolution on the Primary Key. " +
-								"Your query targets columns %s, but the Primary Key is %s. " +
-								"Please remove the explicit conflict target or ensure it matches the Primary Key.",
-								conflictTargetCols, pkColumns
-						)
-				);
-			}
-		}
-		if ( conflictClause.isDoUpdate() ) {
-			validateConflictAssignments( conflictClause, statement.getTargetColumns(), pkColumns );
-			appendSql( "insert or update into " );
-		}
-		else {
-			appendSql( "insert or ignore into " );
-		}
-	}
-
-	@Override
 	protected void visitConflictClause(ConflictClause conflictClause) {
-		// No-op: Spanner handles conflict logic via the insert prefix ('INSERT OR IGNORE').
-		// We suppress the standard 'ON CONFLICT' suffix generation here.
-	}
-
-	private Set<String> resolvePrimaryKeyColumns(InsertSelectStatement statement) {
-		MutationTarget<?, ?> target = statement.getMutationTarget();
-		assert target != null;
-		TableMapping tableMapping = target.getIdentifierTableMapping();
-		if ( tableMapping != null ) {
-			TableDetails.KeyDetails keyDetails = tableMapping.getKeyDetails();
-			if ( keyDetails != null ) {
-				Set<String> pkCols = new HashSet<>();
-				for ( TableDetails.KeyColumn keyColumn : keyDetails.getKeyColumns() ) {
-					pkCols.add( keyColumn.getColumnName() );
-				}
-				return pkCols;
-			}
-		}
-		return Collections.emptySet();
-	}
-
-	private void validateConflictAssignments(ConflictClause conflictClause, List<ColumnReference> insertCols, Set<String> pkColumns) {
-		// Collect all columns explicitly updated in the HQL "SET ..." clause
-		Set<String> assignedCols = getAssignedCols( conflictClause );
-		// Ensure every non-PK column being inserted is also "updated"
-		for ( ColumnReference col : insertCols ) {
-			String colName = col.getColumnExpression();
-			if ( pkColumns.contains( colName ) || assignedCols.contains( colName ) ) {
-				continue;
-			}
-			throw new IllegalQueryOperationException(
-					String.format(
-							"Spanner 'INSERT OR UPDATE' behavior strictly overwrites all columns with the INSERT values. " +
-							"Your query skips updating column '%s'. " +
-							"you must explicitly include 'SET %s = excluded.%s' in your ON CONFLICT clause.",
-							colName, colName, colName
-					)
-			);
-		}
-	}
-
-	private Set<String> getAssignedCols(ConflictClause conflictClause) {
-		// Validates assignments in the ON CONFLICT DO UPDATE clause and extracts the target column names.
-		//
-		// Cloud Spanner's INSERT OR UPDATE statement implies a strict "upsert" semantic where the
-		// existing row is overwritten with the exact values provided in the INSERT clause.
-		// Unlike standard SQL, it does not support arbitrary expressions (e.g., set count = count + 1)
-		// or cross-column mapping (e.g., set a = excluded.b).
-		//
-		// This method enforces three strict rules to ensure generated SQL complies with Spanner syntax:
-		// 1. The value must be a column reference (not a literal or expression).
-		// 2. The value must originate from the special 'excluded' table alias.
-		// 3. The target column must match the source column exactly (e.g., set col = excluded.col).
-		Set<String> assignedCols = new HashSet<>();
-		for ( Assignment assignment : conflictClause.getAssignments() ) {
-			Expression value = assignment.getAssignedValue();
-			Assignable target = assignment.getAssignable();
-			List<ColumnReference> targetRefs = target.getColumnReferences();
-			List<ColumnReference> valueRefs = new ArrayList<>();
-			if ( value instanceof Assignable ) {
-				valueRefs.addAll( ((Assignable) value).getColumnReferences() );
-			}
-			// Ensure we found columns and they match the target structure size
-			if ( valueRefs.size() != targetRefs.size() ) {
-				throw new IllegalQueryOperationException(
-						"Spanner 'INSERT OR UPDATE' SET clause supports only simple column references, not literals or expressions."
-				);
-			}
-			for ( int i = 0; i < targetRefs.size(); i++ ) {
-				ColumnReference tRef = targetRefs.get( i );
-				ColumnReference vRef = valueRefs.get( i );
-				// Check Alias ("excluded")
-				if ( !"excluded".equals( vRef.getQualifier() ) ) {
-					throw new IllegalQueryOperationException(
-							"Spanner 'INSERT OR UPDATE' SET clause must reference the 'excluded' table (e.g. 'SET col = excluded.col')."
-					);
-				}
-				// Check Name Match (a = excluded.a)
-				if ( !tRef.getColumnExpression().equals( vRef.getColumnExpression() ) ) {
-					throw new IllegalQueryOperationException(
-							"Spanner 'INSERT OR UPDATE' SET clause must match columns strictly "
-							+ "(e.g. 'SET " + tRef.getColumnExpression() + " = excluded." + tRef.getColumnExpression() + "')."
-					);
-				}
-				assignedCols.add( tRef.getColumnExpression() );
-			}
-		}
-		return assignedCols;
+		visitStandardConflictClause( conflictClause );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/action/queue/UniqueConstraintOrderingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/action/queue/UniqueConstraintOrderingTest.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import org.hibernate.action.queue.spi.QueueType;
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.cfg.FlushSettings;
+import org.hibernate.dialect.SpannerDialect;
 import org.hibernate.dialect.SpannerPostgreSQLDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
@@ -274,6 +275,7 @@ public class UniqueConstraintOrderingTest {
 
 	@Test
 	@SkipForDialect( dialectClass = SpannerPostgreSQLDialect.class, reason = "Emulator bug")
+	@SkipForDialect( dialectClass = SpannerDialect.class, reason = "Emulator bug")
 	public void testDeleteAndInsertSameEmbeddableUniqueSlot(SessionFactoryScope scope) {
 		var sfi = scope.getSessionFactory();
 		if ( sfi.getActionQueueFactory().getConfiguredQueueType() != QueueType.GRAPH ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationManyToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationManyToManyTest.java
@@ -23,6 +23,7 @@ import org.hibernate.cfg.QuerySettings;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SpannerDialect;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
@@ -144,7 +145,7 @@ public class CollectionFetchPaginationManyToManyTest {
 			assertTrue( generated.contains( "author_book_link" ) );
 			assertTrue( generated.contains( "book_entity" ) );
 			var dialect = scope.getSessionFactory().getJdbcServices().getDialect();
-			if ( !(dialect instanceof HSQLDialect ) && !(dialect instanceof MariaDBDialect) && !(dialect instanceof OracleDialect) ) {
+			if ( !(dialect instanceof HSQLDialect ) && !(dialect instanceof MariaDBDialect) && !(dialect instanceof OracleDialect) && !(dialect instanceof SpannerDialect) ) {
 				final int existsStart = generated.indexOf( "exists(select 1 from author_book_link" );
 				final int existsWhere = generated.indexOf( " where", existsStart );
 				assertTrue( existsStart >= 0 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationOrderItemTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationOrderItemTest.java
@@ -21,6 +21,7 @@ import org.hibernate.cfg.QuerySettings;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SpannerDialect;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
@@ -118,7 +119,7 @@ public class CollectionFetchPaginationOrderItemTest {
 			assertTrue( generated.contains( "from (select" ) );
 			assertTrue( generated.contains( "item_entity" ) );
 			var dialect = scope.getSessionFactory().getJdbcServices().getDialect();
-			if ( !(dialect instanceof HSQLDialect) && !(dialect instanceof MariaDBDialect) && !(dialect instanceof OracleDialect) ) {
+			if ( !(dialect instanceof HSQLDialect) && !(dialect instanceof MariaDBDialect) && !(dialect instanceof OracleDialect) && !(dialect instanceof SpannerDialect) ) {
 				final int existsStart = generated.indexOf( "exists(select 1 from item_entity" );
 				final int existsWhere = generated.indexOf( " where", existsStart );
 				assertTrue( existsStart >= 0 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -642,6 +642,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = SpannerDialect.class, reason = "date and timestamp are not compatible")
 	public void testDateTruncWithLocalDatetimeMinusLocalDate(SessionFactoryScope scope) {
 		scope.inTransaction( session ->
 				assertThat( session.createQuery( "select trunc(local datetime, day) - local date", Duration.class )


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

enable ci for spanner
changes related to on conflict clause reverted by pr HHH-17922 - Redesign ActionQueue for spanner, changing to correct 



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20439 (Sub-task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20439
<!-- Hibernate GitHub Bot issue links end -->