### PR TITLE
HHH-20384 Extract component handling from HbmXmlTransformer into reusable HbmXmlTransformerComponentHandler

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -249,8 +248,7 @@ public class HbmXmlTransformer {
 
 	private final UnsupportedFeatureHandling unsupportedFeatureHandling;
 
-	// todo (7.0) : use transformation-state instead
-	private final Map<String,JaxbEmbeddableImpl> jaxbEmbeddableByClassName = new HashMap<>();
+	private final HbmXmlTransformerComponentHandler componentHandler;
 
 	private Table currentBaseTable;
 
@@ -263,6 +261,11 @@ public class HbmXmlTransformer {
 		this.mappingXmlBinding = mappingXmlBinding;
 		this.transformationState = transformationState;
 		this.unsupportedFeatureHandling = unsupportedFeatureHandling;
+		this.componentHandler = new HbmXmlTransformerComponentHandler(
+				transformationState.getEmbeddableInfoByRole(),
+				mappingXmlBinding.getRoot(),
+				this::transferBaseAttributes
+		);
 	}
 
 
@@ -1313,12 +1316,18 @@ public class HbmXmlTransformer {
 				try {
 					final String componentRole = roleBase + "." + hbmComponent.getName();
 					final var componentTypeInfo = transformationState.getEmbeddableInfoByRole().get( componentRole );
-					final var jaxbEmbeddable = applyEmbeddable(
+					final var jaxbEmbeddable = componentHandler.applyEmbeddable(
 							roleBase,
 							hbmComponent,
 							componentTypeInfo
 					);
-					attributes.getEmbeddedAttributes().add( transformEmbedded( jaxbEmbeddable, hbmComponent ) );
+					final var embedded = componentHandler.transformEmbedded( jaxbEmbeddable, hbmComponent );
+					transferAccess(
+							hbmComponent.getAccess(),
+							embedded::setAccess,
+							embedded::setAttributeAccessor
+					);
+					attributes.getEmbeddedAttributes().add( embedded );
 				}
 				catch (Exception e) {
 					throw new TransformationException( "Error transforming <component/> : " + hbmComponent.getName(), e, origin() );
@@ -1563,74 +1572,6 @@ public class HbmXmlTransformer {
 		return typeNode;
 	}
 
-	private JaxbEmbeddableImpl applyEmbeddable(
-			String roleBase,
-			JaxbHbmCompositeAttributeType hbmComponent,
-			ComponentTypeInfo componentTypeInfo) {
-		final String embeddableClassName = componentTypeInfo.getComponent().getComponentClassName();
-		if ( isNotEmpty( embeddableClassName ) ) {
-			final var existing = jaxbEmbeddableByClassName.get( embeddableClassName );
-			if ( existing != null ) {
-				return existing;
-			}
-		}
-
-		final String role = roleBase + "." + hbmComponent.getName();
-		final String embeddableName = determineEmbeddableName( embeddableClassName, hbmComponent.getName() );
-		final var jaxbEmbeddable = convertEmbeddable(
-				role,
-				embeddableName,
-				embeddableClassName,
-				hbmComponent
-		);
-		mappingXmlBinding.getRoot().getEmbeddables().add( jaxbEmbeddable );
-
-		if ( isNotEmpty( embeddableClassName ) ) {
-			jaxbEmbeddableByClassName.put( embeddableClassName, jaxbEmbeddable );
-		}
-
-		return jaxbEmbeddable;
-	}
-
-
-	private JaxbEmbeddableImpl convertEmbeddable(
-			String role,
-			String embeddableName,
-			String embeddableClassName,
-			JaxbHbmCompositeAttributeType hbmComponent) {
-		final var componentTypeInfo = transformationState.getEmbeddableInfoByRole().get( role );
-
-		final var embeddable = new JaxbEmbeddableImpl();
-		embeddable.setMetadataComplete( true );
-		embeddable.setName( embeddableName );
-		embeddable.setClazz( embeddableClassName );
-
-		embeddable.setAttributes( new JaxbEmbeddableAttributesContainerImpl() );
-		transferBaseAttributes( role, hbmComponent.getAttributes(), componentTypeInfo, embeddable.getAttributes() );
-		return embeddable;
-	}
-
-	private int counter = 1;
-	private String determineEmbeddableName(String componentClassName, String attributeName) {
-		if ( isNotEmpty( componentClassName ) ) {
-			return componentClassName;
-		}
-		return attributeName + "_" + counter++;
-	}
-
-	private JaxbEmbeddedImpl transformEmbedded(
-			JaxbEmbeddableImpl jaxbEmbeddable,
-			JaxbHbmCompositeAttributeType hbmComponent) {
-		final var embedded = new JaxbEmbeddedImpl();
-		embedded.setName( hbmComponent.getName() );
-		transferAccess(
-				hbmComponent.getAccess(),
-				embedded::setAccess,
-				embedded::setAttributeAccessor
-		);
-		embedded.setTarget( jaxbEmbeddable.getName() );
-		return embedded;
-	}
 
 	private void transferOneToOne(JaxbHbmOneToOneType hbmOneToOne, PropertyInfo propertyInfo, JaxbAttributesContainer attributes) {
 		final var oneToOne = new JaxbOneToOneImpl();
@@ -2140,7 +2081,7 @@ public class HbmXmlTransformer {
 		transferCollectionTable( hbmCollection, target );
 
 		final String embeddableClassName = compositeElement.getClazz();
-		final String embeddableName = determineEmbeddableName( embeddableClassName, hbmCollection.getName() );
+		final String embeddableName = componentHandler.determineEmbeddableName( embeddableClassName, hbmCollection.getName() );
 
 		final String partRole = roleBase + "." + hbmCollection.getName() + ".value";
 		final var componentTypeInfo = transformationState.getEmbeddableInfoByRole().get( partRole );
@@ -2653,14 +2594,14 @@ public class HbmXmlTransformer {
 			Property idProperty) {
 		final String embeddableClassName = hbmCompositeId.getClazz();
 		if ( isNotEmpty( embeddableClassName ) ) {
-			final var existing = jaxbEmbeddableByClassName.get( embeddableClassName );
+			final var existing = componentHandler.getJaxbEmbeddableByClassName().get( embeddableClassName );
 			if ( existing != null ) {
 				return existing;
 			}
 		}
 
 		final String role = bootEntityInfo.getPersistentClass().getEntityName() + "." + hbmCompositeId.getName();
-		final String embeddableName = determineEmbeddableName( embeddableClassName, hbmCompositeId.getName() );
+		final String embeddableName = componentHandler.determineEmbeddableName( embeddableClassName, hbmCompositeId.getName() );
 		final var componentTypeInfo = transformationState.getEmbeddableInfoByRole().get( role );
 		final var created = transferEmbeddedIdEmbeddable(
 				role,
@@ -3182,12 +3123,18 @@ public class HbmXmlTransformer {
 				else if ( hbmProperty instanceof JaxbHbmCompositeAttributeType hbmComponent ) {
 					final String componentRole = bootEntityInfo.getPersistentClass().getEntityName() + "." + hbmComponent.getName();
 					final var componentTypeInfo = transformationState.getEmbeddableInfoByRole().get( componentRole );
-					final var jaxbEmbeddable = applyEmbeddable(
+					final var jaxbEmbeddable = componentHandler.applyEmbeddable(
 							bootEntityInfo.getPersistentClass().getEntityName(),
 							hbmComponent,
 							componentTypeInfo
 					);
-					mappingEntity.getAttributes().getEmbeddedAttributes().add( transformEmbedded( jaxbEmbeddable, hbmComponent ) );
+					final var embedded = componentHandler.transformEmbedded( jaxbEmbeddable, hbmComponent );
+					transferAccess(
+							hbmComponent.getAccess(),
+							embedded::setAccess,
+							embedded::setAttributeAccessor
+					);
+					mappingEntity.getAttributes().getEmbeddedAttributes().add( embedded );
 				}
 				else if ( hbmProperty instanceof JaxbHbmManyToOneType hbmManyToOne ) {
 					final var propertyInfo = bootEntityInfo.propertyInfoMap().get( hbmManyToOne.getName() );

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
@@ -1,0 +1,165 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.boot.jaxb.hbm.transform;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributesContainer;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableAttributesContainerImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
+
+import static org.hibernate.internal.util.StringHelper.isNotEmpty;
+
+/**
+ * Handles {@code <component/>} to embeddable conversion during HBM XML transformation.
+ * <p>
+ * This class encapsulates the embeddable creation logic so it can be used both
+ * during the full {@link HbmXmlTransformer} transformation (with a complete boot model)
+ * and standalone at build time (without a boot model) to discover embeddable class names.
+ *
+ * @see HbmXmlTransformer
+ */
+public class HbmXmlTransformerComponentHandler {
+
+	/**
+	 * Callback for processing all nested attributes inside a component,
+	 * used during the full HBM XML transformation.
+	 */
+	@FunctionalInterface
+	public interface NestedAttributeProcessor {
+		void processAttributes(
+				String roleBase,
+				List<?> hbmAttributeMappings,
+				ManagedTypeInfo managedTypeInfo,
+				JaxbAttributesContainer attributes);
+	}
+
+	private final Map<String, ComponentTypeInfo> embeddableInfoByRole;
+	private final JaxbEntityMappingsImpl mappingRoot;
+	private final NestedAttributeProcessor nestedAttributeProcessor;
+
+	// todo (7.0) : use transformation-state instead
+	private final Map<String, JaxbEmbeddableImpl> jaxbEmbeddableByClassName = new HashMap<>();
+	private int counter = 1;
+
+	/**
+	 * Creates a handler for use during the full HBM XML transformation.
+	 *
+	 * @param embeddableInfoByRole component type info populated from the boot model
+	 * @param mappingRoot the target mapping root to add embeddables to
+	 * @param nestedAttributeProcessor callback to process nested attributes inside a component
+	 */
+	public HbmXmlTransformerComponentHandler(
+			Map<String, ComponentTypeInfo> embeddableInfoByRole,
+			JaxbEntityMappingsImpl mappingRoot,
+			NestedAttributeProcessor nestedAttributeProcessor) {
+		this.embeddableInfoByRole = embeddableInfoByRole;
+		this.mappingRoot = mappingRoot;
+		this.nestedAttributeProcessor = nestedAttributeProcessor;
+	}
+
+	/**
+	 * Creates a lightweight handler that only collects component class names,
+	 * without a boot model. Nested components inside a component are discovered
+	 * automatically.
+	 *
+	 * @param mappingRoot the target mapping root to add embeddables to
+	 */
+	public HbmXmlTransformerComponentHandler(JaxbEntityMappingsImpl mappingRoot) {
+		this( Map.of(), mappingRoot, null );
+	}
+
+	/**
+	 * Handles a {@code <component/>} mapping found during attribute traversal.
+	 *
+	 * @return the created or cached embeddable
+	 */
+	public JaxbEmbeddableImpl applyEmbeddable(
+			String roleBase,
+			JaxbHbmCompositeAttributeType hbmComponent,
+			ComponentTypeInfo componentTypeInfo) {
+		final String embeddableClassName = componentTypeInfo != null
+				? componentTypeInfo.getComponent().getComponentClassName()
+				: hbmComponent.getClazz();
+		if ( isNotEmpty( embeddableClassName ) ) {
+			final var existing = jaxbEmbeddableByClassName.get( embeddableClassName );
+			if ( existing != null ) {
+				return existing;
+			}
+		}
+
+		final String role = roleBase + "." + hbmComponent.getName();
+		final String embeddableName = determineEmbeddableName( embeddableClassName, hbmComponent.getName() );
+		final var jaxbEmbeddable = convertEmbeddable(
+				role,
+				embeddableName,
+				embeddableClassName,
+				hbmComponent
+		);
+		mappingRoot.getEmbeddables().add( jaxbEmbeddable );
+
+		if ( isNotEmpty( embeddableClassName ) ) {
+			jaxbEmbeddableByClassName.put( embeddableClassName, jaxbEmbeddable );
+		}
+
+		return jaxbEmbeddable;
+	}
+
+	public JaxbEmbeddedImpl transformEmbedded(
+			JaxbEmbeddableImpl jaxbEmbeddable,
+			JaxbHbmCompositeAttributeType hbmComponent) {
+		final var embedded = new JaxbEmbeddedImpl();
+		embedded.setName( hbmComponent.getName() );
+		embedded.setTarget( jaxbEmbeddable.getName() );
+		return embedded;
+	}
+
+	private JaxbEmbeddableImpl convertEmbeddable(
+			String role,
+			String embeddableName,
+			String embeddableClassName,
+			JaxbHbmCompositeAttributeType hbmComponent) {
+		final var componentTypeInfo = embeddableInfoByRole.get( role );
+
+		final var embeddable = new JaxbEmbeddableImpl();
+		embeddable.setMetadataComplete( true );
+		embeddable.setName( embeddableName );
+		embeddable.setClazz( embeddableClassName );
+
+		embeddable.setAttributes( new JaxbEmbeddableAttributesContainerImpl() );
+		if ( nestedAttributeProcessor != null ) {
+			nestedAttributeProcessor.processAttributes(
+					role,
+					hbmComponent.getAttributes(),
+					componentTypeInfo,
+					embeddable.getAttributes()
+			);
+		}
+		else {
+			for ( Object attr : hbmComponent.getAttributes() ) {
+				if ( attr instanceof JaxbHbmCompositeAttributeType nested ) {
+					applyEmbeddable( role, nested, null );
+				}
+			}
+		}
+		return embeddable;
+	}
+
+	public String determineEmbeddableName(String componentClassName, String attributeName) {
+		if ( isNotEmpty( componentClassName ) ) {
+			return componentClassName;
+		}
+		return attributeName + "_" + counter++;
+	}
+
+	public Map<String, JaxbEmbeddableImpl> getJaxbEmbeddableByClassName() {
+		return jaxbEmbeddableByClassName;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/hbm/transform/HbmXmlComponentVisitorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/hbm/transform/HbmXmlComponentVisitorTest.java
@@ -1,0 +1,218 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.hbm.transform;
+
+import java.util.List;
+
+import org.hibernate.boot.jaxb.Origin;
+import org.hibernate.boot.jaxb.SourceType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDiscriminatorSubclassEntityType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmJoinedSubclassEntityType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmRootEntityType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmUnionSubclassEntityType;
+import org.hibernate.boot.jaxb.hbm.transform.HbmXmlTransformerComponentHandler;
+import org.hibernate.boot.jaxb.hbm.transform.TransformationState;
+import org.hibernate.boot.jaxb.hbm.transform.XmlPreprocessor;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
+import org.hibernate.boot.jaxb.spi.Binding;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that {@link HbmXmlTransformerComponentHandler} can be used standalone
+ * (without a boot model) to create embeddable entries from HBM XML.
+ */
+public class HbmXmlComponentVisitorTest {
+
+	@Test
+	void componentInRootEntity() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType entity = new JaxbHbmRootEntityType();
+		entity.setName( "MyEntity" );
+
+		JaxbHbmCompositeAttributeType component = new JaxbHbmCompositeAttributeType();
+		component.setName( "address" );
+		component.setClazz( "com.example.Address" );
+		entity.getAttributes().add( component );
+
+		hbmMapping.getClazz().add( entity );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() )
+				.hasSize( 1 )
+				.extracting( e -> e.getClazz() )
+				.containsExactly( "com.example.Address" );
+	}
+
+	@Test
+	void nestedComponents() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType entity = new JaxbHbmRootEntityType();
+		entity.setName( "MyEntity" );
+
+		JaxbHbmCompositeAttributeType innerComponent = new JaxbHbmCompositeAttributeType();
+		innerComponent.setName( "city" );
+		innerComponent.setClazz( "com.example.City" );
+
+		JaxbHbmCompositeAttributeType outerComponent = new JaxbHbmCompositeAttributeType();
+		outerComponent.setName( "address" );
+		outerComponent.setClazz( "com.example.Address" );
+		outerComponent.getAttributes().add( innerComponent );
+
+		entity.getAttributes().add( outerComponent );
+		hbmMapping.getClazz().add( entity );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() )
+				.hasSize( 2 )
+				.extracting( e -> e.getClazz() )
+				.containsExactlyInAnyOrder( "com.example.Address", "com.example.City" );
+	}
+
+	@Test
+	void componentInDiscriminatorSubclass() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType rootEntity = new JaxbHbmRootEntityType();
+		rootEntity.setName( "ParentEntity" );
+
+		JaxbHbmDiscriminatorSubclassEntityType subclass = new JaxbHbmDiscriminatorSubclassEntityType();
+		subclass.setName( "ChildEntity" );
+
+		JaxbHbmCompositeAttributeType component = new JaxbHbmCompositeAttributeType();
+		component.setName( "address" );
+		component.setClazz( "com.example.Address" );
+		subclass.getAttributes().add( component );
+
+		rootEntity.getSubclass().add( subclass );
+		hbmMapping.getClazz().add( rootEntity );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() )
+				.hasSize( 1 )
+				.extracting( e -> e.getClazz() )
+				.containsExactly( "com.example.Address" );
+	}
+
+	@Test
+	void componentInJoinedSubclass() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmJoinedSubclassEntityType subclass = new JaxbHbmJoinedSubclassEntityType();
+		subclass.setName( "JoinedChild" );
+
+		JaxbHbmCompositeAttributeType component = new JaxbHbmCompositeAttributeType();
+		component.setName( "details" );
+		component.setClazz( "com.example.Details" );
+		subclass.getAttributes().add( component );
+
+		hbmMapping.getJoinedSubclass().add( subclass );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() )
+				.hasSize( 1 )
+				.extracting( e -> e.getClazz() )
+				.containsExactly( "com.example.Details" );
+	}
+
+	@Test
+	void componentInUnionSubclass() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmUnionSubclassEntityType subclass = new JaxbHbmUnionSubclassEntityType();
+		subclass.setName( "UnionChild" );
+
+		JaxbHbmCompositeAttributeType component = new JaxbHbmCompositeAttributeType();
+		component.setName( "info" );
+		component.setClazz( "com.example.Info" );
+		subclass.getAttributes().add( component );
+
+		hbmMapping.getUnionSubclass().add( subclass );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() )
+				.hasSize( 1 )
+				.extracting( e -> e.getClazz() )
+				.containsExactly( "com.example.Info" );
+	}
+
+	@Test
+	void duplicateComponentClassIsNotDuplicated() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType rootEntity = new JaxbHbmRootEntityType();
+		rootEntity.setName( "ParentEntity" );
+
+		JaxbHbmCompositeAttributeType rootComponent = new JaxbHbmCompositeAttributeType();
+		rootComponent.setName( "address" );
+		rootComponent.setClazz( "com.example.Address" );
+		rootEntity.getAttributes().add( rootComponent );
+
+		JaxbHbmDiscriminatorSubclassEntityType subclass = new JaxbHbmDiscriminatorSubclassEntityType();
+		subclass.setName( "ChildEntity" );
+
+		JaxbHbmCompositeAttributeType subclassComponent = new JaxbHbmCompositeAttributeType();
+		subclassComponent.setName( "shippingAddress" );
+		subclassComponent.setClazz( "com.example.Address" );
+		subclass.getAttributes().add( subclassComponent );
+
+		rootEntity.getSubclass().add( subclass );
+		hbmMapping.getClazz().add( rootEntity );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() )
+				.extracting( e -> e.getClazz() )
+				.containsExactly( "com.example.Address" );
+	}
+
+	@Test
+	void entityWithoutComponentYieldsNoEmbeddables() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType entity = new JaxbHbmRootEntityType();
+		entity.setName( "SimpleEntity" );
+		hbmMapping.getClazz().add( entity );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() ).isEmpty();
+	}
+
+	/**
+	 * Uses the lightweight constructor (no boot model) to collect embeddables.
+	 */
+	private static JaxbEntityMappingsImpl processWithHandler(JaxbHbmHibernateMapping hbmMapping) {
+		final var mappingRoot = new JaxbEntityMappingsImpl();
+		final var handler = new HbmXmlTransformerComponentHandler( mappingRoot );
+
+		final var transformationState = new TransformationState();
+		XmlPreprocessor.preprocessHbmXml(
+				List.of( new Binding<>( hbmMapping, new Origin( SourceType.OTHER, "test" ) ) ),
+				transformationState
+		);
+
+		for ( var entry : transformationState.getHbmEntityByName().entrySet() ) {
+			for ( Object attr : entry.getValue().getAttributes() ) {
+				if ( attr instanceof JaxbHbmCompositeAttributeType composite ) {
+					handler.applyEmbeddable( entry.getKey(), composite, null );
+				}
+			}
+		}
+
+		return mappingRoot;
+	}
+}


