### PR TITLE
Align JUnit versions for JFR module

### DIFF
--- a/hibernate-jfr/hibernate-jfr.gradle
+++ b/hibernate-jfr/hibernate-jfr.gradle
@@ -14,5 +14,8 @@ dependencies {
     implementation project( ':hibernate-core' )
 
     testImplementation project( ':hibernate-testing' )
-    testImplementation libs.test.jfrUnit
+    testImplementation (libs.test.jfrUnit) {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
+    testImplementation libs.test.junit4Engine
 }


### PR DESCRIPTION
to prevent failures as:

Caused by: org.junit.platform.commons.JUnitException: The wrapped NoClassDefFoundError is likely caused by the versions of JUnit jars on the classpath/module path not being properly aligned. Please ensure consistent versions are used (see https://docs.junit.org/6.0.1/user-guide/#dependency-metadata). The following conflicting versions were detected:
- org.junit.jupiter.api: 6.0.1
- org.junit.jupiter.engine: 6.0.1
- org.junit.platform.commons: 6.0.1
- org.junit.platform.engine: 6.0.1
- org.junit.platform.launcher: 6.0.1
- org.junit.vintage.engine: 5.8.2

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
