### PR TITLE
[7.3] HHH-20125 ClassCastException on merge during polymorphic embeddable replace

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -111,7 +111,7 @@ public class ComponentType extends AbstractType
 		if ( discriminator != null ) {
 			this.discriminatorColumnSpan = discriminator.getColumnSpan();
 			this.propertyNames[i] = DISCRIMINATOR_ROLE_NAME;
-			this.propertyTypes[i] = discriminator.getType();
+			this.propertyTypes[i] = component.getDiscriminatorType();
 			this.propertyNullability[i] = false;
 			this.cascade[i] = CascadeStyles.NONE;
 			this.joinedFetch[i] = FetchMode.SELECT;
@@ -540,7 +540,7 @@ public class ComponentType extends AbstractType
 					copyCache
 			);
 
-			if ( target == null || !isMutable() ) {
+			if ( target == null || !isMutable() || embeddableTypeDescriptor().isPolymorphic() ) {
 				return instantiator( original ).instantiate( () -> replacedValues );
 			}
 			else {
@@ -574,7 +574,7 @@ public class ComponentType extends AbstractType
 					foreignKeyDirection
 			);
 
-			if ( target == null || !isMutable() ) {
+			if ( target == null || !isMutable() || embeddableTypeDescriptor().isPolymorphic() ) {
 				return instantiator( original ).instantiate( () -> replacedValues );
 			}
 			else {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/EmbeddableInheritanceReplaceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/EmbeddableInheritanceReplaceTest.java
@@ -13,11 +13,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("JUnitMalformedDeclaration")
 @DomainModel(annotatedClasses = {
@@ -44,6 +47,24 @@ public class EmbeddableInheritanceReplaceTest {
 		} );
 	}
 
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-20125" )
+	void mergeAfterPersist(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var entity = new Ent();
+			entity.setBase( new Emb( 42, "Hello, World!" ) );
+			session.persist( entity );
+			session.flush();
+			session.clear();
+
+			entity.setBase( new Base( 43 ) );
+			var merged = session.merge( entity );
+
+			assertThat( merged.getBase() ).isExactlyInstanceOf( Base.class );
+			assertThat( merged.getBase().getNum() ).isEqualTo( 43 );
+		} );
+	}
+
 	@Embeddable
 	@DiscriminatorValue("E")
 	public static final class Emb extends Next {
@@ -66,7 +87,7 @@ public class EmbeddableInheritanceReplaceTest {
 		protected Base() {
 		}
 
-		public Base(int num, String str) {
+		public Base(int num) {
 			this.num = num;
 		}
 
@@ -86,7 +107,7 @@ public class EmbeddableInheritanceReplaceTest {
 		private String str;
 
 		public Next(int num, String str) {
-			super( num, str );
+			super( num );
 			this.str = str;
 		}
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/12470

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20125 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20125
<!-- Hibernate GitHub Bot issue links end -->