### PR TITLE
HHH-20495 Make sure we release resources (if needed) after stateless session operations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -955,15 +955,20 @@ public class SessionImpl
 			RootGraphImplementor<E> rootGraph,
 			List<Object> keys,
 			FindOption... options) {
-		final var operation = new FindMultipleByKeyOperation<E>(
-				entityDescriptor,
-				lockOptions,
-				getCacheMode(),
-				isDefaultReadOnly(),
-				getFactory(),
-				options
-		);
-		return operation.performFind( keys, graphSemantic, rootGraph, this );
+		try {
+			final var operation = new FindMultipleByKeyOperation<E>(
+					entityDescriptor,
+					lockOptions,
+					getCacheMode(),
+					isDefaultReadOnly(),
+					getFactory(),
+					options
+			);
+			return operation.performFind( keys, graphSemantic, rootGraph, this );
+		}
+		finally {
+			afterOperation( true ); // success value doesn't matter
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -936,12 +936,15 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 				throw new IllegalArgumentException("Null id");
 			}
 		}
-
-		final var persister = requireEntityPersister( entityClass.getName() );
-		final var results = persister.multiLoad( ids.toArray(), this, MULTI_ID_LOAD_OPTIONS );
-		//noinspection unchecked
-		return (List<T>) results;
-
+		try {
+			final var persister = requireEntityPersister( entityClass.getName() );
+			final var results = persister.multiLoad( ids.toArray(), this, MULTI_ID_LOAD_OPTIONS );
+			//noinspection unchecked
+			return (List<T>) results;
+		}
+		finally {
+			afterOperation();
+		}
 //		final List<Object> uncachedIds;
 //		final List<T> list = new ArrayList<>( ids.size() );
 //		if ( persister.canReadFromCache() ) {
