### PR TITLE
HHH-20494 Cache the qualifier-replacement Pattern for formula columns

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -7010,11 +7010,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		if ( columnReference.isColumnExpressionFormula() ) {
 			// For formulas, we have to replace the qualifier as the alias was already rendered into the formula
 			// This is fine for now as this is only temporary anyway until we render aliases for table references
-			final String replacement = qualifier != null ? "$1" + qualifier + ".$3" : "$1$3";
-			appendSql(
-					columnReference.getColumnExpression()
-							.replaceAll( "(\\b)(" + columnReference.getQualifier() + "\\.)(\\b)", replacement )
-			);
+			appendSql( columnReference.getColumnExpression( qualifier ) );
 		}
 		else {
 			columnReference.appendReadExpression( this, qualifier );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/ColumnReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/ColumnReference.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
@@ -39,6 +40,9 @@ public class ColumnReference implements Expression, Assignable {
 	private final boolean isFormula;
 	private final @Nullable String readExpression;
 	private final JdbcMapping jdbcMapping;
+	// For formula columns, the pattern used to swap the alias baked into the formula for the
+	// current render qualifier. Compiled once here instead of on every render. Null otherwise.
+	private final @Nullable Pattern formulaQualifierPattern;
 
 	public ColumnReference(TableReference tableReference, SelectableMapping selectableMapping) {
 		this(
@@ -134,6 +138,9 @@ public class ColumnReference implements Expression, Assignable {
 		this.isFormula = isFormula;
 		this.readExpression = customReadExpression;
 		this.jdbcMapping = jdbcMapping;
+		this.formulaQualifierPattern = isFormula
+				? Pattern.compile( "(\\b)(" + this.qualifier + "\\.)(\\b)" )
+				: null;
 	}
 
 	@Override
@@ -147,6 +154,19 @@ public class ColumnReference implements Expression, Assignable {
 
 	public String getColumnExpression() {
 		return columnExpression;
+	}
+
+	/**
+	 * The column expression of a formula, with the alias that was baked into the formula at
+	 * construction replaced by the {@code renderingQualifier} in use for the current render.
+	 * <p>
+	 * Reuses the {@link Pattern} compiled once per {@code ColumnReference} rather than
+	 * recompiling the regular expression on every render.
+	 */
+	public String getColumnExpression(@Nullable String renderingQualifier) {
+		assert formulaQualifierPattern != null : "Only formula column references support qualifier replacement";
+		return formulaQualifierPattern.matcher( columnExpression )
+				.replaceAll( renderingQualifier != null ? "$1" + renderingQualifier + ".$3" : "$1$3" );
 	}
 
 	public @Nullable String getReadExpression() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20494

AbstractSqlAstTranslator#visitColumnReference compiled a regular expression via String.replaceAll on every render of a @Formula column. The pattern depends only on the immutable ColumnReference qualifier, so compile it once in the constructor and reuse it, avoiding the repeated Pattern.compile on the SQL rendering path. Behavior is unchanged.


----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20494 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->