### PR TITLE
HHH-20505 support CacheStoreMode, CacheRetrieveMode, BatchSize as FetchOptions

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
@@ -468,9 +468,11 @@ public interface SessionFactory extends EntityManagerFactory, Referenceable, Ser
 	/**
 	 * Obtain direct access to the underlying cache regions.
 	 *
-	 * @return The direct cache access API.
+	 * @return The direct cache access API, which is never null,
+	 * not even when the second-level cache is disabled.
 	 */
 	@Override
+	@Nonnull
 	Cache getCache();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/CollectionDataAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/CollectionDataAccess.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.cache.spi.access;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -32,6 +33,7 @@ public interface CollectionDataAccess extends CachedDomainDataAccess {
 	 *
 	 * @return a key which can be used to identify this collection on this same region
 	 */
+	@NonNull
 	Object generateCacheKey(
 			Object id,
 			CollectionPersister collectionDescriptor,

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/EntityDataAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/EntityDataAccess.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.cache.spi.access;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.cache.CacheException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -37,6 +38,7 @@ public interface EntityDataAccess extends CachedDomainDataAccess {
 	 *
 	 * todo (6.0) : the access for an entity knows the entity hierarchy and the factory.  why pass them in?
 	 */
+	@NonNull
 	Object generateCacheKey(
 			Object id,
 			EntityPersister rootEntityDescriptor,

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractCollectionDataAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractCollectionDataAccess.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.cache.spi.support;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.hibernate.cache.cfg.spi.CollectionDataCachingConfig;
 import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.DomainDataRegion;
@@ -32,6 +33,7 @@ public abstract class AbstractCollectionDataAccess
 	}
 
 	@Override
+	@NonNull
 	public Object generateCacheKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
 		return keysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractEntityDataAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractEntityDataAccess.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.cache.spi.support;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.DomainDataRegion;
 import org.hibernate.cache.spi.access.EntityDataAccess;
@@ -30,6 +31,7 @@ public abstract class AbstractEntityDataAccess
 	}
 
 	@Override
+	@NonNull
 	public Object generateCacheKey(
 			Object id,
 			EntityPersister rootEntityDescriptor,

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/CollectionReadWriteAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/CollectionReadWriteAccess.java
@@ -6,6 +6,7 @@ package org.hibernate.cache.spi.support;
 
 import java.util.Comparator;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.hibernate.cache.cfg.spi.CollectionDataCachingConfig;
 import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.DomainDataRegion;
@@ -48,6 +49,7 @@ public class CollectionReadWriteAccess extends AbstractReadWriteAccess implement
 	}
 
 	@Override
+	@NonNull
 	public Object generateCacheKey(
 			Object id,
 			CollectionPersister collectionDescriptor,

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/EntityReadWriteAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/EntityReadWriteAccess.java
@@ -6,6 +6,7 @@ package org.hibernate.cache.spi.support;
 
 import java.util.Comparator;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.hibernate.cache.cfg.spi.EntityDataCachingConfig;
 import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.DomainDataRegion;
@@ -58,6 +59,7 @@ public class EntityReadWriteAccess extends AbstractReadWriteAccess implements En
 	}
 
 	@Override
+	@NonNull
 	public Object generateCacheKey(
 			Object id,
 			EntityPersister rootEntityDescriptor,

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
@@ -4,11 +4,9 @@
  */
 package org.hibernate.collection.spi;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -49,10 +47,8 @@ public interface CollectionInitializerProducer {
 			InitializerParent<?> parent,
 			LockMode lockMode,
 			DomainResult<?> collectionKeyResult,
-				DomainResult<?> collectionValueKeyResult,
-				boolean isResultInitializer,
-				CacheStoreMode cacheStoreMode,
-				CacheRetrieveMode cacheRetrieveMode,
-				Integer batchSize,
-				AssemblerCreationState creationState);
+			DomainResult<?> collectionValueKeyResult,
+			boolean isResultInitializer,
+			FetchOptions fetchOptions,
+			AssemblerCreationState creationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.collection.spi;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -48,5 +50,6 @@ public interface CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.Incubating;
@@ -51,5 +52,6 @@ public interface CollectionInitializerProducer {
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
@@ -49,9 +49,10 @@ public interface CollectionInitializerProducer {
 			InitializerParent<?> parent,
 			LockMode lockMode,
 			DomainResult<?> collectionKeyResult,
-			DomainResult<?> collectionValueKeyResult,
-			boolean isResultInitializer,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			AssemblerCreationState creationState);
+				DomainResult<?> collectionValueKeyResult,
+				boolean isResultInitializer,
+				CacheStoreMode cacheStoreMode,
+				CacheRetrieveMode cacheRetrieveMode,
+				Integer batchSize,
+				AssemblerCreationState creationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
@@ -21,6 +21,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jboss.logging.Logger;
 
 import static org.hibernate.engine.internal.CacheHelper.fromSharedCache;
+import static org.hibernate.internal.util.NullnessUtil.castNonNull;
 import static org.hibernate.internal.util.collections.CollectionHelper.linkedMapOfSize;
 import static org.hibernate.internal.util.collections.CollectionHelper.linkedSetOfSize;
 import static org.hibernate.internal.util.collections.CollectionHelper.mapOfSize;
@@ -458,7 +459,7 @@ public class BatchFetchQueue {
 	private boolean isCached(Object collectionKey, CollectionPersister persister) {
 		final var session = getSession();
 		if ( session.getCacheMode().isGetEnabled() && persister.hasCache() ) {
-			final var cache = persister.getCacheAccessStrategy();
+			final var cache = castNonNull( persister.getCacheAccessStrategy() );
 			final Object cacheKey =
 					cache.generateCacheKey( collectionKey, persister,
 							session.getFactory(), session.getTenantIdentifier() );
@@ -472,7 +473,7 @@ public class BatchFetchQueue {
 	private boolean isCached(EntityKey entityKey, EntityPersister persister) {
 		final var session = getSession();
 		if ( session.getCacheMode().isGetEnabled() && persister.canReadFromCache() ) {
-			final var cache = persister.getCacheAccessStrategy();
+			final var cache = castNonNull( persister.getCacheAccessStrategy() );
 			final Object key =
 					cache.generateCacheKey( entityKey.getIdentifier(), persister,
 							session.getFactory(), session.getTenantIdentifier() );

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/FetchOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/FetchOptions.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.engine.spi;
+
+import java.io.Serializable;
+
+import jakarta.persistence.AttributeNode;
+import jakarta.persistence.BatchSize;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+
+import org.hibernate.CacheMode;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * {@linkplain jakarta.persistence.FetchOption Fetch options}
+ * applied to a particular association fetch.
+ *
+ * @since 6.0
+ * @author Gavin King
+ */
+public record FetchOptions(
+		@Nullable CacheStoreMode cacheStoreMode,
+		@Nullable CacheRetrieveMode cacheRetrieveMode,
+		@Nullable Integer batchSize)
+				implements Serializable {
+
+	public static final FetchOptions NONE = new FetchOptions( null, null, null );
+
+	public static FetchOptions of(
+			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize) {
+		return cacheStoreMode == null
+			&& cacheRetrieveMode == null
+			&& batchSize == null
+				? NONE
+				: new FetchOptions( cacheStoreMode, cacheRetrieveMode, batchSize );
+	}
+
+	public static FetchOptions of(AttributeNode<?> node) {
+		return node == null
+				? NONE
+				: of( cacheStoreMode( node ), cacheRetrieveMode( node ), batchSize( node ) );
+	}
+
+	private static @Nullable CacheStoreMode cacheStoreMode(AttributeNode<?> node) {
+		for ( var option : node.getOptions() ) {
+			if ( option instanceof CacheStoreMode cacheStoreMode ) {
+				return cacheStoreMode;
+			}
+		}
+		return null;
+	}
+
+	private static @Nullable CacheRetrieveMode cacheRetrieveMode(AttributeNode<?> node) {
+		for ( var option : node.getOptions() ) {
+			if ( option instanceof CacheRetrieveMode cacheRetrieveMode ) {
+				return cacheRetrieveMode;
+			}
+		}
+		return null;
+	}
+
+	private static @Nullable Integer batchSize(AttributeNode<?> node) {
+		for ( var option : node.getOptions() ) {
+			if ( option instanceof BatchSize batchSize
+					&& batchSize.batchSize() >= 0 ) {
+				return batchSize.batchSize();
+			}
+		}
+		return null;
+	}
+
+	public boolean hasOptions() {
+		return this != NONE
+			&& ( cacheStoreMode != null || cacheRetrieveMode != null || batchSize != null );
+	}
+
+	public boolean hasCacheModes() {
+		return cacheStoreMode != null || cacheRetrieveMode != null;
+	}
+
+	public boolean hasBatchSize() {
+		return batchSize != null;
+	}
+
+	public CacheMode overrideCacheMode(CacheMode previousCacheMode) {
+		return CacheMode.fromJpaModes(
+				cacheRetrieveMode == null
+						? previousCacheMode.getJpaRetrieveMode()
+						: cacheRetrieveMode,
+				cacheStoreMode == null
+						? previousCacheMode.getJpaStoreMode()
+						: cacheStoreMode
+		);
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -57,6 +57,7 @@ public class LoadQueryInfluencers implements Serializable {
 	private boolean subselectFetchEnabled;
 
 	private int batchSize;
+	private @Nullable Integer batchSizeOverride;
 
 	private final EffectiveEntityGraph effectiveEntityGraph;
 
@@ -301,7 +302,28 @@ public class LoadQueryInfluencers implements Serializable {
 		this.batchSize = batchSize;
 	}
 
+	public boolean hasBatchSizeOverride() {
+		return batchSizeOverride != null;
+	}
+
+	public <T> T fromBatchSize(@Nullable Integer batchSize, Supplier<T> supplier) {
+		if ( batchSize == null ) {
+			return supplier.get();
+		}
+		final var previous = batchSizeOverride;
+		batchSizeOverride = batchSize;
+		try {
+			return supplier.get();
+		}
+		finally {
+			batchSizeOverride = previous;
+		}
+	}
+
 	public int effectiveBatchSize(CollectionPersister persister) {
+		if ( batchSizeOverride != null ) {
+			return batchSizeOverride;
+		}
 		final int persisterBatchSize = persister.getBatchSize();
 		// persister-specific batch size overrides global setting
 		// (note that due to legacy, -1 means no explicit setting)
@@ -309,10 +331,16 @@ public class LoadQueryInfluencers implements Serializable {
 	}
 
 	public boolean effectivelyBatchLoadable(CollectionPersister persister) {
+		if ( batchSizeOverride != null ) {
+			return batchSizeOverride > 1;
+		}
 		return persister.isBatchLoadable() || effectiveBatchSize( persister ) > 1;
 	}
 
 	public int effectiveBatchSize(EntityPersister persister) {
+		if ( batchSizeOverride != null ) {
+			return batchSizeOverride;
+		}
 		final int persisterBatchSize = persister.getBatchSize();
 		// persister-specific batch size overrides global setting
 		// (note that due to legacy, -1 means no explicit setting)
@@ -320,6 +348,9 @@ public class LoadQueryInfluencers implements Serializable {
 	}
 
 	public boolean effectivelyBatchLoadable(EntityPersister persister) {
+		if ( batchSizeOverride != null ) {
+			return batchSizeOverride > 1;
+		}
 		return persister.isBatchLoadable() || effectiveBatchSize( persister ) > 1;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -57,7 +57,7 @@ public class LoadQueryInfluencers implements Serializable {
 	private boolean subselectFetchEnabled;
 
 	private int batchSize;
-	private @Nullable Integer batchSizeOverride;
+	private FetchOptions fetchOptions = FetchOptions.NONE;
 
 	private final EffectiveEntityGraph effectiveEntityGraph;
 
@@ -303,55 +303,81 @@ public class LoadQueryInfluencers implements Serializable {
 	}
 
 	public boolean hasBatchSizeOverride() {
-		return batchSizeOverride != null;
+		return fetchOptions.hasBatchSize();
 	}
 
-	public <T> T fromBatchSize(@Nullable Integer batchSize, Supplier<T> supplier) {
-		if ( batchSize == null ) {
+	public <T> T withFetchOptions(SharedSessionContractImplementor session, FetchOptions options, Supplier<T> supplier) {
+		if ( !options.hasOptions() && !fetchOptions.hasOptions() ) {
 			return supplier.get();
 		}
-		final var previous = batchSizeOverride;
-		batchSizeOverride = batchSize;
-		try {
-			return supplier.get();
-		}
-		finally {
-			batchSizeOverride = previous;
+		else {
+			final var previousOptions = fetchOptions;
+			fetchOptions = options;
+			try {
+				if ( fetchOptions.hasCacheModes() ) {
+					final var previousCacheMode = session.getCacheMode();
+					final var effectiveCacheMode = fetchOptions.overrideCacheMode( previousCacheMode );
+					final boolean overrideCacheMode = effectiveCacheMode != previousCacheMode;
+					if ( overrideCacheMode ) {
+						session.setCacheMode( effectiveCacheMode );
+					}
+					try {
+						return supplier.get();
+					}
+					finally {
+						if ( overrideCacheMode ) {
+							session.setCacheMode( previousCacheMode );
+						}
+					}
+				}
+				else {
+					return supplier.get();
+				}
+			}
+			finally {
+				this.fetchOptions = previousOptions;
+			}
 		}
 	}
 
 	public int effectiveBatchSize(CollectionPersister persister) {
+		final var batchSizeOverride = fetchOptions.batchSize();
 		if ( batchSizeOverride != null ) {
 			return batchSizeOverride;
 		}
-		final int persisterBatchSize = persister.getBatchSize();
-		// persister-specific batch size overrides global setting
-		// (note that due to legacy, -1 means no explicit setting)
-		return persisterBatchSize >= 0 ? persisterBatchSize : batchSize;
+		else {
+			final int persisterBatchSize = persister.getBatchSize();
+			// persister-specific batch size overrides global setting
+			// (note that due to legacy, -1 means no explicit setting)
+			return persisterBatchSize >= 0 ? persisterBatchSize : batchSize;
+		}
 	}
 
 	public boolean effectivelyBatchLoadable(CollectionPersister persister) {
-		if ( batchSizeOverride != null ) {
-			return batchSizeOverride > 1;
-		}
-		return persister.isBatchLoadable() || effectiveBatchSize( persister ) > 1;
+		final var batchSizeOverride = fetchOptions.batchSize();
+		return batchSizeOverride == null
+				? persister.isBatchLoadable() || effectiveBatchSize( persister ) > 1
+				: batchSizeOverride > 1;
 	}
 
 	public int effectiveBatchSize(EntityPersister persister) {
+		final var batchSizeOverride = fetchOptions.batchSize();
 		if ( batchSizeOverride != null ) {
 			return batchSizeOverride;
 		}
-		final int persisterBatchSize = persister.getBatchSize();
-		// persister-specific batch size overrides global setting
-		// (note that due to legacy, -1 means no explicit setting)
-		return persisterBatchSize >= 0 ? persisterBatchSize : batchSize;
+		else {
+			final int persisterBatchSize = persister.getBatchSize();
+			// persister-specific batch size overrides global setting
+			// (note that due to legacy, -1 means no explicit setting)
+			return persisterBatchSize >= 0 ? persisterBatchSize : batchSize;
+		}
 	}
 
 	public boolean effectivelyBatchLoadable(EntityPersister persister) {
-		if ( batchSizeOverride != null ) {
-			return batchSizeOverride > 1;
-		}
-		return persister.isBatchLoadable() || effectiveBatchSize( persister ) > 1;
+		final var batchSizeOverride = fetchOptions.batchSize();
+		return batchSizeOverride == null
+				? persister.isBatchLoadable() || effectiveBatchSize( persister ) > 1
+				: batchSizeOverride > 1;
 	}
 
 	public boolean getSubselectFetchEnabled() {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -101,6 +101,7 @@ public interface SessionFactoryImplementor extends SessionFactory {
 	 * Obtain the {@link CacheImplementor}.
 	 */
 	@Override
+	@Nonnull
 	CacheImplementor getCache();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
@@ -74,7 +74,8 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 					loadedPersister,
 					collection,
 					loadedKey,
-					true
+					true,
+					null
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -1012,6 +1012,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 	}
 
 	@Override
+	@Nonnull
 	public CacheImplementor getCache() {
 		validateNotClosed();
 		return cacheAccess;

--- a/hibernate-core/src/main/java/org/hibernate/internal/find/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/find/Helper.java
@@ -57,6 +57,23 @@ public class Helper {
 		}
 	}
 
+	public static Object[] coerceIds(EntityPersister entityPersister, List<?> keys, SharedSessionContractImplementor session) {
+		Object[] ids = null;
+		final int size = keys.size();
+		for ( int i = 0; i < size; i++ ) {
+			final var factory = session.getFactory();
+			final Object key = keys.get( i );
+			final Object coerced = coerceId( entityPersister, key, factory );
+			if ( coerced != key ) {
+				if ( ids == null ) {
+					ids = new Object[size];
+				}
+				ids[i] = coerced;
+			}
+		}
+		return ids == null ? keys.toArray() : ids;
+	}
+
 	public static Object coerceNaturalId(EntityPersister entityPersister, Object key) {
 		var naturalIdMapping = entityPersister.getNaturalIdMapping();
 		assert naturalIdMapping != null;

--- a/hibernate-core/src/main/java/org/hibernate/internal/find/StatefulFindMultipleByKeyOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/find/StatefulFindMultipleByKeyOperation.java
@@ -17,6 +17,7 @@ import org.hibernate.ReadOnlyMode;
 import org.hibernate.RemovalsMode;
 import org.hibernate.SessionCheckMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.persister.entity.EntityPersister;
@@ -54,25 +55,24 @@ public class StatefulFindMultipleByKeyOperation<T> extends AbstractFindMultipleB
 			List<?> keys,
 			@Nullable GraphSemantic graphSemantic,
 			@Nullable RootGraphImplementor<T> rootGraph) {
-		checkFindRequirements( keys, loadAccessContext.getSession() );
-
+		final var session = loadAccessContext.getSession();
+		checkFindRequirements( keys, session );
 		// todo (natural-id-class) : these impls are temporary
 		//		longer term, move the logic here as much of it can be shared
 		return getKeyType() == KeyType.NATURAL
-				? findByNaturalIds( keys, graphSemantic, rootGraph, loadAccessContext )
-				: findByIds( keys, graphSemantic, rootGraph, loadAccessContext );
+				? findByNaturalIds( keys, graphSemantic, rootGraph )
+				: findByIds( keys, graphSemantic, rootGraph );
 	}
 
-	private List<T> findByNaturalIds(List<?> keys, GraphSemantic graphSemantic, RootGraphImplementor<T> rootGraph, StatefulLoadAccessContext loadAccessContext) {
-		final var naturalIdMapping = getEntityDescriptor().requireNaturalIdMapping();
+	private List<T> findByNaturalIds(List<?> keys, GraphSemantic graphSemantic, RootGraphImplementor<T> rootGraph) {
+		final var entityDescriptor = getEntityDescriptor();
+		final var naturalIdMapping = entityDescriptor.requireNaturalIdMapping();
 		final var session = loadAccessContext.getSession();
-
 		performAnyNeededCrossReferenceSynchronizations(
 				getNaturalIdSynchronization() != NaturalIdSynchronization.DISABLED,
-				getEntityDescriptor(),
+				entityDescriptor,
 				session
 		);
-
 		return withOptions( loadAccessContext, graphSemantic, rootGraph, () -> {
 			// normalize the incoming natural-id values and get them in array form as needed
 			// by MultiNaturalIdLoader
@@ -81,9 +81,8 @@ public class StatefulFindMultipleByKeyOperation<T> extends AbstractFindMultipleB
 				final Object key = keys.get( i );
 				naturalIds[i] = naturalIdMapping.normalizeInput( key );
 			}
-
 			//noinspection unchecked
-			return (List<T>)getEntityDescriptor().getMultiNaturalIdLoader()
+			return (List<T>) entityDescriptor.getMultiNaturalIdLoader()
 					.multiLoad( naturalIds, this, session );
 		} );
 	}
@@ -133,11 +132,15 @@ public class StatefulFindMultipleByKeyOperation<T> extends AbstractFindMultipleB
 				.findCachedIdByNaturalId( normalizedNaturalIdValue, getEntityDescriptor() );
 	}
 
-	private List<T> findByIds(List<?> keys, GraphSemantic graphSemantic, RootGraphImplementor<T> rootGraph, StatefulLoadAccessContext loadAccessContext) {
-		final Object[] ids = keys.toArray( new Object[0] );
+	private List<T> findByIds(
+			List<?> keys,
+			GraphSemantic graphSemantic,
+			RootGraphImplementor<T> rootGraph) {
+		final var session = loadAccessContext.getSession();
+		final var ids = Helper.coerceIds( getEntityDescriptor(),keys, session );
 		//noinspection unchecked
 		return withOptions( loadAccessContext, graphSemantic, rootGraph,
-				() -> (List<T>) getEntityDescriptor().multiLoad( ids, loadAccessContext.getSession(), this ) );
+				() -> (List<T>) getEntityDescriptor().multiLoad( ids, session, this ) );
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/internal/find/StatefulFindMultipleByKeyOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/find/StatefulFindMultipleByKeyOperation.java
@@ -17,7 +17,6 @@ import org.hibernate.ReadOnlyMode;
 import org.hibernate.RemovalsMode;
 import org.hibernate.SessionCheckMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.persister.entity.EntityPersister;

--- a/hibernate-core/src/main/java/org/hibernate/internal/find/StatelessFindMultipleByKeyOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/find/StatelessFindMultipleByKeyOperation.java
@@ -53,7 +53,6 @@ public class StatelessFindMultipleByKeyOperation<T> extends AbstractFindMultiple
 			@Nullable GraphSemantic graphSemantic,
 			@Nullable RootGraphImplementor<T> rootGraph) {
 		checkFindRequirements( keys, loadAccessContext.getStatelessSession() );
-
 		return getKeyType() == KeyType.NATURAL
 				? findByNaturalIds( keys, graphSemantic, rootGraph )
 				: findByIds( keys, graphSemantic, rootGraph );
@@ -71,9 +70,10 @@ public class StatelessFindMultipleByKeyOperation<T> extends AbstractFindMultiple
 			GraphSemantic graphSemantic,
 			RootGraphImplementor<T> rootGraph) {
 		var session = loadAccessContext.getStatelessSession();
+		final var ids = Helper.coerceIds( getEntityDescriptor(), keys, session );
 		return withOptions( session, graphSemantic, rootGraph, () -> {
 			// todo (jpa4) : make sure loading from cache happens inside here
-			final var results = getEntityDescriptor().multiLoad( keys.toArray(), session, multiLoadOptions( getLockMode() ) );
+			final var results = getEntityDescriptor().multiLoad( ids, session, multiLoadOptions( getLockMode() ) );
 			//noinspection unchecked
 			return (List<T>) results;
 		} );

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractCollectionBatchLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractCollectionBatchLoader.java
@@ -112,7 +112,8 @@ public abstract class AbstractCollectionBatchLoader implements CollectionBatchLo
 						entry.getLoadedPersister(),
 						collection,
 						key,
-						true
+						true,
+						null
 				);
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderSubSelectFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderSubSelectFetch.java
@@ -140,7 +140,8 @@ public class CollectionLoaderSubSelectFetch implements CollectionLoader {
 									persister,
 									c,
 									NullnessUtil.castNonNull( c.getKey() ),
-									true
+									true,
+									null
 							);
 						}
 					}

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -827,18 +827,7 @@ public class LoaderSelectBuilder {
 				if ( entityGraphTraversalState != null ) {
 					traversalResult = entityGraphTraversalState.traverse( fetchParent, fetchable, isKeyFetchable );
 					final var fetchStrategy = traversalResult.getFetchStrategy();
-					creationState.registerFetchCacheStoreMode(
-							fetchablePath,
-							traversalResult.getCacheStoreMode()
-					);
-					creationState.registerFetchCacheRetrieveMode(
-							fetchablePath,
-							traversalResult.getCacheRetrieveMode()
-					);
-					creationState.registerFetchBatchSize(
-							fetchablePath,
-							traversalResult.getBatchSize()
-					);
+					creationState.registerFetchOptions( fetchablePath, traversalResult.getFetchOptions() );
 					if ( fetchStrategy != null ) {
 						fetchTiming = fetchStrategy.getFetchTiming();
 						joined = fetchStrategy.isJoined();

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -827,6 +827,10 @@ public class LoaderSelectBuilder {
 				if ( entityGraphTraversalState != null ) {
 					traversalResult = entityGraphTraversalState.traverse( fetchParent, fetchable, isKeyFetchable );
 					final var fetchStrategy = traversalResult.getFetchStrategy();
+					creationState.registerFetchCacheStoreMode(
+							fetchablePath,
+							traversalResult.getCacheStoreMode()
+					);
 					if ( fetchStrategy != null ) {
 						fetchTiming = fetchStrategy.getFetchTiming();
 						joined = fetchStrategy.isJoined();

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -831,6 +831,10 @@ public class LoaderSelectBuilder {
 							fetchablePath,
 							traversalResult.getCacheStoreMode()
 					);
+					creationState.registerFetchCacheRetrieveMode(
+							fetchablePath,
+							traversalResult.getCacheRetrieveMode()
+					);
 					if ( fetchStrategy != null ) {
 						fetchTiming = fetchStrategy.getFetchTiming();
 						joined = fetchStrategy.isJoined();

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -835,6 +835,10 @@ public class LoaderSelectBuilder {
 							fetchablePath,
 							traversalResult.getCacheRetrieveMode()
 					);
+					creationState.registerFetchBatchSize(
+							fetchablePath,
+							traversalResult.getBatchSize()
+					);
 					if ( fetchStrategy != null ) {
 						fetchTiming = fetchStrategy.getFetchTiming();
 						joined = fetchStrategy.isJoined();

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
@@ -70,6 +70,7 @@ public class LoaderSqlAstCreationState
 	private ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide;
 	private final Set<AssociationKey> visitedAssociationKeys = new HashSet<>();
 	private Map<NavigablePath, CacheStoreMode> fetchCacheStoreModes;
+	private Map<NavigablePath, CacheRetrieveMode> fetchCacheRetrieveModes;
 
 	public LoaderSqlAstCreationState(
 			QueryPart queryPart,
@@ -220,6 +221,21 @@ public class LoaderSqlAstCreationState
 	@Override
 	public CacheStoreMode getFetchCacheStoreMode(NavigablePath fetchablePath) {
 		return fetchCacheStoreModes == null ? null : fetchCacheStoreModes.get( fetchablePath );
+	}
+
+	@Override
+	public void registerFetchCacheRetrieveMode(NavigablePath fetchablePath, CacheRetrieveMode cacheRetrieveMode) {
+		if ( cacheRetrieveMode != null ) {
+			if ( fetchCacheRetrieveModes == null ) {
+				fetchCacheRetrieveModes = new HashMap<>();
+			}
+			fetchCacheRetrieveModes.put( fetchablePath, cacheRetrieveMode );
+		}
+	}
+
+	@Override
+	public CacheRetrieveMode getFetchCacheRetrieveMode(NavigablePath fetchablePath) {
+		return fetchCacheRetrieveModes == null ? null : fetchCacheRetrieveModes.get( fetchablePath );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
@@ -71,6 +71,7 @@ public class LoaderSqlAstCreationState
 	private final Set<AssociationKey> visitedAssociationKeys = new HashSet<>();
 	private Map<NavigablePath, CacheStoreMode> fetchCacheStoreModes;
 	private Map<NavigablePath, CacheRetrieveMode> fetchCacheRetrieveModes;
+	private Map<NavigablePath, Integer> fetchBatchSizes;
 
 	public LoaderSqlAstCreationState(
 			QueryPart queryPart,
@@ -236,6 +237,21 @@ public class LoaderSqlAstCreationState
 	@Override
 	public CacheRetrieveMode getFetchCacheRetrieveMode(NavigablePath fetchablePath) {
 		return fetchCacheRetrieveModes == null ? null : fetchCacheRetrieveModes.get( fetchablePath );
+	}
+
+	@Override
+	public void registerFetchBatchSize(NavigablePath fetchablePath, Integer batchSize) {
+		if ( batchSize != null ) {
+			if ( fetchBatchSizes == null ) {
+				fetchBatchSizes = new HashMap<>();
+			}
+			fetchBatchSizes.put( fetchablePath, batchSize );
+		}
+	}
+
+	@Override
+	public Integer getFetchBatchSize(NavigablePath fetchablePath) {
+		return fetchBatchSizes == null ? null : fetchBatchSizes.get( fetchablePath );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
@@ -41,6 +41,7 @@ import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.internal.ImmutableFetchList;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +69,7 @@ public class LoaderSqlAstCreationState
 	private boolean resolvingCircularFetch;
 	private ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide;
 	private final Set<AssociationKey> visitedAssociationKeys = new HashSet<>();
+	private Map<NavigablePath, CacheStoreMode> fetchCacheStoreModes;
 
 	public LoaderSqlAstCreationState(
 			QueryPart queryPart,
@@ -203,6 +205,21 @@ public class LoaderSqlAstCreationState
 	@Override
 	public void setCurrentlyResolvingForeignKeyPart(ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide) {
 		this.currentlyResolvingForeignKeySide = currentlyResolvingForeignKeySide;
+	}
+
+	@Override
+	public void registerFetchCacheStoreMode(NavigablePath fetchablePath, CacheStoreMode cacheStoreMode) {
+		if ( cacheStoreMode != null ) {
+			if ( fetchCacheStoreModes == null ) {
+				fetchCacheStoreModes = new HashMap<>();
+			}
+			fetchCacheStoreModes.put( fetchablePath, cacheStoreMode );
+		}
+	}
+
+	@Override
+	public CacheStoreMode getFetchCacheStoreMode(NavigablePath fetchablePath) {
+		return fetchCacheStoreModes == null ? null : fetchCacheStoreModes.get( fetchablePath );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
@@ -4,12 +4,13 @@
  */
 package org.hibernate.loader.ast.internal;
 
+import jakarta.persistence.Timeout;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
-import jakarta.persistence.Timeout;
 import org.hibernate.FlushMode;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.graph.spi.AppliedGraph;
 import org.hibernate.metamodel.mapping.AssociationKey;
@@ -69,9 +70,7 @@ public class LoaderSqlAstCreationState
 	private boolean resolvingCircularFetch;
 	private ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide;
 	private final Set<AssociationKey> visitedAssociationKeys = new HashSet<>();
-	private Map<NavigablePath, CacheStoreMode> fetchCacheStoreModes;
-	private Map<NavigablePath, CacheRetrieveMode> fetchCacheRetrieveModes;
-	private Map<NavigablePath, Integer> fetchBatchSizes;
+	private Map<NavigablePath, FetchOptions> fetchOptions;
 
 	public LoaderSqlAstCreationState(
 			QueryPart queryPart,
@@ -210,48 +209,18 @@ public class LoaderSqlAstCreationState
 	}
 
 	@Override
-	public void registerFetchCacheStoreMode(NavigablePath fetchablePath, CacheStoreMode cacheStoreMode) {
-		if ( cacheStoreMode != null ) {
-			if ( fetchCacheStoreModes == null ) {
-				fetchCacheStoreModes = new HashMap<>();
+	public void registerFetchOptions(NavigablePath fetchablePath, FetchOptions fetchOptions) {
+		if ( fetchOptions.hasOptions() ) {
+			if ( this.fetchOptions == null ) {
+				this.fetchOptions = new HashMap<>();
 			}
-			fetchCacheStoreModes.put( fetchablePath, cacheStoreMode );
+			this.fetchOptions.put( fetchablePath, fetchOptions );
 		}
 	}
 
 	@Override
-	public CacheStoreMode getFetchCacheStoreMode(NavigablePath fetchablePath) {
-		return fetchCacheStoreModes == null ? null : fetchCacheStoreModes.get( fetchablePath );
-	}
-
-	@Override
-	public void registerFetchCacheRetrieveMode(NavigablePath fetchablePath, CacheRetrieveMode cacheRetrieveMode) {
-		if ( cacheRetrieveMode != null ) {
-			if ( fetchCacheRetrieveModes == null ) {
-				fetchCacheRetrieveModes = new HashMap<>();
-			}
-			fetchCacheRetrieveModes.put( fetchablePath, cacheRetrieveMode );
-		}
-	}
-
-	@Override
-	public CacheRetrieveMode getFetchCacheRetrieveMode(NavigablePath fetchablePath) {
-		return fetchCacheRetrieveModes == null ? null : fetchCacheRetrieveModes.get( fetchablePath );
-	}
-
-	@Override
-	public void registerFetchBatchSize(NavigablePath fetchablePath, Integer batchSize) {
-		if ( batchSize != null ) {
-			if ( fetchBatchSizes == null ) {
-				fetchBatchSizes = new HashMap<>();
-			}
-			fetchBatchSizes.put( fetchablePath, batchSize );
-		}
-	}
-
-	@Override
-	public Integer getFetchBatchSize(NavigablePath fetchablePath) {
-		return fetchBatchSizes == null ? null : fetchBatchSizes.get( fetchablePath );
+	public FetchOptions getFetchOptions(NavigablePath fetchablePath) {
+		return fetchOptions == null ? FetchOptions.NONE : fetchOptions.getOrDefault( fetchablePath, FetchOptions.NONE );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/Loadable.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/Loadable.java
@@ -50,7 +50,8 @@ public interface Loadable extends ModelPart, RootTableGroupProducer {
 	}
 
 	default boolean isAffectedByBatchSize(LoadQueryInfluencers influencers) {
-		return influencers.getBatchSize() > 0
+		return influencers.hasBatchSizeOverride()
+			|| influencers.getBatchSize() > 0
 			&& influencers.getBatchSize() != getBatchSize();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -688,6 +688,7 @@ public class PluralAttributeMappingImpl
 				collectionKeyResult,
 				unfetched,
 				null,
+				null,
 				null
 		);
 	}
@@ -699,7 +700,8 @@ public class PluralAttributeMappingImpl
 			DomainResult<?> collectionKeyResult,
 			boolean unfetched,
 			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode) {
+			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize) {
 		return new DelayedCollectionFetch(
 				fetchedPath,
 				fetchedAttribute,
@@ -707,7 +709,8 @@ public class PluralAttributeMappingImpl
 				collectionKeyResult,
 				unfetched,
 				cacheStoreMode,
-				cacheRetrieveMode
+				cacheRetrieveMode,
+				batchSize
 		);
 	}
 
@@ -725,6 +728,7 @@ public class PluralAttributeMappingImpl
 				collectionKeyDomainResult,
 				fetchParent,
 				null,
+				null,
 				null
 		);
 	}
@@ -735,14 +739,16 @@ public class PluralAttributeMappingImpl
 			DomainResult<?> collectionKeyDomainResult,
 			FetchParent fetchParent,
 			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode) {
+			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize) {
 		return new SelectEagerCollectionFetch(
 				fetchedPath,
 				fetchedAttribute,
 				collectionKeyDomainResult,
 				fetchParent,
 				cacheStoreMode,
-				cacheRetrieveMode
+				cacheRetrieveMode,
+				batchSize
 		);
 	}
 
@@ -796,7 +802,8 @@ public class PluralAttributeMappingImpl
 				collectionKeyDomainResult( fetchParent, fetchablePath, creationState, sqlAstCreationState ),
 				fetchParent,
 				creationState.getFetchCacheStoreMode( fetchablePath ),
-				creationState.getFetchCacheRetrieveMode( fetchablePath ) );
+				creationState.getFetchCacheRetrieveMode( fetchablePath ),
+				creationState.getFetchBatchSize( fetchablePath ) );
 	}
 
 	private @Nullable DomainResult<?> collectionKeyDomainResult(
@@ -881,7 +888,8 @@ public class PluralAttributeMappingImpl
 				collectionKeyDomainResult,
 				unfetched,
 				creationState.getFetchCacheStoreMode( fetchablePath ),
-				creationState.getFetchCacheRetrieveMode( fetchablePath )
+				creationState.getFetchCacheRetrieveMode( fetchablePath ),
+				creationState.getFetchBatchSize( fetchablePath )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.metamodel.mapping.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.MappingException;
 import org.hibernate.cache.MutableCacheKeyBuilder;
@@ -678,7 +680,31 @@ public class PluralAttributeMappingImpl
 			FetchParent fetchParent,
 			DomainResult<?> collectionKeyResult,
 			boolean unfetched) {
-		return new DelayedCollectionFetch( fetchedPath, fetchedAttribute, fetchParent, collectionKeyResult, unfetched );
+		return buildDelayedCollectionFetch(
+				fetchedPath,
+				fetchedAttribute,
+				fetchParent,
+				collectionKeyResult,
+				unfetched,
+				null
+		);
+	}
+
+	protected Fetch buildDelayedCollectionFetch(
+			NavigablePath fetchedPath,
+			PluralAttributeMapping fetchedAttribute,
+			FetchParent fetchParent,
+			DomainResult<?> collectionKeyResult,
+			boolean unfetched,
+			CacheStoreMode cacheStoreMode) {
+		return new DelayedCollectionFetch(
+				fetchedPath,
+				fetchedAttribute,
+				fetchParent,
+				collectionKeyResult,
+				unfetched,
+				cacheStoreMode
+		);
 	}
 
 	/**
@@ -689,7 +715,28 @@ public class PluralAttributeMappingImpl
 			PluralAttributeMapping fetchedAttribute,
 			DomainResult<?> collectionKeyDomainResult,
 			FetchParent fetchParent) {
-		return new SelectEagerCollectionFetch( fetchedPath, fetchedAttribute, collectionKeyDomainResult, fetchParent );
+		return buildSelectEagerCollectionFetch(
+				fetchedPath,
+				fetchedAttribute,
+				collectionKeyDomainResult,
+				fetchParent,
+				null
+		);
+	}
+
+	protected Fetch buildSelectEagerCollectionFetch(
+			NavigablePath fetchedPath,
+			PluralAttributeMapping fetchedAttribute,
+			DomainResult<?> collectionKeyDomainResult,
+			FetchParent fetchParent,
+			CacheStoreMode cacheStoreMode) {
+		return new SelectEagerCollectionFetch(
+				fetchedPath,
+				fetchedAttribute,
+				collectionKeyDomainResult,
+				fetchParent,
+				cacheStoreMode
+		);
 	}
 
 	/**
@@ -740,7 +787,8 @@ public class PluralAttributeMappingImpl
 			SqlAstCreationState sqlAstCreationState) {
 		return buildSelectEagerCollectionFetch( fetchablePath, this,
 				collectionKeyDomainResult( fetchParent, fetchablePath, creationState, sqlAstCreationState ),
-				fetchParent );
+				fetchParent,
+				creationState.getFetchCacheStoreMode( fetchablePath ) );
 	}
 
 	private @Nullable DomainResult<?> collectionKeyDomainResult(
@@ -823,7 +871,8 @@ public class PluralAttributeMappingImpl
 				this,
 				fetchParent,
 				collectionKeyDomainResult,
-				unfetched
+				unfetched,
+				creationState.getFetchCacheStoreMode( fetchablePath )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -4,9 +4,6 @@
  */
 package org.hibernate.metamodel.mapping.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.MappingException;
 import org.hibernate.cache.MutableCacheKeyBuilder;
@@ -687,9 +684,7 @@ public class PluralAttributeMappingImpl
 				fetchParent,
 				collectionKeyResult,
 				unfetched,
-				null,
-				null,
-				null
+				org.hibernate.engine.spi.FetchOptions.NONE
 		);
 	}
 
@@ -699,18 +694,14 @@ public class PluralAttributeMappingImpl
 			FetchParent fetchParent,
 			DomainResult<?> collectionKeyResult,
 			boolean unfetched,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize) {
+			org.hibernate.engine.spi.FetchOptions fetchOptions) {
 		return new DelayedCollectionFetch(
 				fetchedPath,
 				fetchedAttribute,
 				fetchParent,
 				collectionKeyResult,
 				unfetched,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize
+				fetchOptions
 		);
 	}
 
@@ -727,9 +718,7 @@ public class PluralAttributeMappingImpl
 				fetchedAttribute,
 				collectionKeyDomainResult,
 				fetchParent,
-				null,
-				null,
-				null
+				org.hibernate.engine.spi.FetchOptions.NONE
 		);
 	}
 
@@ -738,17 +727,13 @@ public class PluralAttributeMappingImpl
 			PluralAttributeMapping fetchedAttribute,
 			DomainResult<?> collectionKeyDomainResult,
 			FetchParent fetchParent,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize) {
+			org.hibernate.engine.spi.FetchOptions fetchOptions) {
 		return new SelectEagerCollectionFetch(
 				fetchedPath,
 				fetchedAttribute,
 				collectionKeyDomainResult,
 				fetchParent,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize
+				fetchOptions
 		);
 	}
 
@@ -801,9 +786,7 @@ public class PluralAttributeMappingImpl
 		return buildSelectEagerCollectionFetch( fetchablePath, this,
 				collectionKeyDomainResult( fetchParent, fetchablePath, creationState, sqlAstCreationState ),
 				fetchParent,
-				creationState.getFetchCacheStoreMode( fetchablePath ),
-				creationState.getFetchCacheRetrieveMode( fetchablePath ),
-				creationState.getFetchBatchSize( fetchablePath ) );
+				creationState.getFetchOptions( fetchablePath ) );
 	}
 
 	private @Nullable DomainResult<?> collectionKeyDomainResult(
@@ -887,9 +870,7 @@ public class PluralAttributeMappingImpl
 				fetchParent,
 				collectionKeyDomainResult,
 				unfetched,
-				creationState.getFetchCacheStoreMode( fetchablePath ),
-				creationState.getFetchCacheRetrieveMode( fetchablePath ),
-				creationState.getFetchBatchSize( fetchablePath )
+				creationState.getFetchOptions( fetchablePath )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.metamodel.mapping.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -686,6 +687,7 @@ public class PluralAttributeMappingImpl
 				fetchParent,
 				collectionKeyResult,
 				unfetched,
+				null,
 				null
 		);
 	}
@@ -696,14 +698,16 @@ public class PluralAttributeMappingImpl
 			FetchParent fetchParent,
 			DomainResult<?> collectionKeyResult,
 			boolean unfetched,
-			CacheStoreMode cacheStoreMode) {
+			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode) {
 		return new DelayedCollectionFetch(
 				fetchedPath,
 				fetchedAttribute,
 				fetchParent,
 				collectionKeyResult,
 				unfetched,
-				cacheStoreMode
+				cacheStoreMode,
+				cacheRetrieveMode
 		);
 	}
 
@@ -720,6 +724,7 @@ public class PluralAttributeMappingImpl
 				fetchedAttribute,
 				collectionKeyDomainResult,
 				fetchParent,
+				null,
 				null
 		);
 	}
@@ -729,13 +734,15 @@ public class PluralAttributeMappingImpl
 			PluralAttributeMapping fetchedAttribute,
 			DomainResult<?> collectionKeyDomainResult,
 			FetchParent fetchParent,
-			CacheStoreMode cacheStoreMode) {
+			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode) {
 		return new SelectEagerCollectionFetch(
 				fetchedPath,
 				fetchedAttribute,
 				collectionKeyDomainResult,
 				fetchParent,
-				cacheStoreMode
+				cacheStoreMode,
+				cacheRetrieveMode
 		);
 	}
 
@@ -788,7 +795,8 @@ public class PluralAttributeMappingImpl
 		return buildSelectEagerCollectionFetch( fetchablePath, this,
 				collectionKeyDomainResult( fetchParent, fetchablePath, creationState, sqlAstCreationState ),
 				fetchParent,
-				creationState.getFetchCacheStoreMode( fetchablePath ) );
+				creationState.getFetchCacheStoreMode( fetchablePath ),
+				creationState.getFetchCacheRetrieveMode( fetchablePath ) );
 	}
 
 	private @Nullable DomainResult<?> collectionKeyDomainResult(
@@ -872,7 +880,8 @@ public class PluralAttributeMappingImpl
 				fetchParent,
 				collectionKeyDomainResult,
 				unfetched,
-				creationState.getFetchCacheStoreMode( fetchablePath )
+				creationState.getFetchCacheStoreMode( fetchablePath ),
+				creationState.getFetchCacheRetrieveMode( fetchablePath )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -829,9 +829,9 @@ public abstract class AbstractCollectionPersister
 					return subSelectLoader;
 				}
 			}
-			return attributeMapping.isAffectedByInfluencers( influencers, true )
-					? createCollectionLoader( influencers )
-					: getCollectionLoader();
+				return attributeMapping.isAffectedByInfluencers( influencers, true )
+						? createCollectionLoader( influencers )
+						: getCollectionLoader();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -829,9 +829,9 @@ public abstract class AbstractCollectionPersister
 					return subSelectLoader;
 				}
 			}
-				return attributeMapping.isAffectedByInfluencers( influencers, true )
-						? createCollectionLoader( influencers )
-						: getCollectionLoader();
+			return attributeMapping.isAffectedByInfluencers( influencers, true )
+					? createCollectionLoader( influencers )
+					: getCollectionLoader();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -5,6 +5,7 @@
 package org.hibernate.persister.collection;
 
 import jakarta.persistence.metamodel.PluralAttribute;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.AssertionFailure;
 import org.hibernate.Filter;
@@ -226,8 +227,7 @@ public abstract class AbstractCollectionPersister
 	private final BeforeExecutionGenerator identifierGenerator;
 	private final EntityPersister elementPersister;
 	private final @Nullable CollectionDataAccess cacheAccessStrategy;
-
-	private final CacheEntryStructure cacheEntryStructure;
+	private final @NonNull CacheEntryStructure cacheEntryStructure;
 	private final boolean useShallowQueryCacheLayout;
 
 	// dynamic filters for the collection
@@ -904,6 +904,7 @@ public abstract class AbstractCollectionPersister
 	}
 
 	@Override
+	@Nullable
 	public CollectionDataAccess getCacheAccessStrategy() {
 		return cacheAccessStrategy;
 	}
@@ -1376,6 +1377,7 @@ public abstract class AbstractCollectionPersister
 	}
 
 	@Override
+	@NonNull
 	public CacheEntryStructure getCacheEntryStructure() {
 		return cacheEntryStructure;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
@@ -10,6 +10,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.Filter;
 import org.hibernate.HibernateException;
 import org.hibernate.Incubating;
@@ -205,11 +207,13 @@ public interface CollectionPersister extends Restrictable {
 	/**
 	 * Access to the collection's cache region
 	 */
+	@Nullable
 	CollectionDataAccess getCacheAccessStrategy();
 
 	/**
 	 * Get the structure used to store data into the collection's {@linkplain #getCacheAccessStrategy() cache region}
 	 */
+	@NonNull
 	CacheEntryStructure getCacheEntryStructure();
 
 	@Incubating

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -5,6 +5,7 @@
 package org.hibernate.persister.entity;
 
 import jakarta.persistence.PessimisticLockScope;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.AssertionFailure;
 import org.hibernate.FetchMode;
@@ -407,9 +408,9 @@ public abstract class AbstractEntityPersister
 	private SqmMultiTableMutationStrategy sqmMultiTableMutationStrategy;
 	private SqmMultiTableInsertStrategy sqmMultiTableInsertStrategy;
 
-	private final EntityDataAccess cacheAccessStrategy;
+	private final @Nullable EntityDataAccess cacheAccessStrategy;
 	private final NaturalIdDataAccess naturalIdRegionAccessStrategy;
-	private final CacheEntryHelper cacheEntryHelper;
+	private final @NonNull CacheEntryHelper cacheEntryHelper;
 	private final boolean canReadFromCache;
 	private final boolean canWriteToCache;
 	private final boolean invalidateCache;
@@ -4332,16 +4333,19 @@ public abstract class AbstractEntityPersister
 	}
 
 	@Override
+	@Nullable
 	public EntityDataAccess getCacheAccessStrategy() {
 		return cacheAccessStrategy;
 	}
 
 	@Override
+	@Nullable
 	public CacheEntryStructure getCacheEntryStructure() {
 		return cacheEntryHelper.getCacheEntryStructure();
 	}
 
 	@Override
+	@NonNull
 	public CacheEntry buildCacheEntry(Object entity, Object[] state, Object version, SharedSessionContractImplementor session) {
 		return cacheEntryHelper.buildCacheEntry( entity, state, version, session );
 	}
@@ -5059,8 +5063,10 @@ public abstract class AbstractEntityPersister
 	 * Consolidated these onto a single helper because the 2 pieces work in tandem.
 	 */
 	public interface CacheEntryHelper {
+		@NonNull
 		CacheEntryStructure getCacheEntryStructure();
 
+		@NonNull
 		CacheEntry buildCacheEntry(Object entity, Object[] state, Object version, SharedSessionContractImplementor session);
 	}
 
@@ -5072,11 +5078,13 @@ public abstract class AbstractEntityPersister
 		}
 
 		@Override
+		@NonNull
 		public CacheEntryStructure getCacheEntryStructure() {
 			return UnstructuredCacheEntry.INSTANCE;
 		}
 
 		@Override
+		@NonNull
 		public CacheEntry buildCacheEntry(Object entity, Object[] state, Object version, SharedSessionContractImplementor session) {
 			return new StandardCacheEntryImpl( state, persister, version, session, entity );
 		}
@@ -5090,11 +5098,13 @@ public abstract class AbstractEntityPersister
 		}
 
 		@Override
+		@NonNull
 		public CacheEntryStructure getCacheEntryStructure() {
 			return UnstructuredCacheEntry.INSTANCE;
 		}
 
 		@Override
+		@NonNull
 		public CacheEntry buildCacheEntry(Object entity, Object[] state, Object version, SharedSessionContractImplementor session) {
 			return new ReferenceCacheEntryImpl( entity, persister );
 		}
@@ -5110,11 +5120,13 @@ public abstract class AbstractEntityPersister
 		}
 
 		@Override
+		@NonNull
 		public CacheEntryStructure getCacheEntryStructure() {
 			return structure;
 		}
 
 		@Override
+		@NonNull
 		public CacheEntry buildCacheEntry(Object entity, Object[] state, Object version, SharedSessionContractImplementor session) {
 			return new StandardCacheEntryImpl( state, persister, version, session, entity );
 		}
@@ -5124,11 +5136,13 @@ public abstract class AbstractEntityPersister
 		public static final NoopCacheEntryHelper INSTANCE = new NoopCacheEntryHelper();
 
 		@Override
+		@NonNull
 		public CacheEntryStructure getCacheEntryStructure() {
 			return UnstructuredCacheEntry.INSTANCE;
 		}
 
 		@Override
+		@NonNull
 		public CacheEntry buildCacheEntry(Object entity, Object[] state, Object version, SharedSessionContractImplementor session) {
 			throw new HibernateException( "Illegal attempt to build cache entry for non-cached entity" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -5,6 +5,7 @@
 package org.hibernate.persister.entity;
 
 import jakarta.persistence.Entity;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.HibernateException;
 import org.hibernate.Incubating;
@@ -864,15 +865,20 @@ public interface EntityPersister extends EntityMappingType, EntityMutationTarget
 	 */
 	@Deprecated
 	boolean hasCache();
+
 	/**
 	 * Get the cache (optional operation)
 	 */
+	@Nullable
 	EntityDataAccess getCacheAccessStrategy();
+
 	/**
 	 * Get the cache structure
 	 */
+	@Nullable
 	CacheEntryStructure getCacheEntryStructure();
 
+	@NonNull
 	CacheEntry buildCacheEntry(Object entity, Object[] state, Object version, SharedSessionContractImplementor session);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query.sqm.sql;
 
+import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.criteria.Predicate.BooleanOperator;
 import jakarta.persistence.metamodel.SingularAttribute;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -479,6 +480,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 	private boolean resolvingCircularFetch;
 	private boolean deduplicateSelectionItems;
 	private ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide;
+	private Map<NavigablePath, CacheStoreMode> fetchCacheStoreModes;
 	private SqmStatement<?> currentSqmStatement;
 	private final Stack<SqmQueryPart<?>> sqmQueryPartStack = new StandardStack<>();
 	private CteContainer cteContainer;
@@ -8878,6 +8880,10 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 						fetchable,
 						isKeyFetchable
 				);
+				registerFetchCacheStoreMode(
+						fetchablePath,
+						traversalResult.getCacheStoreMode()
+				);
 			}
 		}
 		else {
@@ -8889,6 +8895,10 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 				if ( entityGraphTraversalState != null ) {
 					traversalResult = entityGraphTraversalState.traverse( fetchParent, fetchable, isKeyFetchable );
 					final var fetchStrategy = traversalResult.getFetchStrategy();
+					registerFetchCacheStoreMode(
+							fetchablePath,
+							traversalResult.getCacheStoreMode()
+					);
 					if ( fetchStrategy != null ) {
 						fetchTiming = fetchStrategy.getFetchTiming();
 						joined = fetchStrategy.isJoined();
@@ -9227,6 +9237,21 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 	@Override
 	public void setCurrentlyResolvingForeignKeyPart(ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide) {
 		this.currentlyResolvingForeignKeySide = currentlyResolvingForeignKeySide;
+	}
+
+	@Override
+	public void registerFetchCacheStoreMode(NavigablePath fetchablePath, CacheStoreMode cacheStoreMode) {
+		if ( cacheStoreMode != null ) {
+			if ( fetchCacheStoreModes == null ) {
+				fetchCacheStoreModes = new HashMap<>();
+			}
+			fetchCacheStoreModes.put( fetchablePath, cacheStoreMode );
+		}
+	}
+
+	@Override
+	public CacheStoreMode getFetchCacheStoreMode(NavigablePath fetchablePath) {
+		return fetchCacheStoreModes == null ? null : fetchCacheStoreModes.get( fetchablePath );
 	}
 
 	@Internal

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.query.sqm.sql;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.criteria.Predicate.BooleanOperator;
 import jakarta.persistence.metamodel.SingularAttribute;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -20,6 +18,7 @@ import org.hibernate.dialect.function.TimestampaddFunction;
 import org.hibernate.dialect.function.TimestampdiffFunction;
 import org.hibernate.engine.FetchStyle;
 import org.hibernate.engine.FetchTiming;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.generator.BeforeExecutionGenerator;
@@ -481,9 +480,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 	private boolean resolvingCircularFetch;
 	private boolean deduplicateSelectionItems;
 	private ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide;
-	private Map<NavigablePath, CacheStoreMode> fetchCacheStoreModes;
-	private Map<NavigablePath, CacheRetrieveMode> fetchCacheRetrieveModes;
-	private Map<NavigablePath, Integer> fetchBatchSizes;
+	private Map<NavigablePath, FetchOptions> fetchOptions;
 	private SqmStatement<?> currentSqmStatement;
 	private final Stack<SqmQueryPart<?>> sqmQueryPartStack = new StandardStack<>();
 	private CteContainer cteContainer;
@@ -8883,18 +8880,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 						fetchable,
 						isKeyFetchable
 				);
-				registerFetchCacheStoreMode(
-						fetchablePath,
-						traversalResult.getCacheStoreMode()
-				);
-				registerFetchCacheRetrieveMode(
-						fetchablePath,
-						traversalResult.getCacheRetrieveMode()
-				);
-				registerFetchBatchSize(
-						fetchablePath,
-						traversalResult.getBatchSize()
-				);
+				registerFetchOptions( fetchablePath, traversalResult.getFetchOptions() );
 			}
 		}
 		else {
@@ -8906,18 +8892,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 				if ( entityGraphTraversalState != null ) {
 					traversalResult = entityGraphTraversalState.traverse( fetchParent, fetchable, isKeyFetchable );
 					final var fetchStrategy = traversalResult.getFetchStrategy();
-					registerFetchCacheStoreMode(
-							fetchablePath,
-							traversalResult.getCacheStoreMode()
-					);
-					registerFetchCacheRetrieveMode(
-							fetchablePath,
-							traversalResult.getCacheRetrieveMode()
-					);
-					registerFetchBatchSize(
-							fetchablePath,
-							traversalResult.getBatchSize()
-					);
+					registerFetchOptions( fetchablePath, traversalResult.getFetchOptions() );
 					if ( fetchStrategy != null ) {
 						fetchTiming = fetchStrategy.getFetchTiming();
 						joined = fetchStrategy.isJoined();
@@ -9259,48 +9234,18 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 	}
 
 	@Override
-	public void registerFetchCacheStoreMode(NavigablePath fetchablePath, CacheStoreMode cacheStoreMode) {
-		if ( cacheStoreMode != null ) {
-			if ( fetchCacheStoreModes == null ) {
-				fetchCacheStoreModes = new HashMap<>();
+	public void registerFetchOptions(NavigablePath fetchablePath, FetchOptions fetchOptions) {
+		if ( fetchOptions.hasOptions() ) {
+			if ( this.fetchOptions == null ) {
+				this.fetchOptions = new HashMap<>();
 			}
-			fetchCacheStoreModes.put( fetchablePath, cacheStoreMode );
+			this.fetchOptions.put( fetchablePath, fetchOptions );
 		}
 	}
 
 	@Override
-	public CacheStoreMode getFetchCacheStoreMode(NavigablePath fetchablePath) {
-		return fetchCacheStoreModes == null ? null : fetchCacheStoreModes.get( fetchablePath );
-	}
-
-	@Override
-	public void registerFetchCacheRetrieveMode(NavigablePath fetchablePath, CacheRetrieveMode cacheRetrieveMode) {
-		if ( cacheRetrieveMode != null ) {
-			if ( fetchCacheRetrieveModes == null ) {
-				fetchCacheRetrieveModes = new HashMap<>();
-			}
-			fetchCacheRetrieveModes.put( fetchablePath, cacheRetrieveMode );
-		}
-	}
-
-	@Override
-	public CacheRetrieveMode getFetchCacheRetrieveMode(NavigablePath fetchablePath) {
-		return fetchCacheRetrieveModes == null ? null : fetchCacheRetrieveModes.get( fetchablePath );
-	}
-
-	@Override
-	public void registerFetchBatchSize(NavigablePath fetchablePath, Integer batchSize) {
-		if ( batchSize != null ) {
-			if ( fetchBatchSizes == null ) {
-				fetchBatchSizes = new HashMap<>();
-			}
-			fetchBatchSizes.put( fetchablePath, batchSize );
-		}
-	}
-
-	@Override
-	public Integer getFetchBatchSize(NavigablePath fetchablePath) {
-		return fetchBatchSizes == null ? null : fetchBatchSizes.get( fetchablePath );
+	public FetchOptions getFetchOptions(NavigablePath fetchablePath) {
+		return fetchOptions == null ? FetchOptions.NONE : fetchOptions.getOrDefault( fetchablePath, FetchOptions.NONE );
 	}
 
 	@Internal

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -483,6 +483,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 	private ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide;
 	private Map<NavigablePath, CacheStoreMode> fetchCacheStoreModes;
 	private Map<NavigablePath, CacheRetrieveMode> fetchCacheRetrieveModes;
+	private Map<NavigablePath, Integer> fetchBatchSizes;
 	private SqmStatement<?> currentSqmStatement;
 	private final Stack<SqmQueryPart<?>> sqmQueryPartStack = new StandardStack<>();
 	private CteContainer cteContainer;
@@ -8890,6 +8891,10 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 						fetchablePath,
 						traversalResult.getCacheRetrieveMode()
 				);
+				registerFetchBatchSize(
+						fetchablePath,
+						traversalResult.getBatchSize()
+				);
 			}
 		}
 		else {
@@ -8908,6 +8913,10 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 					registerFetchCacheRetrieveMode(
 							fetchablePath,
 							traversalResult.getCacheRetrieveMode()
+					);
+					registerFetchBatchSize(
+							fetchablePath,
+							traversalResult.getBatchSize()
 					);
 					if ( fetchStrategy != null ) {
 						fetchTiming = fetchStrategy.getFetchTiming();
@@ -9277,6 +9286,21 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 	@Override
 	public CacheRetrieveMode getFetchCacheRetrieveMode(NavigablePath fetchablePath) {
 		return fetchCacheRetrieveModes == null ? null : fetchCacheRetrieveModes.get( fetchablePath );
+	}
+
+	@Override
+	public void registerFetchBatchSize(NavigablePath fetchablePath, Integer batchSize) {
+		if ( batchSize != null ) {
+			if ( fetchBatchSizes == null ) {
+				fetchBatchSizes = new HashMap<>();
+			}
+			fetchBatchSizes.put( fetchablePath, batchSize );
+		}
+	}
+
+	@Override
+	public Integer getFetchBatchSize(NavigablePath fetchablePath) {
+		return fetchBatchSizes == null ? null : fetchBatchSizes.get( fetchablePath );
 	}
 
 	@Internal

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query.sqm.sql;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.criteria.Predicate.BooleanOperator;
 import jakarta.persistence.metamodel.SingularAttribute;
@@ -481,6 +482,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 	private boolean deduplicateSelectionItems;
 	private ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide;
 	private Map<NavigablePath, CacheStoreMode> fetchCacheStoreModes;
+	private Map<NavigablePath, CacheRetrieveMode> fetchCacheRetrieveModes;
 	private SqmStatement<?> currentSqmStatement;
 	private final Stack<SqmQueryPart<?>> sqmQueryPartStack = new StandardStack<>();
 	private CteContainer cteContainer;
@@ -8884,6 +8886,10 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 						fetchablePath,
 						traversalResult.getCacheStoreMode()
 				);
+				registerFetchCacheRetrieveMode(
+						fetchablePath,
+						traversalResult.getCacheRetrieveMode()
+				);
 			}
 		}
 		else {
@@ -8898,6 +8904,10 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 					registerFetchCacheStoreMode(
 							fetchablePath,
 							traversalResult.getCacheStoreMode()
+					);
+					registerFetchCacheRetrieveMode(
+							fetchablePath,
+							traversalResult.getCacheRetrieveMode()
 					);
 					if ( fetchStrategy != null ) {
 						fetchTiming = fetchStrategy.getFetchTiming();
@@ -9252,6 +9262,21 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 	@Override
 	public CacheStoreMode getFetchCacheStoreMode(NavigablePath fetchablePath) {
 		return fetchCacheStoreModes == null ? null : fetchCacheStoreModes.get( fetchablePath );
+	}
+
+	@Override
+	public void registerFetchCacheRetrieveMode(NavigablePath fetchablePath, CacheRetrieveMode cacheRetrieveMode) {
+		if ( cacheRetrieveMode != null ) {
+			if ( fetchCacheRetrieveModes == null ) {
+				fetchCacheRetrieveModes = new HashMap<>();
+			}
+			fetchCacheRetrieveModes.put( fetchablePath, cacheRetrieveMode );
+		}
+	}
+
+	@Override
+	public CacheRetrieveMode getFetchCacheRetrieveMode(NavigablePath fetchablePath) {
+		return fetchCacheRetrieveModes == null ? null : fetchCacheRetrieveModes.get( fetchablePath );
 	}
 
 	@Internal

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
@@ -6,6 +6,8 @@ package org.hibernate.sql.results.graph;
 
 import java.util.function.Function;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.Incubating;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.AssociationKey;
@@ -194,4 +196,18 @@ public interface DomainResultCreationState {
 	ForeignKeyDescriptor.Nature getCurrentlyResolvingForeignKeyPart();
 
 	void setCurrentlyResolvingForeignKeyPart(ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide);
+
+	/**
+	 * Register the {@link CacheStoreMode} applied by an entity graph to a fetch path.
+	 */
+	default void registerFetchCacheStoreMode(NavigablePath fetchablePath, CacheStoreMode cacheStoreMode) {
+	}
+
+	/**
+	 * The {@link CacheStoreMode} applied by an entity graph to this fetch path,
+	 * or {@code null} when the fetch should use the session/query cache mode.
+	 */
+	default CacheStoreMode getFetchCacheStoreMode(NavigablePath fetchablePath) {
+		return null;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
@@ -6,9 +6,6 @@ package org.hibernate.sql.results.graph;
 
 import java.util.function.Function;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.Incubating;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.AssociationKey;
@@ -199,44 +196,17 @@ public interface DomainResultCreationState {
 	void setCurrentlyResolvingForeignKeyPart(ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide);
 
 	/**
-	 * Register the {@link CacheStoreMode} applied by an entity graph to a fetch path.
+	 * Register the fetch options applied by an entity graph to a fetch path.
 	 */
-	default void registerFetchCacheStoreMode(NavigablePath fetchablePath, CacheStoreMode cacheStoreMode) {
+	default void registerFetchOptions(
+			NavigablePath fetchablePath,
+			org.hibernate.engine.spi.FetchOptions fetchOptions) {
 	}
 
 	/**
-	 * The {@link CacheStoreMode} applied by an entity graph to this fetch path,
-	 * or {@code null} when the fetch should use the session/query cache mode.
+	 * The fetch options applied by an entity graph to this fetch path.
 	 */
-	default CacheStoreMode getFetchCacheStoreMode(NavigablePath fetchablePath) {
-		return null;
-	}
-
-	/**
-	 * Register the {@link CacheRetrieveMode} applied by an entity graph to a fetch path.
-	 */
-	default void registerFetchCacheRetrieveMode(NavigablePath fetchablePath, CacheRetrieveMode cacheRetrieveMode) {
-	}
-
-	/**
-	 * The {@link CacheRetrieveMode} applied by an entity graph to this fetch path,
-	 * or {@code null} when the fetch should use the session/query cache mode.
-	 */
-	default CacheRetrieveMode getFetchCacheRetrieveMode(NavigablePath fetchablePath) {
-		return null;
-	}
-
-	/**
-	 * Register the batch size applied by an entity graph to a fetch path.
-	 */
-	default void registerFetchBatchSize(NavigablePath fetchablePath, Integer batchSize) {
-	}
-
-	/**
-	 * The batch size applied by an entity graph to this fetch path,
-	 * or {@code null} if none was applied.
-	 */
-	default Integer getFetchBatchSize(NavigablePath fetchablePath) {
-		return null;
+	default org.hibernate.engine.spi.FetchOptions getFetchOptions(NavigablePath fetchablePath) {
+		return org.hibernate.engine.spi.FetchOptions.NONE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
@@ -6,6 +6,7 @@ package org.hibernate.sql.results.graph;
 
 import java.util.function.Function;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.Incubating;
@@ -208,6 +209,20 @@ public interface DomainResultCreationState {
 	 * or {@code null} when the fetch should use the session/query cache mode.
 	 */
 	default CacheStoreMode getFetchCacheStoreMode(NavigablePath fetchablePath) {
+		return null;
+	}
+
+	/**
+	 * Register the {@link CacheRetrieveMode} applied by an entity graph to a fetch path.
+	 */
+	default void registerFetchCacheRetrieveMode(NavigablePath fetchablePath, CacheRetrieveMode cacheRetrieveMode) {
+	}
+
+	/**
+	 * The {@link CacheRetrieveMode} applied by an entity graph to this fetch path,
+	 * or {@code null} when the fetch should use the session/query cache mode.
+	 */
+	default CacheRetrieveMode getFetchCacheRetrieveMode(NavigablePath fetchablePath) {
 		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
@@ -225,4 +225,18 @@ public interface DomainResultCreationState {
 	default CacheRetrieveMode getFetchCacheRetrieveMode(NavigablePath fetchablePath) {
 		return null;
 	}
+
+	/**
+	 * Register the batch size applied by an entity graph to a fetch path.
+	 */
+	default void registerFetchBatchSize(NavigablePath fetchablePath, Integer batchSize) {
+	}
+
+	/**
+	 * The batch size applied by an entity graph to this fetch path,
+	 * or {@code null} if none was applied.
+	 */
+	default Integer getFetchBatchSize(NavigablePath fetchablePath) {
+		return null;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
@@ -4,9 +4,6 @@
  */
 package org.hibernate.sql.results.graph;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.Incubating;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.graph.spi.GraphImplementor;
@@ -26,25 +23,19 @@ public interface EntityGraphTraversalState {
 	class TraversalResult {
 		private final GraphImplementor<?> previousContext;
 		private final FetchStrategy fetchStrategy;
-		private final CacheStoreMode cacheStoreMode;
-		private final CacheRetrieveMode cacheRetrieveMode;
-		private final Integer batchSize;
+		private final org.hibernate.engine.spi.FetchOptions fetchOptions;
 
 		public TraversalResult(GraphImplementor<?> previousContext, FetchStrategy fetchStrategy) {
-			this( previousContext, fetchStrategy, null, null, null );
+			this( previousContext, fetchStrategy, org.hibernate.engine.spi.FetchOptions.NONE );
 		}
 
 		public TraversalResult(
 				GraphImplementor<?> previousContext,
 				FetchStrategy fetchStrategy,
-				CacheStoreMode cacheStoreMode,
-				CacheRetrieveMode cacheRetrieveMode,
-				Integer batchSize) {
+				org.hibernate.engine.spi.FetchOptions fetchOptions) {
 			this.previousContext = previousContext;
 			this.fetchStrategy = fetchStrategy;
-			this.cacheStoreMode = cacheStoreMode;
-			this.cacheRetrieveMode = cacheRetrieveMode;
-			this.batchSize = batchSize;
+			this.fetchOptions = fetchOptions;
 		}
 
 		public GraphImplementor<?> getGraph() {
@@ -55,16 +46,8 @@ public interface EntityGraphTraversalState {
 			return fetchStrategy;
 		}
 
-		public CacheStoreMode getCacheStoreMode() {
-			return cacheStoreMode;
-		}
-
-		public CacheRetrieveMode getCacheRetrieveMode() {
-			return cacheRetrieveMode;
-		}
-
-		public Integer getBatchSize() {
-			return batchSize;
+		public org.hibernate.engine.spi.FetchOptions getFetchOptions() {
+			return fetchOptions;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.Incubating;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.graph.spi.GraphImplementor;
@@ -23,10 +25,19 @@ public interface EntityGraphTraversalState {
 	class TraversalResult {
 		private final GraphImplementor<?> previousContext;
 		private final FetchStrategy fetchStrategy;
+		private final CacheStoreMode cacheStoreMode;
 
 		public TraversalResult(GraphImplementor<?> previousContext, FetchStrategy fetchStrategy) {
+			this( previousContext, fetchStrategy, null );
+		}
+
+		public TraversalResult(
+				GraphImplementor<?> previousContext,
+				FetchStrategy fetchStrategy,
+				CacheStoreMode cacheStoreMode) {
 			this.previousContext = previousContext;
 			this.fetchStrategy = fetchStrategy;
+			this.cacheStoreMode = cacheStoreMode;
 		}
 
 		public GraphImplementor<?> getGraph() {
@@ -35,6 +46,10 @@ public interface EntityGraphTraversalState {
 
 		public FetchStrategy getFetchStrategy() {
 			return fetchStrategy;
+		}
+
+		public CacheStoreMode getCacheStoreMode() {
+			return cacheStoreMode;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
@@ -28,20 +28,23 @@ public interface EntityGraphTraversalState {
 		private final FetchStrategy fetchStrategy;
 		private final CacheStoreMode cacheStoreMode;
 		private final CacheRetrieveMode cacheRetrieveMode;
+		private final Integer batchSize;
 
 		public TraversalResult(GraphImplementor<?> previousContext, FetchStrategy fetchStrategy) {
-			this( previousContext, fetchStrategy, null, null );
+			this( previousContext, fetchStrategy, null, null, null );
 		}
 
 		public TraversalResult(
 				GraphImplementor<?> previousContext,
 				FetchStrategy fetchStrategy,
 				CacheStoreMode cacheStoreMode,
-				CacheRetrieveMode cacheRetrieveMode) {
+				CacheRetrieveMode cacheRetrieveMode,
+				Integer batchSize) {
 			this.previousContext = previousContext;
 			this.fetchStrategy = fetchStrategy;
 			this.cacheStoreMode = cacheStoreMode;
 			this.cacheRetrieveMode = cacheRetrieveMode;
+			this.batchSize = batchSize;
 		}
 
 		public GraphImplementor<?> getGraph() {
@@ -58,6 +61,10 @@ public interface EntityGraphTraversalState {
 
 		public CacheRetrieveMode getCacheRetrieveMode() {
 			return cacheRetrieveMode;
+		}
+
+		public Integer getBatchSize() {
+			return batchSize;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.Incubating;
@@ -26,18 +27,21 @@ public interface EntityGraphTraversalState {
 		private final GraphImplementor<?> previousContext;
 		private final FetchStrategy fetchStrategy;
 		private final CacheStoreMode cacheStoreMode;
+		private final CacheRetrieveMode cacheRetrieveMode;
 
 		public TraversalResult(GraphImplementor<?> previousContext, FetchStrategy fetchStrategy) {
-			this( previousContext, fetchStrategy, null );
+			this( previousContext, fetchStrategy, null, null );
 		}
 
 		public TraversalResult(
 				GraphImplementor<?> previousContext,
 				FetchStrategy fetchStrategy,
-				CacheStoreMode cacheStoreMode) {
+				CacheStoreMode cacheStoreMode,
+				CacheRetrieveMode cacheRetrieveMode) {
 			this.previousContext = previousContext;
 			this.fetchStrategy = fetchStrategy;
 			this.cacheStoreMode = cacheStoreMode;
+			this.cacheRetrieveMode = cacheRetrieveMode;
 		}
 
 		public GraphImplementor<?> getGraph() {
@@ -50,6 +54,10 @@ public interface EntityGraphTraversalState {
 
 		public CacheStoreMode getCacheStoreMode() {
 			return cacheStoreMode;
+		}
+
+		public CacheRetrieveMode getCacheRetrieveMode() {
+			return cacheRetrieveMode;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionInitializer.java
@@ -43,6 +43,10 @@ public interface CollectionInitializer<Data extends InitializerData> extends Ini
 		return null;
 	}
 
+	default @Nullable Integer getBatchSize() {
+		return null;
+	}
+
 	@Override
 	default boolean isCollectionInitializer() {
 		return true;

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionInitializer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -30,6 +32,10 @@ public interface CollectionInitializer<Data extends InitializerData> extends Ini
 
 	default @Nullable PersistentCollection<?> getCollectionInstance(RowProcessingState rowProcessingState) {
 		return getCollectionInstance( getData( rowProcessingState ) );
+	}
+
+	default @Nullable CacheStoreMode getCacheStoreMode() {
+		return null;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionInitializer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.collection.spi.PersistentCollection;
@@ -35,6 +36,10 @@ public interface CollectionInitializer<Data extends InitializerData> extends Ini
 	}
 
 	default @Nullable CacheStoreMode getCacheStoreMode() {
+		return null;
+	}
+
+	default @Nullable CacheRetrieveMode getCacheRetrieveMode() {
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionInitializer.java
@@ -4,10 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.sql.results.graph.InitializerData;
@@ -35,16 +33,8 @@ public interface CollectionInitializer<Data extends InitializerData> extends Ini
 		return getCollectionInstance( getData( rowProcessingState ) );
 	}
 
-	default @Nullable CacheStoreMode getCacheStoreMode() {
-		return null;
-	}
-
-	default @Nullable CacheRetrieveMode getCacheRetrieveMode() {
-		return null;
-	}
-
-	default @Nullable Integer getBatchSize() {
-		return null;
+	default FetchOptions getFetchOptions() {
+		return FetchOptions.NONE;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
@@ -9,12 +9,9 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
-import org.hibernate.CacheMode;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.CollectionKey;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
@@ -45,9 +42,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 	protected final boolean isResultInitializer;
 	protected final @Nullable InitializerParent<?> parent;
 	protected final @Nullable EntityInitializer<InitializerData> owningEntityInitializer;
-	protected final @Nullable CacheStoreMode cacheStoreMode;
-	protected final @Nullable CacheRetrieveMode cacheRetrieveMode;
-	protected final @Nullable Integer batchSize;
+	protected final FetchOptions fetchOptions;
 
 	/**
 	 * refers to the collection's container value - which collection-key?
@@ -76,26 +71,24 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 	protected AbstractCollectionInitializer(
 			NavigablePath collectionPath,
 			PluralAttributeMapping collectionAttributeMapping,
-			InitializerParent<?> parent,
+			@Nullable InitializerParent<?> parent,
 			@Nullable DomainResult<?> collectionKeyResult,
 			boolean isResultInitializer,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super( creationState );
 		this.collectionPath = collectionPath;
 		this.collectionAttributeMapping = collectionAttributeMapping;
-		this.keyTypeForEqualsHashCode = collectionAttributeMapping.getCollectionDescriptor()
-				.getKeyType()
-				.getTypeForEqualsHashCode();
+		this.keyTypeForEqualsHashCode =
+				collectionAttributeMapping.getCollectionDescriptor()
+						.getKeyType().getTypeForEqualsHashCode();
 		this.isResultInitializer = isResultInitializer;
 		this.parent = parent;
-		this.cacheStoreMode = cacheStoreMode;
-		this.cacheRetrieveMode = cacheRetrieveMode;
-		this.batchSize = batchSize;
+		this.fetchOptions = fetchOptions;
 		//noinspection unchecked
-		this.owningEntityInitializer = (EntityInitializer<InitializerData>) Initializer.findOwningEntityInitializer( parent );
+		this.owningEntityInitializer =
+				(EntityInitializer<InitializerData>)
+						Initializer.findOwningEntityInitializer( parent );
 		this.collectionKeyResultAssembler = collectionKeyResult == null
 				? null
 				: collectionKeyResult.createResultAssembler( this, creationState );
@@ -116,7 +109,9 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 		data.collectionKeyValue = null;
 		if ( collectionKeyResultAssembler != null ) {
 			//noinspection unchecked
-			final Initializer<InitializerData> initializer = (Initializer<InitializerData>) collectionKeyResultAssembler.getInitializer();
+			final Initializer<InitializerData> initializer =
+					(Initializer<InitializerData>)
+							collectionKeyResultAssembler.getInitializer();
 			final RowProcessingState rowProcessingState = data.getRowProcessingState();
 			if ( initializer != null ) {
 				final InitializerData subData = initializer.getData( rowProcessingState );
@@ -172,13 +167,14 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 		data.collectionKey = null;
 		data.setCollectionInstance( null );
 
+		final var rowProcessingState = data.getRowProcessingState();
 		if ( data.collectionKeyValue == null ) {
 			if ( collectionKeyResultAssembler == null ) {
 				assert owningEntityInitializer != null;
-				data.collectionKeyValue = owningEntityInitializer.getEntityIdentifier( data.getRowProcessingState() );
+				data.collectionKeyValue = owningEntityInitializer.getEntityIdentifier( rowProcessingState );
 			}
 			else {
-				data.collectionKeyValue = collectionKeyResultAssembler.assemble( data.getRowProcessingState() );
+				data.collectionKeyValue = collectionKeyResultAssembler.assemble( rowProcessingState );
 			}
 			if ( data.collectionKeyValue == null ) {
 				data.setState( State.MISSING );
@@ -195,7 +191,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 		}
 		else {
 			final var persister = collectionAttributeMapping.getCollectionDescriptor();
-			final var session = data.getRowProcessingState().getSession();
+			final var session = rowProcessingState.getSession();
 			data.collectionKey = session.generateCollectionKey( persister, data.collectionKeyValue );
 			data.setState( State.KEY_RESOLVED );
 		}
@@ -261,44 +257,13 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 	}
 
 	@Override
-	public @Nullable CacheStoreMode getCacheStoreMode() {
-		return cacheStoreMode;
+	public FetchOptions getFetchOptions() {
+		return fetchOptions;
 	}
 
-	@Override
-	public @Nullable CacheRetrieveMode getCacheRetrieveMode() {
-		return cacheRetrieveMode;
-	}
-
-	@Override
-	public @Nullable Integer getBatchSize() {
-		return batchSize;
-	}
-
-	protected <T> T withFetchOptions(SharedSessionContractImplementor session, Supplier<T> action) {
-		return session.getLoadQueryInfluencers()
-				.fromBatchSize( batchSize, () -> withCacheModes( session, action ) );
-	}
-
-	protected <T> T withCacheModes(SharedSessionContractImplementor session, Supplier<T> action) {
-		if ( cacheRetrieveMode == null && cacheStoreMode == null ) {
-			return action.get();
-		}
-		final var previousCacheMode = session.getCacheMode();
-		final var effectiveCacheMode = CacheMode.fromJpaModes(
-				cacheRetrieveMode == null ? previousCacheMode.getJpaRetrieveMode() : cacheRetrieveMode,
-				cacheStoreMode == null ? previousCacheMode.getJpaStoreMode() : cacheStoreMode
-		);
-		if ( effectiveCacheMode == previousCacheMode ) {
-			return action.get();
-		}
-		session.setCacheMode( effectiveCacheMode );
-		try {
-			return action.get();
-		}
-		finally {
-			session.setCacheMode( previousCacheMode );
-		}
+	protected void withFetchOptions(SharedSessionContractImplementor session, Supplier<?> action) {
+		session.getLoadQueryInfluencers()
+				.withFetchOptions( session, fetchOptions, action );
 	}
 
 	@Override
@@ -322,12 +287,17 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 		return isResultInitializer;
 	}
 
-	boolean isReadOnly(CollectionKey collectionKey, RowProcessingState rowProcessingState, SharedSessionContractImplementor session) {
+	boolean isReadOnly(
+			CollectionKey collectionKey,
+			RowProcessingState rowProcessingState,
+			SharedSessionContractImplementor session) {
 		if ( collectionKey.isTemporal() ) {
 			return true;
 		}
-		final Boolean readOnly = rowProcessingState.getQueryOptions().isReadOnly();
-		return readOnly == null ? session.isDefaultReadOnly() : readOnly;
+		else {
+			final Boolean readOnly = rowProcessingState.getQueryOptions().isReadOnly();
+			return readOnly == null ? session.isDefaultReadOnly() : readOnly;
+		}
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
@@ -5,6 +5,7 @@
 package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
@@ -46,6 +47,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 	protected final @Nullable EntityInitializer<InitializerData> owningEntityInitializer;
 	protected final @Nullable CacheStoreMode cacheStoreMode;
 	protected final @Nullable CacheRetrieveMode cacheRetrieveMode;
+	protected final @Nullable Integer batchSize;
 
 	/**
 	 * refers to the collection's container value - which collection-key?
@@ -56,6 +58,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 		// per-row state
 		protected @Nullable Object collectionKeyValue;
 		protected @Nullable CollectionKey collectionKey;
+		protected @Nullable Set<PersistentCollection<?>> nonLazyCollections;
 
 		public CollectionInitializerData(RowProcessingState rowProcessingState) {
 			super( rowProcessingState );
@@ -78,6 +81,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState) {
 		super( creationState );
 		this.collectionPath = collectionPath;
@@ -89,6 +93,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 		this.parent = parent;
 		this.cacheStoreMode = cacheStoreMode;
 		this.cacheRetrieveMode = cacheRetrieveMode;
+		this.batchSize = batchSize;
 		//noinspection unchecked
 		this.owningEntityInitializer = (EntityInitializer<InitializerData>) Initializer.findOwningEntityInitializer( parent );
 		this.collectionKeyResultAssembler = collectionKeyResult == null
@@ -263,6 +268,16 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 	@Override
 	public @Nullable CacheRetrieveMode getCacheRetrieveMode() {
 		return cacheRetrieveMode;
+	}
+
+	@Override
+	public @Nullable Integer getBatchSize() {
+		return batchSize;
+	}
+
+	protected <T> T withFetchOptions(SharedSessionContractImplementor session, Supplier<T> action) {
+		return session.getLoadQueryInfluencers()
+				.fromBatchSize( batchSize, () -> withCacheModes( session, action ) );
 	}
 
 	protected <T> T withCacheModes(SharedSessionContractImplementor session, Supplier<T> action) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
@@ -7,6 +7,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.CollectionKey;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -39,6 +41,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 	protected final boolean isResultInitializer;
 	protected final @Nullable InitializerParent<?> parent;
 	protected final @Nullable EntityInitializer<InitializerData> owningEntityInitializer;
+	protected final @Nullable CacheStoreMode cacheStoreMode;
 
 	/**
 	 * refers to the collection's container value - which collection-key?
@@ -69,6 +72,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 			InitializerParent<?> parent,
 			@Nullable DomainResult<?> collectionKeyResult,
 			boolean isResultInitializer,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		super( creationState );
 		this.collectionPath = collectionPath;
@@ -78,6 +82,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 				.getTypeForEqualsHashCode();
 		this.isResultInitializer = isResultInitializer;
 		this.parent = parent;
+		this.cacheStoreMode = cacheStoreMode;
 		//noinspection unchecked
 		this.owningEntityInitializer = (EntityInitializer<InitializerData>) Initializer.findOwningEntityInitializer( parent );
 		this.collectionKeyResultAssembler = collectionKeyResult == null
@@ -242,6 +247,11 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 	@Override
 	public @Nullable InitializerParent<?> getParent() {
 		return parent;
+	}
+
+	@Override
+	public @Nullable CacheStoreMode getCacheStoreMode() {
+		return cacheStoreMode;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
@@ -6,9 +6,12 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
+import org.hibernate.CacheMode;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.CollectionKey;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -42,6 +45,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 	protected final @Nullable InitializerParent<?> parent;
 	protected final @Nullable EntityInitializer<InitializerData> owningEntityInitializer;
 	protected final @Nullable CacheStoreMode cacheStoreMode;
+	protected final @Nullable CacheRetrieveMode cacheRetrieveMode;
 
 	/**
 	 * refers to the collection's container value - which collection-key?
@@ -73,6 +77,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 			@Nullable DomainResult<?> collectionKeyResult,
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		super( creationState );
 		this.collectionPath = collectionPath;
@@ -83,6 +88,7 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 		this.isResultInitializer = isResultInitializer;
 		this.parent = parent;
 		this.cacheStoreMode = cacheStoreMode;
+		this.cacheRetrieveMode = cacheRetrieveMode;
 		//noinspection unchecked
 		this.owningEntityInitializer = (EntityInitializer<InitializerData>) Initializer.findOwningEntityInitializer( parent );
 		this.collectionKeyResultAssembler = collectionKeyResult == null
@@ -252,6 +258,32 @@ public abstract class AbstractCollectionInitializer<Data extends AbstractCollect
 	@Override
 	public @Nullable CacheStoreMode getCacheStoreMode() {
 		return cacheStoreMode;
+	}
+
+	@Override
+	public @Nullable CacheRetrieveMode getCacheRetrieveMode() {
+		return cacheRetrieveMode;
+	}
+
+	protected <T> T withCacheModes(SharedSessionContractImplementor session, Supplier<T> action) {
+		if ( cacheRetrieveMode == null && cacheStoreMode == null ) {
+			return action.get();
+		}
+		final var previousCacheMode = session.getCacheMode();
+		final var effectiveCacheMode = CacheMode.fromJpaModes(
+				cacheRetrieveMode == null ? previousCacheMode.getJpaRetrieveMode() : cacheRetrieveMode,
+				cacheStoreMode == null ? previousCacheMode.getJpaStoreMode() : cacheStoreMode
+		);
+		if ( effectiveCacheMode == previousCacheMode ) {
+			return action.get();
+		}
+		session.setCacheMode( effectiveCacheMode );
+		try {
+			return action.get();
+		}
+		finally {
+			session.setCacheMode( previousCacheMode );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.LockMode;
@@ -74,6 +75,7 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		super(
 				collectionPath,
@@ -82,6 +84,7 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 				collectionKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState
 		);
 		collectionValueKeyResultAssembler =

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
@@ -76,6 +76,7 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState) {
 		super(
 				collectionPath,
@@ -85,6 +86,7 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 		collectionValueKeyResultAssembler =

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
@@ -7,14 +7,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
-import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentCollection;
-import org.hibernate.engine.spi.CollectionKey;
-import org.hibernate.engine.spi.PersistenceContext;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -23,7 +17,6 @@ import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.graph.InitializerData;
 import org.hibernate.sql.results.graph.InitializerParent;
-import org.hibernate.sql.results.graph.collection.LoadingCollectionEntry;
 import org.hibernate.sql.results.internal.LoadingCollectionEntryImpl;
 import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 
@@ -70,13 +63,10 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 			NavigablePath collectionPath,
 			PluralAttributeMapping collectionAttributeMapping,
 			InitializerParent<?> parent,
-			LockMode lockMode,
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super(
 				collectionPath,
@@ -84,9 +74,7 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 				parent,
 				collectionKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 		collectionValueKeyResultAssembler =
@@ -250,13 +238,14 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 
 				// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 				// First, look for a LoadingCollectionEntry
-				final RowProcessingState rowProcessingState = data.getRowProcessingState();
-				final SharedSessionContractImplementor session = rowProcessingState.getSession();
-				final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
-				final CollectionKey collectionKey = data.collectionKey;
+				final var rowProcessingState = data.getRowProcessingState();
+				final var session = rowProcessingState.getSession();
+				final var persistenceContext = session.getPersistenceContextInternal();
+				final var collectionKey = data.collectionKey;
 				assert collectionKey != null;
-				final LoadingCollectionEntry existingLoadingEntry = persistenceContext.getLoadContexts()
-						.findLoadingCollectionEntry( collectionKey );
+				final var existingLoadingEntry =
+						persistenceContext.getLoadContexts()
+								.findLoadingCollectionEntry( collectionKey );
 				final PersistentCollection<?> existing;
 				final PersistentCollection<?> existingUnowned;
 				if ( existingLoadingEntry != null ) {
@@ -453,8 +442,8 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 			if ( data.collectionValueKey == null && collectionValueKeyResultAssembler != null ) {
 				final var initializer = collectionValueKeyResultAssembler.getInitializer();
 				if ( initializer != null ) {
-					data.collectionValueKey = collectionValueKeyResultAssembler.assemble(
-							data.getRowProcessingState() );
+					data.collectionValueKey =
+							collectionValueKeyResultAssembler.assemble( data.getRowProcessingState() );
 				}
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
@@ -7,6 +7,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.CollectionKey;
@@ -71,6 +73,7 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		super(
 				collectionPath,
@@ -78,6 +81,7 @@ public abstract class AbstractImmediateCollectionInitializer<Data extends Abstra
 				parent,
 				collectionKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState
 		);
 		collectionValueKeyResultAssembler =

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractNonJoinCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractNonJoinCollectionInitializer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -29,6 +30,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 			@Nullable DomainResult<?> collectionKeyResult,
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		super(
 				collectionPath,
@@ -37,6 +39,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 				collectionKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractNonJoinCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractNonJoinCollectionInitializer.java
@@ -4,13 +4,10 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import java.util.Collections;
 import java.util.IdentityHashMap;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
@@ -19,6 +16,8 @@ import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.InitializerParent;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static java.util.Collections.newSetFromMap;
 
 /**
  * Base support for CollectionInitializer implementations that don't join data
@@ -34,9 +33,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 			InitializerParent<?> parent,
 			@Nullable DomainResult<?> collectionKeyResult,
 			boolean isResultInitializer,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super(
 				collectionPath,
@@ -44,9 +41,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 				parent,
 				collectionKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 	}
@@ -107,11 +102,11 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 							}
 						}
 						else {
-							final var collectionDescriptor = collectionAttributeMapping.getCollectionDescriptor();
+							final var persister = collectionAttributeMapping.getCollectionDescriptor();
 							final Object key = collectionKey.getKey();
 							final var collection =
-									collectionDescriptor.getCollectionSemantics()
-											.instantiateWrapper( key, collectionDescriptor, session );
+									persister.getCollectionSemantics()
+											.instantiateWrapper( key, persister, session );
 							data.setCollectionInstance( collection );
 							final Object targetInstance = owningEntityInitializer.getTargetInstance( owningEntityData );
 							assert targetInstance != null;
@@ -119,15 +114,19 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 							withFetchOptions(
 									session,
 									() -> {
-										persistenceContext.addUninitializedCollection( collectionDescriptor, collection, key,
-												isReadOnly( collectionKey, rowProcessingState, session ) );
+										persistenceContext.addUninitializedCollection(
+												persister,
+												collection,
+												key,
+												isReadOnly( collectionKey, rowProcessingState, session )
+										);
 										return null;
 									}
 							);
 							if ( isEager ) {
 								addNonLazyCollection( data, collection );
 							}
-							if ( collectionDescriptor.isArray() ) {
+							if ( persister.isArray() ) {
 								persistenceContext.addCollectionHolder( collection );
 							}
 						}
@@ -186,7 +185,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 		if ( hasLocalFetchOptions() ) {
 			var nonLazyCollections = data.nonLazyCollections;
 			if ( nonLazyCollections == null ) {
-				nonLazyCollections = data.nonLazyCollections = Collections.newSetFromMap( new IdentityHashMap<>() );
+				nonLazyCollections = data.nonLazyCollections = newSetFromMap( new IdentityHashMap<>() );
 			}
 			nonLazyCollections.add( collection );
 		}
@@ -197,7 +196,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 	}
 
 	private boolean hasLocalFetchOptions() {
-		return cacheStoreMode != null || cacheRetrieveMode != null || batchSize != null;
+		return fetchOptions.hasOptions();
 	}
 
 	@Override
@@ -205,9 +204,8 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 		super.endLoading( data );
 		final var nonLazyCollections = data.nonLazyCollections;
 		if ( nonLazyCollections != null ) {
-			final var session = data.getRowProcessingState().getSession();
 			withFetchOptions(
-					session,
+					data.getRowProcessingState().getSession(),
 					() -> {
 						for ( var collection : nonLazyCollections ) {
 							collection.forceInitialization();

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractNonJoinCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractNonJoinCollectionInitializer.java
@@ -4,9 +4,14 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
+
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -31,6 +36,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState) {
 		super(
 				collectionPath,
@@ -40,6 +46,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 	}
@@ -56,7 +63,18 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 				if ( owningEntityData.getState() == State.INITIALIZED ) {
 					// It doesn't matter if it's eager or lazy, the collection object can not be referred to,
 					// so it doesn't make sense to create or initialize it
-					data.setState( State.MISSING );
+					if ( isEager && hasLocalFetchOptions() ) {
+						final Object targetInstance = owningEntityInitializer.getTargetInstance( owningEntityData );
+						if ( targetInstance == null ) {
+							data.setState( State.MISSING );
+						}
+						else {
+							resolveInstance( getInitializedPart().getValue( targetInstance ), data, true );
+						}
+					}
+					else {
+						data.setState( State.MISSING );
+					}
 				}
 				else {
 					// This initializer is done initializing, since this is only invoked for delayed or select initializers
@@ -98,10 +116,16 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 							final Object targetInstance = owningEntityInitializer.getTargetInstance( owningEntityData );
 							assert targetInstance != null;
 							collection.setOwner( targetInstance );
-							persistenceContext.addUninitializedCollection( collectionDescriptor, collection, key,
-									isReadOnly( collectionKey, rowProcessingState, session ) );
+							withFetchOptions(
+									session,
+									() -> {
+										persistenceContext.addUninitializedCollection( collectionDescriptor, collection, key,
+												isReadOnly( collectionKey, rowProcessingState, session ) );
+										return null;
+									}
+							);
 							if ( isEager ) {
-								persistenceContext.addNonLazyCollection( collection );
+								addNonLazyCollection( data, collection );
 							}
 							if ( collectionDescriptor.isArray() ) {
 								persistenceContext.addCollectionHolder( collection );
@@ -127,13 +151,72 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 			// This initializer is done initializing, since this is only invoked for delayed or select initializers
 			data.setState( State.INITIALIZED );
 			if ( isEager && !persistentCollection.wasInitialized() ) {
-				rowProcessingState.getSession().getPersistenceContextInternal()
-						.addNonLazyCollection( persistentCollection );
+				addBatchLoadableCollection( persistentCollection, rowProcessingState.getSession() );
+				addNonLazyCollection( data, persistentCollection );
 			}
 			if ( collectionKeyResultAssembler != null && rowProcessingState.needsResolveState() ) {
 				// Resolve the state of the identifier if result caching is enabled, and this is not a query cache hit
 				collectionKeyResultAssembler.resolveState( rowProcessingState );
 			}
+		}
+	}
+
+	private void addBatchLoadableCollection(
+			PersistentCollection<?> collection,
+			SharedSessionContractImplementor session) {
+		withFetchOptions(
+				session,
+				() -> {
+					final var persistenceContext = session.getPersistenceContextInternal();
+					final var collectionEntry = persistenceContext.getCollectionEntry( collection );
+					if ( collectionEntry != null ) {
+						final var persister = collectionEntry.getLoadedPersister();
+						if ( persister != null
+								&& session.getLoadQueryInfluencers().effectivelyBatchLoadable( persister ) ) {
+							persistenceContext.getBatchFetchQueue()
+									.addBatchLoadableCollection( collection, collectionEntry );
+						}
+					}
+					return null;
+				}
+		);
+	}
+
+	protected void addNonLazyCollection(Data data, PersistentCollection<?> collection) {
+		if ( hasLocalFetchOptions() ) {
+			var nonLazyCollections = data.nonLazyCollections;
+			if ( nonLazyCollections == null ) {
+				nonLazyCollections = data.nonLazyCollections = Collections.newSetFromMap( new IdentityHashMap<>() );
+			}
+			nonLazyCollections.add( collection );
+		}
+		else {
+			data.getRowProcessingState().getSession().getPersistenceContextInternal()
+					.addNonLazyCollection( collection );
+		}
+	}
+
+	private boolean hasLocalFetchOptions() {
+		return cacheStoreMode != null || cacheRetrieveMode != null || batchSize != null;
+	}
+
+	@Override
+	public void endLoading(Data data) {
+		super.endLoading( data );
+		final var nonLazyCollections = data.nonLazyCollections;
+		if ( nonLazyCollections != null ) {
+			final var session = data.getRowProcessingState().getSession();
+			withFetchOptions(
+					session,
+					() -> {
+						for ( var collection : nonLazyCollections ) {
+							collection.forceInitialization();
+						}
+						return null;
+					}
+			);
+			nonLazyCollections.clear();
+			data.nonLazyCollections = null;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractNonJoinCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractNonJoinCollectionInitializer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -26,6 +28,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 			InitializerParent<?> parent,
 			@Nullable DomainResult<?> collectionKeyResult,
 			boolean isResultInitializer,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		super(
 				collectionPath,
@@ -33,6 +36,7 @@ public abstract class AbstractNonJoinCollectionInitializer<Data extends Abstract
 				parent,
 				collectionKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
@@ -7,12 +7,10 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentArrayHolder;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -46,9 +44,7 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
@@ -56,13 +52,10 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 				navigablePath,
 				arrayDescriptor,
 				parent,
-				lockMode,
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 		//noinspection unchecked
@@ -141,14 +134,15 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 		final var initializer = elementAssembler.getInitializer();
 		if ( initializer != null ) {
 			final var rowProcessingState = data.getRowProcessingState();
-			Integer index = listIndexAssembler.assemble( rowProcessingState );
+			final Integer index = listIndexAssembler.assemble( rowProcessingState );
 			if ( index != null ) {
+				int i = index;
 				final var arrayHolder = getCollectionInstance( data );
 				assert arrayHolder != null;
 				if ( indexBase != 0 ) {
-					index -= indexBase;
+					i -= indexBase;
 				}
-				initializer.resolveInstance( get( arrayHolder.getArray(), index ), rowProcessingState );
+				initializer.resolveInstance( get( arrayHolder.getArray(), i ), rowProcessingState );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.HibernateException;
@@ -46,6 +47,7 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
@@ -58,6 +60,7 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState
 		);
 		//noinspection unchecked

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
@@ -48,6 +48,7 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
@@ -61,6 +62,7 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 		//noinspection unchecked

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
@@ -7,6 +7,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentArrayHolder;
@@ -43,6 +45,7 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
@@ -54,6 +57,7 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState
 		);
 		//noinspection unchecked

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -40,6 +42,7 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		return new ArrayInitializer(
 				navigablePath,
@@ -49,6 +52,7 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState,
 				listIndexFetch,
 				elementFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.LockMode;
@@ -43,6 +44,7 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		return new ArrayInitializer(
 				navigablePath,
@@ -53,6 +55,7 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState,
 				listIndexFetch,
 				elementFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
@@ -45,6 +45,7 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		return new ArrayInitializer(
 				navigablePath,
@@ -56,6 +57,7 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState,
 				listIndexFetch,
 				elementFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
@@ -4,11 +4,9 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -43,9 +41,7 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		return new ArrayInitializer(
 				navigablePath,
@@ -55,9 +51,7 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState,
 				listIndexFetch,
 				elementFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
@@ -50,6 +50,7 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState,
 			Fetch elementFetch,
 			@Nullable Fetch collectionIdFetch) {
@@ -63,6 +64,7 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 		elementAssembler = elementFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.AssertionFailure;
@@ -48,6 +49,7 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState,
 			Fetch elementFetch,
 			@Nullable Fetch collectionIdFetch) {
@@ -60,6 +62,7 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState
 		);
 		elementAssembler = elementFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
@@ -7,13 +7,11 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.AssertionFailure;
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentBag;
 import org.hibernate.collection.spi.PersistentIdentifierBag;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -48,9 +46,7 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState,
 			Fetch elementFetch,
 			@Nullable Fetch collectionIdFetch) {
@@ -58,13 +54,10 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				navigablePath,
 				bagDescriptor,
 				parent,
-				lockMode,
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 		elementAssembler = elementFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
@@ -7,6 +7,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.AssertionFailure;
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentBag;
@@ -45,6 +47,7 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState,
 			Fetch elementFetch,
 			@Nullable Fetch collectionIdFetch) {
@@ -56,6 +59,7 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState
 		);
 		elementAssembler = elementFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
@@ -57,6 +57,7 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		return new BagInitializer(
 				navigablePath,
@@ -68,6 +69,7 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState,
 				elementFetch,
 				collectionIdFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
@@ -4,11 +4,9 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -55,9 +53,7 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		return new BagInitializer(
 				navigablePath,
@@ -67,9 +63,7 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState,
 				elementFetch,
 				collectionIdFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.LockMode;
@@ -55,6 +56,7 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		return new BagInitializer(
 				navigablePath,
@@ -65,6 +67,7 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState,
 				elementFetch,
 				collectionIdFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -52,6 +54,7 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		return new BagInitializer(
 				navigablePath,
@@ -61,6 +64,7 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState,
 				elementFetch,
 				collectionIdFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
@@ -113,6 +113,7 @@ public class CollectionDomainResult implements DomainResult, CollectionResultGra
 				true,
 				null,
 				null,
+				null,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
@@ -111,6 +111,7 @@ public class CollectionDomainResult implements DomainResult, CollectionResultGra
 				fkResult,
 				fkResult,
 				true,
+				null,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
@@ -112,6 +112,7 @@ public class CollectionDomainResult implements DomainResult, CollectionResultGra
 				fkResult,
 				true,
 				null,
+				null,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.collection.spi.CollectionSemantics;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
@@ -111,9 +112,7 @@ public class CollectionDomainResult implements DomainResult, CollectionResultGra
 				fkResult,
 				fkResult,
 				true,
-				null,
-				null,
-				null,
+				FetchOptions.NONE,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
@@ -4,9 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -27,23 +25,17 @@ public abstract class CollectionFetch implements FetchParent, Fetch, Initializer
 	private final PluralAttributeMapping fetchedAttribute;
 
 	private final FetchParent fetchParent;
-	private final CacheStoreMode cacheStoreMode;
-	private final CacheRetrieveMode cacheRetrieveMode;
-	private final Integer batchSize;
+	private final FetchOptions fetchOptions;
 
 	public CollectionFetch(
 			NavigablePath fetchedPath,
-				PluralAttributeMapping fetchedAttribute,
-				FetchParent fetchParent,
-				CacheStoreMode cacheStoreMode,
-				CacheRetrieveMode cacheRetrieveMode,
-				Integer batchSize) {
+			PluralAttributeMapping fetchedAttribute,
+			FetchParent fetchParent,
+			FetchOptions fetchOptions) {
 		this.fetchedPath = fetchedPath;
 		this.fetchedAttribute = fetchedAttribute;
 		this.fetchParent = fetchParent;
-		this.cacheStoreMode = cacheStoreMode;
-		this.cacheRetrieveMode = cacheRetrieveMode;
-		this.batchSize = batchSize;
+		this.fetchOptions = fetchOptions;
 	}
 
 	@Override
@@ -56,16 +48,8 @@ public abstract class CollectionFetch implements FetchParent, Fetch, Initializer
 		return fetchedAttribute;
 	}
 
-	public CacheStoreMode getCacheStoreMode() {
-		return cacheStoreMode;
-	}
-
-	public CacheRetrieveMode getCacheRetrieveMode() {
-		return cacheRetrieveMode;
-	}
-
-	public Integer getBatchSize() {
-		return batchSize;
+	public FetchOptions getFetchOptions() {
+		return fetchOptions;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -27,16 +28,19 @@ public abstract class CollectionFetch implements FetchParent, Fetch, Initializer
 
 	private final FetchParent fetchParent;
 	private final CacheStoreMode cacheStoreMode;
+	private final CacheRetrieveMode cacheRetrieveMode;
 
 	public CollectionFetch(
 			NavigablePath fetchedPath,
 			PluralAttributeMapping fetchedAttribute,
 			FetchParent fetchParent,
-			CacheStoreMode cacheStoreMode) {
+			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode) {
 		this.fetchedPath = fetchedPath;
 		this.fetchedAttribute = fetchedAttribute;
 		this.fetchParent = fetchParent;
 		this.cacheStoreMode = cacheStoreMode;
+		this.cacheRetrieveMode = cacheRetrieveMode;
 	}
 
 	@Override
@@ -51,6 +55,10 @@ public abstract class CollectionFetch implements FetchParent, Fetch, Initializer
 
 	public CacheStoreMode getCacheStoreMode() {
 		return cacheStoreMode;
+	}
+
+	public CacheRetrieveMode getCacheRetrieveMode() {
+		return cacheRetrieveMode;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -24,14 +26,17 @@ public abstract class CollectionFetch implements FetchParent, Fetch, Initializer
 	private final PluralAttributeMapping fetchedAttribute;
 
 	private final FetchParent fetchParent;
+	private final CacheStoreMode cacheStoreMode;
 
 	public CollectionFetch(
 			NavigablePath fetchedPath,
 			PluralAttributeMapping fetchedAttribute,
-			FetchParent fetchParent) {
+			FetchParent fetchParent,
+			CacheStoreMode cacheStoreMode) {
 		this.fetchedPath = fetchedPath;
 		this.fetchedAttribute = fetchedAttribute;
 		this.fetchParent = fetchParent;
+		this.cacheStoreMode = cacheStoreMode;
 	}
 
 	@Override
@@ -42,6 +47,10 @@ public abstract class CollectionFetch implements FetchParent, Fetch, Initializer
 	@Override
 	public PluralAttributeMapping getFetchedMapping() {
 		return fetchedAttribute;
+	}
+
+	public CacheStoreMode getCacheStoreMode() {
+		return cacheStoreMode;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
@@ -29,18 +29,21 @@ public abstract class CollectionFetch implements FetchParent, Fetch, Initializer
 	private final FetchParent fetchParent;
 	private final CacheStoreMode cacheStoreMode;
 	private final CacheRetrieveMode cacheRetrieveMode;
+	private final Integer batchSize;
 
 	public CollectionFetch(
 			NavigablePath fetchedPath,
-			PluralAttributeMapping fetchedAttribute,
-			FetchParent fetchParent,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode) {
+				PluralAttributeMapping fetchedAttribute,
+				FetchParent fetchParent,
+				CacheStoreMode cacheStoreMode,
+				CacheRetrieveMode cacheRetrieveMode,
+				Integer batchSize) {
 		this.fetchedPath = fetchedPath;
 		this.fetchedAttribute = fetchedAttribute;
 		this.fetchParent = fetchParent;
 		this.cacheStoreMode = cacheStoreMode;
 		this.cacheRetrieveMode = cacheRetrieveMode;
+		this.batchSize = batchSize;
 	}
 
 	@Override
@@ -59,6 +62,10 @@ public abstract class CollectionFetch implements FetchParent, Fetch, Initializer
 
 	public CacheRetrieveMode getCacheRetrieveMode() {
 		return cacheRetrieveMode;
+	}
+
+	public Integer getBatchSize() {
+		return batchSize;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
@@ -35,8 +35,9 @@ public class DelayedCollectionFetch extends CollectionFetch {
 			DomainResult<?> collectionKeyResult,
 			boolean unfetched,
 			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode) {
-		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode, cacheRetrieveMode );
+			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize) {
+		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode, cacheRetrieveMode, batchSize );
 		this.collectionKeyResult = collectionKeyResult;
 		this.unfetched = unfetched;
 	}
@@ -59,6 +60,7 @@ public class DelayedCollectionFetch extends CollectionFetch {
 				collectionKeyResult,
 				getCacheStoreMode(),
 				getCacheRetrieveMode(),
+				getBatchSize(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
@@ -6,6 +6,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.BitSet;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
@@ -30,8 +32,9 @@ public class DelayedCollectionFetch extends CollectionFetch {
 			PluralAttributeMapping fetchedAttribute,
 			FetchParent fetchParent,
 			DomainResult<?> collectionKeyResult,
-			boolean unfetched) {
-		super( fetchedPath, fetchedAttribute, fetchParent );
+			boolean unfetched,
+			CacheStoreMode cacheStoreMode) {
+		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode );
 		this.collectionKeyResult = collectionKeyResult;
 		this.unfetched = unfetched;
 	}
@@ -52,6 +55,7 @@ public class DelayedCollectionFetch extends CollectionFetch {
 				getFetchedMapping(),
 				parent,
 				collectionKeyResult,
+				getCacheStoreMode(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
@@ -6,10 +6,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.BitSet;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.engine.FetchTiming;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -34,10 +32,8 @@ public class DelayedCollectionFetch extends CollectionFetch {
 			FetchParent fetchParent,
 			DomainResult<?> collectionKeyResult,
 			boolean unfetched,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize) {
-		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode, cacheRetrieveMode, batchSize );
+			FetchOptions fetchOptions) {
+		super( fetchedPath, fetchedAttribute, fetchParent, fetchOptions );
 		this.collectionKeyResult = collectionKeyResult;
 		this.unfetched = unfetched;
 	}
@@ -58,9 +54,7 @@ public class DelayedCollectionFetch extends CollectionFetch {
 				getFetchedMapping(),
 				parent,
 				collectionKeyResult,
-				getCacheStoreMode(),
-				getCacheRetrieveMode(),
-				getBatchSize(),
+				getFetchOptions(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
@@ -6,6 +6,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.BitSet;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.engine.FetchTiming;
@@ -33,8 +34,9 @@ public class DelayedCollectionFetch extends CollectionFetch {
 			FetchParent fetchParent,
 			DomainResult<?> collectionKeyResult,
 			boolean unfetched,
-			CacheStoreMode cacheStoreMode) {
-		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode );
+			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode) {
+		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode, cacheRetrieveMode );
 		this.collectionKeyResult = collectionKeyResult;
 		this.unfetched = unfetched;
 	}
@@ -56,6 +58,7 @@ public class DelayedCollectionFetch extends CollectionFetch {
 				parent,
 				collectionKeyResult,
 				getCacheStoreMode(),
+				getCacheRetrieveMode(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
@@ -4,16 +4,13 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.InitializerParent;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static org.hibernate.internal.log.LoggingHelper.toLoggableString;
 
@@ -27,9 +24,7 @@ public class DelayedCollectionInitializer extends AbstractNonJoinCollectionIniti
 			PluralAttributeMapping fetchedMapping,
 			InitializerParent<?> parent,
 			DomainResult<?> collectionKeyResult,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super(
 				fetchedPath,
@@ -37,9 +32,7 @@ public class DelayedCollectionInitializer extends AbstractNonJoinCollectionIniti
 				parent,
 				collectionKeyResult,
 				false,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
@@ -4,11 +4,15 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.InitializerParent;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static org.hibernate.internal.log.LoggingHelper.toLoggableString;
 
@@ -22,8 +26,9 @@ public class DelayedCollectionInitializer extends AbstractNonJoinCollectionIniti
 			PluralAttributeMapping fetchedMapping,
 			InitializerParent<?> parent,
 			DomainResult<?> collectionKeyResult,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
-		super( fetchedPath, fetchedMapping, parent, collectionKeyResult, false, creationState );
+		super( fetchedPath, fetchedMapping, parent, collectionKeyResult, false, cacheStoreMode, creationState );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
@@ -29,6 +29,7 @@ public class DelayedCollectionInitializer extends AbstractNonJoinCollectionIniti
 			DomainResult<?> collectionKeyResult,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState) {
 		super(
 				fetchedPath,
@@ -38,6 +39,7 @@ public class DelayedCollectionInitializer extends AbstractNonJoinCollectionIniti
 				false,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -27,8 +28,18 @@ public class DelayedCollectionInitializer extends AbstractNonJoinCollectionIniti
 			InitializerParent<?> parent,
 			DomainResult<?> collectionKeyResult,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
-		super( fetchedPath, fetchedMapping, parent, collectionKeyResult, false, cacheStoreMode, creationState );
+		super(
+				fetchedPath,
+				fetchedMapping,
+				parent,
+				collectionKeyResult,
+				false,
+				cacheStoreMode,
+				cacheRetrieveMode,
+				creationState
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
@@ -51,7 +51,13 @@ public class EagerCollectionFetch extends CollectionFetch {
 			boolean needsCollectionKeyResult,
 			FetchParent fetchParent,
 			DomainResultCreationState creationState) {
-		super( fetchedPath, fetchedAttribute, fetchParent, creationState.getFetchCacheStoreMode( fetchedPath ) );
+		super(
+				fetchedPath,
+				fetchedAttribute,
+				fetchParent,
+				creationState.getFetchCacheStoreMode( fetchedPath ),
+				creationState.getFetchCacheRetrieveMode( fetchedPath )
+		);
 		this.collectionTableGroup = (PluralTableGroup) collectionTableGroup;
 
 		final FromClauseAccess fromClauseAccess = creationState.getSqlAstCreationState().getFromClauseAccess();
@@ -126,6 +132,19 @@ public class EagerCollectionFetch extends CollectionFetch {
 				);
 			}
 		}
+		final var cacheRetrieveMode = creationState.getFetchCacheRetrieveMode( fetchedPath );
+		if ( cacheRetrieveMode != null ) {
+			creationState.registerFetchCacheRetrieveMode(
+					fetchedPath.append( CollectionPart.Nature.ELEMENT.getName() ),
+					cacheRetrieveMode
+			);
+			if ( fetchedAttribute.getIndexDescriptor() != null ) {
+				creationState.registerFetchCacheRetrieveMode(
+						fetchedPath.append( CollectionPart.Nature.INDEX.getName() ),
+						cacheRetrieveMode
+				);
+			}
+		}
 
 		fetches = creationState.visitFetches( this );
 		if ( fetchedAttribute.getIndexDescriptor() != null ) {
@@ -175,6 +194,7 @@ public class EagerCollectionFetch extends CollectionFetch {
 				collectionValueKeyResult,
 				false,
 				getCacheStoreMode(),
+				getCacheRetrieveMode(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
@@ -9,6 +9,7 @@ import java.util.BitSet;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.collection.spi.CollectionSemantics;
 import org.hibernate.engine.FetchTiming;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -55,9 +56,7 @@ public class EagerCollectionFetch extends CollectionFetch {
 				fetchedPath,
 				fetchedAttribute,
 				fetchParent,
-				creationState.getFetchCacheStoreMode( fetchedPath ),
-				creationState.getFetchCacheRetrieveMode( fetchedPath ),
-				creationState.getFetchBatchSize( fetchedPath )
+				creationState.getFetchOptions( fetchedPath )
 		);
 		this.collectionTableGroup = (PluralTableGroup) collectionTableGroup;
 
@@ -120,29 +119,21 @@ public class EagerCollectionFetch extends CollectionFetch {
 				creationState
 		);
 
-		final var cacheStoreMode = creationState.getFetchCacheStoreMode( fetchedPath );
-		if ( cacheStoreMode != null ) {
-			creationState.registerFetchCacheStoreMode(
+		final var fetchOptions = creationState.getFetchOptions( fetchedPath );
+		final var nestedFetchOptions = FetchOptions.of(
+				fetchOptions.cacheStoreMode(),
+				fetchOptions.cacheRetrieveMode(),
+				null
+		);
+		if ( nestedFetchOptions.hasOptions() ) {
+			creationState.registerFetchOptions(
 					fetchedPath.append( CollectionPart.Nature.ELEMENT.getName() ),
-					cacheStoreMode
+					nestedFetchOptions
 			);
 			if ( fetchedAttribute.getIndexDescriptor() != null ) {
-				creationState.registerFetchCacheStoreMode(
+				creationState.registerFetchOptions(
 						fetchedPath.append( CollectionPart.Nature.INDEX.getName() ),
-						cacheStoreMode
-				);
-			}
-		}
-		final var cacheRetrieveMode = creationState.getFetchCacheRetrieveMode( fetchedPath );
-		if ( cacheRetrieveMode != null ) {
-			creationState.registerFetchCacheRetrieveMode(
-					fetchedPath.append( CollectionPart.Nature.ELEMENT.getName() ),
-					cacheRetrieveMode
-			);
-			if ( fetchedAttribute.getIndexDescriptor() != null ) {
-				creationState.registerFetchCacheRetrieveMode(
-						fetchedPath.append( CollectionPart.Nature.INDEX.getName() ),
-						cacheRetrieveMode
+						nestedFetchOptions
 				);
 			}
 		}
@@ -194,9 +185,7 @@ public class EagerCollectionFetch extends CollectionFetch {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				false,
-				getCacheStoreMode(),
-				getCacheRetrieveMode(),
-				getBatchSize(),
+				getFetchOptions(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
@@ -51,7 +51,7 @@ public class EagerCollectionFetch extends CollectionFetch {
 			boolean needsCollectionKeyResult,
 			FetchParent fetchParent,
 			DomainResultCreationState creationState) {
-		super( fetchedPath, fetchedAttribute, fetchParent );
+		super( fetchedPath, fetchedAttribute, fetchParent, creationState.getFetchCacheStoreMode( fetchedPath ) );
 		this.collectionTableGroup = (PluralTableGroup) collectionTableGroup;
 
 		final FromClauseAccess fromClauseAccess = creationState.getSqlAstCreationState().getFromClauseAccess();
@@ -113,6 +113,20 @@ public class EagerCollectionFetch extends CollectionFetch {
 				creationState
 		);
 
+		final var cacheStoreMode = creationState.getFetchCacheStoreMode( fetchedPath );
+		if ( cacheStoreMode != null ) {
+			creationState.registerFetchCacheStoreMode(
+					fetchedPath.append( CollectionPart.Nature.ELEMENT.getName() ),
+					cacheStoreMode
+			);
+			if ( fetchedAttribute.getIndexDescriptor() != null ) {
+				creationState.registerFetchCacheStoreMode(
+						fetchedPath.append( CollectionPart.Nature.INDEX.getName() ),
+						cacheStoreMode
+				);
+			}
+		}
+
 		fetches = creationState.visitFetches( this );
 		if ( fetchedAttribute.getIndexDescriptor() != null ) {
 			assert fetches.size() == 2;
@@ -160,6 +174,7 @@ public class EagerCollectionFetch extends CollectionFetch {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				false,
+				getCacheStoreMode(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
@@ -56,7 +56,8 @@ public class EagerCollectionFetch extends CollectionFetch {
 				fetchedAttribute,
 				fetchParent,
 				creationState.getFetchCacheStoreMode( fetchedPath ),
-				creationState.getFetchCacheRetrieveMode( fetchedPath )
+				creationState.getFetchCacheRetrieveMode( fetchedPath ),
+				creationState.getFetchBatchSize( fetchedPath )
 		);
 		this.collectionTableGroup = (PluralTableGroup) collectionTableGroup;
 
@@ -195,6 +196,7 @@ public class EagerCollectionFetch extends CollectionFetch {
 				false,
 				getCacheStoreMode(),
 				getCacheRetrieveMode(),
+				getBatchSize(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.HibernateException;
@@ -48,6 +49,7 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
@@ -60,6 +62,7 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState
 		);
 		//noinspection unchecked

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
@@ -7,12 +7,10 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentList;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -48,9 +46,7 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
@@ -58,13 +54,10 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 				navigablePath,
 				attributeMapping,
 				parent,
-				lockMode,
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 		//noinspection unchecked
@@ -127,14 +120,15 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 		final var initializer = elementAssembler.getInitializer();
 		if ( initializer != null ) {
 			final var rowProcessingState = data.getRowProcessingState();
-			Integer index = listIndexAssembler.assemble( rowProcessingState );
+			final Integer index = listIndexAssembler.assemble( rowProcessingState );
 			if ( index != null ) {
+				int i = index;
 				final var list = getCollectionInstance( data );
 				assert list != null;
 				if ( listIndexBase != 0 ) {
-					index -= listIndexBase;
+					i -= listIndexBase;
 				}
-				initializer.resolveInstance( list.get( index ), rowProcessingState );
+				initializer.resolveInstance( list.get( i ), rowProcessingState );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
@@ -7,6 +7,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentList;
@@ -45,6 +47,7 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
@@ -56,6 +59,7 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState
 		);
 		//noinspection unchecked

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
@@ -50,6 +50,7 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
@@ -63,6 +64,7 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 		//noinspection unchecked

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
@@ -4,11 +4,9 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -43,9 +41,7 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		return new ListInitializer(
 				navigablePath,
@@ -55,9 +51,7 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState,
 				listIndexFetch,
 				elementFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
@@ -45,6 +45,7 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		return new ListInitializer(
 				navigablePath,
@@ -56,6 +57,7 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState,
 				listIndexFetch,
 				elementFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -40,6 +42,7 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		return new ListInitializer(
 				navigablePath,
@@ -49,6 +52,7 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState,
 				listIndexFetch,
 				elementFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.LockMode;
@@ -43,6 +44,7 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		return new ListInitializer(
 				navigablePath,
@@ -53,6 +55,7 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState,
 				listIndexFetch,
 				elementFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
@@ -7,6 +7,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentMap;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -45,6 +47,7 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState,
 			Fetch mapKeyFetch,
 			Fetch mapValueFetch) {
@@ -56,6 +59,7 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState
 		);
 		mapKeyAssembler = mapKeyFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
@@ -50,6 +50,7 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState,
 			Fetch mapKeyFetch,
 			Fetch mapValueFetch) {
@@ -63,6 +64,7 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 		mapKeyAssembler = mapKeyFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.LockMode;
@@ -48,6 +49,7 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState,
 			Fetch mapKeyFetch,
 			Fetch mapValueFetch) {
@@ -60,6 +62,7 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState
 		);
 		mapKeyAssembler = mapKeyFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
@@ -7,11 +7,9 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentMap;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -48,9 +46,7 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState,
 			Fetch mapKeyFetch,
 			Fetch mapValueFetch) {
@@ -58,13 +54,10 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				navigablePath,
 				attributeMapping,
 				parent,
-				lockMode,
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 		mapKeyAssembler = mapKeyFetch.createAssembler( this, creationState );
@@ -136,7 +129,7 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			//   which violate this same requirement (recursion)
 			final Object key = mapKeyAssembler.assemble( rowProcessingState );
 			if ( key != null ) {
-				final PersistentMap<?, ?> map = getCollectionInstance( data );
+				final var map = getCollectionInstance( data );
 				assert map != null;
 				valueInitializer.resolveInstance( map.get( key ), rowProcessingState );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
@@ -4,11 +4,9 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -43,9 +41,7 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		return new MapInitializer(
 				navigablePath,
@@ -55,9 +51,7 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState,
 				mapKeyFetch,
 				mapValueFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.LockMode;
@@ -43,6 +44,7 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		return new MapInitializer(
 				navigablePath,
@@ -53,6 +55,7 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState,
 				mapKeyFetch,
 				mapValueFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -40,6 +42,7 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		return new MapInitializer(
 				navigablePath,
@@ -49,6 +52,7 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState,
 				mapKeyFetch,
 				mapValueFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
@@ -45,6 +45,7 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		return new MapInitializer(
 				navigablePath,
@@ -56,6 +57,7 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState,
 				mapKeyFetch,
 				mapValueFetch

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
@@ -6,6 +6,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.BitSet;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.engine.FetchTiming;
@@ -31,8 +32,9 @@ public class SelectEagerCollectionFetch extends CollectionFetch {
 			PluralAttributeMapping fetchedAttribute,
 			DomainResult<?> collectionKeyDomainResult,
 			FetchParent fetchParent,
-			CacheStoreMode cacheStoreMode) {
-		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode );
+			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode) {
+		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode, cacheRetrieveMode );
 		this.collectionKeyDomainResult = collectionKeyDomainResult;
 	}
 
@@ -53,6 +55,7 @@ public class SelectEagerCollectionFetch extends CollectionFetch {
 				parent,
 				collectionKeyDomainResult,
 				getCacheStoreMode(),
+				getCacheRetrieveMode(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
@@ -6,10 +6,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.BitSet;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.engine.FetchTiming;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -32,10 +30,8 @@ public class SelectEagerCollectionFetch extends CollectionFetch {
 			PluralAttributeMapping fetchedAttribute,
 			DomainResult<?> collectionKeyDomainResult,
 			FetchParent fetchParent,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize) {
-		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode, cacheRetrieveMode, batchSize );
+			FetchOptions fetchOptions) {
+		super( fetchedPath, fetchedAttribute, fetchParent, fetchOptions );
 		this.collectionKeyDomainResult = collectionKeyDomainResult;
 	}
 
@@ -55,9 +51,7 @@ public class SelectEagerCollectionFetch extends CollectionFetch {
 				getFetchedMapping(),
 				parent,
 				collectionKeyDomainResult,
-				getCacheStoreMode(),
-				getCacheRetrieveMode(),
-				getBatchSize(),
+				getFetchOptions(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
@@ -33,8 +33,9 @@ public class SelectEagerCollectionFetch extends CollectionFetch {
 			DomainResult<?> collectionKeyDomainResult,
 			FetchParent fetchParent,
 			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode) {
-		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode, cacheRetrieveMode );
+			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize) {
+		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode, cacheRetrieveMode, batchSize );
 		this.collectionKeyDomainResult = collectionKeyDomainResult;
 	}
 
@@ -56,6 +57,7 @@ public class SelectEagerCollectionFetch extends CollectionFetch {
 				collectionKeyDomainResult,
 				getCacheStoreMode(),
 				getCacheRetrieveMode(),
+				getBatchSize(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
@@ -6,6 +6,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.BitSet;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
@@ -28,8 +30,9 @@ public class SelectEagerCollectionFetch extends CollectionFetch {
 			NavigablePath fetchedPath,
 			PluralAttributeMapping fetchedAttribute,
 			DomainResult<?> collectionKeyDomainResult,
-			FetchParent fetchParent) {
-		super( fetchedPath, fetchedAttribute, fetchParent );
+			FetchParent fetchParent,
+			CacheStoreMode cacheStoreMode) {
+		super( fetchedPath, fetchedAttribute, fetchParent, cacheStoreMode );
 		this.collectionKeyDomainResult = collectionKeyDomainResult;
 	}
 
@@ -49,6 +52,7 @@ public class SelectEagerCollectionFetch extends CollectionFetch {
 				getFetchedMapping(),
 				parent,
 				collectionKeyDomainResult,
+				getCacheStoreMode(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
@@ -30,6 +30,7 @@ public class SelectEagerCollectionInitializer
 			@Nullable DomainResult<?> collectionKeyResult,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState) {
 		super(
 				fetchedPath,
@@ -39,6 +40,7 @@ public class SelectEagerCollectionInitializer
 				false,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 	}
@@ -63,7 +65,7 @@ public class SelectEagerCollectionInitializer
 			final var collection = getCollection( data, instance );
 			data.setState( State.INITIALIZED );
 			data.setCollectionInstance( collection );
-			withCacheModes(
+			withFetchOptions(
 					data.getRowProcessingState().getSession(),
 					() -> {
 						collection.forceInitialization();

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -28,8 +29,18 @@ public class SelectEagerCollectionInitializer
 			InitializerParent<?> parent,
 			@Nullable DomainResult<?> collectionKeyResult,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
-		super( fetchedPath, fetchedMapping, parent, collectionKeyResult, false, cacheStoreMode, creationState );
+		super(
+				fetchedPath,
+				fetchedMapping,
+				parent,
+				collectionKeyResult,
+				false,
+				cacheStoreMode,
+				cacheRetrieveMode,
+				creationState
+		);
 	}
 
 	@Override
@@ -52,7 +63,13 @@ public class SelectEagerCollectionInitializer
 			final var collection = getCollection( data, instance );
 			data.setState( State.INITIALIZED );
 			data.setCollectionInstance( collection );
-			collection.forceInitialization();
+			withCacheModes(
+					data.getRowProcessingState().getSession(),
+					() -> {
+						collection.forceInitialization();
+						return null;
+					}
+			);
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -25,8 +27,9 @@ public class SelectEagerCollectionInitializer
 			PluralAttributeMapping fetchedMapping,
 			InitializerParent<?> parent,
 			@Nullable DomainResult<?> collectionKeyResult,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
-		super( fetchedPath, fetchedMapping, parent, collectionKeyResult, false, creationState );
+		super( fetchedPath, fetchedMapping, parent, collectionKeyResult, false, cacheStoreMode, creationState );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
@@ -4,9 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -28,9 +26,7 @@ public class SelectEagerCollectionInitializer
 			PluralAttributeMapping fetchedMapping,
 			InitializerParent<?> parent,
 			@Nullable DomainResult<?> collectionKeyResult,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super(
 				fetchedPath,
@@ -38,9 +34,7 @@ public class SelectEagerCollectionInitializer
 				parent,
 				collectionKeyResult,
 				false,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.LockMode;
@@ -42,6 +43,7 @@ public class SetInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
+			@Nullable CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState,
 			Fetch elementFetch) {
 		super(
@@ -53,6 +55,7 @@ public class SetInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState
 		);
 		this.elementAssembler = elementFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
@@ -7,11 +7,9 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentSet;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -42,22 +40,17 @@ public class SetInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			@Nullable CacheStoreMode cacheStoreMode,
-			@Nullable CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState,
 			Fetch elementFetch) {
 		super(
 				navigablePath,
 				setDescriptor,
 				parent,
-				lockMode,
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 		this.elementAssembler = elementFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
@@ -7,6 +7,8 @@ package org.hibernate.sql.results.graph.collection.internal;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.PersistentSet;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -39,6 +41,7 @@ public class SetInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			@Nullable CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState,
 			Fetch elementFetch) {
 		super(
@@ -49,6 +52,7 @@ public class SetInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState
 		);
 		this.elementAssembler = elementFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
@@ -44,6 +44,7 @@ public class SetInitializer extends AbstractImmediateCollectionInitializer<Abstr
 			boolean isResultInitializer,
 			@Nullable CacheStoreMode cacheStoreMode,
 			@Nullable CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState,
 			Fetch elementFetch) {
 		super(
@@ -56,6 +57,7 @@ public class SetInitializer extends AbstractImmediateCollectionInitializer<Abstr
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 		this.elementAssembler = elementFetch.createAssembler( this, creationState );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
@@ -42,6 +42,7 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		return new SetInitializer(
 				navigablePath,
@@ -53,6 +54,7 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 				isResultInitializer,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState,
 				elementFetch
 		);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -37,6 +39,7 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		return new SetInitializer(
 				navigablePath,
@@ -46,6 +49,7 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
+				cacheStoreMode,
 				creationState,
 				elementFetch
 		);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
@@ -4,11 +4,9 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
@@ -40,9 +38,7 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionKeyResult,
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		return new SetInitializer(
 				navigablePath,
@@ -52,9 +48,7 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 				collectionKeyResult,
 				collectionValueKeyResult,
 				isResultInitializer,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState,
 				elementFetch
 		);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.LockMode;
@@ -40,6 +41,7 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 			DomainResult<?> collectionValueKeyResult,
 			boolean isResultInitializer,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		return new SetInitializer(
 				navigablePath,
@@ -50,6 +52,7 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 				collectionValueKeyResult,
 				isResultInitializer,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState,
 				elementFetch
 		);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.entity;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.graph.spi.GraphHelper;
@@ -28,6 +29,10 @@ public interface EntityResultGraphNode extends DomainResultGraphNode, FetchParen
 	EntityValuedModelPart getEntityValuedModelPart();
 
 	default CacheStoreMode getCacheStoreMode() {
+		return null;
+	}
+
+	default CacheRetrieveMode getCacheRetrieveMode() {
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
@@ -36,6 +36,10 @@ public interface EntityResultGraphNode extends DomainResultGraphNode, FetchParen
 		return null;
 	}
 
+	default Integer getBatchSize() {
+		return null;
+	}
+
 	@Override
 	default boolean containsAnyNonScalarResults() {
 		return true;

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.entity;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.graph.spi.GraphHelper;
 import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -24,6 +26,10 @@ public interface EntityResultGraphNode extends DomainResultGraphNode, FetchParen
 	NavigablePath getNavigablePath();
 
 	EntityValuedModelPart getEntityValuedModelPart();
+
+	default CacheStoreMode getCacheStoreMode() {
+		return null;
+	}
 
 	@Override
 	default boolean containsAnyNonScalarResults() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
@@ -4,9 +4,7 @@
  */
 package org.hibernate.sql.results.graph.entity;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.graph.spi.GraphHelper;
 import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -28,16 +26,8 @@ public interface EntityResultGraphNode extends DomainResultGraphNode, FetchParen
 
 	EntityValuedModelPart getEntityValuedModelPart();
 
-	default CacheStoreMode getCacheStoreMode() {
-		return null;
-	}
-
-	default CacheRetrieveMode getCacheRetrieveMode() {
-		return null;
-	}
-
-	default Integer getBatchSize() {
-		return null;
+	default FetchOptions getFetchOptions() {
+		return FetchOptions.NONE;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractBatchEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractBatchEntitySelectFetchInitializer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.Hibernate;
@@ -64,9 +65,10 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		super( parent, toOneMapping, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, creationState );
 		//noinspection unchecked
 		owningEntityInitializer =
 				(EntityInitializer<InitializerData>)
@@ -293,7 +295,7 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 	protected Object loadInstance(EntityKey entityKey, SharedSessionContractImplementor session) {
 		final String entityName = entityKey.getEntityName();
 		final Object identifier = entityKey.getIdentifier();
-		final Object instance = withCacheStoreMode(
+		final Object instance = withCacheModes(
 				session,
 				() -> session.internalLoad( entityName, identifier, true,
 						toOneMapping.isInternalLoadNullable() )

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractBatchEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractBatchEntitySelectFetchInitializer.java
@@ -4,12 +4,10 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.Hibernate;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -54,12 +52,16 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 			if ( rowProcessingState.isScrollResult() ) {
 				return true;
 			}
-			return initializer.batchSize != null
-					? initializer.batchSize <= 1
-					: !rowProcessingState.getLoadQueryInfluencers()
-							.effectivelyBatchLoadable(
-									initializer.toOneMapping.getEntityMappingType().getEntityPersister()
-							);
+			else {
+				final var batchSize = initializer.fetchOptions.batchSize();
+				return batchSize != null
+						? batchSize <= 1
+						: !rowProcessingState.getLoadQueryInfluencers()
+								.effectivelyBatchLoadable(
+										initializer.toOneMapping.getEntityMappingType()
+												.getEntityPersister()
+								);
+			}
 		}
 	}
 
@@ -70,12 +72,10 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super( parent, toOneMapping, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
+				fetchOptions, creationState );
 		//noinspection unchecked
 		owningEntityInitializer =
 				(EntityInitializer<InitializerData>)
@@ -130,7 +130,9 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 			initialize( data );
 		}
 		else {
-			data.entityKey = data.getRowProcessingState().getSession().generateEntityKey( data.entityIdentifier, concreteDescriptor );
+			data.entityKey =
+					data.getRowProcessingState().getSession()
+							.generateEntityKey( data.entityIdentifier, concreteDescriptor );
 			data.setInstance( getExistingInitializedInstance( data ) );
 			if ( data.getInstance() == null ) {
 				// need to add the key to the batch queue only when the entity has not been already loaded or
@@ -195,11 +197,8 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 			data.setInstance( lazyInitializer.getImplementation() );
 		}
 
-		data.entityKey = data.getRowProcessingState().getSession().generateEntityKey( data.entityIdentifier, concreteDescriptor );
-		final var entityHolder = persistenceContext.getEntityHolder(
-				data.entityKey
-		);
-
+		data.entityKey = session.generateEntityKey( data.entityIdentifier, concreteDescriptor );
+		final var entityHolder = persistenceContext.getEntityHolder( data.entityKey );
 		if ( entityHolder == null || entityHolder.getEntity() != instance && entityHolder.getProxy() != instance ) {
 			// the existing entity instance is detached or transient
 			if ( entityHolder != null ) {
@@ -275,8 +274,8 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 		withFetchOptions(
 				session,
 				() -> {
-					session.getPersistenceContextInternal()
-							.getBatchFetchQueue().addBatchLoadableEntityKey( data.entityKey );
+					session.getPersistenceContextInternal().getBatchFetchQueue()
+							.addBatchLoadableEntityKey( data.entityKey );
 					return null;
 				}
 		);
@@ -299,7 +298,9 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 		else {
 			final var lazyInitializer = extractLazyInitializer( instance );
 			if ( lazyInitializer != null && lazyInitializer.isUninitialized() ) {
-				data.entityKey = data.getRowProcessingState().getSession().generateEntityKey( lazyInitializer.getInternalIdentifier(), concreteDescriptor );
+				data.entityKey =
+						data.getRowProcessingState().getSession()
+								.generateEntityKey( lazyInitializer.getInternalIdentifier(), concreteDescriptor );
 				registerToBatchFetchQueue( data );
 			}
 			data.setState( State.INITIALIZED );
@@ -309,11 +310,16 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 	protected Object loadInstance(EntityKey entityKey, SharedSessionContractImplementor session) {
 		final String entityName = entityKey.getEntityName();
 		final Object identifier = entityKey.getIdentifier();
-		final Object instance = withFetchOptions(
-				session,
-				() -> session.internalLoad( entityName, identifier, true,
-						toOneMapping.isInternalLoadNullable() )
-		);
+		final Object instance =
+				withFetchOptions(
+						session,
+						() -> session.internalLoad(
+								entityName,
+								identifier,
+								true,
+								toOneMapping.isInternalLoadNullable()
+						)
+				);
 		if ( instance == null ) {
 			checkNotFound( toOneMapping, affectedByFilter, entityName, identifier );
 		}
@@ -328,7 +334,7 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 		final var parentEntityAttributes = new AttributeMapping[size];
 		parentEntityAttributes[ entityDescriptor.getSubclassId() ] =
 				getParentEntityAttribute( entityDescriptor, toOneMapping, attributeName );
-		for ( EntityMappingType subMappingType : entityDescriptor.getSubMappingTypes() ) {
+		for ( var subMappingType : entityDescriptor.getSubMappingTypes() ) {
 			parentEntityAttributes[ subMappingType.getSubclassId() ] =
 					getParentEntityAttribute( subMappingType, toOneMapping, attributeName );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractBatchEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractBatchEntitySelectFetchInitializer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.Hibernate;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.engine.spi.EntityKey;
@@ -61,8 +63,10 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
-		super( parent, toOneMapping, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter, creationState );
+		super( parent, toOneMapping, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
+				cacheStoreMode, creationState );
 		//noinspection unchecked
 		owningEntityInitializer =
 				(EntityInitializer<InitializerData>)
@@ -286,16 +290,14 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 		}
 	}
 
-	protected static Object loadInstance(
-			EntityKey entityKey,
-			ToOneAttributeMapping toOneMapping,
-			boolean affectedByFilter,
-			SharedSessionContractImplementor session) {
+	protected Object loadInstance(EntityKey entityKey, SharedSessionContractImplementor session) {
 		final String entityName = entityKey.getEntityName();
 		final Object identifier = entityKey.getIdentifier();
-		final Object instance =
-				session.internalLoad( entityName, identifier, true,
-						toOneMapping.isInternalLoadNullable() );
+		final Object instance = withCacheStoreMode(
+				session,
+				() -> session.internalLoad( entityName, identifier, true,
+						toOneMapping.isInternalLoadNullable() )
+		);
 		if ( instance == null ) {
 			checkNotFound( toOneMapping, affectedByFilter, entityName, identifier );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractBatchEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractBatchEntitySelectFetchInitializer.java
@@ -51,9 +51,15 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 		private static boolean isBatchDisabled(
 				AbstractBatchEntitySelectFetchInitializer<?> initializer,
 				RowProcessingState rowProcessingState) {
-			return rowProcessingState.isScrollResult()
-				|| !rowProcessingState.getLoadQueryInfluencers()
-					.effectivelyBatchLoadable( initializer.toOneMapping.getEntityMappingType().getEntityPersister() );
+			if ( rowProcessingState.isScrollResult() ) {
+				return true;
+			}
+			return initializer.batchSize != null
+					? initializer.batchSize <= 1
+					: !rowProcessingState.getLoadQueryInfluencers()
+							.effectivelyBatchLoadable(
+									initializer.toOneMapping.getEntityMappingType().getEntityPersister()
+							);
 		}
 	}
 
@@ -66,9 +72,10 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		super( parent, toOneMapping, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
 		//noinspection unchecked
 		owningEntityInitializer =
 				(EntityInitializer<InitializerData>)
@@ -264,8 +271,15 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 
 	protected void registerToBatchFetchQueue(Data data) {
 		assert data.entityKey != null;
-		data.getRowProcessingState().getSession().getPersistenceContextInternal()
-				.getBatchFetchQueue().addBatchLoadableEntityKey( data.entityKey );
+		final var session = data.getRowProcessingState().getSession();
+		withFetchOptions(
+				session,
+				() -> {
+					session.getPersistenceContextInternal()
+							.getBatchFetchQueue().addBatchLoadableEntityKey( data.entityKey );
+					return null;
+				}
+		);
 	}
 
 	@Override
@@ -295,7 +309,7 @@ public abstract class AbstractBatchEntitySelectFetchInitializer<Data extends Abs
 	protected Object loadInstance(EntityKey entityKey, SharedSessionContractImplementor session) {
 		final String entityName = entityKey.getEntityName();
 		final Object identifier = entityKey.getIdentifier();
-		final Object instance = withCacheModes(
+		final Object instance = withFetchOptions(
 				session,
 				() -> session.internalLoad( entityName, identifier, true,
 						toOneMapping.isInternalLoadNullable() )

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
@@ -6,6 +6,8 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.BitSet;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.spi.NavigablePath;
@@ -34,6 +36,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	private final DomainResult<?> keyResult;
 	private final BasicFetch<?> discriminatorFetch;
 	private final boolean selectByUniqueKey;
+	private final CacheStoreMode cacheStoreMode;
 
 	public AbstractNonJoinedEntityFetch(
 			NavigablePath navigablePath,
@@ -49,6 +52,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 		this.keyResult = keyResult;
 		this.discriminatorFetch = selectDiscriminator ? creationState.visitDiscriminatorFetch( this ) : null;
 		this.selectByUniqueKey = selectByUniqueKey;
+		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
 	}
 
 	protected AbstractNonJoinedEntityFetch(
@@ -57,13 +61,15 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 			FetchParent fetchParent,
 			DomainResult<?> keyResult,
 			BasicFetch<?> discriminatorFetch,
-			boolean selectByUniqueKey) {
+			boolean selectByUniqueKey,
+			CacheStoreMode cacheStoreMode) {
 		this.navigablePath = navigablePath;
 		this.fetchedModelPart = fetchedModelPart;
 		this.fetchParent = fetchParent;
 		this.keyResult = keyResult;
 		this.discriminatorFetch = discriminatorFetch;
 		this.selectByUniqueKey = selectByUniqueKey;
+		this.cacheStoreMode = cacheStoreMode;
 	}
 
 	@Override
@@ -79,6 +85,11 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	@Override
 	public ToOneAttributeMapping getEntityValuedModelPart() {
 		return fetchedModelPart;
+	}
+
+	@Override
+	public CacheStoreMode getCacheStoreMode() {
+		return cacheStoreMode;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
@@ -39,6 +39,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	private final boolean selectByUniqueKey;
 	private final CacheStoreMode cacheStoreMode;
 	private final CacheRetrieveMode cacheRetrieveMode;
+	private final Integer batchSize;
 
 	public AbstractNonJoinedEntityFetch(
 			NavigablePath navigablePath,
@@ -56,6 +57,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 		this.selectByUniqueKey = selectByUniqueKey;
 		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
 		this.cacheRetrieveMode = creationState.getFetchCacheRetrieveMode( navigablePath );
+		this.batchSize = creationState.getFetchBatchSize( navigablePath );
 	}
 
 	protected AbstractNonJoinedEntityFetch(
@@ -66,7 +68,8 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 			BasicFetch<?> discriminatorFetch,
 			boolean selectByUniqueKey,
 			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode) {
+			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize) {
 		this.navigablePath = navigablePath;
 		this.fetchedModelPart = fetchedModelPart;
 		this.fetchParent = fetchParent;
@@ -75,6 +78,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 		this.selectByUniqueKey = selectByUniqueKey;
 		this.cacheStoreMode = cacheStoreMode;
 		this.cacheRetrieveMode = cacheRetrieveMode;
+		this.batchSize = batchSize;
 	}
 
 	@Override
@@ -100,6 +104,11 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	@Override
 	public CacheRetrieveMode getCacheRetrieveMode() {
 		return cacheRetrieveMode;
+	}
+
+	@Override
+	public Integer getBatchSize() {
+		return batchSize;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
@@ -6,6 +6,7 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.BitSet;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -37,6 +38,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	private final BasicFetch<?> discriminatorFetch;
 	private final boolean selectByUniqueKey;
 	private final CacheStoreMode cacheStoreMode;
+	private final CacheRetrieveMode cacheRetrieveMode;
 
 	public AbstractNonJoinedEntityFetch(
 			NavigablePath navigablePath,
@@ -53,6 +55,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 		this.discriminatorFetch = selectDiscriminator ? creationState.visitDiscriminatorFetch( this ) : null;
 		this.selectByUniqueKey = selectByUniqueKey;
 		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
+		this.cacheRetrieveMode = creationState.getFetchCacheRetrieveMode( navigablePath );
 	}
 
 	protected AbstractNonJoinedEntityFetch(
@@ -62,7 +65,8 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 			DomainResult<?> keyResult,
 			BasicFetch<?> discriminatorFetch,
 			boolean selectByUniqueKey,
-			CacheStoreMode cacheStoreMode) {
+			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode) {
 		this.navigablePath = navigablePath;
 		this.fetchedModelPart = fetchedModelPart;
 		this.fetchParent = fetchParent;
@@ -70,6 +74,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 		this.discriminatorFetch = discriminatorFetch;
 		this.selectByUniqueKey = selectByUniqueKey;
 		this.cacheStoreMode = cacheStoreMode;
+		this.cacheRetrieveMode = cacheRetrieveMode;
 	}
 
 	@Override
@@ -90,6 +95,11 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	@Override
 	public CacheStoreMode getCacheStoreMode() {
 		return cacheStoreMode;
+	}
+
+	@Override
+	public CacheRetrieveMode getCacheRetrieveMode() {
+		return cacheRetrieveMode;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
@@ -6,9 +6,7 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.BitSet;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.spi.NavigablePath;
@@ -37,9 +35,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	private final DomainResult<?> keyResult;
 	private final BasicFetch<?> discriminatorFetch;
 	private final boolean selectByUniqueKey;
-	private final CacheStoreMode cacheStoreMode;
-	private final CacheRetrieveMode cacheRetrieveMode;
-	private final Integer batchSize;
+	private final FetchOptions fetchOptions;
 
 	public AbstractNonJoinedEntityFetch(
 			NavigablePath navigablePath,
@@ -55,9 +51,7 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 		this.keyResult = keyResult;
 		this.discriminatorFetch = selectDiscriminator ? creationState.visitDiscriminatorFetch( this ) : null;
 		this.selectByUniqueKey = selectByUniqueKey;
-		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
-		this.cacheRetrieveMode = creationState.getFetchCacheRetrieveMode( navigablePath );
-		this.batchSize = creationState.getFetchBatchSize( navigablePath );
+		this.fetchOptions = creationState.getFetchOptions( navigablePath );
 	}
 
 	protected AbstractNonJoinedEntityFetch(
@@ -67,18 +61,14 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 			DomainResult<?> keyResult,
 			BasicFetch<?> discriminatorFetch,
 			boolean selectByUniqueKey,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize) {
+			FetchOptions fetchOptions) {
 		this.navigablePath = navigablePath;
 		this.fetchedModelPart = fetchedModelPart;
 		this.fetchParent = fetchParent;
 		this.keyResult = keyResult;
 		this.discriminatorFetch = discriminatorFetch;
 		this.selectByUniqueKey = selectByUniqueKey;
-		this.cacheStoreMode = cacheStoreMode;
-		this.cacheRetrieveMode = cacheRetrieveMode;
-		this.batchSize = batchSize;
+		this.fetchOptions = fetchOptions;
 	}
 
 	@Override
@@ -97,18 +87,8 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	}
 
 	@Override
-	public CacheStoreMode getCacheStoreMode() {
-		return cacheStoreMode;
-	}
-
-	@Override
-	public CacheRetrieveMode getCacheRetrieveMode() {
-		return cacheRetrieveMode;
-	}
-
-	@Override
-	public Integer getBatchSize() {
-		return batchSize;
+	public FetchOptions getFetchOptions() {
+		return fetchOptions;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntityInsideEmbeddableSelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntityInsideEmbeddableSelectFetchInitializer.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
@@ -65,8 +67,10 @@ public class BatchEntityInsideEmbeddableSelectFetchInitializer extends AbstractB
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
-		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter, creationState );
+		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
+				cacheStoreMode, creationState );
 
 		referencedModelPartSetter = referencedModelPart.getAttributeMetadata().getPropertyAccess().getSetter();
 		final String rootEmbeddablePropertyName =
@@ -173,7 +177,7 @@ public class BatchEntityInsideEmbeddableSelectFetchInitializer extends AbstractB
 				final var session = data.getRowProcessingState().getSession();
 				final var factory = session.getFactory();
 				final var persistenceContext = session.getPersistenceContextInternal();
-				final Object loadedInstance = loadInstance( entityKey, toOneMapping, affectedByFilter, session );
+				final Object loadedInstance = loadInstance( entityKey, session );
 				for ( ParentInfo parentInfo : parentInfos ) {
 					final Object parentEntityInstance = parentInfo.parentEntityInstance;
 					final var parentEntityEntry = persistenceContext.getEntry( parentEntityInstance );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntityInsideEmbeddableSelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntityInsideEmbeddableSelectFetchInitializer.java
@@ -10,9 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
@@ -68,12 +66,10 @@ public class BatchEntityInsideEmbeddableSelectFetchInitializer extends AbstractB
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
+				fetchOptions, creationState );
 
 		referencedModelPartSetter = referencedModelPart.getAttributeMetadata().getPropertyAccess().getSetter();
 		final String rootEmbeddablePropertyName =

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntityInsideEmbeddableSelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntityInsideEmbeddableSelectFetchInitializer.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.engine.spi.EntityKey;
@@ -68,9 +69,10 @@ public class BatchEntityInsideEmbeddableSelectFetchInitializer extends AbstractB
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, creationState );
 
 		referencedModelPartSetter = referencedModelPart.getAttributeMetadata().getPropertyAccess().getSetter();
 		final String rootEmbeddablePropertyName =

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntityInsideEmbeddableSelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntityInsideEmbeddableSelectFetchInitializer.java
@@ -70,9 +70,10 @@ public class BatchEntityInsideEmbeddableSelectFetchInitializer extends AbstractB
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
 
 		referencedModelPartSetter = referencedModelPart.getAttributeMetadata().getPropertyAccess().getSetter();
 		final String rootEmbeddablePropertyName =

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntitySelectFetchInitializer.java
@@ -8,9 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
@@ -48,12 +46,10 @@ public class BatchEntitySelectFetchInitializer extends AbstractBatchEntitySelect
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
+				fetchOptions, creationState );
 		parentAttributes = getParentEntityAttributes( referencedModelPart.getAttributeName() );
 		referencedModelPartSetter = referencedModelPart.getPropertyAccess().getSetter();
 		referencedModelPartType =

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntitySelectFetchInitializer.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.engine.spi.EntityKey;
@@ -48,9 +49,10 @@ public class BatchEntitySelectFetchInitializer extends AbstractBatchEntitySelect
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, creationState );
 		parentAttributes = getParentEntityAttributes( referencedModelPart.getAttributeName() );
 		referencedModelPartSetter = referencedModelPart.getPropertyAccess().getSetter();
 		referencedModelPartType =

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntitySelectFetchInitializer.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
@@ -45,8 +47,10 @@ public class BatchEntitySelectFetchInitializer extends AbstractBatchEntitySelect
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
-		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter, creationState );
+		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
+				cacheStoreMode, creationState );
 		parentAttributes = getParentEntityAttributes( referencedModelPart.getAttributeName() );
 		referencedModelPartSetter = referencedModelPart.getPropertyAccess().getSetter();
 		referencedModelPartType =
@@ -104,7 +108,7 @@ public class BatchEntitySelectFetchInitializer extends AbstractBatchEntitySelect
 			for ( var entry : toBatchLoad.entrySet() ) {
 				final var entityKey = entry.getKey();
 				final var parentInfos = entry.getValue();
-				final Object instance = loadInstance( entityKey, toOneMapping, affectedByFilter, session );
+				final Object instance = loadInstance( entityKey, session );
 				for ( var parentInfo : parentInfos ) {
 					final Object parentInstance = parentInfo.parentInstance;
 					final var entityEntry = persistenceContext.getEntry( parentInstance );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchEntitySelectFetchInitializer.java
@@ -50,9 +50,10 @@ public class BatchEntitySelectFetchInitializer extends AbstractBatchEntitySelect
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		super( parentAccess, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
 		parentAttributes = getParentEntityAttributes( referencedModelPart.getAttributeName() );
 		referencedModelPartSetter = referencedModelPart.getPropertyAccess().getSetter();
 		referencedModelPartType =

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchInitializeEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchInitializeEntitySelectFetchInitializer.java
@@ -46,9 +46,10 @@ public class BatchInitializeEntitySelectFetchInitializer extends AbstractBatchEn
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		super( parent, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
 	}
 
 	@Override
@@ -66,9 +67,11 @@ public class BatchInitializeEntitySelectFetchInitializer extends AbstractBatchEn
 		super.registerToBatchFetchQueue( data );
 		// Force creating a proxy
 		final var entityKey = data.entityKey;
-		final Object instance =
-				data.getRowProcessingState().getSession()
-						.internalLoad( entityKey.getEntityName(), entityKey.getIdentifier(), false, false );
+		final var session = data.getRowProcessingState().getSession();
+		final Object instance = withFetchOptions(
+				session,
+				() -> session.internalLoad( entityKey.getEntityName(), entityKey.getIdentifier(), false, false )
+		);
 		data.setInstance( instance );
 		var toBatchLoad = data.toBatchLoad;
 		if ( toBatchLoad == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchInitializeEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchInitializeEntitySelectFetchInitializer.java
@@ -6,9 +6,7 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.HashSet;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
@@ -44,12 +42,10 @@ public class BatchInitializeEntitySelectFetchInitializer extends AbstractBatchEn
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super( parent, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
+				fetchOptions, creationState );
 	}
 
 	@Override
@@ -68,10 +64,16 @@ public class BatchInitializeEntitySelectFetchInitializer extends AbstractBatchEn
 		// Force creating a proxy
 		final var entityKey = data.entityKey;
 		final var session = data.getRowProcessingState().getSession();
-		final Object instance = withFetchOptions(
-				session,
-				() -> session.internalLoad( entityKey.getEntityName(), entityKey.getIdentifier(), false, false )
-		);
+		final Object instance =
+				withFetchOptions(
+						session,
+						() -> session.internalLoad(
+								entityKey.getEntityName(),
+								entityKey.getIdentifier(),
+								false,
+								false
+						)
+				);
 		data.setInstance( instance );
 		var toBatchLoad = data.toBatchLoad;
 		if ( toBatchLoad == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchInitializeEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchInitializeEntitySelectFetchInitializer.java
@@ -6,6 +6,8 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.HashSet;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
@@ -41,8 +43,10 @@ public class BatchInitializeEntitySelectFetchInitializer extends AbstractBatchEn
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
-		super( parent, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter, creationState );
+		super( parent, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
+				cacheStoreMode, creationState );
 	}
 
 	@Override
@@ -78,7 +82,7 @@ public class BatchInitializeEntitySelectFetchInitializer extends AbstractBatchEn
 		if ( keysToBatchLoad != null ) {
 			final var session = data.getRowProcessingState().getSession();
 			for ( var entityKey : keysToBatchLoad ) {
-				loadInstance( entityKey, toOneMapping, affectedByFilter, session );
+				loadInstance( entityKey, session );
 			}
 			data.toBatchLoad = null;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchInitializeEntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/BatchInitializeEntitySelectFetchInitializer.java
@@ -6,6 +6,7 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.HashSet;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.engine.spi.EntityKey;
@@ -44,9 +45,10 @@ public class BatchInitializeEntitySelectFetchInitializer extends AbstractBatchEn
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		super( parent, referencedModelPart, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, creationState );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityAssembler.java
@@ -35,9 +35,8 @@ public class EntityAssembler<T> implements DomainResultAssembler<T> {
 		// Ensure that the instance really is initialized
 		// This is important for key-many-to-ones that are part of a collection key fk,
 		// as the instance is needed for resolveKey before initializing the instance in RowReader
-		final InitializerData data = initializer.getData( rowProcessingState );
-		final Initializer.State state = data.getState();
-		if ( state == Initializer.State.KEY_RESOLVED ) {
+		final var data = initializer.getData( rowProcessingState );
+		if ( data.getState() == Initializer.State.KEY_RESOLVED ) {
 			initializer.resolveInstance( data );
 		}
 		//noinspection unchecked

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedFetchInitializer.java
@@ -195,9 +195,10 @@ public class EntityDelayedFetchInitializer
 		final var session = rowProcessingState.getSession();
 		final var persistenceContext = session.getPersistenceContextInternal();
 
-		final var ek = entityKey == null ?
-				session.generateEntityKey( data.entityIdentifier, concreteDescriptor ) :
-				entityKey;
+		final var ek =
+				entityKey == null
+						? session.generateEntityKey( data.entityIdentifier, concreteDescriptor )
+						: entityKey;
 		final var holder = persistenceContext.getEntityHolder( ek );
 		if ( holder != null && holder.getEntity() != null ) {
 			return persistenceContext.proxyFor( holder, concreteDescriptor );
@@ -253,9 +254,9 @@ public class EntityDelayedFetchInitializer
 				// field to the interceptor. If we don't get one, we load the entity by unique key.
 				final var persistentAttributeInterceptable =
 						getPersistentAttributeInterceptable( rowProcessingState );
-				if ( (persistentAttributeInterceptable != null ) &&
-					(persistentAttributeInterceptable.$$_hibernate_getInterceptor()
-							instanceof LazyAttributeLoadingInterceptor lazyAttributeLoadingInterceptor) ) {
+				if ( persistentAttributeInterceptable != null
+						&& persistentAttributeInterceptable.$$_hibernate_getInterceptor()
+								instanceof LazyAttributeLoadingInterceptor lazyAttributeLoadingInterceptor ) {
 					lazyAttributeLoadingInterceptor.addLazyFieldByGraph( navigablePath.getLocalName() );
 					instance = UNFETCHED_PROPERTY;
 				}
@@ -292,7 +293,10 @@ public class EntityDelayedFetchInitializer
 		}
 	}
 
-	private Type getUniqueKeyPropertyType(EntityPersister concreteDescriptor, SharedSessionContractImplementor session, String uniqueKeyPropertyName) {
+	private Type getUniqueKeyPropertyType(
+			EntityPersister concreteDescriptor,
+			SharedSessionContractImplementor session,
+			String uniqueKeyPropertyName) {
 		return referencedModelPart.getReferencedPropertyName() == null
 				? concreteDescriptor.getIdentifierType()
 				: session.getFactory().getRuntimeMetamodels()
@@ -336,10 +340,7 @@ public class EntityDelayedFetchInitializer
 			data.entityIdentifier = entityDescriptor.getIdentifier( instance, session );
 
 			final var entityKey = session.generateEntityKey( data.entityIdentifier, entityDescriptor );
-			final var entityHolder = session.getPersistenceContextInternal().getEntityHolder(
-					entityKey
-			);
-
+			final var entityHolder = session.getPersistenceContextInternal().getEntityHolder( entityKey );
 			if ( entityHolder == null || entityHolder.getEntity() != instance && entityHolder.getProxy() != instance ) {
 				// the existing entity instance is detached or transient
 				if ( entityHolder != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
@@ -6,11 +6,9 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.BitSet;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.engine.FetchTiming;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.internal.EntityCollectionPart;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.spi.NavigablePath;
@@ -37,12 +35,11 @@ import org.hibernate.sql.results.graph.internal.ImmutableFetchList;
 public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, InitializerProducer<EntityFetchJoinedImpl> {
 	private final FetchParent fetchParent;
 	private final EntityValuedFetchable fetchContainer;
-	private final EntityResultImpl entityResult;
+	private final EntityResultImpl<?> entityResult;
 	private final DomainResult<?> keyResult;
 	private final NotFoundAction notFoundAction;
 	private final boolean isAffectedByFilter;
-	private final CacheStoreMode cacheStoreMode;
-	private final CacheRetrieveMode cacheRetrieveMode;
+	private final FetchOptions fetchOptions;
 
 	private final String sourceAlias;
 
@@ -60,8 +57,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 		this.notFoundAction = toOneMapping.getNotFoundAction();
 		this.sourceAlias = tableGroup.getSourceAlias();
 		this.isAffectedByFilter = isAffectedByFilter;
-		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
-		this.cacheRetrieveMode = creationState.getFetchCacheRetrieveMode( navigablePath );
+		this.fetchOptions = creationState.getFetchOptions( navigablePath );
 		this.entityResult = new EntityResultImpl<>(
 				navigablePath,
 				toOneMapping,
@@ -83,8 +79,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 		this.keyResult = null;
 		this.sourceAlias = tableGroup.getSourceAlias();
 		this.isAffectedByFilter = false;
-		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
-		this.cacheRetrieveMode = creationState.getFetchCacheRetrieveMode( navigablePath );
+		this.fetchOptions = creationState.getFetchOptions( navigablePath );
 		this.entityResult = new EntityResultImpl<>(
 				navigablePath,
 				collectionPart,
@@ -105,8 +100,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 		this.notFoundAction = original.notFoundAction;
 		this.isAffectedByFilter = original.isAffectedByFilter;
 		this.sourceAlias = original.sourceAlias;
-		this.cacheStoreMode = original.cacheStoreMode;
-		this.cacheRetrieveMode = original.cacheRetrieveMode;
+		this.fetchOptions = original.fetchOptions;
 	}
 
 	@Override
@@ -130,13 +124,8 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 	}
 
 	@Override
-	public CacheStoreMode getCacheStoreMode() {
-		return cacheStoreMode;
-	}
-
-	@Override
-	public CacheRetrieveMode getCacheRetrieveMode() {
-		return cacheRetrieveMode;
+	public FetchOptions getFetchOptions() {
+		return fetchOptions;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
@@ -6,6 +6,7 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.BitSet;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.annotations.NotFoundAction;
@@ -41,6 +42,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 	private final NotFoundAction notFoundAction;
 	private final boolean isAffectedByFilter;
 	private final CacheStoreMode cacheStoreMode;
+	private final CacheRetrieveMode cacheRetrieveMode;
 
 	private final String sourceAlias;
 
@@ -59,6 +61,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 		this.sourceAlias = tableGroup.getSourceAlias();
 		this.isAffectedByFilter = isAffectedByFilter;
 		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
+		this.cacheRetrieveMode = creationState.getFetchCacheRetrieveMode( navigablePath );
 		this.entityResult = new EntityResultImpl<>(
 				navigablePath,
 				toOneMapping,
@@ -81,6 +84,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 		this.sourceAlias = tableGroup.getSourceAlias();
 		this.isAffectedByFilter = false;
 		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
+		this.cacheRetrieveMode = creationState.getFetchCacheRetrieveMode( navigablePath );
 		this.entityResult = new EntityResultImpl<>(
 				navigablePath,
 				collectionPart,
@@ -102,6 +106,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 		this.isAffectedByFilter = original.isAffectedByFilter;
 		this.sourceAlias = original.sourceAlias;
 		this.cacheStoreMode = original.cacheStoreMode;
+		this.cacheRetrieveMode = original.cacheRetrieveMode;
 	}
 
 	@Override
@@ -127,6 +132,11 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 	@Override
 	public CacheStoreMode getCacheStoreMode() {
 		return cacheStoreMode;
+	}
+
+	@Override
+	public CacheRetrieveMode getCacheRetrieveMode() {
+		return cacheRetrieveMode;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
@@ -6,6 +6,8 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.BitSet;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.internal.EntityCollectionPart;
@@ -38,6 +40,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 	private final DomainResult<?> keyResult;
 	private final NotFoundAction notFoundAction;
 	private final boolean isAffectedByFilter;
+	private final CacheStoreMode cacheStoreMode;
 
 	private final String sourceAlias;
 
@@ -55,6 +58,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 		this.notFoundAction = toOneMapping.getNotFoundAction();
 		this.sourceAlias = tableGroup.getSourceAlias();
 		this.isAffectedByFilter = isAffectedByFilter;
+		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
 		this.entityResult = new EntityResultImpl<>(
 				navigablePath,
 				toOneMapping,
@@ -76,6 +80,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 		this.keyResult = null;
 		this.sourceAlias = tableGroup.getSourceAlias();
 		this.isAffectedByFilter = false;
+		this.cacheStoreMode = creationState.getFetchCacheStoreMode( navigablePath );
 		this.entityResult = new EntityResultImpl<>(
 				navigablePath,
 				collectionPart,
@@ -96,6 +101,7 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 		this.notFoundAction = original.notFoundAction;
 		this.isAffectedByFilter = original.isAffectedByFilter;
 		this.sourceAlias = original.sourceAlias;
+		this.cacheStoreMode = original.cacheStoreMode;
 	}
 
 	@Override
@@ -116,6 +122,11 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 	@Override
 	public EntityValuedFetchable getFetchedMapping() {
 		return getEntityValuedModelPart();
+	}
+
+	@Override
+	public CacheStoreMode getCacheStoreMode() {
+		return cacheStoreMode;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
@@ -45,7 +45,8 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 				original.getFetchParent(),
 				original.getKeyResult(),
 				original.getDiscriminatorFetch(),
-				original.isSelectByUniqueKey()
+				original.isSelectByUniqueKey(),
+				original.getCacheStoreMode()
 		);
 		this.isAffectedByFilter = original.isAffectedByFilter();
 	}
@@ -69,6 +70,7 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 				getNavigablePath(),
 				isSelectByUniqueKey(),
 				isAffectedByFilter(),
+				getCacheStoreMode(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
@@ -47,7 +47,8 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 				original.getDiscriminatorFetch(),
 				original.isSelectByUniqueKey(),
 				original.getCacheStoreMode(),
-				original.getCacheRetrieveMode()
+				original.getCacheRetrieveMode(),
+				original.getBatchSize()
 		);
 		this.isAffectedByFilter = original.isAffectedByFilter();
 	}
@@ -73,6 +74,7 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 				isAffectedByFilter(),
 				getCacheStoreMode(),
 				getCacheRetrieveMode(),
+				getBatchSize(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
@@ -46,9 +46,7 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 				original.getKeyResult(),
 				original.getDiscriminatorFetch(),
 				original.isSelectByUniqueKey(),
-				original.getCacheStoreMode(),
-				original.getCacheRetrieveMode(),
-				original.getBatchSize()
+				original.getFetchOptions()
 		);
 		this.isAffectedByFilter = original.isAffectedByFilter();
 	}
@@ -72,9 +70,7 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 				getNavigablePath(),
 				isSelectByUniqueKey(),
 				isAffectedByFilter(),
-				getCacheStoreMode(),
-				getCacheRetrieveMode(),
-				getBatchSize(),
+				getFetchOptions(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
@@ -46,7 +46,8 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 				original.getKeyResult(),
 				original.getDiscriminatorFetch(),
 				original.isSelectByUniqueKey(),
-				original.getCacheStoreMode()
+				original.getCacheStoreMode(),
+				original.getCacheRetrieveMode()
 		);
 		this.isAffectedByFilter = original.isAffectedByFilter();
 	}
@@ -71,6 +72,7 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 				isSelectByUniqueKey(),
 				isAffectedByFilter(),
 				getCacheStoreMode(),
+				getCacheRetrieveMode(),
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.EntityFilterException;
@@ -35,6 +34,7 @@ import org.hibernate.engine.spi.EntityHolder;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.TemporalEntityKey;
 import org.hibernate.engine.spi.EntityUniqueKey;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -113,8 +113,7 @@ public class EntityInitializerImpl
 	private final boolean isPartOfKey;
 	private final boolean isResultInitializer;
 	private final boolean hasKeyManyToOne;
-	private final CacheStoreMode cacheStoreMode;
-	private final CacheRetrieveMode cacheRetrieveMode;
+	private final FetchOptions fetchOptions;
 	/**
 	 * Indicates whether there is a high chance of the previous row to have the same entity key as the current row
 	 * and hence enable a check in the {@link #resolveKey(RowProcessingState)} phase which compare the previously read
@@ -253,8 +252,7 @@ public class EntityInitializerImpl
 						&& !composite.hasContainingClass();
 
 		navigablePath = resultDescriptor.getNavigablePath();
-		cacheStoreMode = resultDescriptor.getCacheStoreMode();
-		cacheRetrieveMode = resultDescriptor.getCacheRetrieveMode();
+		fetchOptions = resultDescriptor.getFetchOptions();
 		isPartOfKey = Initializer.isPartOfKey( navigablePath, parent );
 		// If the parent already has previous row reuse enabled, we can skip that here
 		previousRowReuse = !isPreviousRowReuse( parent ) && (
@@ -1535,7 +1533,7 @@ public class EntityInitializerImpl
 				}
 				// We have to query the second level cache if reference cache entries are used
 				// or if this fetch has an explicit graph cache retrieve mode
-				else if ( entityDescriptor.canUseReferenceCacheEntries() || cacheRetrieveMode != null ) {
+				else if ( entityDescriptor.canUseReferenceCacheEntries() || fetchOptions.cacheRetrieveMode() != null ) {
 				final Object cached = resolveInstanceFromCache( data );
 				if ( cached != null ) {
 					// EARLY EXIT!!!
@@ -2003,18 +2001,21 @@ public class EntityInitializerImpl
 	}
 
 	private boolean isCachePutEnabled(SharedSessionContractImplementor session) {
+		final var cacheStoreMode = fetchOptions.cacheStoreMode();
 		return cacheStoreMode == null
 				? session.getCacheMode().isPutEnabled()
 				: cacheStoreMode != CacheStoreMode.BYPASS;
 	}
 
 	private boolean isCacheRefreshEnabled(SharedSessionContractImplementor session) {
+		final var cacheStoreMode = fetchOptions.cacheStoreMode();
 		return cacheStoreMode == null
 				? session.getCacheMode().isRefreshEnabled()
 				: cacheStoreMode == CacheStoreMode.REFRESH;
 	}
 
 	private <T> T withCacheRetrieveMode(SharedSessionContractImplementor session, Supplier<T> action) {
+		final var cacheRetrieveMode = fetchOptions.cacheRetrieveMode();
 		if ( cacheRetrieveMode == null ) {
 			return action.get();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -9,6 +9,8 @@ import java.util.BitSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.EntityFilterException;
 import org.hibernate.FetchNotFoundException;
 import org.hibernate.Hibernate;
@@ -109,6 +111,7 @@ public class EntityInitializerImpl
 	private final boolean isPartOfKey;
 	private final boolean isResultInitializer;
 	private final boolean hasKeyManyToOne;
+	private final CacheStoreMode cacheStoreMode;
 	/**
 	 * Indicates whether there is a high chance of the previous row to have the same entity key as the current row
 	 * and hence enable a check in the {@link #resolveKey(RowProcessingState)} phase which compare the previously read
@@ -247,6 +250,7 @@ public class EntityInitializerImpl
 						&& !composite.hasContainingClass();
 
 		navigablePath = resultDescriptor.getNavigablePath();
+		cacheStoreMode = resultDescriptor.getCacheStoreMode();
 		isPartOfKey = Initializer.isPartOfKey( navigablePath, parent );
 		// If the parent already has previous row reuse enabled, we can skip that here
 		previousRowReuse = !isPreviousRowReuse( parent ) && (
@@ -1801,7 +1805,7 @@ public class EntityInitializerImpl
 		if ( data.concreteDescriptor.canWriteToCache()
 				// No need to put into the entity cache if this is coming from the query cache already
 				&& !data.getRowProcessingState().isQueryCacheHit()
-				&& session.getCacheMode().isPutEnabled()
+				&& isCachePutEnabled( session )
 				// Don't cache temporal snapshots in the 2LC
 				&& ( data.entityKey == null || !data.entityKey.isTemporal() ) ) {
 			final var cacheAccess = data.concreteDescriptor.getCacheAccessStrategy();
@@ -1913,7 +1917,7 @@ public class EntityInitializerImpl
 			Object cacheKey, CacheEntry cacheEntry) {
 		final boolean minimalPutsEnabled =
 				session.getFactory().getSessionFactoryOptions().isMinimalPutsEnabled()
-						&& !session.getCacheMode().isRefreshEnabled();
+						&& !isCacheRefreshEnabled( session );
 		final var eventListenerManager = session.getEventListenerManager();
 		boolean cacheContentChanged = false;
 		final var eventMonitor = session.getEventMonitor();
@@ -1987,6 +1991,18 @@ public class EntityInitializerImpl
 			);
 			//TODO: Statistics. Treat it like a regular put as above?
 		}
+	}
+
+	private boolean isCachePutEnabled(SharedSessionContractImplementor session) {
+		return cacheStoreMode == null
+				? session.getCacheMode().isPutEnabled()
+				: cacheStoreMode != CacheStoreMode.BYPASS;
+	}
+
+	private boolean isCacheRefreshEnabled(SharedSessionContractImplementor session) {
+		return cacheStoreMode == null
+				? session.getCacheMode().isRefreshEnabled()
+				: cacheStoreMode == CacheStoreMode.REFRESH;
 	}
 
 	protected void registerPossibleUniqueKeyEntries(

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -8,7 +8,9 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.EntityFilterException;
@@ -112,6 +114,7 @@ public class EntityInitializerImpl
 	private final boolean isResultInitializer;
 	private final boolean hasKeyManyToOne;
 	private final CacheStoreMode cacheStoreMode;
+	private final CacheRetrieveMode cacheRetrieveMode;
 	/**
 	 * Indicates whether there is a high chance of the previous row to have the same entity key as the current row
 	 * and hence enable a check in the {@link #resolveKey(RowProcessingState)} phase which compare the previously read
@@ -251,6 +254,7 @@ public class EntityInitializerImpl
 
 		navigablePath = resultDescriptor.getNavigablePath();
 		cacheStoreMode = resultDescriptor.getCacheStoreMode();
+		cacheRetrieveMode = resultDescriptor.getCacheRetrieveMode();
 		isPartOfKey = Initializer.isPartOfKey( navigablePath, parent );
 		// If the parent already has previous row reuse enabled, we can skip that here
 		previousRowReuse = !isPreviousRowReuse( parent ) && (
@@ -1528,9 +1532,10 @@ public class EntityInitializerImpl
 						true,
 						false
 				);
-			}
-			// We have to query the second level cache if reference cache entries are used
-			else if ( entityDescriptor.canUseReferenceCacheEntries() ) {
+				}
+				// We have to query the second level cache if reference cache entries are used
+				// or if this fetch has an explicit graph cache retrieve mode
+				else if ( entityDescriptor.canUseReferenceCacheEntries() || cacheRetrieveMode != null ) {
 				final Object cached = resolveInstanceFromCache( data );
 				if ( cached != null ) {
 					// EARLY EXIT!!!
@@ -1580,12 +1585,16 @@ public class EntityInitializerImpl
 
 	// Used by Hibernate Reactive
 	protected Object resolveInstanceFromCache(EntityInitializerData data) {
-		return loadFromSecondLevelCache(
-				data.getRowProcessingState().getSession().asEventSource(),
-				null,
-				data.lockMode,
-				entityDescriptor,
-				data.entityKey
+		final var session = data.getRowProcessingState().getSession();
+		return withCacheRetrieveMode(
+				session,
+				() -> loadFromSecondLevelCache(
+						session.asEventSource(),
+						null,
+						data.lockMode,
+						entityDescriptor,
+						data.entityKey
+				)
 		);
 	}
 
@@ -2003,6 +2012,27 @@ public class EntityInitializerImpl
 		return cacheStoreMode == null
 				? session.getCacheMode().isRefreshEnabled()
 				: cacheStoreMode == CacheStoreMode.REFRESH;
+	}
+
+	private <T> T withCacheRetrieveMode(SharedSessionContractImplementor session, Supplier<T> action) {
+		if ( cacheRetrieveMode == null ) {
+			return action.get();
+		}
+		final var previousCacheMode = session.getCacheMode();
+		final var effectiveCacheMode = CacheMode.fromJpaModes(
+				cacheRetrieveMode,
+				previousCacheMode.getJpaStoreMode()
+		);
+		if ( effectiveCacheMode == previousCacheMode ) {
+			return action.get();
+		}
+		session.setCacheMode( effectiveCacheMode );
+		try {
+			return action.get();
+		}
+		finally {
+			session.setCacheMode( previousCacheMode );
+		}
 	}
 
 	protected void registerPossibleUniqueKeyEntries(

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.engine.spi.EntityUniqueKey;
@@ -31,9 +32,10 @@ public class EntitySelectFetchByUniqueKeyInitializer
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		super( parent, fetchedAttribute, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, creationState );
 		this.fetchedAttribute = fetchedAttribute;
 	}
 
@@ -55,7 +57,7 @@ public class EntitySelectFetchByUniqueKeyInitializer
 				);
 		data.setInstance( persistenceContext.getEntity( entityUniqueKey ) );
 		if ( data.getInstance() == null ) {
-			final Object instance = withCacheStoreMode(
+			final Object instance = withCacheModes(
 					session,
 					() -> concreteDescriptor.loadByUniqueKey( uniqueKeyPropertyName, data.entityIdentifier, session )
 			);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.engine.spi.EntityUniqueKey;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
@@ -28,8 +30,10 @@ public class EntitySelectFetchByUniqueKeyInitializer
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
-		super( parent, fetchedAttribute, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter, creationState );
+		super( parent, fetchedAttribute, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
+				cacheStoreMode, creationState );
 		this.fetchedAttribute = fetchedAttribute;
 	}
 
@@ -51,8 +55,10 @@ public class EntitySelectFetchByUniqueKeyInitializer
 				);
 		data.setInstance( persistenceContext.getEntity( entityUniqueKey ) );
 		if ( data.getInstance() == null ) {
-			final Object instance =
-					concreteDescriptor.loadByUniqueKey( uniqueKeyPropertyName, data.entityIdentifier, session );
+			final Object instance = withCacheStoreMode(
+					session,
+					() -> concreteDescriptor.loadByUniqueKey( uniqueKeyPropertyName, data.entityIdentifier, session )
+			);
 			data.setInstance( instance );
 			if ( instance == null ) {
 				checkNotFound( data );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
@@ -33,9 +33,10 @@ public class EntitySelectFetchByUniqueKeyInitializer
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		super( parent, fetchedAttribute, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, creationState );
+				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
 		this.fetchedAttribute = fetchedAttribute;
 	}
 
@@ -57,7 +58,7 @@ public class EntitySelectFetchByUniqueKeyInitializer
 				);
 		data.setInstance( persistenceContext.getEntity( entityUniqueKey ) );
 		if ( data.getInstance() == null ) {
-			final Object instance = withCacheModes(
+			final Object instance = withFetchOptions(
 					session,
 					() -> concreteDescriptor.loadByUniqueKey( uniqueKeyPropertyName, data.entityIdentifier, session )
 			);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
@@ -4,9 +4,7 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.EntityUniqueKey;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
@@ -31,12 +29,10 @@ public class EntitySelectFetchByUniqueKeyInitializer
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super( parent, fetchedAttribute, fetchedNavigable, concreteDescriptor, keyResult, affectedByFilter,
-				cacheStoreMode, cacheRetrieveMode, batchSize, creationState );
+				fetchOptions, creationState );
 		this.fetchedAttribute = fetchedAttribute;
 	}
 
@@ -58,10 +54,14 @@ public class EntitySelectFetchByUniqueKeyInitializer
 				);
 		data.setInstance( persistenceContext.getEntity( entityUniqueKey ) );
 		if ( data.getInstance() == null ) {
-			final Object instance = withFetchOptions(
-					session,
-					() -> concreteDescriptor.loadByUniqueKey( uniqueKeyPropertyName, data.entityIdentifier, session )
-			);
+			final Object instance =
+					withFetchOptions(
+							session,
+							() -> concreteDescriptor.loadByUniqueKey(
+									uniqueKeyPropertyName,
+									data.entityIdentifier, session
+							)
+					);
 			data.setInstance( instance );
 			if ( instance == null ) {
 				checkNotFound( data );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
@@ -56,6 +56,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 	protected final boolean hasLazySubInitializer;
 	protected final CacheStoreMode cacheStoreMode;
 	protected final CacheRetrieveMode cacheRetrieveMode;
+	protected final @Nullable Integer batchSize;
 
 	public static class EntitySelectFetchInitializerData extends InitializerData {
 		// per-row state
@@ -83,6 +84,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			@Nullable Integer batchSize,
 			AssemblerCreationState creationState) {
 		super( creationState );
 		this.parent = parent;
@@ -92,6 +94,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 		this.affectedByFilter = affectedByFilter;
 		this.cacheStoreMode = cacheStoreMode;
 		this.cacheRetrieveMode = cacheRetrieveMode;
+		this.batchSize = batchSize;
 
 		isPartOfKey = Initializer.isPartOfKey( fetchedNavigable, parent );
 		keyAssembler = keyResult.createResultAssembler( this, creationState );
@@ -257,7 +260,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 		data.setState( State.INITIALIZED );
 		final String entityName = concreteDescriptor.getEntityName();
 
-		final Object instance = withCacheModes(
+		final Object instance = withFetchOptions(
 				session,
 				() -> session.internalLoad(
 						entityName,
@@ -384,6 +387,11 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 
 	public DomainResultAssembler<?> getKeyAssembler() {
 		return keyAssembler;
+	}
+
+	protected <T> T withFetchOptions(SharedSessionContractImplementor session, Supplier<T> action) {
+		return session.getLoadQueryInfluencers()
+				.fromBatchSize( batchSize, () -> withCacheModes( session, action ) );
 	}
 
 	protected <T> T withCacheModes(SharedSessionContractImplementor session, Supplier<T> action) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.results.graph.entity.internal;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.CacheMode;
@@ -54,6 +55,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 	protected final boolean keyIsEager;
 	protected final boolean hasLazySubInitializer;
 	protected final CacheStoreMode cacheStoreMode;
+	protected final CacheRetrieveMode cacheRetrieveMode;
 
 	public static class EntitySelectFetchInitializerData extends InitializerData {
 		// per-row state
@@ -80,6 +82,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		super( creationState );
 		this.parent = parent;
@@ -88,6 +91,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 		this.concreteDescriptor = concreteDescriptor;
 		this.affectedByFilter = affectedByFilter;
 		this.cacheStoreMode = cacheStoreMode;
+		this.cacheRetrieveMode = cacheRetrieveMode;
 
 		isPartOfKey = Initializer.isPartOfKey( fetchedNavigable, parent );
 		keyAssembler = keyResult.createResultAssembler( this, creationState );
@@ -253,7 +257,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 		data.setState( State.INITIALIZED );
 		final String entityName = concreteDescriptor.getEntityName();
 
-		final Object instance = withCacheStoreMode(
+		final Object instance = withCacheModes(
 				session,
 				() -> session.internalLoad(
 						entityName,
@@ -382,12 +386,15 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 		return keyAssembler;
 	}
 
-	protected <T> T withCacheStoreMode(SharedSessionContractImplementor session, Supplier<T> action) {
-		if ( cacheStoreMode == null ) {
+	protected <T> T withCacheModes(SharedSessionContractImplementor session, Supplier<T> action) {
+		if ( cacheRetrieveMode == null && cacheStoreMode == null ) {
 			return action.get();
 		}
 		final var previousCacheMode = session.getCacheMode();
-		final var effectiveCacheMode = CacheMode.fromJpaModes( previousCacheMode.getJpaRetrieveMode(), cacheStoreMode );
+		final var effectiveCacheMode = CacheMode.fromJpaModes(
+				cacheRetrieveMode == null ? previousCacheMode.getJpaRetrieveMode() : cacheRetrieveMode,
+				cacheStoreMode == null ? previousCacheMode.getJpaStoreMode() : cacheStoreMode
+		);
 		if ( effectiveCacheMode == previousCacheMode ) {
 			return action.get();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
@@ -5,7 +5,11 @@
 package org.hibernate.sql.results.graph.entity.internal;
 
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
+import jakarta.persistence.CacheStoreMode;
+
+import org.hibernate.CacheMode;
 import org.hibernate.EntityFilterException;
 import org.hibernate.FetchNotFoundException;
 import org.hibernate.Hibernate;
@@ -49,6 +53,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 	protected final boolean affectedByFilter;
 	protected final boolean keyIsEager;
 	protected final boolean hasLazySubInitializer;
+	protected final CacheStoreMode cacheStoreMode;
 
 	public static class EntitySelectFetchInitializerData extends InitializerData {
 		// per-row state
@@ -74,6 +79,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		super( creationState );
 		this.parent = parent;
@@ -81,6 +87,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 		this.navigablePath = fetchedNavigable;
 		this.concreteDescriptor = concreteDescriptor;
 		this.affectedByFilter = affectedByFilter;
+		this.cacheStoreMode = cacheStoreMode;
 
 		isPartOfKey = Initializer.isPartOfKey( fetchedNavigable, parent );
 		keyAssembler = keyResult.createResultAssembler( this, creationState );
@@ -246,11 +253,14 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 		data.setState( State.INITIALIZED );
 		final String entityName = concreteDescriptor.getEntityName();
 
-		final Object instance = session.internalLoad(
-				entityName,
-				data.entityIdentifier,
-				true,
-				toOneMapping.isInternalLoadNullable()
+		final Object instance = withCacheStoreMode(
+				session,
+				() -> session.internalLoad(
+						entityName,
+						data.entityIdentifier,
+						true,
+						toOneMapping.isInternalLoadNullable()
+				)
 		);
 		data.setInstance( instance );
 
@@ -370,5 +380,23 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 
 	public DomainResultAssembler<?> getKeyAssembler() {
 		return keyAssembler;
+	}
+
+	protected <T> T withCacheStoreMode(SharedSessionContractImplementor session, Supplier<T> action) {
+		if ( cacheStoreMode == null ) {
+			return action.get();
+		}
+		final var previousCacheMode = session.getCacheMode();
+		final var effectiveCacheMode = CacheMode.fromJpaModes( previousCacheMode.getJpaRetrieveMode(), cacheStoreMode );
+		if ( effectiveCacheMode == previousCacheMode ) {
+			return action.get();
+		}
+		session.setCacheMode( effectiveCacheMode );
+		try {
+			return action.get();
+		}
+		finally {
+			session.setCacheMode( previousCacheMode );
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
@@ -7,16 +7,13 @@ package org.hibernate.sql.results.graph.entity.internal;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
-import org.hibernate.CacheMode;
 import org.hibernate.EntityFilterException;
 import org.hibernate.FetchNotFoundException;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.engine.spi.EntityHolder;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.ModelPart;
@@ -54,15 +51,15 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 	protected final boolean affectedByFilter;
 	protected final boolean keyIsEager;
 	protected final boolean hasLazySubInitializer;
-	protected final CacheStoreMode cacheStoreMode;
-	protected final CacheRetrieveMode cacheRetrieveMode;
-	protected final @Nullable Integer batchSize;
+	protected final FetchOptions fetchOptions;
 
 	public static class EntitySelectFetchInitializerData extends InitializerData {
 		// per-row state
 		protected @Nullable Object entityIdentifier;
 
-		public EntitySelectFetchInitializerData(EntitySelectFetchInitializer<?> initializer, RowProcessingState rowProcessingState) {
+		public EntitySelectFetchInitializerData(
+				EntitySelectFetchInitializer<?> initializer,
+				RowProcessingState rowProcessingState) {
 			super( rowProcessingState );
 		}
 
@@ -82,9 +79,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 			EntityPersister concreteDescriptor,
 			DomainResult<?> keyResult,
 			boolean affectedByFilter,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			@Nullable Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		super( creationState );
 		this.parent = parent;
@@ -92,13 +87,13 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 		this.navigablePath = fetchedNavigable;
 		this.concreteDescriptor = concreteDescriptor;
 		this.affectedByFilter = affectedByFilter;
-		this.cacheStoreMode = cacheStoreMode;
-		this.cacheRetrieveMode = cacheRetrieveMode;
-		this.batchSize = batchSize;
+		this.fetchOptions = fetchOptions;
 
 		isPartOfKey = Initializer.isPartOfKey( fetchedNavigable, parent );
 		keyAssembler = keyResult.createResultAssembler( this, creationState );
-		isEnhancedForLazyLoading = concreteDescriptor.getBytecodeEnhancementMetadata().isEnhancedForLazyLoading();
+		isEnhancedForLazyLoading =
+				concreteDescriptor.getBytecodeEnhancementMetadata()
+						.isEnhancedForLazyLoading();
 
 		keyIsEager = keyAssembler.isEager();
 		hasLazySubInitializer = keyAssembler.hasLazySubInitializers();
@@ -181,7 +176,9 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 				data.entityIdentifier = lazyInitializer.getInternalIdentifier();
 			}
 
-			final var entityKey = data.getRowProcessingState().getSession().generateEntityKey( data.entityIdentifier, concreteDescriptor );
+			final var entityKey =
+					rowProcessingState.getSession()
+							.generateEntityKey( data.entityIdentifier, concreteDescriptor );
 			final var entityHolder = persistenceContext.getEntityHolder(
 					entityKey
 			);
@@ -260,15 +257,16 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 		data.setState( State.INITIALIZED );
 		final String entityName = concreteDescriptor.getEntityName();
 
-		final Object instance = withFetchOptions(
-				session,
-				() -> session.internalLoad(
-						entityName,
-						data.entityIdentifier,
-						true,
-						toOneMapping.isInternalLoadNullable()
-				)
-		);
+		final Object instance =
+				withFetchOptions(
+						session,
+						() -> session.internalLoad(
+								entityName,
+								data.entityIdentifier,
+								true,
+								toOneMapping.isInternalLoadNullable()
+						)
+				);
 		data.setInstance( instance );
 
 		if ( instance == null ) {
@@ -391,27 +389,7 @@ public class EntitySelectFetchInitializer<Data extends EntitySelectFetchInitiali
 
 	protected <T> T withFetchOptions(SharedSessionContractImplementor session, Supplier<T> action) {
 		return session.getLoadQueryInfluencers()
-				.fromBatchSize( batchSize, () -> withCacheModes( session, action ) );
+				.withFetchOptions( session, fetchOptions, action);
 	}
 
-	protected <T> T withCacheModes(SharedSessionContractImplementor session, Supplier<T> action) {
-		if ( cacheRetrieveMode == null && cacheStoreMode == null ) {
-			return action.get();
-		}
-		final var previousCacheMode = session.getCacheMode();
-		final var effectiveCacheMode = CacheMode.fromJpaModes(
-				cacheRetrieveMode == null ? previousCacheMode.getJpaRetrieveMode() : cacheRetrieveMode,
-				cacheStoreMode == null ? previousCacheMode.getJpaStoreMode() : cacheStoreMode
-		);
-		if ( effectiveCacheMode == previousCacheMode ) {
-			return action.get();
-		}
-		session.setCacheMode( effectiveCacheMode );
-		try {
-			return action.get();
-		}
-		finally {
-			session.setCacheMode( previousCacheMode );
-		}
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializerBuilder.java
@@ -4,12 +4,8 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
-import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.internal.StandardEmbeddableInstantiator;
-import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
 import org.hibernate.metamodel.mapping.EntityValuedModelPart;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
@@ -17,7 +13,6 @@ import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.InitializerParent;
-import org.hibernate.sql.results.graph.embeddable.EmbeddableInitializer;
 import org.hibernate.sql.results.graph.entity.EntityInitializer;
 
 import static org.hibernate.sql.results.graph.entity.internal.EntitySelectFetchInitializerBuilder.BatchMode.BATCH_INITIALIZE;
@@ -34,9 +29,7 @@ public class EntitySelectFetchInitializerBuilder {
 			NavigablePath navigablePath,
 			boolean selectByUniqueKey,
 			boolean affectedByFilter,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		if ( selectByUniqueKey ) {
 			return new EntitySelectFetchByUniqueKeyInitializer(
@@ -46,9 +39,7 @@ public class EntitySelectFetchInitializerBuilder {
 					entityPersister,
 					keyResult,
 					affectedByFilter,
-					cacheStoreMode,
-					cacheRetrieveMode,
-					batchSize,
+					fetchOptions,
 					creationState
 			);
 		}
@@ -61,14 +52,11 @@ public class EntitySelectFetchInitializerBuilder {
 					entityPersister,
 					keyResult,
 					affectedByFilter,
-					cacheStoreMode,
-					cacheRetrieveMode,
-					batchSize,
+					fetchOptions,
 					creationState
 			);
 		}
-		final BatchMode batchMode = determineBatchMode( entityPersister, parent, batchSize, creationState );
-		switch ( batchMode ) {
+		switch ( determineBatchMode( entityPersister, parent, fetchOptions, creationState ) ) {
 			case NONE:
 				return new EntitySelectFetchInitializer<>(
 						parent,
@@ -77,9 +65,7 @@ public class EntitySelectFetchInitializerBuilder {
 						entityPersister,
 						keyResult,
 						affectedByFilter,
-						cacheStoreMode,
-						cacheRetrieveMode,
-						batchSize,
+						fetchOptions,
 						creationState
 				);
 			case BATCH_LOAD:
@@ -91,9 +77,7 @@ public class EntitySelectFetchInitializerBuilder {
 							entityPersister,
 							keyResult,
 							affectedByFilter,
-							cacheStoreMode,
-							cacheRetrieveMode,
-							batchSize,
+							fetchOptions,
 							creationState
 					);
 				}
@@ -105,9 +89,7 @@ public class EntitySelectFetchInitializerBuilder {
 							entityPersister,
 							keyResult,
 							affectedByFilter,
-							cacheStoreMode,
-							cacheRetrieveMode,
-							batchSize,
+							fetchOptions,
 							creationState
 					);
 				}
@@ -119,9 +101,7 @@ public class EntitySelectFetchInitializerBuilder {
 						entityPersister,
 						keyResult,
 						affectedByFilter,
-						cacheStoreMode,
-						cacheRetrieveMode,
-						batchSize,
+						fetchOptions,
 						creationState
 				);
 		}
@@ -131,23 +111,22 @@ public class EntitySelectFetchInitializerBuilder {
 	private static BatchMode determineBatchMode(
 			EntityPersister entityPersister,
 			InitializerParent<?> parent,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
+		final var batchSize = fetchOptions.batchSize();
 		if ( batchSize != null && batchSize <= 1 ) {
 			return NONE;
 		}
-		if ( batchSize == null && !entityPersister.isBatchLoadable() ) {
+		else if ( batchSize == null && !entityPersister.isBatchLoadable() ) {
 			return NONE;
 		}
-		if ( creationState.isDynamicInstantiation() ) {
-			if ( canBatchInitializeBeUsed( entityPersister ) ) {
-				return BatchMode.BATCH_INITIALIZE;
-			}
-			return NONE;
+		else if ( creationState.isDynamicInstantiation() ) {
+			return canBatchInitializeBeUsed( entityPersister )
+					? BATCH_INITIALIZE
+					: NONE;
 		}
 		while ( parent.isEmbeddableInitializer() ) {
-			final EmbeddableInitializer<?> embeddableInitializer = parent.asEmbeddableInitializer();
-			final EmbeddableValuedModelPart initializedPart = embeddableInitializer.getInitializedPart();
+			final var initializedPart = parent.asEmbeddableInitializer().getInitializedPart();
 			// For entity identifier mappings we can't batch load,
 			// because the entity identifier needs the instance in the resolveKey phase,
 			// but batch loading is inherently executed out of order
@@ -168,15 +147,14 @@ public class EntitySelectFetchInitializerBuilder {
 		}
 		if ( parent != null ) {
 			assert parent.getInitializedPart() instanceof EntityValuedModelPart;
-			final EntityPersister parentPersister = parent.asEntityInitializer().getEntityDescriptor();
-			final EntityDataAccess cacheAccess = parentPersister.getCacheAccessStrategy();
+			final var parentPersister = parent.asEntityInitializer().getEntityDescriptor();
+			final var cacheAccess = parentPersister.getCacheAccessStrategy();
 			if ( cacheAccess != null ) {
 				// Do batch initialization instead of batch loading if the parent entity is cacheable
 				// to avoid putting entity state into the cache at a point when the association is not yet set
-				if ( canBatchInitializeBeUsed( entityPersister ) ) {
-					return BATCH_INITIALIZE;
-				}
-				return NONE;
+				return canBatchInitializeBeUsed( entityPersister )
+						? BATCH_INITIALIZE
+						: NONE;
 			}
 		}
 		return BATCH_LOAD;

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializerBuilder.java
@@ -36,6 +36,7 @@ public class EntitySelectFetchInitializerBuilder {
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		if ( selectByUniqueKey ) {
 			return new EntitySelectFetchByUniqueKeyInitializer(
@@ -47,6 +48,7 @@ public class EntitySelectFetchInitializerBuilder {
 					affectedByFilter,
 					cacheStoreMode,
 					cacheRetrieveMode,
+					batchSize,
 					creationState
 			);
 		}
@@ -61,10 +63,11 @@ public class EntitySelectFetchInitializerBuilder {
 					affectedByFilter,
 					cacheStoreMode,
 					cacheRetrieveMode,
+					batchSize,
 					creationState
 			);
 		}
-		final BatchMode batchMode = determineBatchMode( entityPersister, parent, creationState );
+		final BatchMode batchMode = determineBatchMode( entityPersister, parent, batchSize, creationState );
 		switch ( batchMode ) {
 			case NONE:
 				return new EntitySelectFetchInitializer<>(
@@ -76,6 +79,7 @@ public class EntitySelectFetchInitializerBuilder {
 						affectedByFilter,
 						cacheStoreMode,
 						cacheRetrieveMode,
+						batchSize,
 						creationState
 				);
 			case BATCH_LOAD:
@@ -89,6 +93,7 @@ public class EntitySelectFetchInitializerBuilder {
 							affectedByFilter,
 							cacheStoreMode,
 							cacheRetrieveMode,
+							batchSize,
 							creationState
 					);
 				}
@@ -102,6 +107,7 @@ public class EntitySelectFetchInitializerBuilder {
 							affectedByFilter,
 							cacheStoreMode,
 							cacheRetrieveMode,
+							batchSize,
 							creationState
 					);
 				}
@@ -115,6 +121,7 @@ public class EntitySelectFetchInitializerBuilder {
 						affectedByFilter,
 						cacheStoreMode,
 						cacheRetrieveMode,
+						batchSize,
 						creationState
 				);
 		}
@@ -124,8 +131,12 @@ public class EntitySelectFetchInitializerBuilder {
 	private static BatchMode determineBatchMode(
 			EntityPersister entityPersister,
 			InitializerParent<?> parent,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
-		if ( !entityPersister.isBatchLoadable() ) {
+		if ( batchSize != null && batchSize <= 1 ) {
+			return NONE;
+		}
+		if ( batchSize == null && !entityPersister.isBatchLoadable() ) {
 			return NONE;
 		}
 		if ( creationState.isDynamicInstantiation() ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializerBuilder.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.cache.spi.access.EntityDataAccess;
@@ -34,6 +35,7 @@ public class EntitySelectFetchInitializerBuilder {
 			boolean selectByUniqueKey,
 			boolean affectedByFilter,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		if ( selectByUniqueKey ) {
 			return new EntitySelectFetchByUniqueKeyInitializer(
@@ -44,6 +46,7 @@ public class EntitySelectFetchInitializerBuilder {
 					keyResult,
 					affectedByFilter,
 					cacheStoreMode,
+					cacheRetrieveMode,
 					creationState
 			);
 		}
@@ -57,6 +60,7 @@ public class EntitySelectFetchInitializerBuilder {
 					keyResult,
 					affectedByFilter,
 					cacheStoreMode,
+					cacheRetrieveMode,
 					creationState
 			);
 		}
@@ -71,6 +75,7 @@ public class EntitySelectFetchInitializerBuilder {
 						keyResult,
 						affectedByFilter,
 						cacheStoreMode,
+						cacheRetrieveMode,
 						creationState
 				);
 			case BATCH_LOAD:
@@ -83,6 +88,7 @@ public class EntitySelectFetchInitializerBuilder {
 							keyResult,
 							affectedByFilter,
 							cacheStoreMode,
+							cacheRetrieveMode,
 							creationState
 					);
 				}
@@ -95,6 +101,7 @@ public class EntitySelectFetchInitializerBuilder {
 							keyResult,
 							affectedByFilter,
 							cacheStoreMode,
+							cacheRetrieveMode,
 							creationState
 					);
 				}
@@ -107,6 +114,7 @@ public class EntitySelectFetchInitializerBuilder {
 						keyResult,
 						affectedByFilter,
 						cacheStoreMode,
+						cacheRetrieveMode,
 						creationState
 				);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializerBuilder.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.metamodel.internal.StandardEmbeddableInstantiator;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
@@ -31,6 +33,7 @@ public class EntitySelectFetchInitializerBuilder {
 			NavigablePath navigablePath,
 			boolean selectByUniqueKey,
 			boolean affectedByFilter,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		if ( selectByUniqueKey ) {
 			return new EntitySelectFetchByUniqueKeyInitializer(
@@ -40,6 +43,7 @@ public class EntitySelectFetchInitializerBuilder {
 					entityPersister,
 					keyResult,
 					affectedByFilter,
+					cacheStoreMode,
 					creationState
 			);
 		}
@@ -52,6 +56,7 @@ public class EntitySelectFetchInitializerBuilder {
 					entityPersister,
 					keyResult,
 					affectedByFilter,
+					cacheStoreMode,
 					creationState
 			);
 		}
@@ -65,6 +70,7 @@ public class EntitySelectFetchInitializerBuilder {
 						entityPersister,
 						keyResult,
 						affectedByFilter,
+						cacheStoreMode,
 						creationState
 				);
 			case BATCH_LOAD:
@@ -76,6 +82,7 @@ public class EntitySelectFetchInitializerBuilder {
 							entityPersister,
 							keyResult,
 							affectedByFilter,
+							cacheStoreMode,
 							creationState
 					);
 				}
@@ -87,6 +94,7 @@ public class EntitySelectFetchInitializerBuilder {
 							entityPersister,
 							keyResult,
 							affectedByFilter,
+							cacheStoreMode,
 							creationState
 					);
 				}
@@ -98,6 +106,7 @@ public class EntitySelectFetchInitializerBuilder {
 						entityPersister,
 						keyResult,
 						affectedByFilter,
+						cacheStoreMode,
 						creationState
 				);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/LoadingCollectionEntryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/LoadingCollectionEntryImpl.java
@@ -88,7 +88,8 @@ public class LoadingCollectionEntryImpl implements LoadingCollectionEntry {
 				collectionDescriptor,
 				collectionInstance,
 				getKey(),
-				hasNoQueuedAdds
+				hasNoQueuedAdds,
+				initializer.getCacheStoreMode()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/LoadingCollectionEntryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/LoadingCollectionEntryImpl.java
@@ -89,7 +89,7 @@ public class LoadingCollectionEntryImpl implements LoadingCollectionEntry {
 				collectionInstance,
 				getKey(),
 				hasNoQueuedAdds,
-				initializer.getCacheStoreMode()
+				initializer.getFetchOptions().cacheStoreMode()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/ResultsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/ResultsHelper.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.results.internal;
 
+import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.SharedSessionContract;
 import org.hibernate.cache.spi.entry.CollectionCacheEntry;
@@ -52,7 +53,8 @@ public class ResultsHelper {
 			CollectionPersister collectionDescriptor,
 			PersistentCollection<?> collection,
 			Object key,
-			boolean hasNoQueuedAdds) {
+			boolean hasNoQueuedAdds,
+			CacheStoreMode cacheStoreMode) {
 		final var session = persistenceContext.getSession();
 		final var collectionEntry =
 				initializedEntry( persistenceContext, collectionDescriptor, collection, key, session );
@@ -60,8 +62,8 @@ public class ResultsHelper {
 			addCollectionHolder( persistenceContext, collectionDescriptor, collection );
 		}
 		persistenceContext.getBatchFetchQueue().removeBatchLoadableCollection( collectionEntry );
-		if ( addToCache( session, collectionEntry, collectionDescriptor, hasNoQueuedAdds ) ) {
-			addCollectionToCache( persistenceContext, collectionDescriptor, collection, key );
+		if ( addToCache( session, collectionEntry, collectionDescriptor, hasNoQueuedAdds, cacheStoreMode ) ) {
+			addCollectionToCache( persistenceContext, collectionDescriptor, collection, key, cacheStoreMode );
 		}
 		final var statistics = session.getFactory().getStatistics();
 		if ( statistics.isStatisticsEnabled() ) {
@@ -81,10 +83,11 @@ public class ResultsHelper {
 			SharedSessionContract session,
 			CollectionEntry collectionEntry,
 			CollectionPersister collectionDescriptor,
-			boolean hasNoQueuedAdds) {
+			boolean hasNoQueuedAdds,
+			CacheStoreMode cacheStoreMode) {
 		return hasNoQueuedAdds  // there were no queued additions
 			&& collectionDescriptor.hasCache()  // the collection role has a cache
-			&& session.getCacheMode().isPutEnabled()  // the session cache mode allows puts
+			&& isCachePutEnabled( session, cacheStoreMode )  // the effective cache mode allows puts
 			&& !collectionEntry.isDoremove();  // this is not a forced initialization during flush
 	}
 
@@ -129,7 +132,8 @@ public class ResultsHelper {
 			PersistenceContext persistenceContext,
 			CollectionPersister collectionDescriptor,
 			PersistentCollection<?> collection,
-			Object key) {
+			Object key,
+			CacheStoreMode cacheStoreMode) {
 		final var session = persistenceContext.getSession();
 
 		if ( CORE_LOGGER.isTraceEnabled() ) {
@@ -162,7 +166,7 @@ public class ResultsHelper {
 			version = null;
 		}
 
-		addCollectionToCache( persistenceContext, collectionDescriptor, collection, key, version );
+		addCollectionToCache( persistenceContext, collectionDescriptor, collection, key, version, cacheStoreMode );
 	}
 
 	private static void addCollectionToCache(
@@ -170,7 +174,8 @@ public class ResultsHelper {
 			CollectionPersister collectionDescriptor,
 			PersistentCollection<?> collection,
 			Object key,
-			Object version) {
+			Object version,
+			CacheStoreMode cacheStoreMode) {
 		final var session = context.getSession();
 		final var factory = session.getFactory();
 		if ( collection.getSession() == null ) {
@@ -189,7 +194,7 @@ public class ResultsHelper {
 		if ( isPutFromLoad( context, collectionDescriptor, entry ) ) {
 			final boolean minimalPutsEnabled =
 					factory.getSessionFactoryOptions().isMinimalPutsEnabled()
-							&& !session.getCacheMode().isRefreshEnabled();
+							&& !isCacheRefreshEnabled( session, cacheStoreMode );
 			final var eventListenerManager = session.getEventListenerManager();
 			final var eventMonitor = session.getEventMonitor();
 			final var cachePutEvent = eventMonitor.beginCachePutEvent();
@@ -224,6 +229,18 @@ public class ResultsHelper {
 				}
 			}
 		}
+	}
+
+	private static boolean isCachePutEnabled(SharedSessionContract session, CacheStoreMode cacheStoreMode) {
+		return cacheStoreMode == null
+				? session.getCacheMode().isPutEnabled()
+				: cacheStoreMode != CacheStoreMode.BYPASS;
+	}
+
+	private static boolean isCacheRefreshEnabled(SharedSessionContract session, CacheStoreMode cacheStoreMode) {
+		return cacheStoreMode == null
+				? session.getCacheMode().isRefreshEnabled()
+				: cacheStoreMode == CacheStoreMode.REFRESH;
 	}
 
 	private static boolean isPutFromLoad(

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.results.internal;
 import java.util.Map;
 import java.util.Objects;
 
+import jakarta.persistence.BatchSize;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.FetchOption;
@@ -63,11 +64,13 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 			final var attributeNode = appliesTo( fetchParent )
 					? currentGraphContext.findNode( fetchable.getFetchableName() )
 					: null;
+			final var batchSize = getBatchSize( attributeNode );
 			currentGraphContext = null;
 			return new TraversalResult( previousContextRoot,
-					handleFetchType( fetchable, exploreKeySubgraph, attributeNode ),
+					handleFetchType( fetchable, exploreKeySubgraph, attributeNode, batchSize ),
 					getCacheStoreMode( attributeNode ),
-					getCacheRetrieveMode( attributeNode ) );
+					getCacheRetrieveMode( attributeNode ),
+					batchSize );
 		}
 	}
 
@@ -95,8 +98,23 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 		return null;
 	}
 
-	private FetchStrategy handleFetchType
-			(Fetchable fetchable, boolean exploreKeySubgraph, AttributeNodeImplementor<?, ?, ?> attributeNode) {
+	private static Integer getBatchSize(AttributeNodeImplementor<?, ?, ?> attributeNode) {
+		if ( attributeNode == null ) {
+			return null;
+		}
+		for ( FetchOption option : attributeNode.getOptions() ) {
+			if ( option instanceof BatchSize batchSize && batchSize.batchSize() >= 0 ) {
+				return batchSize.batchSize();
+			}
+		}
+		return null;
+	}
+
+	private FetchStrategy handleFetchType(
+			Fetchable fetchable,
+			boolean exploreKeySubgraph,
+			AttributeNodeImplementor<?, ?, ?> attributeNode,
+			Integer batchSize) {
 		final var fetchType = attributeNode == null ? null : attributeNode.getFetchType();
 		if ( fetchType != null ) {
 			switch ( fetchType ) {
@@ -123,7 +141,7 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 					if ( subgraphMap != null && subgraphMapKey != null ) {
 						currentGraphContext = subgraphMap.get( subgraphMapKey );
 					}
-					return new FetchStrategy( FetchTiming.IMMEDIATE, true );
+					return new FetchStrategy( FetchTiming.IMMEDIATE, batchSize == null );
 				case LAZY:
 					return new FetchStrategy( FetchTiming.DELAYED, false );
 				default:

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
@@ -7,7 +7,9 @@ package org.hibernate.sql.results.internal;
 import java.util.Map;
 import java.util.Objects;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.FetchOption;
 
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.graph.GraphSemantic;
@@ -64,7 +66,8 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 			currentGraphContext = null;
 			return new TraversalResult( previousContextRoot,
 					handleFetchType( fetchable, exploreKeySubgraph, attributeNode ),
-					getCacheStoreMode( attributeNode ) );
+					getCacheStoreMode( attributeNode ),
+					getCacheRetrieveMode( attributeNode ) );
 		}
 	}
 
@@ -75,6 +78,18 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 		for ( var option : attributeNode.getOptions() ) {
 			if ( option instanceof CacheStoreMode cacheStoreMode ) {
 				return cacheStoreMode;
+			}
+		}
+		return null;
+	}
+
+	private static CacheRetrieveMode getCacheRetrieveMode(AttributeNodeImplementor<?, ?, ?> attributeNode) {
+		if ( attributeNode == null ) {
+			return null;
+		}
+		for ( FetchOption option : attributeNode.getOptions() ) {
+			if ( option instanceof CacheRetrieveMode cacheRetrieveMode ) {
+				return cacheRetrieveMode;
 			}
 		}
 		return null;

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
@@ -7,12 +7,8 @@ package org.hibernate.sql.results.internal;
 import java.util.Map;
 import java.util.Objects;
 
-import jakarta.persistence.BatchSize;
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-import jakarta.persistence.FetchOption;
-
 import org.hibernate.engine.FetchTiming;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.AttributeNodeImplementor;
 import org.hibernate.graph.spi.GraphImplementor;
@@ -64,57 +60,19 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 			final var attributeNode = appliesTo( fetchParent )
 					? currentGraphContext.findNode( fetchable.getFetchableName() )
 					: null;
-			final var batchSize = getBatchSize( attributeNode );
+			final var fetchOptions = FetchOptions.of( attributeNode );
 			currentGraphContext = null;
 			return new TraversalResult( previousContextRoot,
-					handleFetchType( fetchable, exploreKeySubgraph, attributeNode, batchSize ),
-					getCacheStoreMode( attributeNode ),
-					getCacheRetrieveMode( attributeNode ),
-					batchSize );
+					handleFetchType( fetchable, exploreKeySubgraph, attributeNode, fetchOptions ),
+					fetchOptions );
 		}
-	}
-
-	private static CacheStoreMode getCacheStoreMode(AttributeNodeImplementor<?, ?, ?> attributeNode) {
-		if ( attributeNode == null ) {
-			return null;
-		}
-		for ( var option : attributeNode.getOptions() ) {
-			if ( option instanceof CacheStoreMode cacheStoreMode ) {
-				return cacheStoreMode;
-			}
-		}
-		return null;
-	}
-
-	private static CacheRetrieveMode getCacheRetrieveMode(AttributeNodeImplementor<?, ?, ?> attributeNode) {
-		if ( attributeNode == null ) {
-			return null;
-		}
-		for ( FetchOption option : attributeNode.getOptions() ) {
-			if ( option instanceof CacheRetrieveMode cacheRetrieveMode ) {
-				return cacheRetrieveMode;
-			}
-		}
-		return null;
-	}
-
-	private static Integer getBatchSize(AttributeNodeImplementor<?, ?, ?> attributeNode) {
-		if ( attributeNode == null ) {
-			return null;
-		}
-		for ( FetchOption option : attributeNode.getOptions() ) {
-			if ( option instanceof BatchSize batchSize && batchSize.batchSize() >= 0 ) {
-				return batchSize.batchSize();
-			}
-		}
-		return null;
 	}
 
 	private FetchStrategy handleFetchType(
 			Fetchable fetchable,
 			boolean exploreKeySubgraph,
 			AttributeNodeImplementor<?, ?, ?> attributeNode,
-			Integer batchSize) {
+			FetchOptions fetchOptions) {
 		final var fetchType = attributeNode == null ? null : attributeNode.getFetchType();
 		if ( fetchType != null ) {
 			switch ( fetchType ) {
@@ -141,7 +99,7 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 					if ( subgraphMap != null && subgraphMapKey != null ) {
 						currentGraphContext = subgraphMap.get( subgraphMapKey );
 					}
-					return new FetchStrategy( FetchTiming.IMMEDIATE, batchSize == null );
+					return new FetchStrategy( FetchTiming.IMMEDIATE, !fetchOptions.hasBatchSize() );
 				case LAZY:
 					return new FetchStrategy( FetchTiming.DELAYED, false );
 				default:

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
@@ -7,6 +7,8 @@ package org.hibernate.sql.results.internal;
 import java.util.Map;
 import java.util.Objects;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.AttributeNodeImplementor;
@@ -61,8 +63,21 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 					: null;
 			currentGraphContext = null;
 			return new TraversalResult( previousContextRoot,
-					handleFetchType( fetchable, exploreKeySubgraph, attributeNode ) );
+					handleFetchType( fetchable, exploreKeySubgraph, attributeNode ),
+					getCacheStoreMode( attributeNode ) );
 		}
+	}
+
+	private static CacheStoreMode getCacheStoreMode(AttributeNodeImplementor<?, ?, ?> attributeNode) {
+		if ( attributeNode == null ) {
+			return null;
+		}
+		for ( var option : attributeNode.getOptions() ) {
+			if ( option instanceof CacheStoreMode cacheStoreMode ) {
+				return cacheStoreMode;
+			}
+		}
+		return null;
 	}
 
 	private FetchStrategy handleFetchType

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
@@ -6,6 +6,7 @@ package org.hibernate.sql.results.internal.domain;
 
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
 import org.hibernate.engine.FetchTiming;
@@ -74,7 +75,8 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				original.getKeyResult(),
 				original.getDiscriminatorFetch(),
 				original.isSelectByUniqueKey(),
-				original.getCacheStoreMode()
+				original.getCacheStoreMode(),
+				original.getCacheRetrieveMode()
 		);
 		this.timing = original.timing;
 		this.referencedNavigablePath = original.referencedNavigablePath;
@@ -116,6 +118,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				getNavigablePath(),
 				isSelectByUniqueKey(),
 				getCacheStoreMode(),
+				getCacheRetrieveMode(),
 				creationState
 			);
 		}
@@ -140,6 +143,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 			NavigablePath navigablePath,
 			boolean selectByUniqueKey,
 			CacheStoreMode cacheStoreMode,
+			CacheRetrieveMode cacheRetrieveMode,
 			AssemblerCreationState creationState) {
 		return EntitySelectFetchInitializerBuilder.createInitializer(
 				parent,
@@ -150,6 +154,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				selectByUniqueKey,
 				false,
 				cacheStoreMode,
+				cacheRetrieveMode,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
@@ -6,6 +6,8 @@ package org.hibernate.sql.results.internal.domain;
 
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.CacheStoreMode;
+
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
@@ -71,7 +73,8 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				original.getFetchParent(),
 				original.getKeyResult(),
 				original.getDiscriminatorFetch(),
-				original.isSelectByUniqueKey()
+				original.isSelectByUniqueKey(),
+				original.getCacheStoreMode()
 		);
 		this.timing = original.timing;
 		this.referencedNavigablePath = original.referencedNavigablePath;
@@ -110,9 +113,10 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 					getFetchedMapping(),
 					getFetchedMapping().getEntityMappingType().getEntityPersister(),
 					getKeyResult(),
-					getNavigablePath(),
-					isSelectByUniqueKey(),
-					creationState
+				getNavigablePath(),
+				isSelectByUniqueKey(),
+				getCacheStoreMode(),
+				creationState
 			);
 		}
 		else {
@@ -135,6 +139,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 			DomainResult<?> keyResult,
 			NavigablePath navigablePath,
 			boolean selectByUniqueKey,
+			CacheStoreMode cacheStoreMode,
 			AssemblerCreationState creationState) {
 		return EntitySelectFetchInitializerBuilder.createInitializer(
 				parent,
@@ -144,6 +149,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				navigablePath,
 				selectByUniqueKey,
 				false,
+				cacheStoreMode,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
@@ -76,7 +76,8 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				original.getDiscriminatorFetch(),
 				original.isSelectByUniqueKey(),
 				original.getCacheStoreMode(),
-				original.getCacheRetrieveMode()
+				original.getCacheRetrieveMode(),
+				original.getBatchSize()
 		);
 		this.timing = original.timing;
 		this.referencedNavigablePath = original.referencedNavigablePath;
@@ -119,6 +120,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				isSelectByUniqueKey(),
 				getCacheStoreMode(),
 				getCacheRetrieveMode(),
+				getBatchSize(),
 				creationState
 			);
 		}
@@ -144,6 +146,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 			boolean selectByUniqueKey,
 			CacheStoreMode cacheStoreMode,
 			CacheRetrieveMode cacheRetrieveMode,
+			Integer batchSize,
 			AssemblerCreationState creationState) {
 		return EntitySelectFetchInitializerBuilder.createInitializer(
 				parent,
@@ -155,6 +158,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				false,
 				cacheStoreMode,
 				cacheRetrieveMode,
+				batchSize,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
@@ -6,10 +6,8 @@ package org.hibernate.sql.results.internal.domain;
 
 import java.util.function.BiConsumer;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-
 import org.hibernate.engine.FetchTiming;
+import org.hibernate.engine.spi.FetchOptions;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.spi.NavigablePath;
@@ -75,9 +73,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				original.getKeyResult(),
 				original.getDiscriminatorFetch(),
 				original.isSelectByUniqueKey(),
-				original.getCacheStoreMode(),
-				original.getCacheRetrieveMode(),
-				original.getBatchSize()
+				original.getFetchOptions()
 		);
 		this.timing = original.timing;
 		this.referencedNavigablePath = original.referencedNavigablePath;
@@ -118,9 +114,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 					getKeyResult(),
 				getNavigablePath(),
 				isSelectByUniqueKey(),
-				getCacheStoreMode(),
-				getCacheRetrieveMode(),
-				getBatchSize(),
+				getFetchOptions(),
 				creationState
 			);
 		}
@@ -144,9 +138,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 			DomainResult<?> keyResult,
 			NavigablePath navigablePath,
 			boolean selectByUniqueKey,
-			CacheStoreMode cacheStoreMode,
-			CacheRetrieveMode cacheRetrieveMode,
-			Integer batchSize,
+			FetchOptions fetchOptions,
 			AssemblerCreationState creationState) {
 		return EntitySelectFetchInitializerBuilder.createInitializer(
 				parent,
@@ -156,9 +148,7 @@ public class CircularFetchImpl extends AbstractNonJoinedEntityFetch implements B
 				navigablePath,
 				selectByUniqueKey,
 				false,
-				cacheStoreMode,
-				cacheRetrieveMode,
-				batchSize,
+				fetchOptions,
 				creationState
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphBatchSizeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphBatchSizeTest.java
@@ -1,0 +1,222 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.entitygraph;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.orm.test.entitygraph.EntityGraphBatchSizeTest_.Book_;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.BatchSize;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Fetch;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.Hibernate.isInitialized;
+
+@DomainModel(
+		annotatedClasses = {
+				EntityGraphBatchSizeTest.Book.class,
+				EntityGraphBatchSizeTest.BatchedAuthor.class,
+				EntityGraphBatchSizeTest.SingleAuthor.class
+		}
+)
+@SessionFactory(useCollectingStatementInspector = true)
+class EntityGraphBatchSizeTest {
+	private static final String NAMED_GRAPH = "Book.with-batch-sizes";
+
+	@BeforeEach
+	void prepareData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			for ( long id = 1; id <= 3; id++ ) {
+				final var batchedAuthor = new BatchedAuthor( id );
+				final var singleAuthor = new SingleAuthor( id );
+				session.persist( batchedAuthor );
+				session.persist( singleAuthor );
+				session.persist( new Book( id, batchedAuthor, singleAuthor ) );
+			}
+		} );
+		scope.getCollectingStatementInspector().clear();
+	}
+
+	@AfterEach
+	void cleanUp(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	void programmaticGraphBatchSizeControlsAssociationBatching(SessionFactoryScope scope) {
+		final var inspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction( session -> {
+			final var graph = session.createEntityGraph( Book.class );
+			graph.addAttributeNode( Book_.batchedAuthor )
+					.addOption( FetchType.EAGER )
+					.addOption( new BatchSize( 3 ) );
+			graph.addAttributeNode( Book_.singleAuthor )
+					.addOption( FetchType.EAGER )
+					.addOption( new BatchSize( 1 ) );
+			graph.addAttributeNode( Book_.batchedTags )
+					.addOption( FetchType.EAGER )
+					.addOption( new BatchSize( 3 ) );
+			graph.addAttributeNode( Book_.singleTags )
+					.addOption( FetchType.EAGER )
+					.addOption( new BatchSize( 1 ) );
+
+			final var books =
+					session.createQuery( "from GraphBatchBook order by id", Book.class )
+							.setEntityGraph( graph, GraphSemantic.FETCH )
+							.getResultList();
+
+			assertFetched( books );
+		} );
+
+		assertSelectCount( inspector, "GraphBatchBatchedAuthor", 1 );
+		assertSelectCount( inspector, "GraphBatchSingleAuthor", 3 );
+		assertSelectCount( inspector, "GraphBatchBook_batchedTags", 1 );
+		assertSelectCount( inspector, "GraphBatchBook_singleTags", 3 );
+	}
+
+	@Test
+	void fetchAnnotationBatchSizeControlsAssociationBatching(SessionFactoryScope scope) {
+		final var inspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction( session -> {
+			final var books =
+					session.createQuery( "from GraphBatchBook order by id", Book.class )
+							.setEntityGraph( Book_._Book_with_batch_sizes, GraphSemantic.FETCH )
+							.getResultList();
+
+			assertFetched( books );
+		} );
+
+		assertSelectCount( inspector, "GraphBatchBatchedAuthor", 1 );
+		assertSelectCount( inspector, "GraphBatchSingleAuthor", 3 );
+		assertSelectCount( inspector, "GraphBatchBook_batchedTags", 1 );
+		assertSelectCount( inspector, "GraphBatchBook_singleTags", 3 );
+	}
+
+	private static void assertFetched( java.util.List<Book> books ) {
+		assertThat( books ).hasSize( 3 );
+		for ( Book book : books ) {
+			assertThat( isInitialized( book.batchedAuthor ) ).isTrue();
+			assertThat( isInitialized( book.singleAuthor ) ).isTrue();
+			assertThat( isInitialized( book.batchedTags ) ).isTrue();
+			assertThat( isInitialized( book.singleTags ) ).isTrue();
+		}
+	}
+
+	private static void assertSelectCount(
+			SQLStatementInspector inspector,
+			String tableName,
+			int expectedSelectCount) {
+		final var normalizedTableName = tableName.toLowerCase( Locale.ROOT );
+		final var matchingSelects =
+				inspector.getSqlQueries().stream()
+						.map( sql -> sql.toLowerCase( Locale.ROOT ) )
+						.filter( sql -> sql.startsWith( "select" ) )
+						.filter( sql -> sql.contains( normalizedTableName ) )
+						.toList();
+		assertThat( matchingSelects ).hasSize( expectedSelectCount );
+	}
+
+	@Entity(name = "GraphBatchBook")
+	@Table(name = "GraphBatchBook")
+	@NamedEntityGraph(name = NAMED_GRAPH)
+	static class Book {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				batchSize = 3
+		)
+		private BatchedAuthor batchedAuthor;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				batchSize = 1
+		)
+		private SingleAuthor singleAuthor;
+
+		@ElementCollection(fetch = FetchType.LAZY)
+		@CollectionTable(name = "GraphBatchBook_batchedTags")
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				batchSize = 3
+		)
+		private Set<String> batchedTags = new HashSet<>();
+
+		@ElementCollection(fetch = FetchType.LAZY)
+		@CollectionTable(name = "GraphBatchBook_singleTags")
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				batchSize = 1
+		)
+		private Set<String> singleTags = new HashSet<>();
+
+		Book() {
+		}
+
+		Book(Long id, BatchedAuthor batchedAuthor, SingleAuthor singleAuthor) {
+			this.id = id;
+			this.batchedAuthor = batchedAuthor;
+			this.singleAuthor = singleAuthor;
+			batchedTags.add( "batched-" + id );
+			singleTags.add( "single-" + id );
+		}
+	}
+
+	@Entity(name = "GraphBatchBatchedAuthor")
+	@Table(name = "GraphBatchBatchedAuthor")
+	static class BatchedAuthor {
+		@Id
+		private Long id;
+
+		BatchedAuthor() {
+		}
+
+		BatchedAuthor(Long id) {
+			this.id = id;
+		}
+	}
+
+	@Entity(name = "GraphBatchSingleAuthor")
+	@Table(name = "GraphBatchSingleAuthor")
+	static class SingleAuthor {
+		@Id
+		private Long id;
+
+		SingleAuthor() {
+		}
+
+		SingleAuthor(Long id) {
+			this.id = id;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphCacheRetrieveModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphCacheRetrieveModeTest.java
@@ -1,0 +1,271 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.entitygraph;
+
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.orm.test.entitygraph.EntityGraphCacheRetrieveModeTest_.Book_;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Fetch;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.Hibernate.isInitialized;
+import static org.hibernate.cfg.CacheSettings.USE_SECOND_LEVEL_CACHE;
+
+@DomainModel(
+		annotatedClasses = {
+				EntityGraphCacheRetrieveModeTest.Book.class,
+				EntityGraphCacheRetrieveModeTest.Author.class,
+				EntityGraphCacheRetrieveModeTest.Publisher.class,
+				EntityGraphCacheRetrieveModeTest.Tag.class
+		}
+)
+@ServiceRegistry(
+		settings = @Setting(name = USE_SECOND_LEVEL_CACHE, value = "true")
+)
+@SessionFactory(generateStatistics = true)
+class EntityGraphCacheRetrieveModeTest {
+	private static final String NAMED_GRAPH = "Book.with-cache-retrieve-modes";
+
+	@BeforeEach
+	void prepareData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var author = new Author( 1L, "cached author" );
+			final var publisher = new Publisher( 1L, "cached publisher" );
+			final var bypassTag = new Tag( 1L, "cached bypass tag" );
+			final var useTag = new Tag( 2L, "cached use tag" );
+			session.persist( author );
+			session.persist( publisher );
+			session.persist( bypassTag );
+			session.persist( useTag );
+			session.persist( new Book( 1L, author, publisher, bypassTag, useTag ) );
+		} );
+
+		final var sessionFactory = scope.getSessionFactory();
+		final var cache = sessionFactory.getCache();
+		cache.evictAllRegions();
+
+		scope.inTransaction( session -> {
+			assertThat( session.get( Author.class, 1L ).name ).isEqualTo( "cached author" );
+			assertThat( session.get( Publisher.class, 1L ).name ).isEqualTo( "cached publisher" );
+			assertThat( session.get( Tag.class, 1L ).name ).isEqualTo( "cached bypass tag" );
+			assertThat( session.get( Tag.class, 2L ).name ).isEqualTo( "cached use tag" );
+		} );
+
+		assertThat( cache.containsEntity( Author.class, 1L ) ).isTrue();
+		assertThat( cache.containsEntity( Publisher.class, 1L ) ).isTrue();
+		assertThat( cache.containsEntity( Tag.class, 1L ) ).isTrue();
+		assertThat( cache.containsEntity( Tag.class, 2L ) ).isTrue();
+
+		scope.inTransaction( session -> session.doWork( connection -> {
+			updateName( connection, "GraphCacheRetrieveAuthor", 1L, "database author" );
+			updateName( connection, "GraphCacheRetrievePublisher", 1L, "database publisher" );
+			updateName( connection, "GraphCacheRetrieveTag", 1L, "database bypass tag" );
+			updateName( connection, "GraphCacheRetrieveTag", 2L, "database use tag" );
+		} ) );
+
+		cache.evictEntityData( Book.class );
+		sessionFactory.getStatistics().clear();
+	}
+
+	@AfterEach
+	void cleanUp(SessionFactoryScope scope) {
+		final var sessionFactory = scope.getSessionFactory();
+		sessionFactory.getSchemaManager().truncate();
+		sessionFactory.getCache().evictAllRegions();
+		sessionFactory.getStatistics().clear();
+	}
+
+	@Test
+	void programmaticGraphCacheRetrieveModeControlsAssociationGets(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.setCacheRetrieveMode( CacheRetrieveMode.BYPASS );
+
+			final var graph = session.createEntityGraph( Book.class );
+			graph.addAttributeNode( Book_.author ).addOption( CacheRetrieveMode.BYPASS );
+			graph.addAttributeNode( Book_.publisher ).addOption( CacheRetrieveMode.USE );
+			graph.addAttributeNode( Book_.bypassTags ).addOption( CacheRetrieveMode.BYPASS );
+			graph.addAttributeNode( Book_.useTags ).addOption( CacheRetrieveMode.USE );
+
+			final var book =
+					session.createQuery( "from GraphCacheRetrieveBook where id = 1", Book.class )
+							.setEntityGraph( graph, GraphSemantic.FETCH )
+							.getSingleResult();
+
+			assertFetchedState( book );
+		} );
+	}
+
+	@Test
+	void fetchAnnotationCacheRetrieveModeControlsAssociationGets(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.setCacheRetrieveMode( CacheRetrieveMode.BYPASS );
+
+			final var book =
+					session.createQuery( "from GraphCacheRetrieveBook where id = 1", Book.class )
+							.setEntityGraph( Book_._Book_with_cache_retrieve_modes, GraphSemantic.FETCH )
+							.getSingleResult();
+
+			assertFetchedState( book );
+		} );
+	}
+
+	private static void assertFetchedState(Book book) {
+		assertThat( isInitialized( book.author ) ).isTrue();
+		assertThat( isInitialized( book.publisher ) ).isTrue();
+		assertThat( isInitialized( book.bypassTags ) ).isTrue();
+		assertThat( isInitialized( book.useTags ) ).isTrue();
+
+		assertThat( book.author.name ).isEqualTo( "database author" );
+		assertThat( book.publisher.name ).isEqualTo( "cached publisher" );
+		assertThat( book.bypassTags ).extracting( tag -> tag.name ).containsExactly( "database bypass tag" );
+		assertThat( book.useTags ).extracting( tag -> tag.name ).containsExactly( "cached use tag" );
+	}
+
+	private static void updateName(java.sql.Connection connection, String table, Long id, String name)
+			throws SQLException {
+		try ( var statement = connection.prepareStatement( "update " + table + " set name = ? where id = ?" ) ) {
+			statement.setString( 1, name );
+			statement.setLong( 2, id );
+			statement.executeUpdate();
+		}
+	}
+
+	@Entity(name = "GraphCacheRetrieveBook")
+	@Table(name = "GraphCacheRetrieveBook")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	@NamedEntityGraph(name = NAMED_GRAPH)
+	static class Book {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				cacheRetrieveMode = CacheRetrieveMode.BYPASS
+		)
+		private Author author;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				cacheRetrieveMode = CacheRetrieveMode.USE
+		)
+		private Publisher publisher;
+
+		@ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		@JoinTable(name = "GraphCacheRetrieveBook_bypassTags")
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				cacheRetrieveMode = CacheRetrieveMode.BYPASS
+		)
+		private Set<Tag> bypassTags = new HashSet<>();
+
+		@ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		@JoinTable(name = "GraphCacheRetrieveBook_useTags")
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				cacheRetrieveMode = CacheRetrieveMode.USE
+		)
+		private Set<Tag> useTags = new HashSet<>();
+
+		Book() {
+		}
+
+		Book(Long id, Author author, Publisher publisher, Tag bypassTag, Tag useTag) {
+			this.id = id;
+			this.author = author;
+			this.publisher = publisher;
+			bypassTags.add( bypassTag );
+			useTags.add( useTag );
+		}
+	}
+
+	@Entity(name = "GraphCacheRetrieveAuthor")
+	@Table(name = "GraphCacheRetrieveAuthor")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	static class Author {
+		@Id
+		private Long id;
+
+		private String name;
+
+		Author() {
+		}
+
+		Author(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "GraphCacheRetrievePublisher")
+	@Table(name = "GraphCacheRetrievePublisher")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	static class Publisher {
+		@Id
+		private Long id;
+
+		private String name;
+
+		Publisher() {
+		}
+
+		Publisher(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "GraphCacheRetrieveTag")
+	@Table(name = "GraphCacheRetrieveTag")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	static class Tag {
+		@Id
+		private Long id;
+
+		private String name;
+
+		Tag() {
+		}
+
+		Tag(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphCacheStoreModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphCacheStoreModeTest.java
@@ -1,0 +1,210 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.entitygraph;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.orm.test.entitygraph.EntityGraphCacheStoreModeTest_.Book_;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Fetch;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedEntityGraph;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.Hibernate.isInitialized;
+import static org.hibernate.cfg.CacheSettings.USE_SECOND_LEVEL_CACHE;
+
+@DomainModel(
+		annotatedClasses = {
+				EntityGraphCacheStoreModeTest.Book.class,
+				EntityGraphCacheStoreModeTest.Author.class,
+				EntityGraphCacheStoreModeTest.Publisher.class
+		}
+)
+@ServiceRegistry(
+		settings = @Setting(name = USE_SECOND_LEVEL_CACHE, value = "true")
+)
+@SessionFactory(generateStatistics = true)
+class EntityGraphCacheStoreModeTest {
+	private static final String NAMED_GRAPH = "Book.with-cache-store-modes";
+	private static final String BYPASS_TAGS_ROLE = EntityGraphCacheStoreModeTest.Book.class.getName() + ".bypassTags";
+	private static final String USE_TAGS_ROLE = EntityGraphCacheStoreModeTest.Book.class.getName() + ".useTags";
+
+	@BeforeEach
+	void prepareData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var author = new Author( 1L );
+			final var publisher = new Publisher( 1L );
+			session.persist( author );
+			session.persist( publisher );
+			session.persist( new Book( 1L, author, publisher ) );
+		} );
+		final var sessionFactory = scope.getSessionFactory();
+		sessionFactory.getCache().evictAllRegions();
+		sessionFactory.getStatistics().clear();
+	}
+
+	@AfterEach
+	void cleanUp(SessionFactoryScope scope) {
+		final var sessionFactory = scope.getSessionFactory();
+		sessionFactory.getSchemaManager().truncate();
+		sessionFactory.getCache().evictAllRegions();
+		sessionFactory.getStatistics().clear();
+	}
+
+	@Test
+	void programmaticGraphCacheStoreModeControlsAssociationPuts(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var graph = session.createEntityGraph( Book.class );
+			graph.addAttributeNode( Book_.author ).addOption( CacheStoreMode.BYPASS );
+			graph.addAttributeNode( Book_.publisher ).addOption( CacheStoreMode.USE );
+			graph.addAttributeNode( Book_.bypassTags ).addOption( CacheStoreMode.BYPASS );
+			graph.addAttributeNode( Book_.useTags ).addOption( CacheStoreMode.USE );
+
+			final var book =
+					session.createQuery( "from GraphCacheStoreBook where id = 1", Book.class )
+							.setEntityGraph( graph, GraphSemantic.FETCH )
+							.getSingleResult();
+
+			assertThat( isInitialized( book.author ) ).isTrue();
+			assertThat( isInitialized( book.publisher ) ).isTrue();
+			assertThat( isInitialized( book.bypassTags ) ).isTrue();
+			assertThat( isInitialized( book.useTags ) ).isTrue();
+		} );
+
+		final var cache = scope.getSessionFactory().getCache();
+		assertThat( cache.containsEntity( Author.class, 1L ) ).isFalse();
+		assertThat( cache.containsEntity( Publisher.class, 1L ) ).isTrue();
+		assertThat( cache.containsCollection( BYPASS_TAGS_ROLE, 1L ) ).isFalse();
+		assertThat( cache.containsCollection( USE_TAGS_ROLE, 1L ) ).isTrue();
+	}
+
+	@Test
+	void fetchAnnotationCacheStoreModeControlsAssociationPuts(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var book =
+					session.createQuery( "from GraphCacheStoreBook where id = 1", Book.class )
+							.setEntityGraph( Book_._Book_with_cache_store_modes, GraphSemantic.FETCH )
+							.getSingleResult();
+
+			assertThat( isInitialized( book.author ) ).isTrue();
+			assertThat( isInitialized( book.publisher ) ).isTrue();
+			assertThat( isInitialized( book.bypassTags ) ).isTrue();
+			assertThat( isInitialized( book.useTags ) ).isTrue();
+		} );
+
+		final var cache = scope.getSessionFactory().getCache();
+		assertThat( cache.containsEntity( Author.class, 1L ) ).isFalse();
+		assertThat( cache.containsEntity( Publisher.class, 1L ) ).isTrue();
+		assertThat( cache.containsCollection( BYPASS_TAGS_ROLE, 1L ) ).isFalse();
+		assertThat( cache.containsCollection( USE_TAGS_ROLE, 1L ) ).isTrue();
+	}
+
+	@Entity(name = "GraphCacheStoreBook")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	@NamedEntityGraph(name = NAMED_GRAPH)
+	static class Book {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				cacheStoreMode = CacheStoreMode.BYPASS
+		)
+		private Author author;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				cacheStoreMode = CacheStoreMode.USE
+		)
+		private Publisher publisher;
+
+		@ElementCollection(fetch = FetchType.LAZY)
+		@CollectionTable(name = "GraphCacheStoreBook_bypassTags")
+		@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				cacheStoreMode = CacheStoreMode.BYPASS
+		)
+		private Set<String> bypassTags = new HashSet<>();
+
+		@ElementCollection(fetch = FetchType.LAZY)
+		@CollectionTable(name = "GraphCacheStoreBook_useTags")
+		@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+		@Fetch(
+				graph = NAMED_GRAPH,
+				type = FetchType.EAGER,
+				cacheStoreMode = CacheStoreMode.USE
+		)
+		private Set<String> useTags = new HashSet<>();
+
+		Book() {
+		}
+
+		Book(Long id, Author author, Publisher publisher) {
+			this.id = id;
+			this.author = author;
+			this.publisher = publisher;
+			bypassTags.add( "bypass" );
+			useTags.add( "use" );
+		}
+	}
+
+	@Entity(name = "GraphCacheStoreAuthor")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	static class Author {
+		@Id
+		private Long id;
+
+		Author() {
+		}
+
+		Author(Long id) {
+			this.id = id;
+		}
+	}
+
+	@Entity(name = "GraphCacheStorePublisher")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	static class Publisher {
+		@Id
+		private Long id;
+
+		Publisher() {
+		}
+
+		Publisher(Long id) {
+			this.id = id;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/FindMultipleArrayParamValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/FindMultipleArrayParamValidationTest.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.loading.multiLoad;
+
+import java.util.List;
+
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import static org.hibernate.cfg.JpaComplianceSettings.JPA_LOAD_BY_ID_COMPLIANCE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DomainModel( annotatedClasses = FindMultipleArrayParamValidationTest.Record.class )
+@ServiceRegistry(settings = @Setting( name = JPA_LOAD_BY_ID_COMPLIANCE, value = "true" ))
+@SessionFactory
+public class FindMultipleArrayParamValidationTest {
+
+	@Test
+	void statefulFindMultipleRejectsWrongIdentifierTypeBeforeArrayBinding(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			assertThrows(
+					IllegalArgumentException.class,
+					() -> session.findMultiple( Record.class, List.of( 1, "wrong-id-type" ) )
+			);
+			assertThrows(
+					IllegalArgumentException.class,
+					() -> session.getMultiple( Record.class, List.of( 1, "wrong-id-type" ) )
+			);
+
+			final var graph = session.createEntityGraph( Record.class );
+			assertThrows(
+					IllegalArgumentException.class,
+					() -> session.findMultiple( graph, List.of( 1, "wrong-id-type" ) )
+			);
+			assertThrows(
+					IllegalArgumentException.class,
+					() -> session.getMultiple( graph, List.of( 1, "wrong-id-type" ) )
+			);
+		} );
+	}
+
+	@Test
+	void statelessFindMultipleRejectsWrongIdentifierTypeBeforeArrayBinding(SessionFactoryScope scope) {
+		final var graph = scope.getSessionFactory().createEntityGraph( Record.class );
+		scope.inStatelessTransaction( session -> {
+			assertThrows(
+					IllegalArgumentException.class,
+					() -> session.findMultiple( Record.class, List.of( 1, "wrong-id-type" ) )
+			);
+			assertThrows(
+					IllegalArgumentException.class,
+					() -> session.getMultiple( Record.class, List.of( 1, "wrong-id-type" ) )
+			);
+			assertThrows(
+					IllegalArgumentException.class,
+					() -> session.findMultiple( graph, List.of( 1, "wrong-id-type" ) )
+			);
+			assertThrows(
+					IllegalArgumentException.class,
+					() -> session.getMultiple( graph, List.of( 1, "wrong-id-type" ) )
+			);
+		} );
+	}
+
+	@Entity( name = "Record" )
+	static class Record {
+		@Id
+		Integer id;
+		String message;
+
+		Record(Integer id, String message) {
+			this.id = id;
+			this.message = message;
+		}
+
+		Record() {
+		}
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -432,6 +432,7 @@ public abstract class MockSessionFactory
 	}
 
 	@Override
+	@Nonnull
 	public CacheImplementor getCache() {
 		return new DisabledCaching(this);
 	}


### PR DESCRIPTION
JPA 4 allows `CacheXxxxMode` and the mew class `BatchSize` to be passed to `AttributeNode.addOption()`, controlling fetching on a per-association basis in an entity graph.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->Please make sure that the following tasks are completed:
Tasks specific to HHH-20506 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20505 (New Feature):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20505
<!-- Hibernate GitHub Bot issue links end -->