@@ -998,35 +1001,37 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 
 	@Override
 	public void refresh(String entityName, Object entity, LockMode lockMode) {
-		checkOpen();
-		final var persister = getEntityPersister( entityName, entity );
-		final Object id = persister.getIdentifier( entity, this );
-		if ( SESSION_LOGGER.isTraceEnabled() ) {
-			SESSION_LOGGER.refreshingTransient( infoString( persister, id, getFactory() ) );
-		}
-
-		if ( persister.canWriteToCache() ) {
-			final var cacheAccess = persister.getCacheAccessStrategy();
-			if ( cacheAccess != null ) {
-				final Object cacheKey = cacheAccess.generateCacheKey(
-						id,
-						persister,
-						getFactory(),
-						getTenantIdentifier()
-				);
-				cacheAccess.evict( cacheKey );
+		try {
+			checkOpen();
+			final var persister = getEntityPersister( entityName, entity );
+			final Object id = persister.getIdentifier( entity, this );
+			if ( SESSION_LOGGER.isTraceEnabled() ) {
+				SESSION_LOGGER.refreshingTransient( infoString( persister, id, getFactory() ) );
 			}
-		}
 
-		final Object result =
-				getLoadQueryInfluencers()
-						// TODO: This is wrong. StatelessSession is not supposed
-						//       to be affected by cascade = REFRESH. Fix in H8.
-						.fromInternalFetchProfile( CascadingFetchProfile.REFRESH,
-								() -> persister.load( id, entity, getNullSafeLockMode( lockMode ), this ) );
-		UnresolvableObjectException.throwIfNull( result, id, persister.getEntityName() );
-		if ( temporaryPersistenceContext.isLoadFinished() ) {
-			temporaryPersistenceContext.clear();
+			if ( persister.canWriteToCache() ) {
+				final var cacheAccess = persister.getCacheAccessStrategy();
+				if ( cacheAccess != null ) {
+					final Object cacheKey = cacheAccess.generateCacheKey(
+							id,
+							persister,
+							getFactory(),
+							getTenantIdentifier()
+					);
+					cacheAccess.evict( cacheKey );
+				}
+			}
+
+			final Object result =
+					getLoadQueryInfluencers()
+							// TODO: This is wrong. StatelessSession is not supposed
+							//       to be affected by cascade = REFRESH. Fix in H8.
+							.fromInternalFetchProfile( CascadingFetchProfile.REFRESH,
+									() -> persister.load( id, entity, getNullSafeLockMode( lockMode ), this ) );
+			UnresolvableObjectException.throwIfNull( result, id, persister.getEntityName() );
+		}
+		finally {
+			afterOperation();
 		}
 	}
 
@@ -1378,8 +1383,15 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 	//TODO: COPY/PASTE FROM SessionImpl, pull up!
 
 
+	@Override
 	public void afterOperation(boolean success) {
-		temporaryPersistenceContext.clear();
+		afterOperation();
+	}
+
+	private void afterOperation() {
+		if ( temporaryPersistenceContext.isLoadFinished() ) {
+			temporaryPersistenceContext.clear();
+		}
 		if ( !isTransactionInProgress() ) {
 			getJdbcCoordinator().afterTransaction();
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/FindMutipleTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/FindMutipleTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import static org.hibernate.ReadOnlyMode.READ_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,6 +47,21 @@ public class FindMutipleTest {
 			assertSame(record, all.get(0));
 		});
 	}
+
+	@Test void testNonTransactional(SessionFactoryScope scope) {
+		scope.inTransaction(s-> {
+			s.persist(new Record(789L,"hello earth"));
+			s.persist(new Record(101L,"hello mars"));
+		});
+		scope.inSession(s-> {
+			List<Record> all = s.findMultiple(Record.class, List.of(101L, 789L, 2L));
+			assertEquals("hello mars",all.get(0).message);
+			assertEquals("hello earth",all.get(1).message);
+			assertNull(all.get(2));
+			assertFalse(s.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected());
+		});
+	}
+
 	@Entity(name = "Record")
 	static class Record {
 		@Id Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/GetMultipleTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/GetMultipleTest.java
@@ -15,36 +15,65 @@ import java.util.List;
 
 import static org.hibernate.LockMode.PESSIMISTIC_READ;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SessionFactory
 @DomainModel(annotatedClasses = GetMultipleTest.Record.class)
 public class GetMultipleTest {
 	@Test void test(SessionFactoryScope scope) {
-		scope.inStatelessTransaction(s-> {
-			s.insert(new Record(123L,"hello earth"));
-			s.insert(new Record(456L,"hello mars"));
-		});
-		scope.inStatelessTransaction(s-> {
-			List<Record> all = s.getMultiple(Record.class, List.of(456L, 123L, 2L));
-			assertEquals("hello mars",all.get(0).message);
-			assertEquals("hello earth",all.get(1).message);
-			assertNull(all.get(2));
-		});
-		scope.inStatelessTransaction(s-> {
-			List<Record> all = s.getMultiple(Record.class, List.of(123L, 2L, 456L));
-			assertEquals("hello earth",all.get(0).message);
-			assertEquals("hello mars",all.get(2).message);
-			assertNull(all.get(1));
-		});
-		scope.inStatelessTransaction(s-> {
-			List<Record> all = s.getMultiple(Record.class, List.of(456L, 123L, 2L), PESSIMISTIC_READ);
-			assertEquals("hello mars",all.get(0).message);
-			assertEquals("hello earth",all.get(1).message);
-			assertNull(all.get(2));
-		});
+		scope.inStatelessTransaction( s -> {
+			s.insert( new Record( 123L, "hello earth" ) );
+			s.insert( new Record( 456L, "hello mars" ) );
+		} );
+		scope.inStatelessTransaction( s -> {
+			List<Record> all = s.getMultiple( Record.class, List.of( 456L, 123L, 2L ) );
+			assertEquals( "hello mars", all.get( 0 ).message );
+			assertEquals( "hello earth", all.get( 1 ).message );
+			assertNull( all.get( 2 ) );
+		} );
+		scope.inStatelessTransaction( s -> {
+			List<Record> all = s.getMultiple( Record.class, List.of( 123L, 2L, 456L ) );
+			assertEquals( "hello earth", all.get( 0 ).message );
+			assertEquals( "hello mars", all.get( 2 ).message );
+			assertNull( all.get( 1 ) );
+		} );
+		scope.inStatelessTransaction( s -> {
+			List<Record> all = s.getMultiple( Record.class, List.of( 456L, 123L, 2L ), PESSIMISTIC_READ );
+			assertEquals( "hello mars", all.get( 0 ).message );
+			assertEquals( "hello earth", all.get( 1 ).message );
+			assertNull( all.get( 2 ) );
+		} );
 
 	}
+
+	@Test void testNonTransactional(SessionFactoryScope scope) {
+		scope.inStatelessTransaction(s-> {
+			s.insert(new Record(789L,"hello earth"));
+			s.insert(new Record(101L,"hello mars"));
+		});
+		scope.inStatelessSession(s-> {
+			List<Record> all = s.getMultiple(Record.class, List.of(101L, 789L, 2L));
+			assertEquals("hello mars",all.get(0).message);
+			assertEquals("hello earth",all.get(1).message);
+			assertNull(all.get(2));
+			assertFalse(s.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected());
+		});
+	}
+
+	@Test void testRefreshNonTransactional(SessionFactoryScope scope) {
+		scope.inStatelessTransaction(s-> {
+			s.insert(new Record(999L,"hello world"));
+		});
+		scope.inStatelessSession(s-> {
+			Record record = s.get(Record.class, 999L);
+			record.message = "changed";
+			s.refresh(record);
+			assertEquals("hello world", record.message);
+			assertFalse(s.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected());
+		});
+	}
+
 	@Entity(name = "Record")
 	static class Record {
 		@Id Long id;


### PR DESCRIPTION
* backport of https://github.com/hibernate/hibernate-orm/pull/12523

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20495
<!-- Hibernate GitHub Bot issue links end -->

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20495 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->