### PR TITLE
HHH-20454 HbmXmlTransformer generates an incorrect mapping for an HBM file containing a <many-to-one> association with a property-ref attribute

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1692,35 +1692,37 @@ public class HbmXmlTransformer {
 		);
 		jaxbManyToOne.setCascade( convertCascadeType( hbmNode.getCascade() ) );
 
-		if ( isNotEmpty( hbmNode.getPropertyRef() ) ) {
-			jaxbManyToOne.setPropertyRef( new JaxbPropertyRefImpl() );
-			jaxbManyToOne.getPropertyRef().setName( hbmNode.getPropertyRef() );
-		}
-
 		final var manyToOneProperty = propertyInfo.bootModelProperty();
 		final var manyToOne = (ManyToOne) manyToOneProperty.getValue();
-		transferColumnsAndFormulas(
-				manyToOne,
-				new ColumnAndFormulaTarget() {
-					@Override
-					public TargetColumnAdapter makeColumnAdapter(ColumnDefaults columnDefaults) {
-						return new TargetColumnAdapterJaxbJoinColumn( columnDefaults );
-					}
+		if ( isNotEmpty( hbmNode.getPropertyRef() ) ) {
+			final JaxbPropertyRefImpl propertyRef = new JaxbPropertyRefImpl();
+			propertyRef.setName( hbmNode.getPropertyRef() );
+			jaxbManyToOne.setPropertyRef( propertyRef );
+		}
+		else {
+			transferColumnsAndFormulas(
+					manyToOne,
+					new ColumnAndFormulaTarget() {
+						@Override
+						public TargetColumnAdapter makeColumnAdapter(ColumnDefaults columnDefaults) {
+							return new TargetColumnAdapterJaxbJoinColumn( columnDefaults );
+						}
 
-					@Override
-					public void addColumn(TargetColumnAdapter column) {
-						jaxbManyToOne.getJoinColumnOrJoinFormula()
-								.add( ( (TargetColumnAdapterJaxbJoinColumn) column ).getTargetColumn() );
-					}
+						@Override
+						public void addColumn(TargetColumnAdapter column) {
+							jaxbManyToOne.getJoinColumnOrJoinFormula()
+									.add( ((TargetColumnAdapterJaxbJoinColumn) column).getTargetColumn() );
+						}
 
-					@Override
-					public void addFormula(String formula) {
-						jaxbManyToOne.getJoinColumnOrJoinFormula().add( formula );
-					}
-				},
-				new ColumnDefaultsProperty( manyToOneProperty ),
-				propertyInfo.tableName()
-		);
+						@Override
+						public void addFormula(String formula) {
+							jaxbManyToOne.getJoinColumnOrJoinFormula().add( formula );
+						}
+					},
+					new ColumnDefaultsProperty( manyToOneProperty ),
+					propertyInfo.tableName()
+			);
+		}
 
 		jaxbManyToOne.setForeignKey( transformForeignKey( hbmNode.getForeignKey() ) );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -19,6 +19,7 @@ import org.hibernate.boot.jaxb.hbm.transform.UnsupportedFeatureHandling;
 import org.hibernate.boot.jaxb.internal.stax.HbmEventReader;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToOneImpl;
 import org.hibernate.boot.jaxb.spi.Binding;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataImplementor;
