### PR TITLE
HHH-20488 Find by "IdClass" fails under JPA compliance mode enabled

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/find/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/find/Helper.java
@@ -33,7 +33,7 @@ public class Helper {
 		final var identifierMapping = entityPersister.getIdentifierMapping();
 		if ( isLoadByIdComplianceEnabled( factory ) ) {
 			final var javaType = identifierMapping.getJavaType();
-			if ( !javaType.isInstance( id ) ) {
+			if ( !identifierMapping.isVirtual() && !javaType.isInstance( id ) ) {
 				// per expectation of EntityHandler#find / EntityHandler#get
 				throw new IllegalArgumentException(
 						"Given value '%s' did not match expected identifier type '%s' of entity '%s'"


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20488

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20488 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->