### PR TITLE
HHH-20441 Add Service Loader Mediator manifest headers for OSGI

### DIFF
--- a/hibernate-agroal/src/main/java/org/hibernate/agroal/internal/StrategyRegistrationProviderImpl.java
+++ b/hibernate-agroal/src/main/java/org/hibernate/agroal/internal/StrategyRegistrationProviderImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.agroal.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.registry.selector.SimpleStrategyRegistrationImpl;
 import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
@@ -17,6 +18,7 @@ import static java.util.Collections.singleton;
  *
  * @author Luis Barreiro
  */
+@ServiceProvider(value = StrategyRegistrationProvider.class)
 public final class StrategyRegistrationProviderImpl implements StrategyRegistrationProvider {
 
 	@Override

--- a/hibernate-c3p0/src/main/java/org/hibernate/c3p0/internal/StrategyRegistrationProviderImpl.java
+++ b/hibernate-c3p0/src/main/java/org/hibernate/c3p0/internal/StrategyRegistrationProviderImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.c3p0.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.registry.selector.SimpleStrategyRegistrationImpl;
 import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
@@ -17,6 +18,7 @@ import static java.util.Collections.singleton;
  *
  * @author Brett Meyer
  */
+@ServiceProvider(value = StrategyRegistrationProvider.class)
 public final class StrategyRegistrationProviderImpl implements StrategyRegistrationProvider {
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CommunityDialectResolver.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CommunityDialectResolver.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.community.dialect;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolver;
@@ -13,6 +14,7 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolver;
  *
  * @author Christian Beikov
  */
+@ServiceProvider(value = DialectResolver.class)
 public class CommunityDialectResolver implements DialectResolver {
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CommunityDialectSelector.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CommunityDialectSelector.java
@@ -6,9 +6,11 @@ package org.hibernate.community.dialect;
 
 import java.util.Objects;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.registry.selector.spi.DialectSelector;
 import org.hibernate.dialect.Dialect;
 
+@ServiceProvider(value = DialectSelector.class)
 public class CommunityDialectSelector implements DialectSelector {
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -8,6 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.FetchType;
@@ -105,6 +108,8 @@ import static org.hibernate.internal.util.collections.CollectionHelper.isNotEmpt
 /**
  * @author Steve Ebersole
  */
+@ServiceConsumer(value = MetadataSourcesContributor.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
+@ServiceConsumer(value = MetadataBuilderInitializer.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeContributions {
 
 	private final MetadataSources sources;

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -20,6 +20,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import jakarta.persistence.AttributeConverter;
 import org.hibernate.AssertionFailure;
 import org.hibernate.Internal;
@@ -123,6 +126,8 @@ import static org.hibernate.internal.util.config.ConfigurationHelper.getPreferre
  *
  * @author Steve Ebersole
  */
+@ServiceConsumer(value = AdditionalMappingContributor.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
+@ServiceConsumer(value = TypeContributor.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class MetadataBuildingProcess {
 
 	private static final Comparator<TypeContributor> TYPE_CONTRIBUTOR_COMPARATOR = Comparator.comparingInt(

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/StandardServiceRegistryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/StandardServiceRegistryBuilder.java
@@ -12,6 +12,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.hibernate.Internal;
 import org.hibernate.boot.cfgxml.internal.ConfigLoader;
 import org.hibernate.boot.cfgxml.spi.LoadedConfig;
@@ -39,6 +42,7 @@ import static org.hibernate.boot.cfgxml.spi.CfgXmlAccessService.LOADED_CONFIG_KE
  * @see StandardServiceRegistryImpl
  * @see BootstrapServiceRegistryBuilder
  */
+@ServiceConsumer(value = ServiceContributor.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class StandardServiceRegistryBuilder {
 	/**
 	 * Creates a {@code StandardServiceRegistryBuilder} specific to the needs

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
@@ -7,6 +7,9 @@ package org.hibernate.boot.registry.selector.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategy;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyComponentPathImpl;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
@@ -62,6 +65,8 @@ import static org.hibernate.boot.BootLogging.BOOT_LOGGER;
  *
  * @author Steve Ebersole
  */
+@ServiceConsumer(value = DialectSelector.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
+@ServiceConsumer(value = StrategyRegistrationProvider.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class StrategySelectorBuilder {
 
 	private final List<StrategyRegistration<?>> explicitStrategyRegistrations = new ArrayList<>();

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
@@ -7,12 +7,16 @@ package org.hibernate.bytecode.internal;
 import java.util.Map;
 import java.util.ServiceLoader;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.hibernate.Internal;
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
+@ServiceConsumer(value = BytecodeProvider.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public final class BytecodeProviderInitiator implements StandardServiceInitiator<BytecodeProvider> {
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.bytecode.enhance.internal.bytebuddy.BridgeMembersClassInfo;
@@ -54,6 +55,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static org.hibernate.internal.CoreMessageLogger.CORE_LOGGER;
 
+@ServiceProvider(value = BytecodeProvider.class)
 public class BytecodeProviderImpl implements BytecodeProvider {
 
 	private static final String INSTANTIATOR_PROXY_NAMING_SUFFIX = "$HibernateInstantiator";

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectResolverInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectResolverInitiator.java
@@ -7,6 +7,9 @@ package org.hibernate.engine.jdbc.dialect.internal;
 import java.util.Collection;
 import java.util.Map;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.hibernate.HibernateException;
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
@@ -21,6 +24,7 @@ import org.hibernate.service.spi.ServiceRegistryImplementor;
  *
  * @author Steve Ebersole
  */
+@ServiceConsumer(value = DialectResolver.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class DialectResolverInitiator implements StandardServiceInitiator<DialectResolver> {
 	/**
 	 * Singleton access

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/EventEngine.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/EventEngine.java
@@ -4,6 +4,9 @@
  */
 package org.hibernate.event.spi;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.hibernate.HibernateException;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataImplementor;
@@ -28,6 +31,7 @@ import static org.hibernate.internal.util.collections.CollectionHelper.isNotEmpt
  *
  * @author Steve Ebersole
  */
+@ServiceConsumer(value = EventEngineContributor.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class EventEngine {
 
 	private final Map<String,EventType<?>> registeredEventTypes;

--- a/hibernate-core/src/main/java/org/hibernate/integrator/internal/IntegratorServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/integrator/internal/IntegratorServiceImpl.java
@@ -6,6 +6,9 @@ package org.hibernate.integrator.internal;
 
 import java.util.LinkedHashSet;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.hibernate.boot.beanvalidation.BeanValidationIntegrator;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.cache.internal.CollectionCacheInvalidator;
@@ -17,6 +20,7 @@ import static org.hibernate.service.internal.ServiceLogger.SERVICE_LOGGER;
 /**
  * @author Steve Ebersole
  */
+@ServiceConsumer(value = Integrator.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class IntegratorServiceImpl implements IntegratorService {
 
 	private final LinkedHashSet<Integrator> integrators = new LinkedHashSet<>();

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -4,6 +4,9 @@
  */
 package org.hibernate.internal;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import jakarta.persistence.EntityAgent;
 import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityHandler;
@@ -171,6 +174,7 @@ import static org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode.DEL
  * @author Chris Cranford
  */
 // Extended by Hibernate Reactive
+@ServiceConsumer(value = EventMonitor.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class SessionFactoryImpl implements SessionFactoryImplementor {
 
 	private final String name;

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryEngineImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryEngineImpl.java
@@ -4,6 +4,9 @@
  */
 package org.hibernate.query.internal;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
@@ -49,6 +52,7 @@ import static org.hibernate.internal.util.config.ConfigurationHelper.getInteger;
  *
  * @author Steve Ebersole
  */
+@ServiceConsumer(value = FunctionContributor.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class QueryEngineImpl implements QueryEngine {
 
 	private static final Logger LOG_HQL_FUNCTIONS = Logger.getLogger( "org.hibernate.HQL_FUNCTIONS" );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -33,6 +33,9 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.criteria.BooleanExpression;
 import jakarta.persistence.criteria.CriteriaDelete;
@@ -185,6 +188,7 @@ import static org.hibernate.query.sqm.tree.select.SqmDynamicInstantiation.mapIns
  * @author Steve Ebersole
  * @author Yoobin Yoon
  */
+@ServiceConsumer(value = CriteriaBuilderExtension.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 
 	private final String uuid;

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryFactoryImpl.java
@@ -4,6 +4,9 @@
  */
 package org.hibernate.service.internal;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -18,6 +21,7 @@ import org.hibernate.service.spi.SessionFactoryServiceRegistryFactory;
  *
  * @author Steve Ebersole
  */
+@ServiceConsumer(value = SessionFactoryServiceContributor.class, cardinality = Cardinality.MULTIPLE, resolution = Resolution.OPTIONAL)
 public class SessionFactoryServiceRegistryFactoryImpl implements SessionFactoryServiceRegistryFactory {
 	private final ServiceRegistryImplementor theBasicServiceRegistry;
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/AdditionalMappingContributorImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/AdditionalMappingContributorImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.envers.boot.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.HibernateException;
 import org.hibernate.boot.ResourceStreamLocator;
 import org.hibernate.boot.spi.AdditionalMappingContributions;
@@ -18,6 +19,7 @@ import static org.hibernate.cfg.AvailableSettings.XML_MAPPING_ENABLED;
 /**
  * @author Steve Ebersole
  */
+@ServiceProvider(value = AdditionalMappingContributor.class)
 public class AdditionalMappingContributorImpl implements AdditionalMappingContributor {
 	@Override
 	public String getContributorName() {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/AuditStrategyRegistrationProvider.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/AuditStrategyRegistrationProvider.java
@@ -7,6 +7,7 @@ package org.hibernate.envers.boot.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.registry.selector.SimpleStrategyRegistrationImpl;
 import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
@@ -21,6 +22,7 @@ import org.hibernate.envers.strategy.ValidityAuditStrategy;
  * @author Chris Cranford
  * @since 6.0
  */
+@ServiceProvider(value = StrategyRegistrationProvider.class)
 public class AuditStrategyRegistrationProvider implements StrategyRegistrationProvider {
 
 	private static final List<StrategyRegistration<?>> STRATEGIES = new ArrayList<>();

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.envers.boot.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.HibernateException;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
@@ -33,6 +34,7 @@ import org.jboss.logging.Logger;
  * @author Steve Ebersole
  * @author Chris Cranford
  */
+@ServiceProvider(value = Integrator.class)
 public class EnversIntegrator implements Integrator {
 	private static final Logger log = Logger.getLogger( EnversIntegrator.class );
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceContributor.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.envers.boot.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.service.spi.ServiceContributor;
 
@@ -13,6 +14,7 @@ import org.hibernate.service.spi.ServiceContributor;
  *
  * @author Steve Ebersole
  */
+@ServiceProvider(value = ServiceContributor.class)
 public class EnversServiceContributor implements ServiceContributor {
 	@Override
 	public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/FunctionContributorImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/FunctionContributorImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.envers.boot.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.envers.function.OrderByFragmentFunction;
@@ -13,6 +14,7 @@ import org.hibernate.envers.function.OrderByFragmentFunction;
  *
  * @author Christian Beikov
  */
+@ServiceProvider(value = FunctionContributor.class)
 public class FunctionContributorImpl implements FunctionContributor {
 
 	@Override

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/ModifiedColumnNamingStrategyRegistrationProvider.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/ModifiedColumnNamingStrategyRegistrationProvider.java
@@ -7,6 +7,7 @@ package org.hibernate.envers.boot.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.registry.selector.SimpleStrategyRegistrationImpl;
 import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
@@ -17,6 +18,7 @@ import org.hibernate.envers.boot.spi.ModifiedColumnNamingStrategy;
  *
  * @author Chris Cranford
  */
+@ServiceProvider(value = StrategyRegistrationProvider.class)
 public class ModifiedColumnNamingStrategyRegistrationProvider implements StrategyRegistrationProvider {
 	@Override
 	public Iterable<StrategyRegistration<?>> getStrategyRegistrations() {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/TypeContributorImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/TypeContributorImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.envers.boot.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.envers.internal.entities.RevisionTypeType;
@@ -14,6 +15,7 @@ import org.hibernate.service.ServiceRegistry;
  *
  * @author Brett Meyer
  */
+@ServiceProvider(value = TypeContributor.class)
 public class TypeContributorImpl implements TypeContributor {
 	@Override
 	public void contribute(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {

--- a/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/StrategyRegistrationProviderImpl.java
+++ b/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/StrategyRegistrationProviderImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.hikaricp.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.registry.selector.SimpleStrategyRegistrationImpl;
 import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
@@ -17,6 +18,7 @@ import static java.util.Collections.singleton;
  *
  * @author Brett Meyer
  */
+@ServiceProvider(value = StrategyRegistrationProvider.class)
 public final class StrategyRegistrationProviderImpl implements StrategyRegistrationProvider {
 
 	@Override

--- a/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/internal/StrategyRegistrationProviderImpl.java
+++ b/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/internal/StrategyRegistrationProviderImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.cache.jcache.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.registry.selector.SimpleStrategyRegistrationImpl;
 import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
@@ -19,6 +20,7 @@ import static java.util.Collections.singleton;
  *
  * @author Steve Ebersole
  */
+@ServiceProvider(value = StrategyRegistrationProvider.class)
 public final class StrategyRegistrationProviderImpl implements StrategyRegistrationProvider {
 
 	@Override

--- a/hibernate-jfr/src/main/java/org/hibernate/event/jfr/internal/JfrEventMonitor.java
+++ b/hibernate-jfr/src/main/java/org/hibernate/event/jfr/internal/JfrEventMonitor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.event.jfr.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.LockMode;
 import org.hibernate.cache.spi.Region;
 import org.hibernate.cache.spi.access.CachedDomainDataAccess;
@@ -23,6 +24,7 @@ import java.util.Objects;
 
 
 @AllowNonPortable
+@ServiceProvider(value = EventMonitor.class)
 public class JfrEventMonitor implements EventMonitor {
 
 	private static final EventType sessionOpenEventType = EventType.getEventType( SessionOpenEvent.class );

--- a/hibernate-scan-jandex/src/main/java/org/hibernate/scan/jandex/ScanningProviderImpl.java
+++ b/hibernate-scan-jandex/src/main/java/org/hibernate/scan/jandex/ScanningProviderImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.scan.jandex;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.scan.spi.Scanner;
 import org.hibernate.boot.scan.spi.ScanningContext;
 import org.hibernate.boot.scan.spi.ScanningProvider;
@@ -12,6 +13,7 @@ import org.jboss.jandex.IndexView;
 /// Jandex-based implementation of ScannerProvider.
 ///
 /// @author Steve Ebersole
+@ServiceProvider(value = ScanningProvider.class)
 public class ScanningProviderImpl implements ScanningProvider {
 	public static final String JANDEX_INDEX = "hibernate.jandex.index";
 

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/contributor/SpatialFunctionContributor.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/contributor/SpatialFunctionContributor.java
@@ -4,9 +4,11 @@
  */
 package org.hibernate.spatial.contributor;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 
+@ServiceProvider(value = FunctionContributor.class)
 public class SpatialFunctionContributor implements FunctionContributor {
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/contributor/SpatialTypeContributor.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/contributor/SpatialTypeContributor.java
@@ -4,10 +4,12 @@
  */
 package org.hibernate.spatial.contributor;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.service.ServiceRegistry;
 
+@ServiceProvider(value = TypeContributor.class)
 public class SpatialTypeContributor implements TypeContributor {
 	@Override
 	public void contribute(

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/criteria/internal/GeolatteSpatialCriteriaExtension.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/criteria/internal/GeolatteSpatialCriteriaExtension.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.spatial.criteria.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.spi.CriteriaBuilderExtension;
 import org.hibernate.spatial.criteria.GeolatteSpatialCriteriaBuilder;
@@ -11,6 +12,7 @@ import org.hibernate.spatial.criteria.GeolatteSpatialCriteriaBuilder;
 /**
  * @author Marco Belladelli
  */
+@ServiceProvider(value = CriteriaBuilderExtension.class)
 public class GeolatteSpatialCriteriaExtension implements CriteriaBuilderExtension {
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/criteria/internal/JTSSpatialCriteriaExtension.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/criteria/internal/JTSSpatialCriteriaExtension.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.spatial.criteria.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.spi.CriteriaBuilderExtension;
 import org.hibernate.spatial.criteria.JTSSpatialCriteriaBuilder;
@@ -11,6 +12,7 @@ import org.hibernate.spatial.criteria.JTSSpatialCriteriaBuilder;
 /**
  * @author Marco Belladelli
  */
+@ServiceProvider(value = CriteriaBuilderExtension.class)
 public class JTSSpatialCriteriaExtension implements CriteriaBuilderExtension {
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/integration/SpatialInitializer.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/integration/SpatialInitializer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.spatial.integration;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.service.spi.ServiceContributor;
 
@@ -13,6 +14,7 @@ import org.hibernate.service.spi.ServiceContributor;
  * @author Karel Maesen, Geovise BVBA
  * @author Steve Ebersole
  */
+@ServiceProvider(value = ServiceContributor.class)
 public class SpatialInitializer implements ServiceContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/CockroachFunctionContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/CockroachFunctionContributor.java
@@ -5,10 +5,12 @@
 package org.hibernate.vector.internal;
 
 import org.hibernate.boot.model.FunctionContributions;
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.Dialect;
 
+@ServiceProvider(value = FunctionContributor.class)
 public class CockroachFunctionContributor implements FunctionContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/CockroachTypeContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/CockroachTypeContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.dialect.CockroachDialect;
@@ -20,6 +21,7 @@ import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
+@ServiceProvider(value = TypeContributor.class)
 public class CockroachTypeContributor implements TypeContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/DB2VectorFunctionContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/DB2VectorFunctionContributor.java
@@ -5,6 +5,7 @@
 package org.hibernate.vector.internal;
 
 import org.hibernate.boot.model.FunctionContributions;
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
@@ -12,6 +13,7 @@ import org.hibernate.type.BasicType;
 import org.hibernate.type.spi.TypeConfiguration;
 
 
+@ServiceProvider(value = FunctionContributor.class)
 public class DB2VectorFunctionContributor implements FunctionContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/DB2VectorTypeContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/DB2VectorTypeContributor.java
@@ -5,6 +5,7 @@
 package org.hibernate.vector.internal;
 
 import org.hibernate.boot.model.TypeContributions;
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
@@ -21,6 +22,7 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
+@ServiceProvider(value = TypeContributor.class)
 public class DB2VectorTypeContributor implements TypeContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/HANAVectorFunctionContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/HANAVectorFunctionContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.dialect.Dialect;
@@ -15,6 +16,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 
 import static org.hibernate.query.sqm.produce.function.FunctionParameterType.INTEGER;
 
+@ServiceProvider(value = FunctionContributor.class)
 public class HANAVectorFunctionContributor implements FunctionContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/HANAVectorTypeContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/HANAVectorTypeContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.dialect.Dialect;
@@ -20,6 +21,7 @@ import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
+@ServiceProvider(value = TypeContributor.class)
 public class HANAVectorTypeContributor implements TypeContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/MariaDBFunctionContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/MariaDBFunctionContributor.java
@@ -4,11 +4,13 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.MariaDBDialect;
 
+@ServiceProvider(value = FunctionContributor.class)
 public class MariaDBFunctionContributor implements FunctionContributor {
 	@Override
 	public void contributeFunctions(FunctionContributions functionContributions) {

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/MariaDBTypeContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/MariaDBTypeContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.dialect.Dialect;
@@ -20,6 +21,7 @@ import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
+@ServiceProvider(value = TypeContributor.class)
 public class MariaDBTypeContributor implements TypeContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/MySQLFunctionContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/MySQLFunctionContributor.java
@@ -4,11 +4,13 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.MySQLDialect;
 
+@ServiceProvider(value = FunctionContributor.class)
 public class MySQLFunctionContributor implements FunctionContributor {
 	@Override
 	public void contributeFunctions(FunctionContributions functionContributions) {

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/MySQLTypeContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/MySQLTypeContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.dialect.Dialect;
@@ -20,6 +21,7 @@ import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
+@ServiceProvider(value = TypeContributor.class)
 public class MySQLTypeContributor implements TypeContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/OracleVectorFunctionContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/OracleVectorFunctionContributor.java
@@ -4,11 +4,13 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.OracleDialect;
 
+@ServiceProvider(value = FunctionContributor.class)
 public class OracleVectorFunctionContributor implements FunctionContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/OracleVectorTypeContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/OracleVectorTypeContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.dialect.Dialect;
@@ -20,6 +21,7 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
+@ServiceProvider(value = TypeContributor.class)
 public class OracleVectorTypeContributor implements TypeContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/PGVectorFunctionContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/PGVectorFunctionContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.dialect.Dialect;
@@ -17,6 +18,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 
 import static org.hibernate.query.sqm.produce.function.FunctionParameterType.INTEGER;
 
+@ServiceProvider(value = FunctionContributor.class)
 public class PGVectorFunctionContributor implements FunctionContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/PGVectorTypeContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/PGVectorTypeContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.dialect.Dialect;
@@ -23,6 +24,7 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
+@ServiceProvider(value = TypeContributor.class)
 public class PGVectorTypeContributor implements TypeContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/SQLServerTypeContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/SQLServerTypeContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.HibernateError;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.TypeContributor;
@@ -26,6 +27,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 
 import java.lang.reflect.InvocationTargetException;
 
+@ServiceProvider(value = TypeContributor.class)
 public class SQLServerTypeContributor implements TypeContributor {
 
 	@Override

--- a/hibernate-vector/src/main/java/org/hibernate/vector/internal/SQLServerVectorFunctionContributor.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/internal/SQLServerVectorFunctionContributor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.vector.internal;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.dialect.Dialect;
@@ -12,6 +13,7 @@ import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolv
 import org.hibernate.type.BasicType;
 import org.hibernate.type.spi.TypeConfiguration;
 
+@ServiceProvider(value = FunctionContributor.class)
 public class SQLServerVectorFunctionContributor implements FunctionContributor {
 
 	@Override

--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation libs.logging
 
     compileOnly libs.loggingAnnotations
+    compileOnly 'biz.aQute.bnd:biz.aQute.bnd.annotation:7.2.0'
     // Used for compiling some Oracle specific JdbcTypes
     compileOnly libs.jdbc.oracle
     compileOnly (libs.jdbc.oracleJdbcJacksonOsonExtension) {


### PR DESCRIPTION
In this branch I added the appropriate annotations for the service loadable interfaces, so that the bnd plugin will add the needed headers to the manifest.

See https://bnd.bndtools.org/chapters/240-spi-annotations.html




----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20441 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20441
<!-- Hibernate GitHub Bot issue links end -->