### PR TITLE
HHH-19214 [7.4] Record as @IdClass - some tests are failing when record componets of ID class are not alphabetically sorted, but passing when sorted

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneLazyFetchingWithIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneLazyFetchingWithIdClassTest.java
@@ -1,0 +1,169 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.annotations.formula;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.LazyInitializationException;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinFormula;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+@JiraKey(value = "HHH-19214")
+@Jpa(
+		annotatedClasses = {
+				JoinFormulaManyToOneLazyFetchingWithIdClassTest.Stock.class,
+				JoinFormulaManyToOneLazyFetchingWithIdClassTest.StockCode.class,
+		}
+)
+public class JoinFormulaManyToOneLazyFetchingWithIdClassTest {
+
+
+	@BeforeAll
+	protected void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			StockCode code = new StockCode();
+			code.setId( 1L );
+			code.setCodeType( CodeType.TYPE_A );
+			code.setRefNumber( "ABC" );
+			entityManager.persist( code );
+
+			Stock stock1 = new Stock();
+			stock1.setId( 1L );
+			stock1.setCode( code );
+			entityManager.persist( stock1 );
+
+			Stock stock2 = new Stock();
+			stock2.setId( 2L );
+			entityManager.persist( stock2 );
+		} );
+	}
+
+	@Test
+	public void testLazyLoading(EntityManagerFactoryScope scope) {
+		List<Stock> stocks = scope.fromTransaction( entityManager ->
+				entityManager.createQuery( "SELECT s FROM Stock s", Stock.class ).getResultList()
+		);
+		assertThat( stocks.size() ).isEqualTo( 2 );
+
+		try {
+			assertThat( stocks.get( 0 ).getCode().getRefNumber() ).isEqualTo( "ABC" );
+
+			fail( "Should have thrown LazyInitializationException" );
+		}
+		catch (LazyInitializationException expected) {
+
+		}
+	}
+
+	@Test
+	public void testEagerLoading(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			List<Stock> stocks = entityManager.createQuery(
+							"SELECT s FROM Stock s", Stock.class )
+					.getResultList();
+
+			assertThat( stocks.size() ).isEqualTo( 2 );
+			assertThat( stocks.get( 0 ).getCode().getRefNumber() ).isEqualTo( "ABC" );
+
+			// In 5.x, for some reason, we didn't understand that a component is a FK,
+			// hence a partial null was wrongly handled, but in 6.0 we handle this in a unified way
+			assertThat( stocks.get( 1 ).getCode() ).isNull();
+		} );
+	}
+
+	@Entity(name = "Stock")
+	public static class Stock implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumnOrFormula(column = @JoinColumn(name = "CODE_ID", referencedColumnName = "ID"))
+		@JoinColumnOrFormula(formula = @JoinFormula(referencedColumnName = "TYPE", value = "'TYPE_A'"))
+		private StockCode code;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public StockCode getCode() {
+			return code;
+		}
+
+		public void setCode(StockCode code) {
+			this.code = code;
+		}
+	}
+
+	@Entity(name = "StockCode")
+	@IdClass(StockCode.ID.class)
+	public static class StockCode implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@Id
+		@Enumerated(EnumType.STRING)
+		@Column(name = "TYPE")
+		private CodeType codeType;
+
+		private String refNumber;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public CodeType getCodeType() {
+			return codeType;
+		}
+
+		public void setCodeType(CodeType codeType) {
+			this.codeType = codeType;
+		}
+
+		public String getRefNumber() {
+			return refNumber;
+		}
+
+		public void setRefNumber(String refNumber) {
+			this.refNumber = refNumber;
+		}
+
+		public record ID(Long id, CodeType codeType) {}
+	}
+
+	public enum CodeType {
+		TYPE_A, TYPE_B
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneNotIgnoreLazyFetchingWithIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneNotIgnoreLazyFetchingWithIdClassTest.java
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.annotations.formula;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinFormula;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.testing.logger.Triggerable;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.logger.LoggerInspectionExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.Serializable;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.boot.BootLogging.BOOT_LOGGER;
+
+@JiraKey(value = "HHH-19214")
+@Jpa(
+		annotatedClasses = {
+				JoinFormulaManyToOneNotIgnoreLazyFetchingWithIdClassTest.Stock.class,
+				JoinFormulaManyToOneNotIgnoreLazyFetchingWithIdClassTest.StockCode.class,
+		}
+)
+public class JoinFormulaManyToOneNotIgnoreLazyFetchingWithIdClassTest {
+
+	private Triggerable triggerable;
+
+	@RegisterExtension
+	public LoggerInspectionExtension logger =
+			LoggerInspectionExtension.builder().setLogger( BOOT_LOGGER ).build();
+
+	@BeforeAll
+	public void beforeAll(EntityManagerFactoryScope scope) {
+		triggerable = logger.watchForLogMessages( "HHH160133" );
+		triggerable.reset();
+
+		scope.inTransaction( entityManager -> {
+			StockCode code = new StockCode();
+			code.setId( 1L );
+			code.setCodeType( CodeType.TYPE_A );
+			code.setRefNumber( "ABC" );
+			entityManager.persist( code );
+
+			Stock stock1 = new Stock();
+			stock1.setId( 1L );
+			stock1.setCode( code );
+			entityManager.persist( stock1 );
+
+			Stock stock2 = new Stock();
+			stock2.setId( 2L );
+			entityManager.persist( stock2 );
+		} );
+	}
+
+	@Test
+	public void testLazyLoading(EntityManagerFactoryScope scope) {
+		assertThat( triggerable.wasTriggered() )
+				.describedAs( "Expecting WARN message to be logged" )
+				.isTrue();
+
+		List<Stock> stocks = scope.fromTransaction( entityManager ->
+				entityManager.createQuery( "SELECT s FROM Stock s", Stock.class ).getResultList()
+		);
+		assertThat( stocks.size() ).isEqualTo( 2 );
+
+		assertThat( stocks.get( 0 ).getCode().getRefNumber() ).isEqualTo( "ABC" );
+		assertThat( stocks.get( 1 ).getCode() ).isNull();
+	}
+
+	@Entity(name = "Stock")
+	public static class Stock implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@NotFound(action = NotFoundAction.IGNORE)
+		@JoinColumnOrFormula(column = @JoinColumn(name = "CODE_ID", referencedColumnName = "ID"))
+		@JoinColumnOrFormula(formula = @JoinFormula(referencedColumnName = "TYPE", value = "'TYPE_A'"))
+		private StockCode code;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public StockCode getCode() {
+			return code;
+		}
+
+		public void setCode(StockCode code) {
+			this.code = code;
+		}
+	}
+
+	@Entity(name = "StockCode")
+	@IdClass(StockCode.ID.class)
+	public static class StockCode implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@Id
+		@Enumerated(EnumType.STRING)
+		@Column(name = "TYPE")
+		private CodeType codeType;
+
+		private String refNumber;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public CodeType getCodeType() {
+			return codeType;
+		}
+
+		public void setCodeType(CodeType codeType) {
+			this.codeType = codeType;
+		}
+
+		public String getRefNumber() {
+			return refNumber;
+		}
+
+		public void setRefNumber(String refNumber) {
+			this.refNumber = refNumber;
+		}
+
+		public record ID(Long id, CodeType codeType) {}
+	}
+
+	public enum CodeType {
+		TYPE_A, TYPE_B
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaOneToOneNotIgnoreLazyFetchingWithIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaOneToOneNotIgnoreLazyFetchingWithIdClassTest.java
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.annotations.formula;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinFormula;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.testing.logger.Triggerable;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.logger.LoggerInspectionExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.Serializable;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.boot.BootLogging.BOOT_LOGGER;
+
+@JiraKey(value = "HHH-19214")
+@Jpa(
+		annotatedClasses = {
+				JoinFormulaOneToOneNotIgnoreLazyFetchingWithIdClassTest.Stock.class,
+				JoinFormulaOneToOneNotIgnoreLazyFetchingWithIdClassTest.StockCode.class,
+		}
+)
+public class JoinFormulaOneToOneNotIgnoreLazyFetchingWithIdClassTest {
+	private Triggerable triggerable;
+
+	@RegisterExtension
+	public LoggerInspectionExtension logger =
+			LoggerInspectionExtension.builder().setLogger( BOOT_LOGGER ).build();
+
+	@BeforeAll
+	public void beforeAll(EntityManagerFactoryScope scope) {
+		triggerable = logger.watchForLogMessages( "HHH160133" );
+		triggerable.reset();
+
+		scope.inTransaction( entityManager -> {
+			StockCode code = new StockCode();
+			code.setId( 1L );
+			code.setCodeType( CodeType.TYPE_A );
+			code.setRefNumber( "ABC" );
+			entityManager.persist( code );
+
+			Stock stock1 = new Stock();
+			stock1.setId( 1L );
+			stock1.setCode( code );
+			entityManager.persist( stock1 );
+
+			Stock stock2 = new Stock();
+			stock2.setId( 2L );
+			entityManager.persist( stock2 );
+		} );
+	}
+
+	@Test
+	public void testLazyLoading(EntityManagerFactoryScope scope) {
+		assertThat( triggerable.wasTriggered() )
+				.describedAs( "Expecting WARN message to be logged" )
+				.isTrue();
+
+		List<Stock> stocks = scope.fromTransaction( entityManager ->
+				entityManager.createQuery( "SELECT s FROM Stock s", Stock.class ).getResultList()
+		);
+
+		assertThat( stocks.size() ).isEqualTo( 2 );
+
+		assertThat( stocks.get( 0 ).getCode().getRefNumber() ).isEqualTo( "ABC" );
+		assertThat( stocks.get( 1 ).getCode() ).isNull();
+	}
+
+	@Entity(name = "Stock")
+	public static class Stock implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@OneToOne(fetch = FetchType.LAZY)
+		@NotFound(action = NotFoundAction.IGNORE)
+		@JoinColumnOrFormula(column = @JoinColumn(name = "CODE_ID", referencedColumnName = "ID"))
+		@JoinColumnOrFormula(formula = @JoinFormula(referencedColumnName = "TYPE", value = "'TYPE_A'"))
+		private StockCode code;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public StockCode getCode() {
+			return code;
+		}
+
+		public void setCode(StockCode code) {
+			this.code = code;
+		}
+	}
+
+	@Entity(name = "StockCode")
+	@IdClass(StockCode.ID.class)
+	public static class StockCode implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@Id
+		@Enumerated(EnumType.STRING)
+		@Column(name = "TYPE")
+		private CodeType codeType;
+
+		private String refNumber;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public CodeType getCodeType() {
+			return codeType;
+		}
+
+		public void setCodeType(CodeType codeType) {
+			this.codeType = codeType;
+		}
+
+		public String getRefNumber() {
+			return refNumber;
+		}
+
+		public void setRefNumber(String refNumber) {
+			this.refNumber = refNumber;
+		}
+
+		public record ID(Long id, CodeType codeType) {}
+	}
+
+	public enum CodeType {
+		TYPE_A, TYPE_B
+	}
+
+}


### PR DESCRIPTION
[HHH-19214 Record as @IdClass - some tests are failing when record componets of ID class are not alphabetically sorted, but passing when sorted](https://hibernate.atlassian.net/browse/HHH-19214)

Test classes only; problem has been fixed by [PR#12428](https://github.com/hibernate/hibernate-orm/pull/12428)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19214 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->