### PR TITLE
HHH-12235 - Map Oracle ORA-08177 to TransactionSerializationException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -57,6 +57,7 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.exception.ConstraintViolationException.ConstraintKind;
 import org.hibernate.exception.LockAcquisitionException;
 import org.hibernate.exception.LockTimeoutException;
+import org.hibernate.exception.TransactionSerializationException;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor;
 import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
@@ -1265,6 +1266,11 @@ public class OracleDialect extends Dialect {
 				case 4020 ->
 					// ORA-04020 deadlock detected while trying to lock object
 						new LockAcquisitionException( message, sqlException, sql );
+
+				// serialization failures ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+				case 8177 ->
+					// ORA-08177: can't serialize access for this transaction
+						new TransactionSerializationException( message, sqlException, sql );
 
 				// query cancelled ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 				case 1013 ->

--- a/hibernate-core/src/main/java/org/hibernate/exception/TransactionSerializationException.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/TransactionSerializationException.java
@@ -12,7 +12,8 @@ import java.sql.SQLException;
  * A {@link JDBCException} indicating a transaction failed because it could not be placed into a serializable ordering
  * among all currently-executing transactions
  *
- * @apiNote At present, this is only used to represent {@code WriteTooOldError} on CockroachDB.
+ * @apiNote This is used to represent {@code WriteTooOldError} on CockroachDB and
+ *          {@code ORA-08177: can't serialize access for this transaction} on Oracle.
  *
  * @author Karel Maesen
  */

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/OracleDialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/OracleDialectTestCase.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.dialect;
+
+import org.hibernate.JDBCException;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.exception.TransactionSerializationException;
+import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test case for Oracle specific things.
+ */
+@RequiresDialect(OracleDialect.class)
+public class OracleDialectTestCase {
+
+	@Test
+	@JiraKey(value = "HHH-12235")
+	public void testSerializationFailureConversion() {
+		final OracleDialect dialect = new OracleDialect();
+		final SQLExceptionConversionDelegate delegate = dialect.buildSQLExceptionConversionDelegate();
+		assertNotNull( delegate );
+
+		// ORA-08177: can't serialize access for this transaction
+		final JDBCException exception = delegate.convert(
+				new SQLException( "ORA-08177: can't serialize access for this transaction", "72000", 8177 ),
+				"",
+				""
+		);
+		assertInstanceOf( TransactionSerializationException.class, exception );
+	}
+}


### PR DESCRIPTION
HHH-12235: Oracle `ORA-08177` ("can't serialize access for this transaction") was converted to a generic `JDBCException` rather than a serialization-specific one.

Maps error code `8177` to `TransactionSerializationException` in `OracleDialect`, following the CockroachDB precedent from HHH-18760.

Testing: `OracleDialectTestCase.testSerializationFailureConversion`.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-12235 (Improvement):
- [x] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-12235
<!-- Hibernate GitHub Bot issue links end -->