### PR TITLE
HHH-20421 fix default sequence increment size not being applied

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/NativeGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/NativeGenerator.java
@@ -30,7 +30,6 @@ import java.util.Properties;
 
 import static org.hibernate.boot.model.internal.GeneratorParameters.collectParameters;
 import static org.hibernate.id.IdentifierGenerator.GENERATOR_NAME;
-import static org.hibernate.id.OptimizableGenerator.INCREMENT_PARAM;
 
 /**
  * Generator that picks a strategy based on the {@linkplain Dialect#getNativeValueGenerationStrategy() dialect}.
@@ -176,6 +175,5 @@ public class NativeGenerator
 				context.getServiceRegistry()
 						.requireService( ConfigurationService.class )
 		);
-		properties.put( INCREMENT_PARAM, 1 );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/n_ative/NativeGeneratorTypeSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/n_ative/NativeGeneratorTypeSequenceTest.java
@@ -68,7 +68,7 @@ public class NativeGeneratorTypeSequenceTest {
 	@ParameterizedTest
 	@ArgumentsSource(TestArguments.class)
 	@JiraKey(value = "HHH-20421")
-	public void testNormalBoundary(Class<?> entityClass, int expectedInitialValue, int expectedAllocationSize, SessionFactoryScope scope)
+	public void testNativeGeneratorHonorsSequenceGeneratorInitialValueAndAllocationSize(Class<?> entityClass, int expectedInitialValue, int expectedAllocationSize, SessionFactoryScope scope)
 			throws Exception {
 		final EntityPersister persister = scope.getSessionFactory()
 				.getMappingMetamodel()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/n_ative/NativeGeneratorTypeSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/n_ative/NativeGeneratorTypeSequenceTest.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.idgen.n_ative;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.NativeGenerator;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.lang.reflect.Field;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("JUnitMalformedDeclaration")
+@SessionFactory
+@DomainModel(
+		annotatedClasses = {
+				NativeGeneratorTypeSequenceTest.DefaultIncrSizeDefaultStart.class,
+				NativeGeneratorTypeSequenceTest.IncrSizeOneStartOne.class,
+				NativeGeneratorTypeSequenceTest.IncrSizeFiveStartTen.class
+		}
+)
+public class NativeGeneratorTypeSequenceTest {
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@BeforeAll
+	static void setUp(SessionFactoryScope scope) {
+		Assumptions.assumeTrue( dialectDefaultsToSequenceGenerator( scope ),
+				"sequence generator is not the default for this dialect" );
+	}
+
+	static class TestArguments implements ArgumentsProvider {
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+			return Stream.of(
+					Arguments.of( DefaultIncrSizeDefaultStart.class, 1, 50 ),
+					Arguments.of( IncrSizeOneStartOne.class, 1, 1 ),
+					Arguments.of( IncrSizeFiveStartTen.class, 10, 5 )
+			);
+		}
+	}
+
+	@ParameterizedTest
+	@ArgumentsSource(TestArguments.class)
+	@JiraKey(value = "HHH-20421")
+	public void testNormalBoundary(Class<?> entityClass, int expectedInitialValue, int expectedAllocationSize, SessionFactoryScope scope)
+			throws Exception {
+		final EntityPersister persister = scope.getSessionFactory()
+				.getMappingMetamodel()
+				.getEntityDescriptor( entityClass.getName() );
+		assertThat( persister.getGenerator() ).isInstanceOf( org.hibernate.id.NativeGenerator.class );
+
+		final org.hibernate.id.NativeGenerator generator = (org.hibernate.id.NativeGenerator) persister.getGenerator();
+		SequenceStyleGenerator sequenceStyleGenerator = getSequenceStyleGenerator( generator );
+
+		assertEquals( expectedInitialValue, sequenceStyleGenerator.getDatabaseStructure().getInitialValue() );
+		assertEquals( expectedAllocationSize, sequenceStyleGenerator.getDatabaseStructure().getIncrementSize() );
+	}
+
+	private static SequenceStyleGenerator getSequenceStyleGenerator(org.hibernate.id.NativeGenerator generator)
+			throws NoSuchFieldException, IllegalAccessException {
+		Field nativeGeneratorField = org.hibernate.id.NativeGenerator.class.getDeclaredField(
+				"dialectNativeGenerator" );
+		nativeGeneratorField.setAccessible( true );
+
+		Object nativeGenerator = nativeGeneratorField.get( generator );
+		assertThat( nativeGenerator ).isInstanceOf( SequenceStyleGenerator.class );
+
+		return (SequenceStyleGenerator) nativeGenerator;
+	}
+
+	private static boolean dialectDefaultsToSequenceGenerator(SessionFactoryScope scope) {
+		return scope.getSessionFactory().getJdbcServices().getDialect()
+					.getNativeValueGenerationStrategy() == GenerationType.SEQUENCE;
+	}
+
+	@Entity(name = "DefaultIncrSizeDefaultStart")
+	@Table(name = "DefaultIncrSizeDefaultStart")
+	public static class DefaultIncrSizeDefaultStart {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		@NativeGenerator(sequenceForm = @SequenceGenerator())
+		public Integer id;
+	}
+
+	@Entity(name = "IncrSizeOneStartOne")
+	@Table(name = "IncrSizeOneStartOne")
+	public static class IncrSizeOneStartOne {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		@NativeGenerator(sequenceForm = @SequenceGenerator(initialValue = 1, allocationSize = 1))
+		public Integer id;
+	}
+
+	@Entity(name = "IncrSizeFiveStartTen")
+	@Table(name = "IncrSizeFiveStartTen")
+	public static class IncrSizeFiveStartTen {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		@NativeGenerator(sequenceForm = @SequenceGenerator(initialValue = 10, allocationSize = 5))
+		public Integer id;
+	}
+
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

This fixes `NativeGenerator`'s `SequenceStyleGenerator` to honor the actual values given in the `@SequenceGenerator` annotation. `NativeGenerator` used to set increment as 1 and `SequenceStyleGenerator` thinks that the default (50) is already set in this case, resulting in value 1 being used as the increment value.

I was too afraid to touch the `SequenceStyleGenerator`, I assume it works and it is used elsewhere. So I came to the conclusion that `NativeGenerator` is the culprit. I removed the hard coded setting, I hope this doesn't have any side effects. Tests included to test that the annotation values are honored when dialect uses SEQUENCE type.

Resolves https://hibernate.atlassian.net/browse/HHH-20421.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20421 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->