### PR TITLE
HHH-20482 Avoid mutating any final field in tests + add --illegal-final-field-mutation to JDK 26+ test runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,12 +49,13 @@ stage('Configure') {
 		// even if we don't use these features, just enabling them can cause side effects
 		// and it's useful to test that.
 		new BuildEnvironment( testJdkVersion: '25', testJdkLauncherArgs: '--enable-preview' ),
-		new BuildEnvironment( testJdkVersion: '26', testJdkLauncherArgs: '--enable-preview' ),
+		// --illegal-final-field-mutation=deny: check we don't try to mutate final fields anywhere in tests, because that'll be forbidden eventually.
+		new BuildEnvironment( testJdkVersion: '26', testJdkLauncherArgs: '--enable-preview --illegal-final-field-mutation=deny' ),
 		// The following JDKs aren't supported by Hibernate ORM out-of-the box yet:
 		// they require the use of -Dnet.bytebuddy.experimental=true.
 		// Make sure to remove that argument as soon as possible
 		// -- generally that requires upgrading bytebuddy after the JDK goes GA.
-		new BuildEnvironment( testJdkVersion: '27', testJdkLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true', additionalOptions: '-PskipJacoco=true' )
+		new BuildEnvironment( testJdkVersion: '27', testJdkLauncherArgs: '--enable-preview --illegal-final-field-mutation=deny -Dnet.bytebuddy.experimental=true', additionalOptions: '-PskipJacoco=true' )
 	];
 
 	if ( env.CHANGE_ID ) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ org.gradle.java.installations.auto-download=false
 # externalized definition of JDK versions so that they are available in both Project (build.gradle) and Settings (settings.gradle)
 orm.jdk.base=17
 orm.jdk.min=25
-# See gradlew/wrapper/gradle-wrapper.properties, https://docs.gradle.org/current/userguide/compatibility.html#java_runtime
-orm.jdk.max=25
+# See gradle/wrapper/gradle-wrapper.properties, https://docs.gradle.org/current/userguide/compatibility.html#java_runtime
+orm.jdk.max=26
 
 # The minimum version of Gradle supported for the ORM Gradle plugin.
 # This is the version used in the plugin tests, used to make sure we do not break compatibility.

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/cascade/CodedPairSetHolder.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/cascade/CodedPairSetHolder.java
@@ -37,7 +37,7 @@ class CodedPairSetHolder implements Serializable {
 			joinColumns = @JoinColumn(name = "CODED_PAIR_HOLDER_ID"),
 			foreignKey = @ForeignKey(name = "FK_PAIR_SET"))
 
-	private final Set<PersonPair> pairs = new HashSet<PersonPair>(0);
+	private Set<PersonPair> pairs = new HashSet<PersonPair>(0);
 
 	CodedPairSetHolder() {
 		super();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/idclassgeneratedvalue/MultiplePK.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/idclassgeneratedvalue/MultiplePK.java
@@ -12,11 +12,11 @@ import java.io.Serializable;
  */
 public class MultiplePK implements Serializable
 {
-private final Long id1;
-private final Long id2;
-private final Long id3;
+private Long id1;
+private Long id2;
+private Long id3;
 // AnnotationSourceProcessor (incorrectly) requires this to be transient; see HHH-4819 and HHH-4820
-private final transient int cachedHashCode;
+private transient int cachedHashCode;
 
 private MultiplePK()
 {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/idclassgeneratedvalue/SimplePK.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/idclassgeneratedvalue/SimplePK.java
@@ -11,8 +11,8 @@ import java.io.Serializable;
  * @author Stale W. Pedersen
  */
 public class SimplePK implements Serializable {
-	private final Long id1;
-	private final Long id2;
+	private Long id1;
+	private Long id2;
 
 	private SimplePK() {
 		id1 = null;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/inheritance/SingleTableInheritanceEagerAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/inheritance/SingleTableInheritanceEagerAssociationTest.java
@@ -83,11 +83,11 @@ public class SingleTableInheritanceEagerAssociationTest {
 	public static class Message {
 
 		@Id
-		private final String messageId;
+		private String messageId;
 
 		@ManyToOne( cascade = CascadeType.ALL)
 		@JoinColumn(name = "SENDER_ADDRESS_ID")
-		private final Address address;
+		private Address address;
 
 		private int version;
 
@@ -192,7 +192,7 @@ public class SingleTableInheritanceEagerAssociationTest {
 	public static abstract class User {
 
 		@Id
-		private final String userId;
+		private String userId;
 
 		@Version
 		private int version;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/inheritance/SingleTableInheritanceLazyAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/inheritance/SingleTableInheritanceLazyAssociationTest.java
@@ -93,11 +93,11 @@ public class SingleTableInheritanceLazyAssociationTest {
 	public static class Message {
 
 		@Id
-		private final String messageId;
+		private String messageId;
 
 		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 		@JoinColumn(name = "SENDER_ADDRESS_ID")
-		private final Address address;
+		private Address address;
 
 		private int version;
 
@@ -202,7 +202,7 @@ public class SingleTableInheritanceLazyAssociationTest {
 	public static abstract class User {
 
 		@Id
-		private final String userId;
+		private String userId;
 
 		@Version
 		private int version;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/Asset.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/Asset.java
@@ -13,11 +13,11 @@ public class Asset implements Serializable {
 
 	@Id
 	@Column(name = "id_asset")
-	private final Integer idAsset;
+	private Integer idAsset;
 
 	@Id
 	@Column(name = "id_test")
-	private final Integer test;
+	private Integer test;
 
 	@ManyToOne(cascade = { CascadeType.ALL })
 	@JoinColumn(nullable = false)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/Employee.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/Employee.java
@@ -13,7 +13,7 @@ public class Employee {
 
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "employee", orphanRemoval = true)
 	@OrderBy // order by PK
-	private final List<Asset> assets = new ArrayList<>();
+	private List<Asset> assets = new ArrayList<>();
 
 	@Id
 	@Column(name = "id")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchUpdateAndVersionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchUpdateAndVersionTest.java
@@ -172,7 +172,7 @@ public class BatchUpdateAndVersionTest {
 
 		@ManyToMany
 		@JoinTable(name = "ENTITY_A_TO_ENTITY_A", inverseJoinColumns = @JoinColumn(name = "SIDE_B"), joinColumns = @JoinColumn(name = "SIDE_A"))
-		final List<EntityA> owners = new ArrayList<>();
+		List<EntityA> owners = new ArrayList<>();
 
 		public EntityA() {
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/EmbeddableAndFetchModeSelectTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/EmbeddableAndFetchModeSelectTest.java
@@ -320,7 +320,7 @@ public class EmbeddableAndFetchModeSelectTest {
 		String name;
 
 		@OneToMany(mappedBy = "entityB")
-		final List<EntityA> listOfEntityA = new ArrayList<>();
+		List<EntityA> listOfEntityA = new ArrayList<>();
 
 		public EntityB() {
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/CacheModeGetUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/CacheModeGetUpdateTest.java
@@ -162,7 +162,7 @@ public class CacheModeGetUpdateTest {
 		private String name;
 
 		@OneToMany( fetch = FetchType.LAZY, mappedBy = "person" )
-		private final Set<Phone> phones = new HashSet<>();
+		private Set<Phone> phones = new HashSet<>();
 
 		public Person() {
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/TransactionalConcurrencyCollectionCacheEvictionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/TransactionalConcurrencyCollectionCacheEvictionTest.java
@@ -153,7 +153,7 @@ public class TransactionalConcurrencyCollectionCacheEvictionTest {
 
 		@OneToMany(fetch = FetchType.LAZY, mappedBy = "person")
 		@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
-		private final Set<Phone> phones = new HashSet<>();
+		private Set<Phone> phones = new HashSet<>();
 
 		public Person() {
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cascade/CascadeMergeToProxyEntityCopyAllowedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cascade/CascadeMergeToProxyEntityCopyAllowedTest.java
@@ -170,7 +170,7 @@ public class CascadeMergeToProxyEntityCopyAllowedTest {
 		private int version;
 
 		@Column(nullable = false, unique = true, length = 36)
-		private final String bID;
+		private String bID;
 
 		protected AbstractEntity() {
 			bID = UUID.nameUUIDFromBytes(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cascade/circle/delete/Person.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cascade/circle/delete/Person.java
@@ -28,7 +28,7 @@ public class Person {
 	private String name;
 
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "person")
-	private final List<Address> addresses = new ArrayList<>();
+	private List<Address> addresses = new ArrayList<>();
 
 	@OneToOne(cascade = { CascadeType.ALL })
 	private Address currentAddress;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/compositefk/OneToOneEmbeddedIdWithGenericsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/compositefk/OneToOneEmbeddedIdWithGenericsTest.java
@@ -87,7 +87,7 @@ public class OneToOneEmbeddedIdWithGenericsTest {
 	@MappedSuperclass
 	public abstract static class DomainEntityId implements Serializable {
 		@Column(name = "id_value")
-		private final Long value;
+		private Long value;
 
 		protected DomainEntityId() {
 			Random random = new Random();
@@ -102,7 +102,7 @@ public class OneToOneEmbeddedIdWithGenericsTest {
 	@MappedSuperclass
 	public abstract static class DomainEntityModel<ID extends DomainEntityId> {
 		@EmbeddedId
-		private final ID id;
+		private ID id;
 
 		protected DomainEntityModel(ID id) {
 			this.id = id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassSingleOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassSingleOneToOneTest.java
@@ -125,7 +125,7 @@ public class IdClassSingleOneToOneTest {
 	}
 
 	static class EntityBId {
-		private final Integer entityA;
+		private Integer entityA;
 
 		EntityBId() {
 			entityA = null;
@@ -147,7 +147,7 @@ public class IdClassSingleOneToOneTest {
 	}
 
 	static class EntityCId {
-		private final Integer entityA;
+		private Integer entityA;
 
 		EntityCId() {
 			entityA = null;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/foreign/ForeignGeneratorResourceLocalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/foreign/ForeignGeneratorResourceLocalTest.java
@@ -190,7 +190,7 @@ public class ForeignGeneratorResourceLocalTest {
 	public static class Customer {
 		@OneToMany(mappedBy = "customer", fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE },
 				orphanRemoval = true, targetEntity = CustomerContractRelation.class)
-		private final Set<CustomerContractRelation> contractRelations = new HashSet<>();
+		private Set<CustomerContractRelation> contractRelations = new HashSet<>();
 		@Id
 		@GeneratedValue
 		private Long id;
@@ -287,7 +287,7 @@ public class ForeignGeneratorResourceLocalTest {
 	@Table(name = "CUSTOMER_CONTRACT_RELATION")
 	public static class CustomerContractRelation {
 		@EmbeddedId
-		private final CustomerContractId id = new CustomerContractId();
+		private CustomerContractId id = new CustomerContractId();
 
 		@Temporal(TemporalType.TIMESTAMP)
 		@Column(nullable = true, name = "SIGNEDONDATE")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/insertordering/ElementCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/insertordering/ElementCollectionTest.java
@@ -66,7 +66,7 @@ public class ElementCollectionTest extends BaseInsertOrderingTest {
 		@ElementCollection(targetClass = Category.class)
 		@CollectionTable(name = "TASK_CATEGORY", joinColumns = { @JoinColumn(name = "TASK_ID") })
 		@Enumerated(EnumType.STRING)
-		private final Set<Category> categories = new HashSet<>();
+		private Set<Category> categories = new HashSet<>();
 
 		public void addCategory(Category c) {
 			categories.add( c );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/insertordering/InsertOrderingWithCascadeOnPersist.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/insertordering/InsertOrderingWithCascadeOnPersist.java
@@ -117,7 +117,7 @@ public class InsertOrderingWithCascadeOnPersist {
 		private String bidGroup;
 
 		@OneToMany(mappedBy = "group")
-		private final Set<MarketBid> marketBids = new HashSet<>();
+		private Set<MarketBid> marketBids = new HashSet<>();
 
 		public void addMarketBid(MarketBid marketBid) {
 			this.marketBids.add( marketBid );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/DetachedPreviousRowStateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/DetachedPreviousRowStateTest.java
@@ -126,7 +126,7 @@ class DetachedPreviousRowStateTest {
 		private String description;
 
 		@OneToMany(mappedBy = "product")
-		private final List<Version> versions = new ArrayList<>();
+		private List<Version> versions = new ArrayList<>();
 	}
 
 	@Entity(name = "Description")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/EmptyMapTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/EmptyMapTest.java
@@ -64,7 +64,7 @@ public class EmptyMapTest {
 				cascade = CascadeType.ALL,
 				orphanRemoval = true)
 		@MapKeyJoinColumn
-		private final Map<Identity, UserIdentity> userIdentityByIdentity = new HashMap<>();
+		private Map<Identity, UserIdentity> userIdentityByIdentity = new HashMap<>();
 
 		public User() {
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/graphs/CacheableEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/graphs/CacheableEntityGraphTest.java
@@ -103,7 +103,7 @@ public class CacheableEntityGraphTest {
 		@Enumerated(EnumType.STRING)
 		@ElementCollection(fetch = FetchType.EAGER)
 		@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-		public final Set<TagType> types = new LinkedHashSet<>();
+		public Set<TagType> types = new LinkedHashSet<>();
 
 		public Tag() {
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/PersistAndQueryingInSameTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/PersistAndQueryingInSameTransactionTest.java
@@ -138,7 +138,7 @@ public class PersistAndQueryingInSameTransactionTest {
 		private String id;
 
 		@OneToMany(orphanRemoval = true, mappedBy = "parent", cascade = CascadeType.ALL)
-		private final List<Child> children = new ArrayList<>();
+		private List<Child> children = new ArrayList<>();
 
 		public Parent() {
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/RemoveEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/RemoveEntityTest.java
@@ -120,7 +120,7 @@ public class RemoveEntityTest {
 		private String email;
 
 		@OneToMany(targetEntity = LinkEntity.class, mappedBy = "employee")
-		final Set<LinkEntity> folderLink = new HashSet<>();
+		Set<LinkEntity> folderLink = new HashSet<>();
 
 		public Collection<LinkEntity> getFolderLink() {
 			return folderLink;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/generic/ManyToManyGenericTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/generic/ManyToManyGenericTest.java
@@ -87,7 +87,7 @@ public class ManyToManyGenericTest {
 				joinColumns = {@JoinColumn(name = "TREE_ID", referencedColumnName = "TREE_ID"), @JoinColumn(name = "NODE_ID", referencedColumnName = "ID")},
 				inverseJoinColumns = {@JoinColumn(name = "CHILD_ID", referencedColumnName = "ID")}
 		)
-		private final Set<GenericNode<?>> children = new HashSet<>();
+		private Set<GenericNode<?>> children = new HashSet<>();
 
 		public Set<GenericNode<?>> getChildren() {
 			return children;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/generic/ManyToManyNonGenericTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/generic/ManyToManyNonGenericTest.java
@@ -92,7 +92,7 @@ public class ManyToManyNonGenericTest {
 				joinColumns = {@JoinColumn(name = "TREE_ID", referencedColumnName = "TREE_ID"), @JoinColumn(name = "NODE_ID", referencedColumnName = "ID")},
 				inverseJoinColumns = {@JoinColumn(name = "CHILD_ID", referencedColumnName = "ID")}
 		)
-		private final Set<Node> children = new HashSet<>();
+		private Set<Node> children = new HashSet<>();
 
 		public Set<Node> getChildren() {
 			return children;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/FinalEmbeddableFieldTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/FinalEmbeddableFieldTest.java
@@ -14,6 +14,8 @@ import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.util.ReflectionUtil;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,6 +27,14 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 @SessionFactory(useCollectingStatementInspector = true)
 @BytecodeEnhanced(runNotEnhancedAsWell = true)
 public class FinalEmbeddableFieldTest {
+
+	@BeforeAll
+	static void assumeEnhancedOrNoIllegalFinalFieldMutation() {
+		boolean enhanced = Managed.class.isAssignableFrom( EntityWithFinalField.class );
+
+		assumeFalse( ReflectionUtil.isFinalFieldMutationDenied() && !enhanced,
+				"Skipping non-enhanced variant when JVM denies final field mutation" );
+	}
 
 	@Test
 	public void finalFieldNotUpdatable(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/FinalEmbeddableFieldTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/FinalEmbeddableFieldTest.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import org.hibernate.engine.spi.Managed;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -17,9 +19,11 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DomainModel(annotatedClasses = FinalEmbeddableFieldTest.EntityWithFinalField.class)
 @SessionFactory(useCollectingStatementInspector = true)
+@BytecodeEnhanced(runNotEnhancedAsWell = true)
 public class FinalEmbeddableFieldTest {
 
 	@Test
@@ -49,7 +53,7 @@ public class FinalEmbeddableFieldTest {
 	}
 
 	@Test
-	public void finalFieldNotDirtyChecked(SessionFactoryScope scope) {
+	public void finalImmutableFieldNotDirtyChecked(SessionFactoryScope scope) {
 		var statementInspector = scope.getCollectingStatementInspector();
 
 		var persistedEntity = new EntityWithFinalField( new EmbeddableWithFinalField( "foo", "foo".toCharArray() ) );
@@ -75,6 +79,20 @@ public class FinalEmbeddableFieldTest {
 
 		assertEquals( 1, statementInspector.getSqlQueries().size() );
 		assertTrue( statementInspector.getSqlQueries().get( 0 ).startsWith( "select" ) );
+	}
+
+	@Test
+	public void finalMutableFieldDirtyChecked(SessionFactoryScope scope) {
+		assumeFalse( Managed.class.isAssignableFrom( EntityWithFinalField.class ),
+				"https://hibernate.atlassian.net/browse/HHH-20541" );
+
+		var statementInspector = scope.getCollectingStatementInspector();
+
+		var persistedEntity = new EntityWithFinalField( new EmbeddableWithFinalField( "foo", "foo".toCharArray() ) );
+		persistedEntity.setName( "Some name" );
+		scope.inTransaction( s -> {
+			s.persist( persistedEntity );
+		} );
 
 		statementInspector.clear();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/FinalFieldTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/FinalFieldTest.java
@@ -4,20 +4,51 @@
  */
 package org.hibernate.orm.test.mapping.basic;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.hibernate.engine.spi.Managed;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-@DomainModel(annotatedClasses = FinalFieldTest.EntityWithFinalField.class)
+@DomainModel(annotatedClasses = {
+		FinalFieldTest.EntityWithFinalField.class,
+		FinalFieldTest.EntityWithFinalId.class,
+		FinalFieldTest.EntityWithFinalIdClass.class,
+		FinalFieldTest.EntityWithFinalIdClassRecord.class,
+		FinalFieldTest.EntityWithFinalEmbeddedId.class,
+		FinalFieldTest.ParentWithFinalOneToMany.class,
+		FinalFieldTest.ChildOfParent.class,
+		FinalFieldTest.AuthorWithFinalManyToMany.class,
+		FinalFieldTest.BookWithFinalManyToMany.class,
+		FinalFieldTest.EntityWithFinalElementCollection.class
+})
 @SessionFactory(useCollectingStatementInspector = true)
+@BytecodeEnhanced(runNotEnhancedAsWell = true)
 public class FinalFieldTest {
 
 	@Test
@@ -129,6 +160,514 @@ public class FinalFieldTest {
 
 		public String getImmutable() {
 			return immutable;
+		}
+	}
+
+	@Test
+	public void testFinalIdField(SessionFactoryScope scope) {
+		Long entityId = scope.fromTransaction( s -> {
+			EntityWithFinalId entity = new EntityWithFinalId( 1L, "test" );
+			s.persist( entity );
+			return entity.getId();
+		} );
+
+		scope.inTransaction( s -> {
+			EntityWithFinalId loaded = s.find( EntityWithFinalId.class, entityId );
+			assertNotNull( loaded );
+			assertEquals( entityId, loaded.getId() );
+			assertEquals( "test", loaded.getName() );
+		} );
+	}
+
+	@Test
+	public void testFinalIdClassFields(SessionFactoryScope scope) {
+		assumeFalse( Managed.class.isAssignableFrom( EntityWithFinalIdClass.class ),
+				"https://hibernate.atlassian.net/browse/HHH-20542" );
+
+		scope.inTransaction( s -> {
+			EntityWithFinalIdClass entity = new EntityWithFinalIdClass( 1L, 2L, "test" );
+			s.persist( entity );
+		} );
+
+		scope.inTransaction( s -> {
+			EntityWithFinalIdClass loaded = s.find( EntityWithFinalIdClass.class, new CompositeId( 1L, 2L ) );
+			assertNotNull( loaded );
+			assertEquals( 1L, loaded.getId1() );
+			assertEquals( 2L, loaded.getId2() );
+			assertEquals( "test", loaded.getName() );
+		} );
+	}
+
+	@Test
+	public void testFinalIdClassFieldsAsRecord(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			EntityWithFinalIdClassRecord entity = new EntityWithFinalIdClassRecord( 1L, 2L, "test" );
+			s.persist( entity );
+		} );
+
+		scope.inTransaction( s -> {
+			EntityWithFinalIdClassRecord loaded = s.find( EntityWithFinalIdClassRecord.class, new CompositeIdRecord( 1L, 2L ) );
+			assertNotNull( loaded );
+			assertEquals( 1L, loaded.getId1() );
+			assertEquals( 2L, loaded.getId2() );
+			assertEquals( "test", loaded.getName() );
+		} );
+	}
+
+	@Test
+	public void testFinalEmbeddedIdField(SessionFactoryScope scope) {
+		EmbeddedCompositeId id = new EmbeddedCompositeId( 1L, 2L );
+
+		scope.inTransaction( s -> {
+			EntityWithFinalEmbeddedId entity = new EntityWithFinalEmbeddedId( id, "test" );
+			s.persist( entity );
+		} );
+
+		scope.inTransaction( s -> {
+			EntityWithFinalEmbeddedId loaded = s.find( EntityWithFinalEmbeddedId.class, id );
+			assertNotNull( loaded );
+			assertEquals( id, loaded.getId() );
+			assertEquals( "test", loaded.getName() );
+		} );
+	}
+
+	@Test
+	public void testFinalOneToManyField(SessionFactoryScope scope) {
+		Long parentId = scope.fromTransaction( s -> {
+			ParentWithFinalOneToMany parent = new ParentWithFinalOneToMany( "parent" );
+			ChildOfParent child1 = new ChildOfParent( "child1", parent );
+			ChildOfParent child2 = new ChildOfParent( "child2", parent );
+			parent.getChildren().add( child1 );
+			parent.getChildren().add( child2 );
+			s.persist( parent );
+			return parent.getId();
+		} );
+
+		scope.inTransaction( s -> {
+			ParentWithFinalOneToMany loaded = s.find( ParentWithFinalOneToMany.class, parentId );
+			assertNotNull( loaded );
+			assertEquals( "parent", loaded.getName() );
+			assertEquals( 2, loaded.getChildren().size() );
+		} );
+	}
+
+	@Test
+	public void testFinalManyToManyField(SessionFactoryScope scope) {
+		Long authorId = scope.fromTransaction( s -> {
+			AuthorWithFinalManyToMany author = new AuthorWithFinalManyToMany( "author" );
+			BookWithFinalManyToMany book1 = new BookWithFinalManyToMany( "book1" );
+			BookWithFinalManyToMany book2 = new BookWithFinalManyToMany( "book2" );
+			author.getBooks().add( book1 );
+			author.getBooks().add( book2 );
+			book1.getAuthors().add( author );
+			book2.getAuthors().add( author );
+			s.persist( author );
+			return author.getId();
+		} );
+
+		scope.inTransaction( s -> {
+			AuthorWithFinalManyToMany loaded = s.find( AuthorWithFinalManyToMany.class, authorId );
+			assertNotNull( loaded );
+			assertEquals( "author", loaded.getName() );
+			assertEquals( 2, loaded.getBooks().size() );
+		} );
+	}
+
+	@Test
+	public void testFinalElementCollectionField(SessionFactoryScope scope) {
+		Long entityId = scope.fromTransaction( s -> {
+			EntityWithFinalElementCollection entity = new EntityWithFinalElementCollection( "entity" );
+			entity.getTags().add( "tag1" );
+			entity.getTags().add( "tag2" );
+			entity.getTags().add( "tag3" );
+			s.persist( entity );
+			return entity.getId();
+		} );
+
+		scope.inTransaction( s -> {
+			EntityWithFinalElementCollection loaded = s.find( EntityWithFinalElementCollection.class, entityId );
+			assertNotNull( loaded );
+			assertEquals( "entity", loaded.getName() );
+			assertEquals( 3, loaded.getTags().size() );
+			assertTrue( loaded.getTags().contains( "tag1" ) );
+			assertTrue( loaded.getTags().contains( "tag2" ) );
+			assertTrue( loaded.getTags().contains( "tag3" ) );
+		} );
+	}
+
+	@Entity(name = "EntityWithFinalId")
+	public static class EntityWithFinalId {
+
+		@Id
+		private final Long id;
+
+		private String name;
+
+		protected EntityWithFinalId() {
+			this.id = null;
+		}
+
+		public EntityWithFinalId(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "EntityWithFinalIdClass")
+	@IdClass(FinalFieldTest.CompositeId.class)
+	public static class EntityWithFinalIdClass {
+
+		@Id
+		private final Long id1;
+
+		@Id
+		private final Long id2;
+
+		private String name;
+
+		protected EntityWithFinalIdClass() {
+			this.id1 = null;
+			this.id2 = null;
+		}
+
+		public EntityWithFinalIdClass(Long id1, Long id2, String name) {
+			this.id1 = id1;
+			this.id2 = id2;
+			this.name = name;
+		}
+
+		public Long getId1() {
+			return id1;
+		}
+
+		public Long getId2() {
+			return id2;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	public static class CompositeId implements Serializable {
+		private final Long id1;
+		private final Long id2;
+
+		protected CompositeId() {
+			this.id1 = null;
+			this.id2 = null;
+		}
+
+		public CompositeId(Long id1, Long id2) {
+			this.id1 = id1;
+			this.id2 = id2;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			CompositeId that = (CompositeId) o;
+			return Objects.equals( id1, that.id1 ) && Objects.equals( id2, that.id2 );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( id1, id2 );
+		}
+	}
+
+	@Entity(name = "EntityWithFinalIdClassRecord")
+	@IdClass(FinalFieldTest.CompositeIdRecord.class)
+	public static class EntityWithFinalIdClassRecord {
+
+		@Id
+		private final Long id1;
+
+		@Id
+		private final Long id2;
+
+		private String name;
+
+		protected EntityWithFinalIdClassRecord() {
+			this.id1 = null;
+			this.id2 = null;
+		}
+
+		public EntityWithFinalIdClassRecord(Long id1, Long id2, String name) {
+			this.id1 = id1;
+			this.id2 = id2;
+			this.name = name;
+		}
+
+		public Long getId1() {
+			return id1;
+		}
+
+		public Long getId2() {
+			return id2;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	public record CompositeIdRecord(Long id1, Long id2) {}
+
+	@Entity(name = "EntityWithFinalEmbeddedId")
+	public static class EntityWithFinalEmbeddedId {
+
+		@EmbeddedId
+		private final EmbeddedCompositeId id;
+
+		private String name;
+
+		protected EntityWithFinalEmbeddedId() {
+			this.id = null;
+		}
+
+		public EntityWithFinalEmbeddedId(EmbeddedCompositeId id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public EmbeddedCompositeId getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Embeddable
+	public static class EmbeddedCompositeId implements Serializable {
+		private final Long part1;
+		private final Long part2;
+
+		protected EmbeddedCompositeId() {
+			this.part1 = null;
+			this.part2 = null;
+		}
+
+		public EmbeddedCompositeId(Long part1, Long part2) {
+			this.part1 = part1;
+			this.part2 = part2;
+		}
+
+		public Long getPart1() {
+			return part1;
+		}
+
+		public Long getPart2() {
+			return part2;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			EmbeddedCompositeId that = (EmbeddedCompositeId) o;
+			return Objects.equals( part1, that.part1 ) && Objects.equals( part2, that.part2 );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( part1, part2 );
+		}
+	}
+
+	@Entity(name = "ParentWithFinalOneToMany")
+	public static class ParentWithFinalOneToMany {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+		private final List<ChildOfParent> children = new ArrayList<>();
+
+		protected ParentWithFinalOneToMany() {
+		}
+
+		public ParentWithFinalOneToMany(String name) {
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public List<ChildOfParent> getChildren() {
+			return children;
+		}
+	}
+
+	@Entity(name = "ChildOfParent")
+	public static class ChildOfParent {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		@ManyToOne
+		private ParentWithFinalOneToMany parent;
+
+		protected ChildOfParent() {
+		}
+
+		public ChildOfParent(String name, ParentWithFinalOneToMany parent) {
+			this.name = name;
+			this.parent = parent;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public ParentWithFinalOneToMany getParent() {
+			return parent;
+		}
+	}
+
+	@Entity(name = "AuthorWithFinalManyToMany")
+	public static class AuthorWithFinalManyToMany {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		@ManyToMany(cascade = CascadeType.ALL)
+		private final Set<BookWithFinalManyToMany> books = new HashSet<>();
+
+		protected AuthorWithFinalManyToMany() {
+		}
+
+		public AuthorWithFinalManyToMany(String name) {
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Set<BookWithFinalManyToMany> getBooks() {
+			return books;
+		}
+	}
+
+	@Entity(name = "BookWithFinalManyToMany")
+	public static class BookWithFinalManyToMany {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String title;
+
+		@ManyToMany(mappedBy = "books")
+		private final Set<AuthorWithFinalManyToMany> authors = new HashSet<>();
+
+		protected BookWithFinalManyToMany() {
+		}
+
+		public BookWithFinalManyToMany(String title) {
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public Set<AuthorWithFinalManyToMany> getAuthors() {
+			return authors;
+		}
+	}
+
+	@Entity(name = "EntityWithFinalElementCollection")
+	public static class EntityWithFinalElementCollection {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		@ElementCollection
+		private final Set<String> tags = new HashSet<>();
+
+		protected EntityWithFinalElementCollection() {
+		}
+
+		public EntityWithFinalElementCollection(String name) {
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Set<String> getTags() {
+			return tags;
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/FinalFieldTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/FinalFieldTest.java
@@ -20,6 +20,8 @@ import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.util.ReflectionUtil;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
@@ -50,6 +52,14 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 @SessionFactory(useCollectingStatementInspector = true)
 @BytecodeEnhanced(runNotEnhancedAsWell = true)
 public class FinalFieldTest {
+
+	@BeforeAll
+	static void assumeEnhancedOrNoIllegalFinalFieldMutation() {
+		boolean enhanced = Managed.class.isAssignableFrom( EntityWithFinalField.class );
+
+		assumeFalse( ReflectionUtil.isFinalFieldMutationDenied() && !enhanced,
+				"Skipping non-enhanced variant when JVM denies final field mutation" );
+	}
 
 	@Test
 	public void finalFieldNotUpdatable(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/cascade/PersistOnLazyCollectionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/cascade/PersistOnLazyCollectionTests.java
@@ -135,7 +135,7 @@ public class PersistOnLazyCollectionTests {
 
 		@OneToMany( cascade = CascadeType.PERSIST )
 		@JoinColumn(name = "order_fk")
-		private final Set<LineItem> lineItems = new HashSet<>();
+		private Set<LineItem> lineItems = new HashSet<>();
 
 		public Order() {
 			super();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/ElementCollectionMapUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/ElementCollectionMapUpdateTest.java
@@ -77,7 +77,7 @@ public class ElementCollectionMapUpdateTest {
 
 		@ElementCollection
 		@MapKeyColumn( name = "name", insertable = false, updatable = false )
-		private final Map<String, MarketData> data = new HashMap<>();
+		private Map<String, MarketData> data = new HashMap<>();
 
 		public Company() {
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/map/MapElementBaseTypeConversionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/map/MapElementBaseTypeConversionTest.java
@@ -66,7 +66,7 @@ public class MapElementBaseTypeConversionTest {
 
 		@ElementCollection(fetch = FetchType.EAGER)
 		@Convert(converter = MyStringConverter.class) // note omitted attributeName
-		private final Map<String, String> colors = new HashMap<>();
+		private Map<String, String> colors = new HashMap<>();
 
 		public Map<String, String> getColors() {
 			return colors;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/cid/AId.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/cid/AId.java
@@ -12,7 +12,7 @@ import jakarta.persistence.Embeddable;
 
 @Embeddable
 public class AId implements java.io.Serializable {
-	private final int id;
+	private int id;
 
 	protected AId() {
 		this.id = 0;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/composite/AccountId.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/composite/AccountId.java
@@ -11,7 +11,7 @@ import jakarta.persistence.Embeddable;
  */
 @Embeddable
 public class AccountId implements java.io.Serializable {
-	private final int id;
+	private int id;
 
 	protected AccountId() {
 		this.id = 0;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/OneToManyLazyAndEagerProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/OneToManyLazyAndEagerProxyTest.java
@@ -91,7 +91,7 @@ public class OneToManyLazyAndEagerProxyTest {
 		private String id;
 
 		@OneToMany(targetEntity = OrderItem.class, mappedBy = "order", fetch = FetchType.EAGER)
-		private final Set<OrderItem> orderItems = new HashSet<>();
+		private Set<OrderItem> orderItems = new HashSet<>();
 
 		@ManyToOne(fetch = FetchType.EAGER)
 		private User user;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ElementCollectionLeftJoinSubqueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ElementCollectionLeftJoinSubqueryTest.java
@@ -126,7 +126,7 @@ public class ElementCollectionLeftJoinSubqueryTest {
 
 		@ElementCollection
 		@CollectionTable( name = "c_embeddables", joinColumns = { @JoinColumn( name = "id" ) } )
-		private final Set<EmbeddableC> cCollection = new HashSet<>();
+		private Set<EmbeddableC> cCollection = new HashSet<>();
 
 		public EntityA getA() {
 			return a;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/Named.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/Named.java
@@ -23,11 +23,11 @@ import jakarta.persistence.Inheritance;
 public abstract class Named {
 
 	@Id
-	private final String name;
+	private String name;
 
 	@Column
 	@Audited
-	private final String type;
+	private String type;
 
 	@Column
 	@Audited

--- a/hibernate-testing/src/main/java/org/hibernate/testing/util/ReflectionUtil.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/util/ReflectionUtil.java
@@ -15,6 +15,37 @@ import java.util.function.Supplier;
  */
 public class ReflectionUtil {
 
+	private static final boolean FINAL_FIELD_MUTATION_DENIED;
+
+	static {
+		// Test if the JVM denies final field mutation by actually trying it
+		class TestClass {
+			final String finalField = "original";
+		}
+		boolean denied;
+		try {
+			var testInstance = new TestClass();
+			var field = TestClass.class.getDeclaredField( "finalField" );
+			field.setAccessible( true );
+			field.set( testInstance, "modified" );
+			denied = false; // Mutation succeeded, not denied
+		}
+		catch (Exception e) {
+			denied = true; // Mutation failed, it's denied
+		}
+		FINAL_FIELD_MUTATION_DENIED = denied;
+	}
+
+	/**
+	 * Check if the JVM denies final field mutation (e.g., JDK 26+ with --illegal-final-field-mutation flag).
+	 * This is detected at class initialization by attempting to mutate a final field via reflection.
+	 *
+	 * @return true if final field mutation is denied, false otherwise
+	 */
+	public static boolean isFinalFieldMutationDenied() {
+		return FINAL_FIELD_MUTATION_DENIED;
+	}
+
 	/**
 	 * Get a field from a given class
 	 *

--- a/tooling/hibernate-maven-plugin/src/test/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojoTest.java
+++ b/tooling/hibernate-maven-plugin/src/test/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojoTest.java
@@ -341,9 +341,10 @@ public class HibernateEnhancerMojoTest {
 		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_TYPE_DISCOVERY));
 		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ENDING_TYPE_DISCOVERY));
 		logMessages.clear();
-		List<File> sourceSet = new ArrayList<File>();
+		@SuppressWarnings("unchecked")
+		List<File> sourceSet = (List<File>) sourceSetField.get(enhanceMojo);
+		sourceSet.clear();
 		sourceSet.add(barClassFile);
-		sourceSetField.set(enhanceMojo, sourceSet);
 		discoverTypesMethod.invoke(enhanceMojo);
 		assertTrue(hasRun.contains(true));
 		// verify the log messages
@@ -501,9 +502,10 @@ public class HibernateEnhancerMojoTest {
 					}
 				});
 		enhancerField.set(enhanceMojo, enhancer);
-		List<File> sourceSet = new ArrayList<File>();
+		@SuppressWarnings("unchecked")
+		List<File> sourceSet = (List<File>) sourceSetField.get(enhanceMojo);
+		sourceSet.clear();
 		sourceSet.add(barClassFile);
-		sourceSetField.set(enhanceMojo, sourceSet);
 		long lastModified = barClassFile.lastModified();
 		assertFalse(hasRun.contains(true));
 		assertNotEquals("foobar", new String(Files.readAllBytes(barClassFile.toPath())));
@@ -562,10 +564,11 @@ public class HibernateEnhancerMojoTest {
 		compiler.run(null, null, null, options);
 		String barBytesString = new String(Files.readAllBytes(barClassFile.toPath()));
 		String fooBytesString = new String(Files.readAllBytes(fooClassFile.toPath()));
-		List<File> sourceSet = new ArrayList<File>();
+		@SuppressWarnings("unchecked")
+		List<File> sourceSet = (List<File>) sourceSetField.get(enhanceMojo);
+		sourceSet.clear();
 		sourceSet.add(barClassFile);
 		sourceSet.add(fooClassFile);
-		sourceSetField.set(enhanceMojo, sourceSet);
 		assertTrue(logMessages.isEmpty());
 		executeMethod.invoke(enhanceMojo);
 		assertNotEquals(barBytesString, new String(Files.readAllBytes(barClassFile.toPath())));

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/export/mapping/MappingExporter.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/export/mapping/MappingExporter.java
@@ -49,6 +49,18 @@ public class MappingExporter implements Exporter {
 		marshaller = createMarshaller();
 	}
 
+	// For tests
+	public MappingExporter(MappingBinder mappingBinder) {
+		this.mappingBinder = mappingBinder;
+		this.marshaller = createMarshaller();
+	}
+
+	// For tests
+	public MappingExporter(Marshaller marshaller) {
+		mappingBinder = createMappingBinder();
+		this.marshaller = marshaller;
+	}
+
 	public void setHbmFiles(List<File> fileList) {
 		hbmXmlFiles = new UnmodifiableList<>( fileList );
 	}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/export/mapping/MappingExporterTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/export/mapping/MappingExporterTest.java
@@ -111,9 +111,7 @@ public class MappingExporterTest {
 		File file = new File(this.tempDir, "foo.bar");
 		Files.writeString(file.toPath(), "foobar");
 		final MappingBinder mappingBinder = new TestMappingBinder(file, "barfoo");
-		Field mappingBinderField = MappingExporter.class.getDeclaredField("mappingBinder");
-		mappingBinderField.setAccessible(true);
-		mappingBinderField.set(mappingExporter, mappingBinder);
+		mappingExporter = new MappingExporter(mappingBinder);
 		assertNotEquals("barfoo", Files.readString(file.toPath()));
 		Object object = bindMappingMethod.invoke(mappingExporter, new HbmXmlOrigin(file));
 		assertInstanceOf(Binding.class, object);
@@ -134,10 +132,9 @@ public class MappingExporterTest {
 		File file = new File(this.tempDir, "foo.bar");
 		Files.writeString(file.toPath(), "foobar");
 		hbmXmlFiles.add(file);
+		final MappingBinder mappingBinder = new TestMappingBinder(file, "barfoo");
+		mappingExporter = new MappingExporter(mappingBinder);
 		hbmFilesField.set(mappingExporter, new UnmodifiableList<>(hbmXmlFiles));
-		Field mappingBinderField = MappingExporter.class.getDeclaredField("mappingBinder");
-		mappingBinderField.setAccessible(true);
-		mappingBinderField.set(mappingExporter, new TestMappingBinder(file, "barfoo"));
 		Object object = getHbmMappingsMethod.invoke(mappingExporter);
 		assertInstanceOf(List.class, object);
 		assertEquals(1, ((List<?>)object).size());
@@ -155,9 +152,7 @@ public class MappingExporterTest {
 		assertNotNull(createMarshallerMethod);
 		createMarshallerMethod.setAccessible(true);
 		final MappingBinder mappingBinder = new TestMappingBinder(new File("foo"), "foobar");
-		Field mappingBinderField = MappingExporter.class.getDeclaredField("mappingBinder");
-		mappingBinderField.setAccessible(true);
-		mappingBinderField.set(mappingExporter, mappingBinder);
+		mappingExporter = new MappingExporter(mappingBinder);
 		assertSame(
 				DUMMY_MARSHALLER,
 				createMarshallerMethod.invoke(mappingExporter));
@@ -171,9 +166,7 @@ public class MappingExporterTest {
 				File.class);
 		assertNotNull(marshallMethod);
 		marshallMethod.setAccessible(true);
-		Field marshallerField = MappingExporter.class.getDeclaredField("marshaller");
-		marshallerField.setAccessible(true);
-		marshallerField.set(mappingExporter, DUMMY_MARSHALLER);
+		mappingExporter = new MappingExporter(DUMMY_MARSHALLER);
 		File hbmFile = new File(this.tempDir, "foo.hbm.xml");
 		File mappingFile = new File(this.tempDir, "foo.mapping.xml");
 		Files.writeString(mappingFile.toPath(), "<foo><bar>foobar</bar></foo>");


### PR DESCRIPTION
To gain confidence that the move of OpenJDK to forbid final field mutation (eventually) will not affect Hibernate -- as we expect.

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20482 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20482
<!-- Hibernate GitHub Bot issue links end -->