### PR TITLE
add covariant override for defaultToOneFetchType()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceConfiguration.java
@@ -8,6 +8,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.PersistenceConfiguration;
 import jakarta.persistence.PersistenceUnitTransactionType;
 import jakarta.persistence.SchemaManagementAction;
@@ -763,6 +764,13 @@ public class HibernatePersistenceConfiguration extends PersistenceConfiguration 
 	@Nonnull
 	public HibernatePersistenceConfiguration validationMode(@Nonnull ValidationMode validationMode) {
 		super.validationMode( validationMode );
+		return this;
+	}
+
+	@Override
+	@Nonnull
+	public HibernatePersistenceConfiguration defaultToOneFetchType(@Nonnull FetchType defaultToOneFetchType) {
+		super.defaultToOneFetchType( defaultToOneFetchType );
 		return this;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/DefaultToOneFetchTypeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/DefaultToOneFetchTypeTests.java
@@ -91,6 +91,15 @@ public class DefaultToOneFetchTypeTests {
 	}
 
 	@Test
+	void testCovariantPersistenceConfiguration() {
+		final HibernatePersistenceConfiguration configuration = new HibernatePersistenceConfiguration( "unit" )
+				.defaultToOneFetchType( FetchType.LAZY )
+				.jdbcUrl( "jdbc:h2:mem:db_covariant_persistence_configuration" );
+
+		assertThat( configuration.defaultToOneFetchType() ).isEqualTo( FetchType.LAZY );
+	}
+
+	@Test
 	void testEagerPersistenceConfiguration() {
 		try( final EntityManagerFactory emf = new HibernatePersistenceConfiguration( "unit" )
 				.defaultToOneFetchType( FetchType.EAGER )


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
