### PR TITLE
unbreak query by method name

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/namedquery/NamedQueryTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/namedquery/NamedQueryTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
 import static org.hibernate.processor.test.util.TestUtil.assertNoMetamodelClassGeneratedFor;
 import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Gavin King
@@ -24,7 +26,12 @@ class NamedQueryTest {
 		System.out.println( getMetaModelSourceAsString( Book.class ) );
 		System.out.println( getMetaModelSourceAsString( Author.class, true ) );
 		System.out.println( getMetaModelSourceAsString( Book.class, true ) );
-		System.out.println( getMetaModelSourceAsString( BookAuthorRepository.class, true ) );
+		final String repository = getMetaModelSourceAsString( BookAuthorRepository.class, true );
+		System.out.println( repository );
+		assertFalse( repository.contains( "createNamedQuery(\"BookAuthorRepository$.findByTitleLike\"" ) );
+		assertFalse( repository.contains( "createNamedQuery(\"BookAuthorRepository$.findByTypeIn\"" ) );
+		assertTrue( repository.contains( "createSelectionQuery(FIND_BY_TITLE_LIKE_String, Book.class)" ) );
+		assertTrue( repository.contains( "createSelectionQuery(FIND_BY_TYPE_IN_Set, Book.class)" ) );
 		assertMetamodelClassGeneratedFor( Author.class, true );
 		assertMetamodelClassGeneratedFor( Book.class, true );
 		assertMetamodelClassGeneratedFor( Author.class );

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -4267,7 +4267,11 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	}
 
 	private @Nullable String namedRepositoryQueryName(ExecutableElement method, AnnotationMirror mirror) {
-		return repository && isNamedRepositoryQueryAnnotation( mirror ) ? staticQueryName( method ) : null;
+		return repository
+			&& !isCompanionMethod( method )
+			&& isNamedRepositoryQueryAnnotation( mirror )
+				? staticQueryName( method )
+				: null;
 	}
 
 	private static boolean isNamedRepositoryQueryAnnotation(AnnotationMirror mirror) {


### PR DESCRIPTION
they can't use named query lookup

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
