### PR TITLE
HHH-19214 [7.1] Record as @IdClass - some tests are failing when record componets of ID class are not alphabetically sorted, but passing when sorted

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableHelper.java
@@ -4,14 +4,19 @@
  */
 package org.hibernate.metamodel.internal;
 
-import java.util.Arrays;
 
 public class EmbeddableHelper {
 	public static int[] determineMappingIndex(String[] sortedNames, String[] names) {
 		final int[] index = new int[sortedNames.length];
 		int i = 0;
 		for ( String name : names ) {
-			final int mappingIndex = Arrays.binarySearch( sortedNames, name );
+			int mappingIndex = -1;
+			for ( int j = 0; j < sortedNames.length; j++ ) {
+				if ( name.equals( sortedNames[j] ) ) {
+					mappingIndex = j;
+					break;
+				}
+			}
 			if ( mappingIndex != -1 ) {
 				index[i++] = mappingIndex;
 			}
@@ -22,7 +27,13 @@ public class EmbeddableHelper {
 	public static boolean resolveIndex(String[] sortedComponentNames, String[] componentNames, int[] index) {
 		boolean hasGaps = false;
 		for ( int i = 0; i < componentNames.length; i++ ) {
-			final int newIndex = Arrays.binarySearch( sortedComponentNames, componentNames[i] );
+			int newIndex = -1;
+			for ( int j = 0; j < sortedComponentNames.length; j++ ) {
+				if ( componentNames[i].equals( sortedComponentNames[j] ) ) {
+					newIndex = j;
+					break;
+				}
+			}
 			index[i] = newIndex;
 			hasGaps = hasGaps || newIndex < 0;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneLazyFetchingWithIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneLazyFetchingWithIdClassTest.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.annotations.formula;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.LazyInitializationException;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinFormula;
+import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.List;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+@JiraKey(value = "HHH-19214")
+public class JoinFormulaManyToOneLazyFetchingWithIdClassTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Stock.class,
+				StockCode.class,
+		};
+	}
+
+	@Override
+	protected void afterEntityManagerFactoryBuilt() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			StockCode code = new StockCode();
+			code.setId( 1L );
+			code.setCodeType( CodeType.TYPE_A );
+			code.setRefNumber( "ABC" );
+			entityManager.persist( code );
+
+			Stock stock1 = new Stock();
+			stock1.setId( 1L );
+			stock1.setCode( code );
+			entityManager.persist( stock1 );
+
+			Stock stock2 = new Stock();
+			stock2.setId( 2L );
+			entityManager.persist( stock2 );
+		} );
+	}
+
+	@Test
+	public void testLazyLoading() {
+		List<Stock> stocks = doInJPA( this::entityManagerFactory, entityManager -> {
+			return entityManager.createQuery(
+					"SELECT s FROM Stock s", Stock.class )
+					.getResultList();
+		} );
+		assertEquals( 2, stocks.size() );
+
+		try {
+			assertEquals( "ABC", stocks.get( 0 ).getCode().getRefNumber() );
+
+			fail( "Should have thrown LazyInitializationException" );
+		}
+		catch (LazyInitializationException expected) {
+
+		}
+	}
+
+	@Test
+	public void testEagerLoading() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			List<Stock> stocks =  entityManager.createQuery(
+					"SELECT s FROM Stock s", Stock.class )
+					.getResultList();
+
+			assertEquals( 2, stocks.size() );
+			assertEquals( "ABC", stocks.get( 0 ).getCode().getRefNumber() );
+
+			// In 5.x, for some reason, we didn't understand that a component is a FK,
+			// hence a partial null was wrongly handled, but in 6.0 we handle this in a unified way
+			assertNull( stocks.get( 1 ).getCode() );
+		} );
+	}
+
+	@Entity(name = "Stock")
+	public static class Stock implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumnOrFormula(column = @JoinColumn(name = "CODE_ID", referencedColumnName = "ID"))
+		@JoinColumnOrFormula(formula = @JoinFormula(referencedColumnName = "TYPE", value = "'TYPE_A'"))
+		private StockCode code;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public StockCode getCode() {
+			return code;
+		}
+
+		public void setCode(StockCode code) {
+			this.code = code;
+		}
+	}
+
+	@Entity(name = "StockCode")
+	@IdClass(StockCode.ID.class)
+	public static class StockCode implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@Id
+		@Enumerated(EnumType.STRING)
+		@Column(name = "TYPE")
+		private CodeType codeType;
+
+		private String refNumber;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public CodeType getCodeType() {
+			return codeType;
+		}
+
+		public void setCodeType(CodeType codeType) {
+			this.codeType = codeType;
+		}
+
+		public String getRefNumber() {
+			return refNumber;
+		}
+
+		public void setRefNumber(String refNumber) {
+			this.refNumber = refNumber;
+		}
+
+		public record ID(Long id, CodeType codeType) {}
+	}
+
+	public enum CodeType {
+		TYPE_A, TYPE_B;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneNotIgnoreLazyFetchingWithIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneNotIgnoreLazyFetchingWithIdClassTest.java
@@ -1,0 +1,171 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.annotations.formula;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinFormula;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.boot.model.internal.ToOneBinder;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.logger.LoggerInspectionRule;
+import org.hibernate.testing.logger.Triggerable;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.jboss.logging.Logger;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@JiraKey(value = "HHH-19214")
+public class JoinFormulaManyToOneNotIgnoreLazyFetchingWithIdClassTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Rule
+	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, ToOneBinder.class.getName() )
+	);
+
+	private final Triggerable triggerable = logInspection.watchForLogMessages( "HHH000491" );
+
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Stock.class,
+				StockCode.class,
+		};
+	}
+
+	@Override
+	protected void afterEntityManagerFactoryBuilt() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			StockCode code = new StockCode();
+			code.setId( 1L );
+			code.setCodeType( CodeType.TYPE_A );
+			code.setRefNumber( "ABC" );
+			entityManager.persist( code );
+
+			Stock stock1 = new Stock();
+			stock1.setId( 1L );
+			stock1.setCode( code );
+			entityManager.persist( stock1 );
+
+			Stock stock2 = new Stock();
+			stock2.setId( 2L );
+			entityManager.persist( stock2 );
+		} );
+	}
+
+	@Test
+	public void testLazyLoading() {
+		assertThat( triggerable.wasTriggered() )
+				.describedAs( "Expecting WARN message to be logged" )
+				.isTrue();
+
+		List<Stock> stocks = doInJPA( this::entityManagerFactory, entityManager -> {
+			return entityManager.createQuery(
+					"SELECT s FROM Stock s", Stock.class )
+					.getResultList();
+		} );
+		assertEquals( 2, stocks.size() );
+
+		assertEquals( "ABC", stocks.get( 0 ).getCode().getRefNumber() );
+		assertNull( stocks.get( 1 ).getCode() );
+	}
+
+	@Entity(name = "Stock")
+	public static class Stock implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@NotFound(action = NotFoundAction.IGNORE)
+		@JoinColumnOrFormula(column = @JoinColumn(name = "CODE_ID", referencedColumnName = "ID"))
+		@JoinColumnOrFormula(formula = @JoinFormula(referencedColumnName = "TYPE", value = "'TYPE_A'"))
+		private StockCode code;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public StockCode getCode() {
+			return code;
+		}
+
+		public void setCode(StockCode code) {
+			this.code = code;
+		}
+	}
+
+	@Entity(name = "StockCode")
+	@IdClass(StockCode.ID.class)
+	public static class StockCode implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@Id
+		@Enumerated(EnumType.STRING)
+		@Column(name = "TYPE")
+		private CodeType codeType;
+
+		private String refNumber;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public CodeType getCodeType() {
+			return codeType;
+		}
+
+		public void setCodeType(CodeType codeType) {
+			this.codeType = codeType;
+		}
+
+		public String getRefNumber() {
+			return refNumber;
+		}
+
+		public void setRefNumber(String refNumber) {
+			this.refNumber = refNumber;
+		}
+
+		public record ID(Long id, CodeType codeType) {}
+	}
+
+	public enum CodeType {
+		TYPE_A, TYPE_B;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaOneToOneNotIgnoreLazyFetchingWithIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaOneToOneNotIgnoreLazyFetchingWithIdClassTest.java
@@ -1,0 +1,171 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.annotations.formula;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinFormula;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.boot.model.internal.ToOneBinder;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.logger.LoggerInspectionRule;
+import org.hibernate.testing.logger.Triggerable;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.jboss.logging.Logger;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@JiraKey(value = "HHH-19214")
+public class JoinFormulaOneToOneNotIgnoreLazyFetchingWithIdClassTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Rule
+	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, ToOneBinder.class.getName() )
+	);
+
+	private final Triggerable triggerable = logInspection.watchForLogMessages( "HHH000491" );
+
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Stock.class,
+				StockCode.class,
+		};
+	}
+
+	@Override
+	protected void afterEntityManagerFactoryBuilt() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			StockCode code = new StockCode();
+			code.setId( 1L );
+			code.setCodeType( CodeType.TYPE_A );
+			code.setRefNumber( "ABC" );
+			entityManager.persist( code );
+
+			Stock stock1 = new Stock();
+			stock1.setId( 1L );
+			stock1.setCode( code );
+			entityManager.persist( stock1 );
+
+			Stock stock2 = new Stock();
+			stock2.setId( 2L );
+			entityManager.persist( stock2 );
+		} );
+	}
+
+	@Test
+	public void testLazyLoading() {
+		assertThat( triggerable.wasTriggered() )
+				.describedAs( "Expecting WARN message to be logged" )
+				.isTrue();
+
+		List<Stock> stocks = doInJPA( this::entityManagerFactory, entityManager -> {
+			return entityManager.createQuery(
+					"SELECT s FROM Stock s", Stock.class )
+					.getResultList();
+		} );
+		assertEquals( 2, stocks.size() );
+
+		assertEquals( "ABC", stocks.get( 0 ).getCode().getRefNumber() );
+		assertNull( stocks.get( 1 ).getCode() );
+	}
+
+	@Entity(name = "Stock")
+	public static class Stock implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@OneToOne(fetch = FetchType.LAZY)
+		@NotFound(action = NotFoundAction.IGNORE)
+		@JoinColumnOrFormula(column = @JoinColumn(name = "CODE_ID", referencedColumnName = "ID"))
+		@JoinColumnOrFormula(formula = @JoinFormula(referencedColumnName = "TYPE", value = "'TYPE_A'"))
+		private StockCode code;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public StockCode getCode() {
+			return code;
+		}
+
+		public void setCode(StockCode code) {
+			this.code = code;
+		}
+	}
+
+	@Entity(name = "StockCode")
+	@IdClass(StockCode.ID.class)
+	public static class StockCode implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@Id
+		@Enumerated(EnumType.STRING)
+		@Column(name = "TYPE")
+		private CodeType codeType;
+
+		private String refNumber;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public CodeType getCodeType() {
+			return codeType;
+		}
+
+		public void setCodeType(CodeType codeType) {
+			this.codeType = codeType;
+		}
+
+		public String getRefNumber() {
+			return refNumber;
+		}
+
+		public void setRefNumber(String refNumber) {
+			this.refNumber = refNumber;
+		}
+
+		public record ID(Long id, CodeType codeType) {}
+	}
+
+	public enum CodeType {
+		TYPE_A, TYPE_B;
+	}
+
+}


### PR DESCRIPTION
[HHH-19214 Record as @IdClass - some tests are failing when record componets of ID class are not alphabetically sorted, but passing when sorted](https://hibernate.atlassian.net/browse/HHH-19214)

Problem has been partially fixed by [PR#12431](https://github.com/hibernate/hibernate-orm/pull/12431)



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19214 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->