### PR TITLE
Upgrade Jaxen to 2.0.3 and make xerces an explicit test dependency for hibernate-spatial

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,8 @@ weld = "6.0.4.Final"
 wildFlyTxnClient = "3.0.5.Final"
 jfrUnit = "1.0.0.Alpha2"
 hibernateValidator = "9.1.0.Final"
-jaxen = "1.1"
+jaxen = "2.0.3"
+xerces = "2.12.2"
 dom4j = "2.2.0"
 javaxMoney = "1.1"
 moneta = "1.4.5"
@@ -205,6 +206,7 @@ test-wildFlyTxnClient = { group = "org.wildfly.transaction", name = "wildfly-tra
 test-weld = { group = "org.jboss.weld.se", name = "weld-se-shaded", version.ref = "weld" }
 test-jfrUnit = { group = "org.moditect.jfrunit", name = "jfrunit-core", version.ref = "jfrUnit" }
 test-jaxen = { group = "jaxen", name = "jaxen", version.ref = "jaxen" }
+test-xerces = { group = "xerces", name = "xercesImpl", version.ref = "xerces" }
 test-dom4j = { group = "org.dom4j", name = "dom4j", version.ref = "dom4j" }
 test-javaxMoney = { group = "javax.money", name = "money-api", version.ref = "javaxMoney" }
 test-moneta = { group = "org.javamoney.moneta", name = "moneta-core", version.ref = "moneta" }

--- a/hibernate-spatial/hibernate-spatial.gradle
+++ b/hibernate-spatial/hibernate-spatial.gradle
@@ -31,6 +31,7 @@ dependencies {
 	testImplementation libs.jdbc.h2gis
 
     testRuntimeOnly libs.test.jaxen
+	testRuntimeOnly libs.test.xerces
 	testRuntimeOnly libs.byteBuddy
 }
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
