### PR TITLE
HHH-20451 Hbm <map-key-many-to-many> is ignored during HbmXmlTransformer conversion

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -128,6 +128,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbJoinTableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToOneImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbMapKeyColumnImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbMapKeyJoinColumnImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNamedNativeQueryImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNamedHqlQueryImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNaturalIdImpl;
@@ -1971,6 +1972,32 @@ public class HbmXmlTransformer {
 			// TODO: multiple columns?
 			mapKey.setName( source.getIndex().getColumnAttribute() );
 			target.setMapKeyColumn( mapKey );
+		}
+		else if ( source.getMapKeyManyToMany() != null ) {
+			final var hbmMapKeyManyToMany = source.getMapKeyManyToMany();
+			if ( isNotEmpty( hbmMapKeyManyToMany.getColumnAttribute() ) ) {
+				final var mapKeyJoinColumn = new JaxbMapKeyJoinColumnImpl();
+				mapKeyJoinColumn.setName( hbmMapKeyManyToMany.getColumnAttribute() );
+				target.getMapKeyJoinColumns().add( mapKeyJoinColumn );
+			}
+			else if ( isNotEmpty( hbmMapKeyManyToMany.getColumnOrFormula() ) ) {
+				for ( Serializable columnOrFormula : hbmMapKeyManyToMany.getColumnOrFormula() ) {
+					if ( columnOrFormula instanceof JaxbHbmColumnType column ) {
+						final var mapKeyJoinColumn = new JaxbMapKeyJoinColumnImpl();
+						mapKeyJoinColumn.setName( column.getName() );
+						target.getMapKeyJoinColumns().add( mapKeyJoinColumn );
+					}
+					else {
+						handleUnsupported(
+								"Transformation of formula within map-key-many-to-many is not supported - `%s`",
+								origin()
+						);
+					}
+				}
+			}
+			if ( isNotEmpty( hbmMapKeyManyToMany.getForeignKey() ) ) {
+				target.setMapKeyForeignKey( transformForeignKey( hbmMapKeyManyToMany.getForeignKey() ) );
+			}
 		}
 		else if ( source.getMapKey() != null ) {
 			if ( ! isEmpty( source.getMapKey().getFormulaAttribute() ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -19,12 +19,14 @@ import org.hibernate.boot.jaxb.hbm.transform.UnsupportedFeatureHandling;
 import org.hibernate.boot.jaxb.internal.stax.HbmEventReader;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
 import org.hibernate.boot.jaxb.spi.Binding;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.xsd.MappingXsdSupport;
 import org.hibernate.orm.test.boot.jaxb.JaxbHelper;
 
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.ServiceRegistryScope;
 import org.junit.jupiter.api.Test;
@@ -45,6 +47,68 @@ public class HbmTransformationJaxbTests {
 	public void hbmTransformationTest(ServiceRegistryScope scope) {
 		scope.withService( ClassLoaderService.class, (cls) -> {
 			verifyHbm( "xml/jaxb/mapping/basic/hbm.xml", cls, scope );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20451" )
+	public void mapKeyManyToManyTransformationTest(ServiceRegistryScope scope) {
+		scope.withService( ClassLoaderService.class, (cls) -> {
+			try ( final InputStream inputStream = cls.locateResourceStream( "xml/jaxb/mapping/ternary/hbm.xml" ) ) {
+				withStaxEventReader( inputStream, cls, (staxEventReader) -> {
+					final XMLEventReader reader = new HbmEventReader( staxEventReader, XMLEventFactory.newInstance() );
+
+					try {
+						final JAXBContext jaxbCtx = JAXBContext.newInstance( JaxbHbmHibernateMapping.class );
+						final JaxbHbmHibernateMapping hbmMapping = JaxbHelper.VALIDATING.jaxb(
+								reader,
+								MappingXsdSupport.hbmXml.getSchema(),
+								jaxbCtx
+						);
+						assertThat( hbmMapping ).isNotNull();
+						assertThat( hbmMapping.getClazz() ).hasSize( 2 );
+
+						final MetadataImplementor metadata = (MetadataImplementor) new MetadataSources( scope.getRegistry() )
+								.addHbmXmlBinding( new Binding<>(
+										hbmMapping,
+										new Origin( SourceType.RESOURCE, "xml/jaxb/mapping/ternary/hbm.xml" )
+								) )
+								.buildMetadata();
+						final List<Binding<JaxbEntityMappingsImpl>> transformedBindingList = HbmXmlTransformer.transform(
+								singletonList( new Binding<>(
+										hbmMapping,
+										new Origin( SourceType.RESOURCE, "xml/jaxb/mapping/ternary/hbm.xml" )
+								) ),
+								metadata,
+								UnsupportedFeatureHandling.ERROR
+						);
+						final JaxbEntityMappingsImpl transformed = transformedBindingList.get( 0 ).getRoot();
+
+						assertThat( transformed ).isNotNull();
+						assertThat( transformed.getEntities() ).hasSize( 2 );
+
+						final JaxbEntityImpl mapKeyManyToManyEntity = transformed.getEntities().stream()
+								.filter( e -> "MapKeyManyToManyEntity".equals( e.getClazz() ) )
+								.findFirst()
+								.orElseThrow();
+
+						assertThat( mapKeyManyToManyEntity.getAttributes().getManyToManyAttributes() ).hasSize( 1 );
+
+						final JaxbManyToManyImpl managersAttr = mapKeyManyToManyEntity.getAttributes()
+								.getManyToManyAttributes()
+								.get( 0 );
+						assertThat( managersAttr.getName() ).isEqualTo( "managers" );
+						assertThat( managersAttr.getMapKeyJoinColumns() ).hasSize( 1 );
+						assertThat( managersAttr.getMapKeyJoinColumns().get( 0 ).getName() ).isEqualTo( "siteId" );
+					}
+					catch (JAXBException e) {
+						throw new RuntimeException( "Error during JAXB processing", e );
+					}
+				} );
+			}
+			catch (IOException e) {
+				throw new RuntimeException( "Error accessing mapping file", e );
+			}
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/MapKeyManyToManyEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/MapKeyManyToManyEntity.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapKeyManyToManyEntity {
+	private Long id;
+	private Map<SimpleEntity, MapKeyManyToManyEntity> managers = new HashMap<>();
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public Map<SimpleEntity, MapKeyManyToManyEntity> getManagers() {
+		return managers;
+	}
+
+	public void setManagers(Map<SimpleEntity, MapKeyManyToManyEntity> managers) {
+		this.managers = managers;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/ternary/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/ternary/hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="MapKeyManyToManyEntity">
+        <id name="id"/>
+        <map name="managers" table="entity_managers">
+            <key column="entityId" not-null="true"/>
+            <map-key-many-to-many column="siteId" class="SimpleEntity"/>
+            <many-to-many column="managerId" class="MapKeyManyToManyEntity"/>
+        </map>
+    </class>
+    <class name="SimpleEntity" table="simple_entity_table">
+        <id name="id"/>
+        <property name="name"/>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
backport of https://github.com/hibernate/hibernate-orm/pull/12464 for 7.3

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20451 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20451
<!-- Hibernate GitHub Bot issue links end -->