### PR TITLE
StoredProcedureQuery.executeUpdate() requires a transaction and should throw TransactionRequiredException if one is missing

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -1210,6 +1210,7 @@ public class ProcedureCallImpl<R>
 
 	@Override @SuppressWarnings("removal")
 	public int executeUpdate() {
+		session.checkTransactionNeededForUpdateOperation( "No active transaction for stored procedure call" );
 		try {
 			execute();
 			// The expectation is that there is just one Output,


### PR DESCRIPTION
A regular execute doesn't have this `throws` in the javadoc but executeUpdate does 🫣 

https://develocity.commonhaus.dev/s/2x7pf7i7cbkz2/tests/task/:hibernate-tck-runner:test/details/ee.jakarta.tck.persistence.core.StoredProcedureQuery.Client1/executeUpdateTransactionRequiredExceptionTest()?top-execution=1

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