@@ -46,6 +47,62 @@ public class HbmTransformationJaxbTests {
 		scope.withService( ClassLoaderService.class, (cls) -> {
 			verifyHbm( "xml/jaxb/mapping/basic/hbm.xml", cls, scope );
 		} );
+	}
+
+	@Test
+	public void manyToOnePropertyRefTransformationTest(ServiceRegistryScope scope) {
+		scope.withService( ClassLoaderService.class, (cls) -> {
+			verifyManyToOnePropertyRef( "xml/jaxb/mapping/many-to-one-property-ref/hbm.xml", cls, scope );
+		} );
+	}
+
+	private void verifyManyToOnePropertyRef(String resourceName, ClassLoaderService cls, ServiceRegistryScope scope) {
+		try ( final InputStream inputStream = cls.locateResourceStream( resourceName ) ) {
+			withStaxEventReader( inputStream, cls, (staxEventReader) -> {
+				final XMLEventReader reader = new HbmEventReader( staxEventReader, XMLEventFactory.newInstance() );
+
+				try {
+					final JAXBContext jaxbCtx = JAXBContext.newInstance( JaxbHbmHibernateMapping.class );
+					final JaxbHbmHibernateMapping hbmMapping = JaxbHelper.VALIDATING.jaxb( reader, MappingXsdSupport.hbmXml.getSchema(), jaxbCtx );
+					assertThat( hbmMapping ).isNotNull();
+					assertThat( hbmMapping.getClazz() ).hasSize( 2 );
+
+					final MetadataImplementor metadata = (MetadataImplementor) new MetadataSources( scope.getRegistry() ).addHbmXmlBinding( new Binding<>(
+							hbmMapping,
+							new Origin( SourceType.RESOURCE, resourceName )
+					) ).buildMetadata();
+					final List<Binding<JaxbEntityMappingsImpl>> transformedBindingList = HbmXmlTransformer.transform(
+							singletonList( new Binding<>( hbmMapping, new Origin( SourceType.RESOURCE, resourceName ) ) ),
+							metadata,
+							UnsupportedFeatureHandling.ERROR
+					);
+					final JaxbEntityMappingsImpl transformed = transformedBindingList.get( 0 ).getRoot();
+
+					assertThat( transformed ).isNotNull();
+					assertThat( transformed.getEntities() ).hasSize( 2 );
+
+					final JaxbEntityImpl sourceEntity = transformed.getEntities().stream()
+							.filter( e -> "PropertyRefSourceEntity".equals( e.getClazz() ) )
+							.findFirst()
+							.orElseThrow();
+
+					assertThat( sourceEntity.getAttributes().getManyToOneAttributes() ).hasSize( 1 );
+
+					final JaxbManyToOneImpl manyToOne = sourceEntity.getAttributes().getManyToOneAttributes().get( 0 );
+					assertThat( manyToOne.getName() ).isEqualTo( "target" );
+					assertThat( manyToOne.getTargetEntity() ).isEqualTo( "PropertyRefTargetEntity" );
+					assertThat( manyToOne.getPropertyRef() ).isNotNull();
+					assertThat( manyToOne.getPropertyRef().getName() ).isEqualTo( "name" );
+					assertThat( manyToOne.getJoinColumnOrJoinFormula() ).isEmpty();
+				}
+				catch (JAXBException e) {
+					throw new RuntimeException( "Error during JAXB processing", e );
+				}
+			} );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( "Error accessing mapping file", e );
+		}
 	}
 
 	private void verifyHbm(String resourceName, ClassLoaderService cls, ServiceRegistryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/PropertyRefSourceEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/PropertyRefSourceEntity.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "property_ref_source")
+public class PropertyRefSourceEntity {
+	@Id
+	private Integer id;
+	@ManyToOne
+	private PropertyRefTargetEntity target;
+
+	private PropertyRefSourceEntity() {
+	}
+
+	public PropertyRefSourceEntity(Integer id) {
+		this.id = id;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public PropertyRefTargetEntity getTarget() {
+		return target;
+	}
+
+	public void setTarget(PropertyRefTargetEntity target) {
+		this.target = target;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/PropertyRefTargetEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/PropertyRefTargetEntity.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "property_ref_target")
+public class PropertyRefTargetEntity {
+	@Id
+	private Integer id;
+	@Basic
+	@Column(name = "target_name", unique = true)
+	private String name;
+
+	private PropertyRefTargetEntity() {
+	}
+
+	public PropertyRefTargetEntity(Integer id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/many-to-one-property-ref/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/many-to-one-property-ref/hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm" package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="PropertyRefTargetEntity" table="property_ref_target">
+        <id name="id" type="integer" column="id">
+            <generator class="assigned"/>
+        </id>
+        <property name="name">
+            <column name="target_name" unique="true"/>
+        </property>
+    </class>
+    <class name="PropertyRefSourceEntity" table="property_ref_source">
+        <id name="id" type="integer" column="id">
+            <generator class="assigned"/>
+        </id>
+        <many-to-one name="target"
+                     class="PropertyRefTargetEntity"
+                     column="target_name"
+                     property-ref="name"/>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
backport of for 7.3
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20454 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20454
<!-- Hibernate GitHub Bot issue links end -->