### PR TITLE
HHH-20489 ResultSetMapping/resultClass ignored in StoredProcedureQuery.getSingleResult(..)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -10,6 +10,7 @@ import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityGraph;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.NoResultException;
 import jakarta.persistence.Parameter;
 import jakarta.persistence.ParameterMode;
 import jakarta.persistence.PessimisticLockScope;
@@ -1234,26 +1235,49 @@ public class ProcedureCallImpl<R>
 
 	@Override
 	public <R1> R1 getSingleResult(Class<R1> aClass) {
-		//noinspection unchecked
-		return (R1) getSingleResult();
+		try {
+			return getSingleResult( getResultList( aClass ) );
+		}
+		catch ( HibernateException e ) {
+			throw getExceptionConverter().convert( e, getQueryOptions().getLockOptions() );
+		}
 	}
 
 	@Override
 	public <R1> R1 getSingleResult(jakarta.persistence.sql.ResultSetMapping<R1> resultSetMapping) {
-		//noinspection unchecked
-		return (R1) getSingleResult();
+		try {
+			return getSingleResult( getResultList( resultSetMapping ) );
+		}
+		catch ( HibernateException e ) {
+			throw getExceptionConverter().convert( e, getQueryOptions().getLockOptions() );
+		}
+	}
+
+	private <R1> R1 getSingleResult(List<R1> results) {
+		if ( results.isEmpty() ) {
+			throw new NoResultException( "No result found for query [" + getQueryString() + "]" );
+		}
+		return uniqueElement( results );
 	}
 
 	@Override
 	public <R1> R1 getSingleResultOrNull(Class<R1> aClass) {
-		//noinspection unchecked
-		return (R1) getSingleResultOrNull();
+		try {
+			return uniqueElement( getResultList( aClass ) );
+		}
+		catch ( HibernateException e ) {
+			throw getExceptionConverter().convert( e, getQueryOptions().getLockOptions() );
+		}
 	}
 
 	@Override
 	public <R1> R1 getSingleResultOrNull(jakarta.persistence.sql.ResultSetMapping<R1> resultSetMapping) {
-		//noinspection unchecked
-		return (R1) getSingleResultOrNull();
+		try {
+			return uniqueElement( getResultList( resultSetMapping ) );
+		}
+		catch ( HibernateException e ) {
+			throw getExceptionConverter().convert( e, getQueryOptions().getLockOptions() );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/procedure/PostgreSQLStoredProcedureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/procedure/PostgreSQLStoredProcedureTest.java
@@ -99,6 +99,49 @@ public class PostgreSQLStoredProcedureTest {
 	}
 
 	@Test
+	@RequiresDialect(value = PostgreSQLDialect.class, majorVersion = 14, comment = "Stored procedure OUT parameters are only supported since version 14")
+	public void testTypedGetResultListWithRefCursor(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			StoredProcedureQuery query = entityManager.createStoredProcedureQuery( "sp_person_by_id" );
+			query.registerStoredProcedureParameter( 1, Long.class, ParameterMode.IN );
+			query.registerStoredProcedureParameter( 2, void.class, ParameterMode.REF_CURSOR );
+			query.setParameter( 1, 1L );
+
+			List<Person> persons = query.getResultList( Person.class );
+			assertEquals( 1, persons.size() );
+			assertEquals( "John Doe", persons.get( 0 ).getName() );
+		} );
+	}
+
+	@Test
+	@RequiresDialect(value = PostgreSQLDialect.class, majorVersion = 14, comment = "Stored procedure OUT parameters are only supported since version 14")
+	public void testTypedGetSingleResultWithRefCursor(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			StoredProcedureQuery query = entityManager.createStoredProcedureQuery( "sp_person_by_id" );
+			query.registerStoredProcedureParameter( 1, Long.class, ParameterMode.IN );
+			query.registerStoredProcedureParameter( 2, void.class, ParameterMode.REF_CURSOR );
+			query.setParameter( 1, 1L );
+
+			Person person = query.getSingleResult( Person.class );
+			assertEquals( "John Doe", person.getName() );
+		} );
+	}
+
+	@Test
+	@RequiresDialect(value = PostgreSQLDialect.class, majorVersion = 14, comment = "Stored procedure OUT parameters are only supported since version 14")
+	public void testTypedGetSingleResultOrNullWithRefCursor(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			StoredProcedureQuery query = entityManager.createStoredProcedureQuery( "sp_person_by_id" );
+			query.registerStoredProcedureParameter( 1, Long.class, ParameterMode.IN );
+			query.registerStoredProcedureParameter( 2, void.class, ParameterMode.REF_CURSOR );
+			query.setParameter( 1, 99L );
+
+			Person person = query.getSingleResultOrNull( Person.class );
+			assertEquals( null, person );
+		} );
+	}
+
+	@Test
 	public void testStoredProcedureWithJDBC(EntityManagerFactoryScope scope) {
 		scope.inTransaction( entityManager -> {
 			Session session = entityManager.unwrap( Session.class );
@@ -381,6 +424,19 @@ public class PostgreSQLStoredProcedureTest {
 								"LANGUAGE plpgsql;"
 				);
 				statement.executeUpdate(
+						"CREATE OR REPLACE PROCEDURE sp_person_by_id(IN p_id BIGINT, INOUT p_recordset REFCURSOR) " +
+								"    AS " +
+								"$BODY$ " +
+								"    BEGIN " +
+								"        OPEN p_recordset FOR  " +
+								"            SELECT id, name, nickName, address, createdOn, version " +
+								"            FROM Person   " +
+								"            WHERE id = p_id;  " +
+								"    END; " +
+								"$BODY$ " +
+								"LANGUAGE plpgsql"
+				);
+				statement.executeUpdate(
 						"CREATE OR REPLACE PROCEDURE sp_is_null( " +
 								"   IN param varchar(255), " +
 								"   INOUT result boolean) " +
@@ -465,6 +521,7 @@ public class PostgreSQLStoredProcedureTest {
 				try (Statement statement = connection.createStatement()) {
 					statement.executeUpdate( "DROP PROCEDURE sp_count_phones(bigint, bigint)" );
 					statement.executeUpdate( "DROP PROCEDURE sp_phones(bigint, refcursor)" );
+					statement.executeUpdate( "DROP PROCEDURE sp_person_by_id(bigint, refcursor)" );
 					statement.executeUpdate( "DROP PROCEDURE singleRefCursor(refcursor)" );
 					statement.executeUpdate( "DROP PROCEDURE sp_is_null(varchar, boolean)" );
 					statement.executeUpdate( "DROP PROCEDURE sp_get_address_by_street_city(varchar,varchar,refcursor)" );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20489

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20489 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->