### PR TITLE
three fixes to JPA4 entity graph and query handling

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1272,12 +1272,12 @@ public interface Session extends SharedSessionContract, EntityManager {
 	@Override
 	RootGraph<?> createEntityGraph(String graphName);
 
-	/// Obtain an immutable reference to a predefined
-	/// [named entity graph][jakarta.persistence.NamedEntityGraph]
-	/// or return `null` if there is no predefined graph with the given
-	/// name.
+	/// Obtain a mutable copy of a predefined
+	/// [named entity graph][jakarta.persistence.NamedEntityGraph].
 	///
 	/// @param graphName The name of the predefined named entity graph
+	/// @throws IllegalArgumentException if there is no predefined graph
+	///         with the given name
 	///
 	/// @apiNote This method returns `RootGraph<?>`, requiring an
 	/// unchecked typecast before use. It's cleaner to obtain a graph using

--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionContract.java
@@ -861,7 +861,7 @@ public interface SharedSessionContract extends EntityHandler, AutoCloseable, Ser
 	<T> RootGraph<T> createEntityGraph(Class<T> rootType, String graphName);
 
 	/**
-	 * Obtain an immutable reference to a predefined
+	 * Obtain a mutable copy of a predefined
 	 * {@linkplain jakarta.persistence.NamedEntityGraph named entity graph}.
 	 *
 	 * @param graphName the name of the predefined named entity graph

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/internal/NamedHqlSelectionDefinitionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/internal/NamedHqlSelectionDefinitionImpl.java
@@ -203,7 +203,7 @@ public class NamedHqlSelectionDefinitionImpl<R>
 				location == null ? null : location.getName(),
 				annotation.query(),
 				annotation.resultClass() == void.class ? null : annotation.resultClass(),
-				null,
+				annotation.entityGraph(),
 				FlushModeTypeHelper.getFlushMode( annotation.flush() ),
 				null,
 				null,

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -621,8 +621,17 @@ abstract class AbstractSharedSessionContract implements SharedSessionContractImp
 
 	@Override
 	public <T> EntityGraph<T> getEntityGraph(Class<T> entityClass, String name) {
-		//noinspection unchecked
-		return (EntityGraph<T>) factory.getNamedEntityGraphs( entityClass ).get( name );
+		final var entityGraph = getEntityGraph( name );
+		final var type = getFactory().getJpaMetamodel().managedType( entityClass );
+		final var graphedType = entityGraph.getGraphedType();
+		if ( !Objects.equals( graphedType.getTypeName(), type.getTypeName() ) ) {
+			throw new IllegalArgumentException(
+					"Named entity graph '" + name + "' is for type '" + graphedType.getTypeName() + "'"
+			);
+		}
+		@SuppressWarnings("unchecked") // this cast is sound, because we just checked
+		final var graph = (EntityGraph<T>) entityGraph;
+		return graph;
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2204,7 +2213,9 @@ abstract class AbstractSharedSessionContract implements SharedSessionContractImp
 		if ( named == null ) {
 			throw new IllegalArgumentException( "No EntityGraph with given name '" + graphName + "'" );
 		}
-		return named;
+		//TODO: we're using the deprecated operation
+		//      here to preserve the graph name
+		return named.makeRootGraph( graphName, true );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractSqmQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractSqmQuery.java
@@ -43,8 +43,8 @@ public abstract class AbstractSqmQuery<R>
 		super( session );
 	}
 
-	public AbstractSqmQuery(AbstractSqmQuery<R> original) {
-		super( original.session );
+	public AbstractSqmQuery(AbstractSqmQuery<?> original) {
+		super( original.session, original.queryOptions.makeCopy() );
 	}
 
 	protected void applyMementoOptions(NamedSqmQueryMemento<?> memento) {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryOptionsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryOptionsImpl.java
@@ -77,14 +77,16 @@ public class QueryOptionsImpl implements MutableQueryOptions, AppliedGraph {
 		this.flushMode = original.flushMode;
 		this.timeout = original.timeout;
 		this.comment = original.comment;
-		this.databaseHints = new ArrayList<>( original.databaseHints );
+		this.databaseHints = copy( original.databaseHints );
 		this.fetchSize = original.fetchSize;
 		this.readOnlyEnabled = original.readOnlyEnabled;
 		this.resultCachingEnabled = original.resultCachingEnabled;
 		this.cacheRetrieveMode = original.cacheRetrieveMode;
 		this.cacheStoreMode = original.cacheStoreMode;
 		this.resultCacheRegionName = original.resultCacheRegionName;
+		this.refreshSession = original.refreshSession;
 		this.queryPlanCachingEnabled = original.queryPlanCachingEnabled;
+		this.limitInMemoryEnabled = original.limitInMemoryEnabled;
 		this.limit = original.limit.makeCopy();
 		this.lockOptions = original.lockOptions.makeCopy();
 		this.tupleTransformer = original.tupleTransformer;
@@ -100,6 +102,10 @@ public class QueryOptionsImpl implements MutableQueryOptions, AppliedGraph {
 			return null;
 		}
 		return new HashSet<>( original );
+	}
+
+	private <E> List<E> copy(List<E> original) {
+		return original == null ? null : new ArrayList<>( original );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/SelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/SelectionQueryImpl.java
@@ -41,7 +41,6 @@ import org.hibernate.query.Order;
 import org.hibernate.query.Page;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.ResultListTransformer;
-import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.TupleTransformer;
 import org.hibernate.query.hql.internal.QuerySplitter;
 import org.hibernate.query.named.NamedSqmQueryMemento;
@@ -292,6 +291,32 @@ public class SelectionQueryImpl<R>
 		}
 	}
 
+	/// Used by JPA 4 fluent narrowing operations.
+	private <X> SelectionQueryImpl(
+			SelectionQueryImpl<?> original,
+			Class<X> providedResultType,
+			RootGraphImplementor<?> providedResultGraph,
+			GraphSemantic graphSemantic) {
+		super( original );
+
+		hql = original.hql;
+		queryStringCacheKey = original.queryStringCacheKey;
+		sqm = (SqmSelectStatement<R>) original.sqm;
+		parameterMetadata = original.parameterMetadata;
+		domainParameterXref = original.domainParameterXref.copy();
+		parameterBindings = parameterMetadata.createBindings( session.getFactory() );
+		original.getQueryParameterBindings().visitBindings( this::setBindValues );
+
+		validateQuery( (Class<R>) providedResultType, sqm, hql );
+
+		this.providedResultType = (Class<R>) providedResultType;
+		actualResultType = determineResultType( sqm, providedResultType );
+		tupleMetadata = buildTupleMetadata( sqm, providedResultType, getQueryOptions().getTupleTransformer() );
+		if ( providedResultGraph != null ) {
+			queryOptions.applyGraph( providedResultGraph, graphSemantic );
+		}
+	}
+
 	@Override
 	public String getQueryString() {
 		return hql;
@@ -323,20 +348,22 @@ public class SelectionQueryImpl<R>
 
 	@Override
 	public <X> SelectionQueryImplementor<X> asSelectionQuery(Class<X> type) {
-		// todo (jpa4) : type validation
-		return (SelectionQueryImplementor<X>) this;
+		return new SelectionQueryImpl<>( this, type, null, null );
 	}
 
 	@Override
 	public <X> SelectionQueryImplementor<X> asSelectionQuery(EntityGraph<X> entityGraph) {
-		// todo (jpa4) : type validation
-		return (SelectionQueryImplementor<X>) this;
+		return asSelectionQuery( entityGraph, GraphSemantic.LOAD );
 	}
 
 	@Override
-	public <X> SelectionQuery<X> asSelectionQuery(EntityGraph<X> entityGraph, GraphSemantic graphSemantic) {
-		// todo (jpa4) : type validation
-		return (SelectionQueryImplementor<X>) this;
+	public <X> SelectionQueryImplementor<X> asSelectionQuery(EntityGraph<X> entityGraph, GraphSemantic graphSemantic) {
+		return new SelectionQueryImpl<>(
+				this,
+				entityGraph.getGraphedType().getJavaType(),
+				(RootGraphImplementor<X>) entityGraph,
+				graphSemantic
+		);
 	}
 
 	@Override
@@ -346,13 +373,12 @@ public class SelectionQueryImpl<R>
 
 	@Override
 	public <X> SelectionQueryImplementor<X> withEntityGraph(EntityGraph<X> entityGraph) {
-		return (SelectionQueryImplementor<X>) asSelectionQuery( entityGraph, GraphSemantic.LOAD );
+		return asSelectionQuery( entityGraph, GraphSemantic.LOAD );
 	}
 
 	@Override
 	public <R> SelectionQueryImplementor<R> withResultSetMapping(ResultSetMapping<R> mapping) {
-		// todo (jpa4) : type validation
-		return (SelectionQueryImplementor<R>) this;
+		throw new IllegalStateException( "Result set mappings can only be used with native SQL queries" );
 	}
 
 
@@ -1342,6 +1368,10 @@ public class SelectionQueryImpl<R>
 
 	private <T> void setBindValues(QueryParameter<?> parameter, QueryParameterBinding<T> binding) {
 		final var parameterBinding = parameterBindings.getBinding( binding.getQueryParameter() );
+		parameterBinding.setType( binding.getType() );
+		if ( !binding.isBound() ) {
+			return;
+		}
 		final var explicitTemporalPrecision = binding.getExplicitTemporalPrecision();
 		if ( explicitTemporalPrecision != null ) {
 			if ( binding.isMultiValued() ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/parser/BasicEntityGraphTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/parser/BasicEntityGraphTests.java
@@ -24,7 +24,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hibernate.testing.hamcrest.CollectionMatchers.hasSize;
 import static org.hibernate.testing.hamcrest.CollectionMatchers.isEmpty;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Steve Ebersole
@@ -86,24 +85,12 @@ public class BasicEntityGraphTests {
 
 					assertThat( graphRoot.getName(), is( "immutable" ) );
 					assertThat( graphRoot.getAttributeNodes(), hasSize( 2 ) );
-					try {
-						graphRoot.addAttributeNodes( "parent" );
-						fail( "Should have failed" );
-					}
-					catch (IllegalStateException ignore) {
-						// expected outcome
-					}
+					graphRoot.addAttributeNodes( "parent" );
 
 					for ( AttributeNode<?> attrNode : graphRoot.getAttributeNodes() ) {
 						assertThat( attrNode.getSubgraphs().entrySet(), hasSize( 1 ) );
 						Subgraph<?> subgraph = attrNode.getSubgraphs().values().iterator().next();
-						try {
-							graphRoot.addAttributeNodes( "parent" );
-							fail( "Should have failed" );
-						}
-						catch (IllegalStateException ignore) {
-							// expected outcome
-						}
+						graphRoot.addAttributeNodes( "parent" );
 					}
 				}
 		);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/ABCTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/ABCTest.java
@@ -150,7 +150,7 @@ public class ABCTest {
 
 		scope.inTransaction(
 				session -> {
-					List<C1> bs = session.createQuery( "from B" ).ofType( C1.class ).getResultList();
+					List<C1> bs = session.createQuery( "from B" ).getResultList();
 					for ( C1 b : bs ) {
 						session.remove( b );
 						session.remove( b.getD() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/graph/QueryWithGraphTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/graph/QueryWithGraphTests.java
@@ -5,8 +5,10 @@
 package org.hibernate.orm.test.query.graph;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityGraph;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import org.hibernate.Hibernate;
@@ -24,6 +26,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * @author Steve Ebersole
@@ -62,11 +65,87 @@ public class QueryWithGraphTests {
 		} );
 	}
 
+	@Test
+	void namedQueryAppliesEntityGraph(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var results = session.createNamedQuery( "Publisher.findAllWithGraph", Publisher.class ).list();
+			assertThat( results ).hasSize( 1 );
+			assertThat( Hibernate.isInitialized( results.get( 0 ).books ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void getEntityGraphReturnsMutableCopy(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			final EntityGraph<Publisher> entityGraph = session.getEntityGraph( Publisher.class, "pub-base" );
+			assertThat( entityGraph.getName() ).isEqualTo( "pub-base" );
+			assertThat( entityGraph.hasAttributeNode( "books" ) ).isFalse();
+
+			entityGraph.addAttributeNode( "books" );
+			assertThat( entityGraph.hasAttributeNode( "books" ) ).isTrue();
+
+			final EntityGraph<Publisher> entityGraphAgain = session.getEntityGraph( Publisher.class, "pub-base" );
+			assertThat( entityGraphAgain.getName() ).isEqualTo( "pub-base" );
+			assertThat( entityGraphAgain.hasAttributeNode( "books" ) ).isFalse();
+		} );
+	}
+
+	@Test
+	void withEntityGraphAppliesEntityGraph(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			final EntityGraph<Publisher> entityGraph = session.getEntityGraph( Publisher.class, "pub-with-books" );
+			final var query = session.createQuery( "from Publisher", Publisher.class );
+			final var graphedQuery = query.withEntityGraph( entityGraph );
+			assertThat( graphedQuery ).isNotSameAs( query );
+
+			final var plainResults = query.getResultList();
+			assertThat( plainResults ).hasSize( 1 );
+			assertThat( Hibernate.isInitialized( plainResults.get( 0 ).books ) ).isFalse();
+		} );
+		factoryScope.inTransaction( (session) -> {
+			final EntityGraph<Publisher> entityGraph = session.getEntityGraph( Publisher.class, "pub-with-books" );
+			var results = session.createQuery( "from Publisher", Publisher.class )
+					.withEntityGraph( entityGraph )
+					.getResultList();
+			assertThat( results ).hasSize( 1 );
+			assertThat( Hibernate.isInitialized( results.get( 0 ).books ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void ofTypeReturnsCloneWithCopiedParameters(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			final var query = session.createQuery( "select p.name from Publisher p where p.id = :id" );
+			query.setParameter( "id", 1 );
+
+			final var typedQuery = query.ofType( String.class );
+			assertThat( typedQuery ).isNotSameAs( query );
+			assertThat( typedQuery.getSingleResult() ).isEqualTo( "Me" );
+		} );
+	}
+
+	@Test
+	void resultSetMappingIsRejectedForJpaQuery(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> assertThatIllegalStateException()
+				.isThrownBy( () -> session.createQuery( "from Publisher" )
+						.withResultSetMapping( jakarta.persistence.sql.ResultSetMapping.entity( Publisher.class ) ) ) );
+	}
+
 	@Entity(name="Publisher")
 	@Table(name="Publisher")
+	@NamedQuery(
+			name = "Publisher.findAllWithGraph",
+			query = "from Publisher",
+			resultClass = Publisher.class,
+			entityGraph = "pub-with-books"
+	)
 	@NamedEntityGraph(
 			name = "pub-with-books",
 			graph = "id, name, books"
+	)
+	@NamedEntityGraph(
+			name = "pub-base",
+			graph = "id, name"
 	)
 	public static class Publisher {
 		@Id


### PR DESCRIPTION
1. propagate entityGraph from @NamedQuery to momento
2. getEntityGraph() now returns a mutable graph
3. fix asSelectionQuery() implementations

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
