### PR TITLE
HHH-20384 Collect entity subclasses in DomainModelCategorizationCollector

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -32,6 +32,7 @@ public class DomainModelCategorizationCollector {
 	private final ModelsContext modelsContext;
 
 	private final Set<ClassDetails> rootEntities = new HashSet<>();
+	private final Set<ClassDetails> entitySubclasses = new HashSet<>();
 	private final Map<String,ClassDetails> mappedSuperclasses = new HashMap<>();
 	private final Map<String,ClassDetails> embeddables = new HashMap<>();
 
@@ -48,6 +49,16 @@ public class DomainModelCategorizationCollector {
 
 	public Set<ClassDetails> getRootEntities() {
 		return rootEntities;
+	}
+
+	public Set<ClassDetails> getEntitySubclasses() {
+		return entitySubclasses;
+	}
+
+	public Set<ClassDetails> getAllEntities() {
+		Set<ClassDetails> all = new HashSet<>( rootEntities );
+		all.addAll( entitySubclasses );
+		return all;
 	}
 
 	public Map<String, ClassDetails> getMappedSuperclasses() {
@@ -114,6 +125,9 @@ public class DomainModelCategorizationCollector {
 		else if ( isEntity( classDetails ) ) {
 			if ( isRootEntity( classDetails ) ) {
 				rootEntities.add( classDetails );
+			}
+			else {
+				entitySubclasses.add( classDetails );
 			}
 		}
 		else if ( isEmbeddable( classDetails ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -31,6 +31,7 @@ public class DomainModelCategorizationCollector {
 	private final ModelsContext modelsContext;
 
 	private final Set<ClassDetails> rootEntities = new HashSet<>();
+	private final Set<ClassDetails> entitySubclasses = new HashSet<>();
 	private final Map<String,ClassDetails> mappedSuperclasses = new HashMap<>();
 	private final Map<String,ClassDetails> embeddables = new HashMap<>();
 
@@ -47,6 +48,16 @@ public class DomainModelCategorizationCollector {
 
 	public Set<ClassDetails> getRootEntities() {
 		return rootEntities;
+	}
+
+	public Set<ClassDetails> getEntitySubclasses() {
+		return entitySubclasses;
+	}
+
+	public Set<ClassDetails> getAllEntities() {
+		Set<ClassDetails> all = new HashSet<>( rootEntities );
+		all.addAll( entitySubclasses );
+		return all;
 	}
 
 	public Map<String, ClassDetails> getMappedSuperclasses() {
@@ -118,6 +129,9 @@ public class DomainModelCategorizationCollector {
 		else if ( isEntity( classDetails ) ) {
 			if ( isRootEntity( classDetails ) ) {
 				rootEntities.add( classDetails );
+			}
+			else {
+				entitySubclasses.add( classDetails );
 			}
 		}
 		else if ( isEmbeddable( classDetails ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/EntityInheritanceCategorizationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/categorization/EntityInheritanceCategorizationTest.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.categorization;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.boot.models.internal.DomainModelCategorizationCollector;
+import org.hibernate.boot.models.internal.GlobalRegistrationsImpl;
+import org.hibernate.models.spi.ClassDetails;
+import org.hibernate.models.spi.ModelsContext;
+import org.hibernate.testing.boot.BootstrapContextImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.boot.models.SourceModelTestHelper.createBuildingContext;
+
+/**
+ * Tests that {@link DomainModelCategorizationCollector} correctly categorizes
+ * entity inheritance hierarchies, including non-root entity subclasses.
+ */
+public class EntityInheritanceCategorizationTest {
+
+	private BootstrapContextImpl bootstrapContext;
+
+	@AfterEach
+	void tearDown() {
+		if ( bootstrapContext != null ) {
+			bootstrapContext.close();
+		}
+	}
+
+	private DomainModelCategorizationCollector collectFrom(Class<?>... classes) {
+		final ModelsContext modelsContext = createBuildingContext( classes );
+		bootstrapContext = new BootstrapContextImpl();
+		final GlobalRegistrationsImpl globalRegistrations =
+				new GlobalRegistrationsImpl( modelsContext, bootstrapContext );
+		final DomainModelCategorizationCollector collector =
+				new DomainModelCategorizationCollector( globalRegistrations, modelsContext );
+		modelsContext.getClassDetailsRegistry().forEachClassDetails( collector::apply );
+		return collector;
+	}
+
+	@Entity
+	public static class ParentEntity {
+		@Id
+		private Long id;
+	}
+
+	@Entity
+	public static class ChildEntity extends ParentEntity {
+		private String name;
+	}
+
+	@Test
+	void parentIsRootChildIsSubEntity() {
+		final DomainModelCategorizationCollector collector = collectFrom(
+				ParentEntity.class,
+				ChildEntity.class
+		);
+
+		assertThat( collector.getRootEntities() )
+				.extracting( ClassDetails::getClassName )
+				.containsExactly( ParentEntity.class.getName() );
+
+		assertThat( collector.getEntitySubclasses() )
+				.extracting( ClassDetails::getClassName )
+				.containsExactly( ChildEntity.class.getName() );
+
+		assertThat( collector.getAllEntities() )
+				.extracting( ClassDetails::getClassName )
+				.containsExactlyInAnyOrder(
+						ParentEntity.class.getName(),
+						ChildEntity.class.getName()
+				);
+	}
+
+	@MappedSuperclass
+	public static class BaseMappedSuperclass {
+		@Id
+		private Long id;
+	}
+
+	@Entity
+	public static class RootEntityWithSuperclass extends BaseMappedSuperclass {
+		private String name;
+	}
+
+	@Test
+	void mappedSuperclassIsNotRootEntityAndNoSubEntities() {
+		final DomainModelCategorizationCollector collector = collectFrom(
+				BaseMappedSuperclass.class,
+				RootEntityWithSuperclass.class
+		);
+
+		assertThat( collector.getRootEntities() )
+				.extracting( ClassDetails::getClassName )
+				.containsExactly( RootEntityWithSuperclass.class.getName() );
+
+		assertThat( collector.getEntitySubclasses() ).isEmpty();
+
+		assertThat( collector.getMappedSuperclasses() )
+				.containsKey( BaseMappedSuperclass.class.getName() );
+	}
+}


### PR DESCRIPTION
## Summary
- Forward port of https://github.com/hibernate/hibernate-orm/pull/12248 (targeting 7.3) to main
- Collect entity subclasses during categorization so Quarkus can discover all entity types at build time without a full bootstrap
- Needed for quarkusio/quarkus#48005
- Part of https://hibernate.atlassian.net/browse/HHH-20384

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20384 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->