### PR TITLE
HHH-20406 - Deprecate hibernate-envers

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Configuration.adoc
+++ b/documentation/src/main/asciidoc/introduction/Configuration.adoc
@@ -120,7 +120,7 @@ and `com.github.ben-manes.caffeine:jcache`
 `com.fasterxml.jackson.core:jackson-databind`, `tools.jackson.core:jackson-databind` +
 or `org.eclipse:yasson`
 | <<spatial,Hibernate Spatial>> | `org.hibernate.orm:hibernate-spatial`
-| <<envers,Envers>>, for auditing historical data | `org.hibernate.orm:hibernate-envers`
+| <<envers,Envers>>, deprecated since Hibernate ORM 8.0, for auditing historical data | `org.hibernate.orm:hibernate-envers`
 | <<jfr,Hibernate JFR>>, for monitoring via Java Flight Recorder | `org.hibernate.orm:hibernate-jfr`
 | Hibernate Jandex integration, for <<entity-discovery,entity discovery>> | `org.hibernate.orm:hibernate-scan-jandex`
 | link:{doc-dialect-url}#community-dialects[Community dialects] | `org.hibernate.orm:hibernate-community-dialects`
@@ -625,4 +625,3 @@ You may set `hibernate.jdbc.time_zone` to the time zone of the database server i
 We do not recommend this approach.
 
 On the other hand, we would love to recommend the use of `hibernate.type.java_time_use_direct_jdbc`, but this option is still experimental for now, and does result in some subtle differences in behavior which might affect legacy programs using Hibernate.
-

--- a/documentation/src/main/asciidoc/introduction/Entities.adoc
+++ b/documentation/src/main/asciidoc/introduction/Entities.adoc
@@ -88,7 +88,7 @@ There's information in the {maps}[User Guide], if you're curious.
 
 This must sound like a weird feature for a project that places importance on type-safety.
 Actually, it's a useful capability for a very particular sort of generic code.
-For example, {envers}[Hibernate Envers] is a great auditing/versioning system for Hibernate entities.
+For example, the deprecated {envers}[Hibernate Envers] module is an auditing/versioning system for Hibernate entities.
 Envers makes use of maps to represent its _versioned model_ of the data.
 ****
 

--- a/documentation/src/main/asciidoc/quickstart/guides/obtaining.adoc
+++ b/documentation/src/main/asciidoc/quickstart/guides/obtaining.adoc
@@ -40,7 +40,7 @@ transitive dependencies based on the features being used or not.
 .API-oriented modules
 |===
 |hibernate-core| The core object/relational mapping engine
-|hibernate-envers| Entity versioning and auditing
+|hibernate-envers| Entity versioning and auditing (deprecated since Hibernate ORM 8.0; prefer core temporal and audit support for new development)
 |hibernate-spatial| Support for spatial/GIS data types using https://github.com/GeoLatte/geolatte-geom[GeoLatte]
 |hibernate-processor| An annotation processor that generates a JPA-compliant metamodel, plus optional Hibernate extras
 |hibernate-vector| Support for mathematical vector types and functions useful for AI/ML topics like vector similarity search and Retrieval-Augmented Generation (RAG)

--- a/documentation/src/main/asciidoc/userguide/chapters/envers/Envers.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/envers/Envers.adoc
@@ -7,6 +7,13 @@
 [[envers-basics]]
 === Basics
 
+[IMPORTANT]
+====
+The `hibernate-envers` module is deprecated since Hibernate ORM 8.0.
+For new development, prefer Hibernate ORM's core temporal and audit support using
+`@org.hibernate.annotations.Temporal` and `@org.hibernate.annotations.Audited`.
+====
+
 To audit changes that are performed on an entity, you only need two things:
 
 * the `hibernate-envers` jar on the classpath,
@@ -1655,4 +1662,3 @@ And sometime in 2011, the last partition (or 'extension bucket') is split into t
 .  https://hibernate.atlassian.net/[JIRA issue tracker] (when adding issues concerning Envers, be sure to select the "envers" component!)
 .  https://hibernate.zulipchat.com/#narrow/stream/132096-hibernate-user[Zulip channel]
 .  https://community.jboss.org/wiki/EnversFAQ[FAQ]
-

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
@@ -272,4 +272,11 @@ public interface DeprecationLogger extends BasicLogger {
 					"Specify the root entity using the 'root' attribute instead of prefixing the graph with the entity type."
 	)
 	void deprecatedNamedEntityGraphTextThatContainTypeIndicator();
+
+	@LogMessage(level = WARN)
+	@Message(
+			id = 90000045,
+			value = "Hibernate-envers is considered deprecated in favor of @Temporal and @Audited in hibernate-core."
+	)
+	void envers();
 }

--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -8,7 +8,7 @@ plugins {
     id "local.publishing-group-relocation"
 }
 
-description = "Hibernate's entity version (audit/history) support"
+description = "Deprecated - Hibernate's entity version (audit/history) support"
 
 dependencies {
     api project( ':hibernate-core' )

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/AdditionalMappingContributorImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/AdditionalMappingContributorImpl.java
@@ -19,6 +19,10 @@ import static org.hibernate.cfg.AvailableSettings.XML_MAPPING_ENABLED;
  * @author Steve Ebersole
  */
 public class AdditionalMappingContributorImpl implements AdditionalMappingContributor {
+	public AdditionalMappingContributorImpl() {
+		DeprecationLoggingManager.logDeprecation();
+	}
+
 	@Override
 	public String getContributorName() {
 		return "envers";

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/DeprecationLoggingManager.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/DeprecationLoggingManager.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.envers.boot.internal;
+
+import org.hibernate.internal.log.DeprecationLogger;
+
+/**
+ * Let's make sure we are only logging this once, rather than spamming.
+ *
+ * @author Steve Ebersole
+ */
+public class DeprecationLoggingManager {
+	private static boolean logged = false;
+
+	public static void logDeprecation() {
+		if ( !logged ) {
+			DeprecationLogger.DEPRECATION_LOGGER.envers();
+			logged = true;
+		}
+	}
+
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
@@ -38,6 +38,10 @@ public class EnversIntegrator implements Integrator {
 
 	public static final String AUTO_REGISTER = "hibernate.envers.autoRegisterListeners";
 
+	public EnversIntegrator() {
+		DeprecationLoggingManager.logDeprecation();
+	}
+
 	public void integrate(
 			Metadata metadata,
 			BootstrapContext bootstrapContext,

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceContributor.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceContributor.java
@@ -14,6 +14,10 @@ import org.hibernate.service.spi.ServiceContributor;
  * @author Steve Ebersole
  */
 public class EnversServiceContributor implements ServiceContributor {
+	public EnversServiceContributor() {
+		DeprecationLoggingManager.logDeprecation();
+	}
+
 	@Override
 	public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
 		serviceRegistryBuilder.addInitiator( EnversServiceInitiator.INSTANCE );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/package-info.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+
+/**
+ * Hibernate's entity version (audit/history) support.
+ *
+ * @apiNote This entire package (and subpackages) is considered deprecated.  Migrate to
+ * {@linkplain org.hibernate.annotations.Temporal} / {@linkplain org.hibernate.annotations.Audited}
+ * instead.
+ */
+@Deprecated(since = "8.0")
+package org.hibernate.envers;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

HHH-20406 - Deprecate hibernate-envers
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20406
<!-- Hibernate GitHub Bot issue links end -->