### PR TITLE
fallout from JPA4: clean up Sesssion.xxxEntityGraph stuff

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1249,28 +1249,13 @@ public interface Session extends SharedSessionContract, EntityManager {
 	///
 	/// @param rootType The root entity of the graph
 	///
+	/// @see #get(EntityGraph, Object, FindOption...)
 	/// @see #find(EntityGraph, Object, FindOption...)
-	/// @see org.hibernate.query.SelectionQuery#setEntityGraph(EntityGraph, org.hibernate.graph.GraphSemantic)
+	/// @see #createQuery(String, EntityGraph)
+	/// @see jakarta.persistence.StatementOrTypedQuery#withEntityGraph(EntityGraph)
 	/// @see org.hibernate.graph.EntityGraphs#createGraph(jakarta.persistence.metamodel.EntityType)
 	@Override
 	<T> RootGraph<T> createEntityGraph(Class<T> rootType);
-
-	/// Create a new mutable instance of [EntityGraph], based on
-	/// a predefined [named entity graph][jakarta.persistence.NamedEntityGraph],
-	/// allowing customization of the graph, or return `null` if there is no
-	/// predefined graph with the given name.
-	///
-	/// @param graphName The name of the predefined named entity graph
-	///
-	/// @apiNote This method returns `RootGraph<?>`, requiring an
-	/// unchecked typecast before use. It's cleaner to obtain a graph using
-	/// [#createEntityGraph(Class,String)] instead.
-	///
-	/// @see #find(EntityGraph, Object, FindOption...)
-	/// @see org.hibernate.query.SelectionQuery#setEntityGraph(EntityGraph, org.hibernate.graph.GraphSemantic)
-	/// @see jakarta.persistence.EntityManagerFactory#addNamedEntityGraph(String, EntityGraph)
-	@Override
-	RootGraph<?> createEntityGraph(String graphName);
 
 	/// Obtain a mutable copy of a predefined
 	/// [named entity graph][jakarta.persistence.NamedEntityGraph].
@@ -1281,14 +1266,61 @@ public interface Session extends SharedSessionContract, EntityManager {
 	///
 	/// @apiNote This method returns `RootGraph<?>`, requiring an
 	/// unchecked typecast before use. It's cleaner to obtain a graph using
-	/// the static metamodel for the class which defines the graph, or by
-	/// calling [SessionFactory#getNamedEntityGraphs(Class)] instead.
+	/// the static metamodel for the class which defines the graph, by
+	/// calling {@link #getEntityGraph(Class, String)}, or by calling
+	/// [SessionFactory#getNamedEntityGraphs(Class)].
 	///
+	/// @see #get(EntityGraph, Object, FindOption...)
 	/// @see #find(EntityGraph, Object, FindOption...)
-	/// @see org.hibernate.query.SelectionQuery#setEntityGraph(EntityGraph, org.hibernate.graph.GraphSemantic)
+	/// @see #createQuery(String, EntityGraph)
+	/// @see jakarta.persistence.StatementOrTypedQuery#withEntityGraph(EntityGraph)
 	/// @see jakarta.persistence.EntityManagerFactory#addNamedEntityGraph(String, EntityGraph)
 	@Override
 	RootGraph<?> getEntityGraph(String graphName);
+
+	/// Obtain a mutable copy of a predefined
+	/// [named entity graph][jakarta.persistence.NamedEntityGraph]
+	/// whose root type is exactly the given entity type.
+	///
+	/// @param rootType the root entity class of the graph
+	/// @param graphName The name of the predefined named entity graph
+	/// @throws IllegalArgumentException if there is no predefined graph
+	///         with the given name, or if the graph with the given name
+	/// 	    does not have the given entity type as its root
+	///
+	/// @see #get(EntityGraph, Object, FindOption...)
+	/// @see #find(EntityGraph, Object, FindOption...)
+	/// @see #createQuery(String, EntityGraph)
+	/// @see jakarta.persistence.StatementOrTypedQuery#withEntityGraph(EntityGraph)
+	/// @see org.hibernate.query.SelectionQuery#setEntityGraph(EntityGraph, org.hibernate.graph.GraphSemantic)
+	/// @see jakarta.persistence.EntityManagerFactory#addNamedEntityGraph(String, EntityGraph)
+	///
+	/// @since 8.0
+	@Override
+	<T> RootGraph<T> getEntityGraph(Class<T> rootType, String graphName);
+
+	/// Create a new mutable instance of [EntityGraph], based on
+	/// a predefined [named entity graph][jakarta.persistence.NamedEntityGraph],
+	/// allowing customization of the graph, or return `null` if there is no
+	/// predefined graph with the given name.
+	///
+	/// @param graphName The name of the predefined named entity graph
+	///
+	/// @deprecated Use [#getEntityGraph(String)] instead.
+	@Override @Deprecated
+	RootGraph<?> createEntityGraph(String graphName);
+
+	/// Create a new mutable instance of [EntityGraph], based on
+	/// a predefined [named entity graph][jakarta.persistence.NamedEntityGraph]
+	/// whose root type is exactly the given entity type, allowing customization
+	/// of the graph, or return `null` if there is no predefined graph with the
+	/// given name.
+	///
+	/// @param graphName The name of the predefined named entity graph
+	///
+	/// @deprecated Use [#getEntityGraph(Class, String)] instead.
+	@Override @Deprecated
+	<T> RootGraph<T> createEntityGraph(Class<T> rootType, String graphName);
 
 	/// Retrieve all named [EntityGraph]s with the given root entity type.
 	///
@@ -1340,6 +1372,5 @@ public interface Session extends SharedSessionContract, EntityManager {
 	/// move to using [jakarta.persistence.sql.ResultSetMapping].
 	@Deprecated @SuppressWarnings("rawtypes")
 	NativeQuery getNamedNativeQuery(String name);
-
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionContract.java
@@ -828,15 +828,11 @@ public interface SharedSessionContract extends EntityHandler, AutoCloseable, Ser
 	 *
 	 * @param graphName the name of the graph
 	 *
-	 * @apiNote This method returns {@code RootGraph<?>}, requiring an
-	 * unchecked typecast before use. It's cleaner to obtain a graph using
-	 * {@link #createEntityGraph(Class, String)} instead.
-	 *
-	 * @see SessionFactory#getNamedEntityGraphs(Class)
-	 * @see jakarta.persistence.EntityManagerFactory#addNamedEntityGraph(String, EntityGraph)
+	 * @deprecated Use {@link #getEntityGraph(String)} instead.
 	 *
 	 * @since 6.3
 	 */
+	@Deprecated(since = "8.0", forRemoval = true)
 	RootGraph<?> createEntityGraph(String graphName);
 
 	/**
@@ -848,16 +844,14 @@ public interface SharedSessionContract extends EntityHandler, AutoCloseable, Ser
 	 *
 	 * @param rootType the root entity class of the graph
 	 * @param graphName the name of the predefined named entity graph
-	 *
-	 * @see jakarta.persistence.EntityManagerFactory#addNamedEntityGraph(String, EntityGraph)
-	 *
 	 * @throws IllegalArgumentException if the graph with the given
 	 *         name does not have the given entity type as its root
 	 *
-	 * @see jakarta.persistence.EntityManager#createEntityGraph(String)
+	 * @deprecated Use {@link #getEntityGraph(Class, String)} instead.
 	 *
 	 * @since 6.3
 	 */
+	@Deprecated(since = "8.0", forRemoval = true)
 	<T> RootGraph<T> createEntityGraph(Class<T> rootType, String graphName);
 
 	/**
@@ -870,8 +864,9 @@ public interface SharedSessionContract extends EntityHandler, AutoCloseable, Ser
 	 *
 	 * @apiNote This method returns {@code RootGraph<?>}, requiring an
 	 * unchecked typecast before use. It's cleaner to obtain a graph using
-	 * the static metamodel for the class which defines the graph, or by
-	 * calling {@link SessionFactory#getNamedEntityGraphs(Class)} instead.
+	 * the static metamodel for the class which defines the graph, by
+	 * calling {@link #getEntityGraph(Class, String)}, or by calling
+	 * {@link SessionFactory#getNamedEntityGraphs(Class)}.
 	 *
 	 * @see jakarta.persistence.EntityManager#getEntityGraph(String)
 	 * @see SessionFactory#getNamedEntityGraphs(Class)
@@ -880,6 +875,25 @@ public interface SharedSessionContract extends EntityHandler, AutoCloseable, Ser
 	 * @since 6.3
 	 */
 	RootGraph<?> getEntityGraph(String graphName);
+
+	/**
+	 * Obtain a mutable copy of a predefined
+	 * {@linkplain jakarta.persistence.NamedEntityGraph named entity graph}
+	 * whose root type is exactly the given entity type.
+	 *
+	 * @param rootType the root entity class of the graph
+	 * @param graphName the name of the predefined named entity graph
+	 * @throws IllegalArgumentException if there is no predefined graph
+	 *         with the given name, or if the graph with the given name
+	 *         does not have the given entity type as its root
+	 *
+	 * @see jakarta.persistence.EntityManager#getEntityGraph(Class,String)
+	 * @see SessionFactory#getNamedEntityGraphs(Class)
+	 * @see jakarta.persistence.EntityManagerFactory#addNamedEntityGraph(String, EntityGraph)
+	 *
+	 * @since 8.0
+	 */
+	<T> RootGraph<T> getEntityGraph(Class<T> rootType, String graphName);
 
 	/**
 	 * Retrieve all named {@link EntityGraph}s with the given root entity type.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -583,7 +583,7 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
-	public <T> EntityGraph<T> getEntityGraph(Class<T> entityClass, String name) {
+	public <T> RootGraph<T> getEntityGraph(Class<T> entityClass, String name) {
 		//noinspection resource
 		return delegate().getEntityGraph( entityClass, name );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
@@ -517,7 +517,7 @@ public class SessionLazyDelegator implements Session {
 	}
 
 	@Override
-	public <T> EntityGraph<T> getEntityGraph(Class<T> entityClass, String name) {
+	public <T> RootGraph<T> getEntityGraph(Class<T> entityClass, String name) {
 		return this.lazySession.get().getEntityGraph( entityClass, name );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -215,7 +215,7 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	}
 
 	@Override
-	public <T> EntityGraph<T> getEntityGraph(Class<T> entityClass, String name) {
+	public <T> RootGraph<T> getEntityGraph(Class<T> entityClass, String name) {
 		return delegate().getEntityGraph( entityClass, name );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -620,7 +620,7 @@ abstract class AbstractSharedSessionContract implements SharedSessionContractImp
 	}
 
 	@Override
-	public <T> EntityGraph<T> getEntityGraph(Class<T> entityClass, String name) {
+	public <T> RootGraph<T> getEntityGraph(Class<T> entityClass, String name) {
 		final var entityGraph = getEntityGraph( name );
 		final var type = getFactory().getJpaMetamodel().managedType( entityClass );
 		final var graphedType = entityGraph.getGraphedType();
@@ -630,7 +630,7 @@ abstract class AbstractSharedSessionContract implements SharedSessionContractImp
 			);
 		}
 		@SuppressWarnings("unchecked") // this cast is sound, because we just checked
-		final var graph = (EntityGraph<T>) entityGraph;
+		final var graph = (RootGraph<T>) entityGraph;
 		return graph;
 	}
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
