### PR TITLE
HHH-20471 - IF [NOT] EXISTS DDL for 19.28+ (but not 21c) versions of Oracle Database

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -1155,22 +1155,26 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public boolean supportsIfExistsBeforeTableName() {
-		return getVersion().isSameOrAfter( 23 );
+		return getVersion().isSameOrAfter( 23 ) ||
+			(getVersion().getDatabaseMajorVersion() != 21 && getVersion().isSameOrAfter( 19, 28 ));
 	}
 
 	@Override
 	public boolean supportsIfExistsAfterAlterTable() {
-		return getVersion().isSameOrAfter( 23 );
+		return getVersion().isSameOrAfter( 23 ) ||
+			(getVersion().getDatabaseMajorVersion() != 21 && getVersion().isSameOrAfter( 19, 28 ));
 	}
 
 	@Override
 	public boolean supportsIfExistsBeforeIndexName() {
-		return getVersion().isSameOrAfter( 23 );
+		return getVersion().isSameOrAfter( 23 ) ||
+			(getVersion().getDatabaseMajorVersion() != 21 && getVersion().isSameOrAfter( 19, 28 ));
 	}
 
 	@Override
 	public boolean supportsIfExistsBeforeTypeName() {
-		return getVersion().isSameOrAfter( 23 );
+		return getVersion().isSameOrAfter( 23 ) ||
+			(getVersion().getDatabaseMajorVersion() != 21 && getVersion().isSameOrAfter( 19, 28 ));
 	}
 
 	@Override


### PR DESCRIPTION
This PR adds the support of IF [NOT] EXISTS DDL for Oracle databases versions 19.28+ (but not for 21c). [It was indeed backported recently.](https://docs.oracle.com/en/database/oracle/oracle-database/19/newft/ru-19-28.html)

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20471 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20471
<!-- Hibernate GitHub Bot issue links end -->