### PR TITLE
HHH-20504 DataException (Parameter is not set) when updating only a collection of a versioned entity with with a @SQLUpdate

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
@@ -85,14 +85,16 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 
 	private final MutationOperationGroup versionUpdateGroup;
 	private final BatchKey versionUpdateBatchkey;
+	private final boolean hasCustomVersionUpdateSql;
 
 	public UpdateCoordinatorStandard(AbstractEntityPersister entityPersister, SessionFactoryImplementor factory) {
 		super( entityPersister, factory );
 
 		// NOTE : even given dynamic-update and/or dirty optimistic locking
 		// there are cases where we need the full static updates.
-		this.staticUpdateGroup = buildStaticUpdateGroup();
-		this.versionUpdateGroup = buildVersionUpdateGroup();
+		staticUpdateGroup = buildStaticUpdateGroup();
+		versionUpdateGroup = buildVersionUpdateGroup();
+		hasCustomVersionUpdateSql = hasCustomVersionUpdateSql( versionUpdateGroup );
 		if ( entityPersister.hasUpdateGeneratedProperties() ) {
 			// disable batching in case of update generated properties
 			this.batchKey = null;
@@ -123,6 +125,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 		this.batchKey = batchKey;
 		this.versionUpdateGroup = versionUpdateGroup;
 		this.versionUpdateBatchkey = versionUpdateBatchkey;
+		this.hasCustomVersionUpdateSql = hasCustomVersionUpdateSql( versionUpdateGroup );
 	}
 
 	@Override
@@ -423,7 +426,13 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 		final boolean isSimpleVersionUpdate;
 		final Object newVersion;
 
-		if ( incomingDirtyAttributeIndexes != null ) {
+		if ( hasCustomVersionUpdateSql ) {
+			// Can't use the version-only update:
+			// a custom update SQL is defined which would
+			// be bypassed by the version-only update path
+			return null;
+		}
+		else if ( incomingDirtyAttributeIndexes != null ) {
 			if ( incomingDirtyAttributeIndexes.length == 1
 					&& versionMapping.getVersionAttribute() == entityPersister().getAttributeMapping( incomingDirtyAttributeIndexes[0] ) ) {
 				// special case of only the version attribute itself as dirty
@@ -464,6 +473,11 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 		else {
 			return null;
 		}
+	}
+
+	private static boolean hasCustomVersionUpdateSql(MutationOperationGroup versionUpdateGroup) {
+		return versionUpdateGroup != null
+				&& versionUpdateGroup.getSingleOperation().getTableDetails().getUpdateDetails().getCustomSql() != null;
 	}
 
 	private static boolean isValueGenerated(Generator generator) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/version/CallableSqlUpdateWithVersionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/version/CallableSqlUpdateWithVersionTest.java
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.version;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import org.hibernate.annotations.SQLUpdate;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				CallableSqlUpdateWithVersionTest.EntityA.class,
+				CallableSqlUpdateWithVersionTest.EntityB.class
+		}
+)
+@SessionFactory
+@RequiresDialect(org.hibernate.dialect.H2Dialect.class)
+@JiraKey( "HHH-20504" )
+public class CallableSqlUpdateWithVersionTest {
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createNativeQuery(
+									"CREATE ALIAS UPDATE_A FOR \"" + CallableSqlUpdateWithVersionTest.class.getCanonicalName() + ".updateA\";" )
+							.executeUpdate();
+
+					EntityA entityA = new EntityA( 1L, "system" );
+					EntityB entityB = new EntityB( "system2" );
+					entityA.addB( entityB );
+
+					session.persist( entityA );
+					session.persist( entityB );
+				}
+		);
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createMutationQuery( "delete from EntityA" ).executeUpdate();
+			session.createMutationQuery( "delete from EntityB" ).executeUpdate();
+			session.createNativeQuery( "DROP ALIAS IF EXISTS UPDATE_A" ).executeUpdate();
+		} );
+
+	}
+
+	@Test
+	public void testUpdate(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					EntityA entityA = session.find( EntityA.class, 1L );
+					assertThat( entityA.getVersion() ).isEqualTo( 0L );
+					entityA.getBs().clear();
+				}
+		);
+		scope.inTransaction(
+				session -> {
+					EntityA entityA = session.find( EntityA.class, 1L );
+					assertThat( entityA.getVersion() ).isEqualTo( 1L );
+					assertThat( entityA.getBs() ).isEmpty();
+				}
+		);
+	}
+
+	@Entity(name = "EntityA")
+	@SQLUpdate(sql = "{call UPDATE_A(?, ?, ?, ?)}", callable = true)
+	@Table(name = "table_a")
+	public static class EntityA {
+
+		@Id
+		Long id;
+
+		@Version
+		@Column(name = "version")
+		long version;
+
+		@Column(name = "created_by")
+		String createdBy;
+
+
+		@ManyToMany
+		@JoinTable(name = "a_b", joinColumns = @JoinColumn(name = "a_id"),
+				inverseJoinColumns = @JoinColumn(name = "b_id"))
+		Set<EntityB> entityBS = new LinkedHashSet<>();
+
+		public EntityA() {
+		}
+
+		public EntityA(Long id, String createdBy) {
+			this.id = id;
+			this.createdBy = createdBy;
+		}
+
+		public long getVersion() {
+			return version;
+		}
+
+		public Set<EntityB> getBs() {
+			return entityBS;
+		}
+
+		public void addB(EntityB entityB) {
+			this.entityBS.add( entityB );
+		}
+	}
+
+	@Entity(name = "EntityB")
+	public static class EntityB {
+
+		@Id
+		@GeneratedValue
+		Long id;
+
+		String name;
+
+		public EntityB() {
+		}
+
+		public EntityB(String name) {
+			this.name = name;
+		}
+	}
+
+	public static int updateA(
+			Connection con,
+			String createdBy,
+			long oldVersion,
+			long id,
+			long newVersion) throws SQLException {
+
+		try (PreparedStatement ps = con.prepareStatement(
+				"update table_a set created_by=?, version=? where id=? and version=?" )) {
+			ps.setString( 1, createdBy );
+			ps.setLong( 2, oldVersion );
+			ps.setLong( 3, id );
+			ps.setLong( 4, newVersion );
+			return ps.executeUpdate();
+		}
+	}
+}


### PR DESCRIPTION
backport of https://github.com/hibernate/hibernate-orm/pull/12560 for 6.6

https://hibernate.atlassian.net/browse/HHH-20504

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20504 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->