### PR TITLE
HHH-20491 Persisting and then removing OneToOne entities in same flush throws StaleObjectStateException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/queue/internal/decompose/entity/UpdateDecomposer.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/queue/internal/decompose/entity/UpdateDecomposer.java
@@ -165,7 +165,14 @@ public class UpdateDecomposer extends AbstractDecomposer<EntityUpdateAction>
 				// No dirty fields - skip the UPDATE
 				return;
 			}
-			// Has dirty fields - must be a NULL-before-DELETE update, allow it to proceed
+			// Has dirty fields - must be a NULL-before-DELETE update, allow it to proceed.
+			// But if the entity is also being inserted in this same flush, the row was never
+			// written to the database (InsertDecomposer skips inserts for entities being deleted),
+			// so there is nothing to update.
+			if ( decompositionContext != null
+					&& decompositionContext.isBeingInsertedInCurrentFlush( entity ) ) {
+				return;
+			}
 		}
 
 		action.handleNaturalIdLocalResolutions( identifier, entityPersister, session.getPersistenceContext() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetoone/OneToOnePersistAndRemoveTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetoone/OneToOnePersistAndRemoveTest.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.orphan.onetoone;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Jpa(annotatedClasses = {
+		OneToOnePersistAndRemoveTest.AEntity.class,
+		OneToOnePersistAndRemoveTest.BEntity.class
+})
+public class OneToOnePersistAndRemoveTest {
+
+	@Test
+	public void testPersistAndRemoveBothEntitiesInSameFlush(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			AEntity a = new AEntity( 1L, "a1", 1 );
+			BEntity b = new BEntity( 1L, "b1", 1, a );
+			em.persist( b );
+
+			em.remove( b.a );
+			em.remove( b );
+			em.flush();
+
+			assertNull( em.find( AEntity.class, 1L ) );
+			assertNull( em.find( BEntity.class, 1L ) );
+		} );
+	}
+
+	@Test
+	public void testPersistAndRemoveOnlyOwnerInSameFlush(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			AEntity a = new AEntity( 2L, "a2", 2 );
+			BEntity b = new BEntity( 2L, "b2", 2, a );
+			em.persist( b );
+
+			em.remove( b );
+			em.flush();
+
+			assertNull( em.find( BEntity.class, 2L ) );
+		} );
+	}
+
+	@AfterEach
+	void tearDown(EntityManagerFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Entity(name = "PersistRemove1x1_A")
+	@Table(name = "PERSIST_REMOVE_1X1_A")
+	public static class AEntity {
+		@Id
+		Long id;
+
+		String name;
+
+		int aValue;
+
+		@OneToOne(mappedBy = "a")
+		BEntity b;
+
+		public AEntity() {
+		}
+
+		public AEntity(Long id, String name, int aValue) {
+			this.id = id;
+			this.name = name;
+			this.aValue = aValue;
+		}
+	}
+
+	@Entity(name = "PersistRemove1x1_B")
+	@Table(name = "PERSIST_REMOVE_1X1_B")
+	public static class BEntity {
+		@Id
+		Long id;
+
+		String name;
+
+		int bValue;
+
+		@OneToOne(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER, orphanRemoval = true)
+		@JoinColumn(name = "FK_FOR_A")
+		AEntity a;
+
+		public BEntity() {
+		}
+
+		public BEntity(Long id, String name, int bValue, AEntity a) {
+			this.id = id;
+			this.name = name;
+			this.bValue = bValue;
+			this.a = a;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20491

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20491 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->