### PR TITLE
HHH-20496 Deprecate ValidationMode.DDL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/ActivationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/ActivationContext.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import org.hibernate.boot.Metadata;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+import org.hibernate.tool.schema.ValidationConstraintDdlInfluence;
 
 /**
  * Defines the context needed to call the {@link TypeSafeActivator}.
@@ -47,4 +48,9 @@ public interface ActivationContext {
 	 * @return The SessionFactoryServiceRegistry
 	 */
 	SessionFactoryServiceRegistry getServiceRegistry();
+
+	/**
+	 * @return Resolved validation constraint influence on DDL.
+	 */
+	ValidationConstraintDdlInfluence getValidationConstraintDdlInfluence();
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationIntegrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationIntegrator.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.hibernate.HibernateException;
 import org.hibernate.boot.Metadata;
+import org.hibernate.cfg.SchemaToolingSettings;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.engine.config.spi.ConfigurationService;
@@ -17,6 +18,7 @@ import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+import org.hibernate.tool.schema.ValidationConstraintDdlInfluence;
 
 import static org.hibernate.boot.beanvalidation.BeanValidationLogger.BEAN_VALIDATION_LOGGER;
 
@@ -27,6 +29,10 @@ import static org.hibernate.boot.beanvalidation.BeanValidationLogger.BEAN_VALIDA
  */
 public class BeanValidationIntegrator implements Integrator {
 
+	/**
+	 * @deprecated Use {@link org.hibernate.cfg.SchemaToolingSettings#APPLY_VALIDATION_CONSTRAINTS} instead
+	 */
+	@Deprecated(since = "8.0", forRemoval = true)
 	public static final String APPLY_CONSTRAINTS = "hibernate.validator.apply_to_ddl";
 
 	public static final String JAKARTA_BV_CHECK_CLASS = "jakarta.validation.ConstraintViolation";
@@ -88,31 +94,24 @@ public class BeanValidationIntegrator implements Integrator {
 		final var serviceRegistry = sessionFactory.getServiceRegistry();
 		// IMPL NOTE: see the comments on ActivationContext.getValidationModes() as to why this is multi-valued...
 		final var modes = getValidationModes( serviceRegistry );
-		switch ( modes.size() ) {
-			case 0:
-				// should never happen, since getValidationModes()
-				// always returns at least one mode
-				return;
-			case 1:
-				if ( modes.contains( ValidationMode.NONE ) ) {
-					// we have nothing to do; just return
-					return;
-				}
-				break;
-			default:
-				BEAN_VALIDATION_LOGGER.multipleValidationModes( ValidationMode.loggable( modes ) );
+		ValidationConstraintDdlInfluence constraintInfluence = ValidationConstraintDdlInfluence.resolve( serviceRegistry, modes );
+		if ( constraintInfluence == ValidationConstraintDdlInfluence.DISABLED && modes.contains( ValidationMode.NONE ) ) {
+			return;
 		}
-		activate( metadata, sessionFactory, serviceRegistry, modes );
+		if ( modes.size() > 1 ) {
+			BEAN_VALIDATION_LOGGER.multipleValidationModes( ValidationMode.loggable( modes ) );
+		}
+		activate( metadata, sessionFactory, serviceRegistry, modes, constraintInfluence );
 	}
 
-	private void activate(Metadata metadata, SessionFactoryImplementor sessionFactory, ServiceRegistryImplementor serviceRegistry, Set<ValidationMode> modes) {
+	private void activate(Metadata metadata, SessionFactoryImplementor sessionFactory, ServiceRegistryImplementor serviceRegistry, Set<ValidationMode> modes, ValidationConstraintDdlInfluence constraintInfluence) {
 		final var classLoaderService = serviceRegistry.requireService( ClassLoaderService.class );
 		// see if the Bean Validation API is available on the classpath
 		if ( isBeanValidationApiAvailable( classLoaderService ) ) {
 			// and if so, call out to the TypeSafeActivator
 			try {
 				final var activationContext =
-						new ActivationContextImpl( modes, metadata, sessionFactory,
+						new ActivationContextImpl( modes, constraintInfluence, metadata, sessionFactory,
 								(SessionFactoryServiceRegistry) serviceRegistry );
 				callActivateMethod( classLoaderService, activationContext );
 			}
@@ -123,7 +122,7 @@ public class BeanValidationIntegrator implements Integrator {
 		else {
 			// otherwise check the validation modes
 			// todo : in many ways this duplicates the checks done on the TypeSafeActivator when a ValidatorFactory could not be obtained
-			validateMissingBeanValidationApi( modes );
+			validateMissingBeanValidationApi( modes, constraintInfluence );
 		}
 	}
 
@@ -169,16 +168,17 @@ public class BeanValidationIntegrator implements Integrator {
 	}
 
 	/**
-	 * Used to validate the case when the Bean Validation API is not available.
+	 * Used to validate the case when the Jakarta Validation API is not available.
 	 *
 	 * @param modes The requested validation modes.
 	 */
-	private void validateMissingBeanValidationApi(Set<ValidationMode> modes) {
+	private void validateMissingBeanValidationApi(Set<ValidationMode> modes, ValidationConstraintDdlInfluence constraintInfluence) {
 		if ( modes.contains( ValidationMode.CALLBACK ) ) {
-			throw new IntegrationException( "Bean Validation API was not available, but 'callback' validation was requested" );
+			throw new IntegrationException( "Jakarta Validation API was not available, but 'callback' validation was requested" );
 		}
-		if ( modes.contains( ValidationMode.DDL ) ) {
-			throw new IntegrationException( "Bean Validation API was not available, but 'ddl' validation was requested" );
+		if ( constraintInfluence == ValidationConstraintDdlInfluence.REQUIRED ) {
+			throw new IntegrationException( "Bean Validation API was not available, but '"
+					+ SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS + "' was set to 'REQUIRED'" );
 		}
 	}
 
@@ -198,6 +198,7 @@ public class BeanValidationIntegrator implements Integrator {
 
 	private record ActivationContextImpl(
 			Set<ValidationMode> modes,
+			ValidationConstraintDdlInfluence constraintInfluence,
 			Metadata metadata,
 			SessionFactoryImplementor sessionFactory,
 			SessionFactoryServiceRegistry serviceRegistry)
@@ -221,6 +222,11 @@ public class BeanValidationIntegrator implements Integrator {
 		@Override
 		public SessionFactoryServiceRegistry getServiceRegistry() {
 			return serviceRegistry;
+		}
+
+		@Override
+		public ValidationConstraintDdlInfluence getValidationConstraintDdlInfluence() {
+			return constraintInfluence;
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationLogger.java
@@ -43,10 +43,6 @@ public interface BeanValidationLogger extends BasicLogger {
 	void validationFactorySkipped();
 
 	@LogMessage(level = DEBUG)
-	@Message(id = 101002, value = "Skipping application of relational constraints from legacy Hibernate Validator")
-	void skippingLegacyHVConstraints();
-
-	@LogMessage(level = DEBUG)
 	@Message(id = 101003, value = "ConstraintComposition type could not be determined. Assuming AND")
 	void constraintCompositionTypeUnknown(@Cause Throwable ex);
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/TypeSafeActivator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/TypeSafeActivator.java
@@ -37,7 +37,7 @@ import org.hibernate.boot.spi.ClassLoaderAccess;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
-import org.hibernate.engine.config.spi.StandardConverters;
+import org.hibernate.tool.schema.ValidationConstraintDdlInfluence;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.spi.EventType;
@@ -56,7 +56,8 @@ import jakarta.validation.metadata.ConstraintDescriptor;
 import jakarta.validation.metadata.PropertyDescriptor;
 
 import static java.util.Collections.disjoint;
-import static org.hibernate.boot.beanvalidation.BeanValidationIntegrator.APPLY_CONSTRAINTS;
+import static org.hibernate.cfg.SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS;
+import static org.hibernate.tool.schema.ValidationConstraintDdlInfluence.DISABLED;
 import static org.hibernate.boot.beanvalidation.BeanValidationLogger.BEAN_VALIDATION_LOGGER;
 import static org.hibernate.boot.beanvalidation.GroupsPerOperation.buildGroupsForOperation;
 import static org.hibernate.boot.model.internal.BinderHelper.findPropertyByName;
@@ -73,7 +74,6 @@ import static org.hibernate.internal.util.StringHelper.isNotEmpty;
  * @author Steve Ebersole
  */
 class TypeSafeActivator {
-
 
 	/**
 	 * Used to validate a supplied ValidatorFactory instance as being castable to ValidatorFactory.
@@ -95,12 +95,12 @@ class TypeSafeActivator {
 			factory = getValidatorFactory( context );
 		}
 		catch (IntegrationException exception) {
-			final var validationModes = context.getValidationModes();
-			if ( validationModes.contains( ValidationMode.CALLBACK ) ) {
+			if ( context.getValidationModes().contains( ValidationMode.CALLBACK ) ) {
 				throw new IntegrationException( "Jakarta Validation provider was not available, but 'callback' validation mode was requested", exception );
 			}
-			else if ( validationModes.contains( ValidationMode.DDL ) ) {
-				throw new IntegrationException( "Jakarta Validation provider was not available, but 'ddl' validation mode was requested", exception );
+			else if ( context.getValidationConstraintDdlInfluence() == ValidationConstraintDdlInfluence.REQUIRED ) {
+				throw new IntegrationException( "Jakarta Validation provider was not available, but '"
+						+ APPLY_VALIDATION_CONSTRAINTS + "' was resolved to 'REQUIRED'", exception );
 			}
 			else {
 				if ( exception.getCause() instanceof NoProviderFoundException ) {
@@ -170,16 +170,7 @@ class TypeSafeActivator {
 	}
 
 	private static boolean isConstraintBasedValidationEnabled(ActivationContext context) {
-		if ( context.getServiceRegistry().requireService( ConfigurationService.class )
-				.getSetting( APPLY_CONSTRAINTS, StandardConverters.BOOLEAN, true ) ) {
-			final var modes = context.getValidationModes();
-			return modes.contains( ValidationMode.DDL )
-				|| modes.contains( ValidationMode.AUTO );
-		}
-		else {
-			BEAN_VALIDATION_LOGGER.skippingLegacyHVConstraints();
-			return false;
-		}
+		return context.getValidationConstraintDdlInfluence() != DISABLED;
 	}
 
 	private static void applyRelationalConstraints(ValidatorFactory factory, ActivationContext context) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/ValidationMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/ValidationMode.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.hibernate.HibernateException;
+import org.hibernate.tool.schema.ValidationConstraintDdlInfluence;
 
 import static org.hibernate.internal.util.StringHelper.split;
 import static org.hibernate.internal.util.collections.CollectionHelper.setOfSize;
@@ -22,6 +23,15 @@ public enum ValidationMode {
 	AUTO,
 	CALLBACK,
 	NONE,
+	/**
+	 * @deprecated The influence of Jakarta Validation constraints on DDL schema generation
+	 * is now enabled by default when the validation mode is {@link #AUTO}. Use the setting
+	 * {@value org.hibernate.cfg.SchemaToolingSettings#APPLY_VALIDATION_CONSTRAINTS} to
+	 * control this behavior instead. To require that a Jakarta Validation provider is
+	 * available (as this mode did), use
+	 * {@link ValidationConstraintDdlInfluence#REQUIRED REQUIRED}.
+	 */
+	@Deprecated(since = "8.0", forRemoval = true)
 	DDL;
 
 	private String externalForm() {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/SchemaToolingSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/SchemaToolingSettings.java
@@ -4,11 +4,13 @@
  */
 package org.hibernate.cfg;
 
+import org.hibernate.Incubating;
 import org.hibernate.query.sqm.mutation.internal.temptable.GlobalTemporaryTableStrategy;
 import org.hibernate.query.sqm.mutation.internal.temptable.LocalTemporaryTableStrategy;
 import org.hibernate.query.sqm.mutation.internal.temptable.PersistentTableStrategy;
 import org.hibernate.tool.schema.JdbcMetadataAccessStrategy;
 import org.hibernate.tool.schema.UniqueConstraintSchemaUpdateStrategy;
+import org.hibernate.tool.schema.ValidationConstraintDdlInfluence;
 
 /**
  * @author Steve Ebersole
@@ -433,6 +435,23 @@ public interface SchemaToolingSettings {
 	///
 	/// @since 7.3
 	String UNIQUE_KEY_VALIDATION =  "hibernate.tooling.schema.unique_key_validation";
+
+	/// Whether constraints from Jakarta Validation annotations (for example,
+	/// {@link jakarta.validation.constraints.NotNull @NotNull},
+	/// {@link jakarta.validation.constraints.Size @Size},
+	/// {@link jakarta.validation.constraints.Digits @Digits})
+	/// should influence the generated DDL schema — for example, by making
+	/// a column non-nullable or setting its length, precision, or scale.
+	///
+	/// Valid values are defined by
+	/// {@link ValidationConstraintDdlInfluence}.
+	///
+	/// @settingDefault {@link ValidationConstraintDdlInfluence#AUTO}
+	///
+	/// @since 8.0
+	/// @see ValidationConstraintDdlInfluence
+	@Incubating
+	String APPLY_VALIDATION_CONSTRAINTS = "hibernate.tooling.schema.apply_validation_constraints";
 
 	/**
 	 * Specifies whether to automatically create also the database schema/catalog.

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/ValidationConstraintDdlInfluence.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/ValidationConstraintDdlInfluence.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.schema;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.Incubating;
+import org.hibernate.boot.beanvalidation.BeanValidationIntegrator;
+import org.hibernate.boot.beanvalidation.ValidationMode;
+import org.hibernate.cfg.SchemaToolingSettings;
+import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.engine.config.spi.StandardConverters;
+import org.hibernate.service.ServiceRegistry;
+
+/// Controls whether Jakarta Validation constraints (such as
+/// {@link jakarta.validation.constraints.NotNull @NotNull},
+/// {@link jakarta.validation.constraints.Size @Size},
+/// {@link jakarta.validation.constraints.Digits @Digits} and others)
+/// influence the generated DDL schema.
+///
+/// @see SchemaToolingSettings#APPLY_VALIDATION_CONSTRAINTS
+///
+/// @since 8.0
+@Incubating
+public enum ValidationConstraintDdlInfluence {
+	/// Apply validation constraints to the DDL schema if a Jakarta Validation
+	/// provider is available on the classpath; silently skip otherwise.
+	AUTO,
+	/// Apply validation constraints to the DDL schema, failing with an error
+	/// if no Jakarta Validation provider is available.
+	REQUIRED,
+	/// Do not apply validation constraints to the DDL schema.
+	DISABLED;
+
+	@SuppressWarnings( "removal" )
+	public static ValidationConstraintDdlInfluence resolve(ServiceRegistry serviceRegistry, Set<ValidationMode> validationModes) {
+		final var configurationService = serviceRegistry.requireService( ConfigurationService.class );
+		final var settings = configurationService.getSettings();
+		if ( settings.containsKey( SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS ) ) {
+			return resolveSettingValue( settings );
+		}
+		// legacy: treat deprecated ValidationMode.DDL as REQUIRED
+		for ( var mode : validationModes ) {
+			if ( mode == ValidationMode.DDL ) {
+				return REQUIRED;
+			}
+		}
+		// legacy boolean setting fallback
+		if ( !configurationService.getSetting( BeanValidationIntegrator.APPLY_CONSTRAINTS, StandardConverters.BOOLEAN, true ) ) {
+			return DISABLED;
+		}
+		return AUTO;
+	}
+
+	private static ValidationConstraintDdlInfluence resolveSettingValue(Map<String, Object> configurationValues) {
+		final Object setting = configurationValues.get( SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS );
+		if ( setting == null ) {
+			return AUTO;
+		}
+
+		if ( setting instanceof ValidationConstraintDdlInfluence type ) {
+			return type;
+		}
+
+		return valueOf( setting.toString().trim().toUpperCase( Locale.ROOT ) );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/BeanValidationDisabledTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/BeanValidationDisabledTest.java
@@ -5,6 +5,7 @@
 package org.hibernate.orm.test.annotations.beanvalidation;
 
 import jakarta.validation.ConstraintViolationException;
+import org.hibernate.cfg.SchemaToolingSettings;
 import org.hibernate.cfg.ValidationSettings;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
@@ -24,7 +25,10 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Emmanuel Bernard
  */
 @ServiceRegistry(
-		settings = @Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "none")
+		settings = {
+				@Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "none"),
+				@Setting(name = SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS, value = "DISABLED")
+		}
 )
 @DomainModel(annotatedClasses = {
 		Address.class,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/DDLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/DDLTest.java
@@ -6,7 +6,7 @@ package org.hibernate.orm.test.annotations.beanvalidation;
 
 import java.util.List;
 
-import org.hibernate.cfg.ValidationSettings;
+import org.hibernate.cfg.SchemaToolingSettings;
 import org.hibernate.mapping.CheckConstraint;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Hardy Ferentschik
  */
 @ServiceRegistry(settings = {
-		@Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "DDL"),
+		@Setting(name = SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS, value = "REQUIRED"),
 		@Setting(name = PersistentTableStrategy.DROP_ID_TABLES, value = "true"),
 		@Setting(name = GlobalTemporaryTableMutationStrategy.DROP_ID_TABLES, value = "true"),
 		@Setting(name = LocalTemporaryTableMutationStrategy.DROP_ID_TABLES, value = "true")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/DDLWithoutCallbackTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/DDLWithoutCallbackTest.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PersistenceException;
 import jakarta.validation.ConstraintViolationException;
 
+import org.hibernate.cfg.SchemaToolingSettings;
 import org.hibernate.cfg.ValidationSettings;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
@@ -34,9 +35,10 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Vladimir Klyushnikov
  * @author Hardy Ferentschik
  */
-@ServiceRegistry(
-		settings = @Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "ddl")
-)
+@ServiceRegistry(settings = {
+		@Setting(name = SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS, value = "REQUIRED"),
+		@Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "NONE")
+})
 @DomainModel(annotatedClasses = {
 		Address.class,
 		CupHolder.class,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/beanvalidation/BeanValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/beanvalidation/BeanValidationTest.java
@@ -5,6 +5,7 @@
 package org.hibernate.orm.test.jpa.beanvalidation;
 
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.SchemaToolingSettings;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
@@ -26,7 +27,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Jpa(
 		annotatedClasses = { CupHolder.class },
-		integrationSettings = { @Setting(name = AvailableSettings.JAKARTA_VALIDATION_MODE, value = "auto") }
+		integrationSettings = { @Setting(name = AvailableSettings.JAKARTA_VALIDATION_MODE, value = "auto"),
+				@Setting(name = SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS, value = "REQUIRED") }
 )
 public class BeanValidationTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/CreateCharDiscriminatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/CreateCharDiscriminatorTest.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.Table;
+import org.hibernate.cfg.SchemaToolingSettings;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.DomainModelScope;
 import org.hibernate.testing.orm.junit.JiraKey;
@@ -24,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("JUnitMalformedDeclaration")
 @JiraKey("HHH-16551")
-@ServiceRegistry(settings = @Setting(name="jakarta.persistence.validation.mode", value = "ddl"))
+@ServiceRegistry(settings = @Setting(name = SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS, value = "REQUIRED"))
 @DomainModel(annotatedClasses = CreateCharDiscriminatorTest.Parent.class)
 public class CreateCharDiscriminatorTest {
 

--- a/hibernate-core/src/test/resources/hibernate.properties
+++ b/hibernate-core/src/test/resources/hibernate.properties
@@ -25,6 +25,7 @@ hibernate.cache.region_prefix hibernate.test
 hibernate.cache.region.factory_class org.hibernate.testing.cache.CachingRegionFactory
 
 jakarta.persistence.validation.mode=NONE
+hibernate.tooling.schema.apply_validation_constraints=DISABLED
 hibernate.service.allow_crawling=false
 hibernate.session.events.log=true
 hibernate.query.mutation_strategy.global_temporary.drop_tables=true

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -248,6 +248,30 @@ bootstrapping and supply the root and/or non-root URLs.
 This section describes changes in behavior that applications should be aware of.
 
 
+[[validation-ddl-influence]]
+=== Jakarta Validation DDL influence enabled by default
+
+Jakarta Persistence 4.0 specifies that constraints from Jakarta Validation annotations,
+such as `@NotNull`, `@Size`, `@Digits` and others, should influence the generated DDL
+schema. For example, a property annotated `@NotNull` will result in a non-nullable column.
+
+Previously, this behavior required explicitly setting the validation mode to `DDL`
+(a Hibernate-specific extension to the JPA `ValidationMode` enum).
+
+As a result:
+
+* `org.hibernate.boot.beanvalidation.ValidationMode.DDL` is deprecated for removal.
+* A new setting `hibernate.tooling.schema.apply_validation_constraints` has been added to
+  `SchemaToolingSettings` as the way to control the influence of Jakarta Validation constraints
+  on the generated DDL schema. Valid values are defined by `ValidationConstraintDdlInfluence`:
+  - `AUTO` (default) — apply constraints if a Jakarta Validation provider is available,
+    silently skip otherwise
+  - `REQUIRED` — apply constraints and fail if no Jakarta Validation provider is available
+  - `DISABLED` — do not apply constraints
+* The legacy setting `hibernate.validator.apply_to_ddl` is also deprecated for removal
+  in favor of the new setting.
+
+
 [[graph-flushing-behavior]]
 === Graph-based Flushing
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20496

This is what I was thinking we could do to deal with "DDL mode" now always being "on". Since the DDL is a bit out of place anyway, let's just deprecate the mode and move the setting closer to the schema settings (deprecate the existing one `hibernate.validator.apply_to_ddl` and add an alternative more specific to DDL)  ?

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20496 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->