### PR TITLE
HHH-20425 Identifier not detected while `@Id` is placed in `@MappedSuperClass` and combined with `@Access`

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyContainer.java
@@ -167,9 +167,7 @@ public class PropertyContainer {
 		// Check fields...
 		for ( int i = 0; i < fields.size(); i++ ) {
 			final var fieldDetails = fields.get( i );
-			final var localAccessAnnotation = fieldDetails.getDirectAnnotationUsage( Access.class );
-			if ( localAccessAnnotation != null
-					&& localAccessAnnotation.value() == jakarta.persistence.AccessType.FIELD ) {
+			if ( fieldDetails.hasDirectAnnotationUsage( Access.class ) ) {
 				persistentAttributeMap.put( fieldDetails.getName(), fieldDetails );
 			}
 		}
@@ -177,9 +175,7 @@ public class PropertyContainer {
 		// Check getters...
 		for ( int i = 0; i < getters.size(); i++ ) {
 			final var getterDetails = getters.get( i );
-			final var localAccessAnnotation = getterDetails.getDirectAnnotationUsage( Access.class );
-			if ( localAccessAnnotation != null
-					&& localAccessAnnotation.value() == jakarta.persistence.AccessType.PROPERTY ) {
+			if ( getterDetails.hasDirectAnnotationUsage( Access.class ) ) {
 				final String name = getterDetails.resolveAttributeName();
 				// HHH-10242 detect registration of the same property getter twice - eg boolean isId() + UUID getId()
 				final var previous = persistentAttributesFromGetters.get( name );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/access/jpa/AccessMappingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/access/jpa/AccessMappingTest.java
@@ -16,11 +16,18 @@ import org.hibernate.property.access.spi.GetterMethodImpl;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.testing.ServiceRegistryBuilder;
 import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.type.descriptor.java.spi.JdbcTypeRecommendationException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -236,5 +243,77 @@ public class AccessMappingTest {
 		cfg.addAnnotatedClass( Course8.class );
 		cfg.addAnnotatedClass( Student.class );
 		cfg.buildSessionFactory( serviceRegistry ).close();
+	}
+
+	@Jira("https://hibernate.atlassian.net/browse/HHH-20425")
+	@Test
+	public void testFieldAccessOnIdGetter() {
+		var cfg = new Configuration();
+		cfg.addAnnotatedClass( AnimalEntity.class );
+		try (SessionFactoryImplementor factory = (SessionFactoryImplementor) cfg.buildSessionFactory( serviceRegistry )) {
+			final var entityPersister = factory.getRuntimeMetamodels()
+					.getMappingMetamodel()
+					.getEntityDescriptor( AnimalEntity.class.getName() );
+			final var identifierMapping =
+					(BasicEntityIdentifierMappingImpl) entityPersister.getIdentifierMapping();
+			assertThat( identifierMapping.getPropertyAccess().getGetter() )
+					.describedAs( "Field access should be used." )
+					.isInstanceOf( GetterFieldImpl.class );
+		}
+	}
+
+	@Jira("https://hibernate.atlassian.net/browse/HHH-20425")
+	@Test
+	public void testPropertyAccessOnIdField() {
+		var cfg = new Configuration();
+		cfg.addAnnotatedClass( PlantEntity.class );
+		try (SessionFactoryImplementor factory = (SessionFactoryImplementor) cfg.buildSessionFactory( serviceRegistry )) {
+			final var entityPersister = factory.getRuntimeMetamodels()
+					.getMappingMetamodel()
+					.getEntityDescriptor( PlantEntity.class.getName() );
+			final var identifierMapping =
+					(BasicEntityIdentifierMappingImpl) entityPersister.getIdentifierMapping();
+			assertThat( identifierMapping.getPropertyAccess().getGetter() )
+					.describedAs( "Property access should be used." )
+					.isInstanceOf( GetterMethodImpl.class );
+		}
+	}
+
+	@MappedSuperclass
+	static class AnimalSuperclass {
+		private Long id;
+
+		@Id
+		@Access(AccessType.FIELD)
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+	}
+
+	@Entity(name = "AnimalEntity")
+	static class AnimalEntity extends AnimalSuperclass {
+	}
+
+	@MappedSuperclass
+	static class PlantSuperclass {
+		@Id
+		@Access(AccessType.PROPERTY)
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+	}
+
+	@Entity(name = "PlantEntity")
+	static class PlantEntity extends PlantSuperclass {
 	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-20425

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20425 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->