### PR TITLE
HHH-20579 Remove org.moditect.jfrunit dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,7 +62,6 @@ shrinkwrap = "1.2.6"
 shrinkwrapDescriptors = "2.0.0"
 weld = "6.0.4.Final"
 wildFlyTxnClient = "3.0.5.Final"
-jfrUnit = "1.0.0.Alpha2"
 hibernateValidator = "9.1.0.Final"
 jaxen = "2.0.6"
 xerces = "2.12.2"
@@ -221,7 +220,6 @@ test-jbossJta = { group = "org.jboss.narayana.jta", name = "narayana-jta", versi
 test-jbossTxSpi = { group = "org.jboss", name = "jboss-transaction-spi", version.ref = "jbossTxSpi" }
 test-wildFlyTxnClient = { group = "org.wildfly.transaction", name = "wildfly-transaction-client", version.ref = "wildFlyTxnClient" }
 test-weld = { group = "org.jboss.weld.se", name = "weld-se-shaded", version.ref = "weld" }
-test-jfrUnit = { group = "org.moditect.jfrunit", name = "jfrunit-core", version.ref = "jfrUnit" }
 test-jaxen = { group = "jaxen", name = "jaxen", version.ref = "jaxen" }
 test-xerces = { group = "xerces", name = "xercesImpl", version.ref = "xerces" }
 test-dom4j = { group = "org.dom4j", name = "dom4j", version.ref = "dom4j" }

--- a/hibernate-jfr/hibernate-jfr.gradle
+++ b/hibernate-jfr/hibernate-jfr.gradle
@@ -14,8 +14,4 @@ dependencies {
     implementation project( ':hibernate-core' )
 
     testImplementation project( ':hibernate-testing' )
-    testImplementation (libs.test.jfrUnit) {
-        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-    }
-    testImplementation libs.test.junit4Engine
 }

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/DirtyCalculationEventTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/DirtyCalculationEventTests.java
@@ -18,9 +18,9 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/JdbcBatchExecutionEventTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/JdbcBatchExecutionEventTests.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/JdbcConnectionEventTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/JdbcConnectionEventTests.java
@@ -16,9 +16,9 @@ import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/JdbcPreparedStatementEventTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/JdbcPreparedStatementEventTests.java
@@ -22,9 +22,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.ParameterMode;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/SessionEventTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/SessionEventTests.java
@@ -15,9 +15,9 @@ import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/CacheGetEventTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/CacheGetEventTests.java
@@ -22,9 +22,9 @@ import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/EntityInsertCachePutEventTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/EntityInsertCachePutEventTests.java
@@ -24,9 +24,9 @@ import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/EntityUpdateCachePutEventTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/EntityUpdateCachePutEventTests.java
@@ -25,9 +25,9 @@ import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/NaturalIdGetCacheTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/NaturalIdGetCacheTests.java
@@ -24,9 +24,9 @@ import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/NaturalIdPutCacheTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/NaturalIdPutCacheTests.java
@@ -25,9 +25,9 @@ import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/QueryCachePutEventTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/cache/QueryCachePutEventTests.java
@@ -22,9 +22,9 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/AutoFlushTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/AutoFlushTests.java
@@ -17,9 +17,9 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/ExplicitFlushTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/ExplicitFlushTests.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/FlushTests.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/FlushTests.java
@@ -17,9 +17,9 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/PrePartialFlushTest.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/PrePartialFlushTest.java
@@ -18,9 +18,9 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jdk.jfr.consumer.RecordedEvent;
-import org.moditect.jfrunit.EnableEvent;
-import org.moditect.jfrunit.JfrEventTest;
-import org.moditect.jfrunit.JfrEvents;
+import org.hibernate.event.jfr.testing.EnableEvent;
+import org.hibernate.event.jfr.testing.JfrEventTest;
+import org.hibernate.event.jfr.testing.JfrEvents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/package-info.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/package-info.java
@@ -4,7 +4,7 @@
  */
 
 /**
- * Tests for Hibernate's JFR events.  Well the events are roduced on Java 11, the JfrUnit
- * framewqork used in testing only works on JDK 16+.
+ * Tests for Hibernate's JFR events, using a custom JUnit 5 extension
+ * backed by JDK built-in JFR APIs ({@code jdk.jfr.Recording}).
  */
 package org.hibernate.event.jfr;

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/EnableEvent.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/EnableEvent.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.event.jfr.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a JFR event type to enable for the annotated test method.
+ * Repeatable: multiple events can be enabled on the same method.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(EnableEvents.class)
+public @interface EnableEvent {
+	String value();
+}

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/EnableEvents.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/EnableEvents.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.event.jfr.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Container annotation for {@link EnableEvent} repeatability.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableEvents {
+	EnableEvent[] value();
+}

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/JfrEventTest.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/JfrEventTest.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.event.jfr.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Activates JFR event recording for a test class.
+ * Uses JDK built-in JFR APIs ({@code jdk.jfr.Recording}) instead of external libraries.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(JfrEventTestExtension.class)
+public @interface JfrEventTest {
+}

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/JfrEventTestExtension.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/JfrEventTestExtension.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.event.jfr.testing;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+/**
+ * JUnit 5 extension that manages JFR recording lifecycle for test classes
+ * annotated with {@link JfrEventTest}.
+ *
+ * <p>Before each test method, reads the {@link EnableEvent} annotations to
+ * determine which JFR event types to record, finds the {@link JfrEvents} field
+ * on the test instance, and starts the recording.
+ * After each test method, stops the recording and cleans up temporary files.</p>
+ */
+class JfrEventTestExtension implements BeforeEachCallback, AfterEachCallback {
+
+	@Override
+	public void beforeEach(final ExtensionContext context) throws Exception {
+		final List<String> eventNames = readEnabledEventNames( context );
+		for ( final JfrEvents jfrEvents : findJfrEventsFields( context ) ) {
+			jfrEvents.configure( eventNames );
+		}
+	}
+
+	@Override
+	public void afterEach(final ExtensionContext context) throws Exception {
+		for ( final JfrEvents jfrEvents : findJfrEventsFields( context ) ) {
+			jfrEvents.cleanup();
+		}
+	}
+
+	/**
+	 * Extracts event type names from all {@link EnableEvent} annotations
+	 * on the current test method.
+	 */
+	private static List<String> readEnabledEventNames(final ExtensionContext context) {
+		final var annotations = AnnotationSupport.findRepeatableAnnotations(
+				context.getRequiredTestMethod(),
+				EnableEvent.class
+		);
+		final List<String> names = new ArrayList<>( annotations.size() );
+		for ( final EnableEvent annotation : annotations ) {
+			names.add( annotation.value() );
+		}
+		return names;
+	}
+
+	/**
+	 * Finds all {@link JfrEvents} fields in the test instance's class hierarchy
+	 * and returns their values.
+	 */
+	private static List<JfrEvents> findJfrEventsFields(final ExtensionContext context) throws IllegalAccessException {
+		final Object testInstance = context.getRequiredTestInstance();
+		final List<JfrEvents> result = new ArrayList<>();
+		// walk the class hierarchy to handle potential JUnit proxying
+		Class<?> clazz = testInstance.getClass();
+		while ( clazz != null && clazz != Object.class ) {
+			for ( final Field field : clazz.getDeclaredFields() ) {
+				if ( JfrEvents.class.equals( field.getType() ) ) {
+					field.setAccessible( true );
+					final JfrEvents value = (JfrEvents) field.get( testInstance );
+					if ( value == null ) {
+						throw new IllegalStateException(
+								"JfrEvents field '" + field.getName() + "' in " + clazz.getName()
+										+ " is null — initialize it with 'new JfrEvents()'" );
+					}
+					result.add( value );
+				}
+			}
+			clazz = clazz.getSuperclass();
+		}
+		return result;
+	}
+}

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/JfrEvents.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/testing/JfrEvents.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.event.jfr.testing;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+/**
+ * Captures JFR events emitted during a test.
+ *
+ * <p>Uses the dump-and-read approach: each {@link #events()} call dumps the running
+ * {@link Recording} to a temporary file and reads the events via
+ * {@link RecordingFile#readAllEvents(Path)}.
+ * {@link #reset()} discards accumulated events by stopping the current recording
+ * and starting a fresh one with the same enabled events.</p>
+ *
+ * <p>Lifecycle is managed by {@link JfrEventTestExtension}:
+ * {@link #configure(List)} is called before each test,
+ * {@link #cleanup()} after each test.</p>
+ */
+public class JfrEvents {
+
+	private Recording recording;
+	private List<String> enabledEventNames;
+	private final List<Path> tempFiles = new ArrayList<>();
+
+	/**
+	 * Configures and starts recording the given event types.
+	 * Called by {@link JfrEventTestExtension} before each test method.
+	 */
+	void configure(final List<String> eventNames) {
+		this.enabledEventNames = new ArrayList<>( eventNames );
+		startNewRecording();
+	}
+
+	/**
+	 * Discards all previously recorded events and begins a fresh recording
+	 * with the same enabled event types.
+	 */
+	public void reset() {
+		checkActiveRecording();
+		stopAndCloseRecording();
+		startNewRecording();
+	}
+
+	/**
+	 * Returns a stream of all events recorded since the last {@link #reset()}
+	 * (or since {@link #configure(List)} if reset was never called).
+	 *
+	 * <p>The recording remains running — this method dumps a snapshot to a
+	 * temporary file without stopping the recording, so subsequent calls
+	 * return the same events plus any new ones.</p>
+	 */
+	public Stream<RecordedEvent> events() {
+		checkActiveRecording();
+		try {
+			final Path tempFile = Files.createTempFile( "hibernate-jfr-test-", ".jfr" );
+			tempFiles.add( tempFile );
+			recording.dump( tempFile );
+			return RecordingFile.readAllEvents( tempFile ).stream();
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException( "Failed to dump or read JFR recording", e );
+		}
+	}
+
+	/**
+	 * Stops the recording and deletes temporary files.
+	 * Called by {@link JfrEventTestExtension} after each test method.
+	 * Idempotent — safe to call multiple times.
+	 */
+	void cleanup() {
+		stopAndCloseRecording();
+		for ( final Path tempFile : tempFiles ) {
+			try {
+				Files.deleteIfExists( tempFile );
+			}
+			catch (IOException ignored) {
+				// best-effort cleanup — temp files will be removed by the OS eventually
+			}
+		}
+		tempFiles.clear();
+	}
+
+	private void checkActiveRecording() {
+		if ( recording == null ) {
+			throw new IllegalStateException(
+					"No active JFR recording — was @JfrEventTest applied to the test class?" );
+		}
+	}
+
+	private void startNewRecording() {
+		recording = new Recording();
+		for ( final String eventName : enabledEventNames ) {
+			recording.enable( eventName );
+		}
+		recording.start();
+	}
+
+	private void stopAndCloseRecording() {
+		if ( recording != null ) {
+			try {
+				recording.stop();
+			}
+			catch (IllegalStateException ignored) {
+				// recording was already stopped — not an error
+			}
+			recording.close();
+			recording = null;
+		}
+	}
+}


### PR DESCRIPTION
It appears that org.moditect.jfrunit is no longer actively maintained. 
The latest release was published around four years ago and is still labeled as 1.0.0.Alpha2, which suggests the project may not have reached a stable production-ready state.

This is an attempt to  replace it with a minimal in-house JUnit 5 extension backed by JDK built-in JFR APIs (jdk.jfr.Recording).

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20579 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20579
<!-- Hibernate GitHub Bot issue links end -->