### PR DESCRIPTION
[HHH-20384](https://hibernate.atlassian.net/browse/HHH-20384)

This is a substitute implementation for #12412, addressing the concern raised in
https://github.com/hibernate/hibernate-orm/pull/12412#issuecomment-4450949548
that the XmlPreprocessor should not be modified for logic that only external
consumers (like Quarkus) need.

Instead of adding component collection to XmlPreprocessor, this PR extracts the
existing `applyEmbeddable`, `convertEmbeddable`, `transformEmbedded`, and
`determineEmbeddableName` methods from `HbmXmlTransformer` into a new
`HbmXmlTransformerComponentHandler` class. The handler takes its dependencies as
constructor parameters:

- `embeddableInfoByRole` — component type info from the boot model
- `mappingRoot` — the target mapping root to add embeddables to
- `nestedAttributeProcessor` — callback for processing nested attributes

`HbmXmlTransformer` creates the handler in its constructor, passing
`this::transferBaseAttributes` as the nested processor, so the full
transformation behavior is unchanged for existing users.

A lightweight constructor `HbmXmlTransformerComponentHandler(mappingRoot)` is
also provided for use without a boot model. When the nested processor is null,
the handler recurses into nested components internally.

This does not change the normal HBM XML processing path — `XmlPreprocessor`
is untouched.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

[HHH-20384]: https://hibernate.atlassian.net/browse/HHH-20384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20384 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->