### PR TITLE
More JPA4 fallout

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SharedStatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedStatelessSessionBuilder.java
@@ -36,7 +36,6 @@ import java.util.function.UnaryOperator;
  * A child stateless session with a shared transaction context also receives
  * parent flush and close notifications, so its JDBC batch is executed with the
  * parent, and the child is automatically closed when the parent is closed.
- * <p>
  * <pre>{@code
  * try (var statelessSession
  *          = session.statelessWithOptions()

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
@@ -1411,7 +1411,7 @@ public class PropertyBinder {
 			final var basic = attributeMember.getDirectAnnotationUsage( Basic.class );
 			if ( basic != null ) {
 				return basic.optional()
-				       && attributeMember.getType().getTypeKind() != TypeDetails.Kind.PRIMITIVE;
+					&& attributeMember.getType().getTypeKind() != TypeDetails.Kind.PRIMITIVE;
 			}
 			else if ( attributeMember.isArray() ) {
 				return true;

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/NamedMutationDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/NamedMutationDefinition.java
@@ -21,6 +21,7 @@ import org.hibernate.query.spi.JpaStatementReference;
 public interface NamedMutationDefinition<T>
 		extends NamedQueryDefinition<T>, JpaStatementReference<T> {
 	@Override
+	@Nullable
 	default String getName() {
 		return getRegistrationName();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/NamedSelectionDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/NamedSelectionDefinition.java
@@ -23,6 +23,7 @@ public interface NamedSelectionDefinition<R>
 	String getQueryString();
 
 	@Override
+	@Nullable
 	default String getName() {
 		return getRegistrationName();
 	}
@@ -30,7 +31,7 @@ public interface NamedSelectionDefinition<R>
 	/**
 	 * The expected result type of the query, or {@code null}.
 	 */
-	@Nullable
+	@Nullable //FIXME: declared @Nonnull by JPA
 	Class<R> getResultType();
 
 	Boolean getReadOnly();
@@ -52,5 +53,6 @@ public interface NamedSelectionDefinition<R>
 	Integer getFetchSize();
 
 	@Override
+	@Nullable
 	String getEntityGraphName();
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/internal/AbstractNamedQueryDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/internal/AbstractNamedQueryDefinition.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.boot.query.internal;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.Timeout;
 import jakarta.annotation.Nullable;
 import org.hibernate.FlushMode;
@@ -55,6 +56,7 @@ public abstract class AbstractNamedQueryDefinition<T> implements NamedQueryDefin
 	}
 
 	@Override
+	@Nonnull
 	public Map<String, Object> getHints() {
 		return hints;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/internal/NamedHqlSelectionDefinitionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/internal/NamedHqlSelectionDefinitionImpl.java
@@ -96,11 +96,13 @@ public class NamedHqlSelectionDefinitionImpl<R>
 	}
 
 	@Override
-	public @Nullable Class<R> getResultType() {
+	@Nullable
+	public Class<R> getResultType() {
 		return resultType;
 	}
 
 	@Override
+	@Nullable
 	public String getEntityGraphName() {
 		return entityGraphName;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/internal/NamedNativeSelectionDefinitionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/internal/NamedNativeSelectionDefinitionImpl.java
@@ -103,11 +103,13 @@ public class NamedNativeSelectionDefinitionImpl<R> extends AbstractNamedSelectio
 	}
 
 	@Override
-	public @Nullable Class<R> getResultType() {
+	@Nullable
+	public Class<R> getResultType() {
 		return resultType;
 	}
 
 	@Override
+	@Nullable
 	public String getEntityGraphName() {
 		return null;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/named/internal/AbstractQueryMemento.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/named/internal/AbstractQueryMemento.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query.named.internal;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.Timeout;
 import jakarta.annotation.Nullable;
 import org.hibernate.FlushMode;
@@ -53,6 +54,7 @@ public abstract class AbstractQueryMemento<R>
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return name;
 	}
@@ -78,6 +80,7 @@ public abstract class AbstractQueryMemento<R>
 	}
 
 	@Override
+	@Nonnull
 	public Map<String, Object> getHints() {
 		return hints;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/named/internal/AbstractSelectionMemento.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/named/internal/AbstractSelectionMemento.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.query.named.internal;
 
-import jakarta.annotation.Nonnull;
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.Timeout;
 import jakarta.annotation.Nullable;
@@ -75,9 +74,8 @@ public abstract class AbstractSelectionMemento<R>
 	}
 
 	@Override
-	@Nonnull
+	@Nullable //FIXME: declared @Nonnull by JPA
 	public Class<? extends R> getResultType() {
-		//TODO: fix!!
 		return queryType;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/named/internal/CriteriaSelectionMementoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/named/internal/CriteriaSelectionMementoImpl.java
@@ -96,6 +96,7 @@ public class CriteriaSelectionMementoImpl<R>
 	}
 
 	@Override
+	@Nullable
 	public String getEntityGraphName() {
 		return null;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/named/internal/HqlSelectionMementoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/named/internal/HqlSelectionMementoImpl.java
@@ -94,11 +94,13 @@ public class HqlSelectionMementoImpl<R>
 	}
 
 	@Override
+	@Nullable //FIXME: declared @Nonnull by JPA
 	public Class<? extends R> getResultType() {
 		return queryType;
 	}
 
 	@Override
+	@Nullable
 	public String getEntityGraphName() {
 		return entityGraphName;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/named/internal/NativeSelectionMementoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/named/internal/NativeSelectionMementoImpl.java
@@ -80,6 +80,7 @@ public class NativeSelectionMementoImpl<R>
 	}
 
 	@Override
+	@Nullable
 	public String getEntityGraphName() {
 		return null;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/jpa/EntityBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/jpa/EntityBuilder.java
@@ -9,6 +9,7 @@ import jakarta.persistence.sql.EmbeddedMapping;
 import jakarta.persistence.sql.EntityMapping;
 import jakarta.persistence.sql.FieldMapping;
 import jakarta.persistence.sql.MemberMapping;
+import org.hibernate.LockMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.metamodel.mapping.AttributeMapping;
@@ -46,6 +47,7 @@ import static org.hibernate.internal.util.collections.CollectionHelper.arrayList
 public class EntityBuilder<T> extends AbstractMappingElementBuilder<T> implements ResultBuilderEntityValued {
 	private final EntityPersister entityDescriptor;
 	private final NavigablePath rootPath;
+	private final LockMode lockMode;
 	private final FetchBuilder identifierFetchBuilder;
 	private final FetchBuilderBasicValued discriminatorFetchBuilder;
 	private final Map<String,FetchBuilder> attributeFetchBuilders = new HashMap<>();
@@ -57,6 +59,7 @@ public class EntityBuilder<T> extends AbstractMappingElementBuilder<T> implement
 				sessionFactory.getMappingMetamodel()
 						.getEntityDescriptor( entityMapping.entityClass() );
 		rootPath = new NavigablePath( entityDescriptor.getRootPathName() );
+		lockMode = LockMode.fromJpaLockMode( entityMapping.lockMode() );
 
 		if ( StringHelper.isBlank( entityMapping.discriminatorColumn() ) ) {
 			discriminatorFetchBuilder = null;
@@ -346,12 +349,14 @@ public class EntityBuilder<T> extends AbstractMappingElementBuilder<T> implement
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
 			DomainResultCreationState creationState) {
-		applyTableGroup( resultPosition, creationState );
+		final String resultAlias = applyTableGroup( resultPosition, creationState );
 
 		return new EntityResultImpl<>(
 				entityDescriptor,
 				javaType,
 				rootPath,
+				resultAlias,
+				lockMode,
 				identifierFetchBuilder,
 				discriminatorFetchBuilder,
 				attributeFetchBuilders,
@@ -360,7 +365,7 @@ public class EntityBuilder<T> extends AbstractMappingElementBuilder<T> implement
 		);
 	}
 
-	private void applyTableGroup(int resultPosition, DomainResultCreationState creationState) {
+	private String applyTableGroup(int resultPosition, DomainResultCreationState creationState) {
 		final String implicitAlias = entityDescriptor.getSqlAliasStem() + resultPosition;
 		final var sqlAliasBase = creationState.getSqlAliasBaseManager().createSqlAliasBase( implicitAlias );
 
@@ -377,6 +382,7 @@ public class EntityBuilder<T> extends AbstractMappingElementBuilder<T> implement
 						creationState.getSqlAstCreationState()
 				)
 		);
+		return implicitAlias;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/jpa/EntityBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/jpa/EntityBuilder.java
@@ -11,11 +11,8 @@ import jakarta.persistence.sql.FieldMapping;
 import jakarta.persistence.sql.MemberMapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.StringHelper;
-import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.mapping.AttributeMapping;
-import org.hibernate.metamodel.mapping.BasicValuedModelPart;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
-import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ManagedMappingType;
 import org.hibernate.metamodel.mapping.NonAggregatedIdentifierMapping;
@@ -186,7 +183,7 @@ public class EntityBuilder<T> extends AbstractMappingElementBuilder<T> implement
 		}
 		else {
 			throw new IllegalArgumentException( "Unrecognized member mapping type: "
-			                                    + memberMapping.getClass().getName());
+												+ memberMapping.getClass().getName());
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/jpa/EntityResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/jpa/EntityResultImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query.results.internal.jpa;
 
+import org.hibernate.LockMode;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.EntityValuedModelPart;
@@ -38,6 +39,7 @@ class EntityResultImpl<E> implements EntityResult<E> {
 
 	private final JavaType<E> javaType;
 	private final NavigablePath navigablePath;
+	private final String resultAlias;
 
 	private final Fetch identifierFetch;
 	private final BasicFetch<?> discriminatorFetch;
@@ -47,6 +49,8 @@ class EntityResultImpl<E> implements EntityResult<E> {
 			EntityMappingType entityDescriptor,
 			JavaType<E> javaType,
 			NavigablePath navigablePath,
+			String resultAlias,
+			LockMode lockMode,
 			FetchBuilder identifierFetchBuilder,
 			FetchBuilderBasicValued discriminatorFetchBuilder,
 			Map<String, FetchBuilder> attributeFetchBuilders,
@@ -55,6 +59,8 @@ class EntityResultImpl<E> implements EntityResult<E> {
 		this.entityDescriptor = entityDescriptor;
 		this.javaType = javaType;
 		this.navigablePath = navigablePath;
+		this.resultAlias = resultAlias;
+		creationState.getSqlAstCreationState().registerLockMode( resultAlias, lockMode );
 
 		this.identifierFetch = identifierFetchBuilder.buildFetch(
 				this,
@@ -115,7 +121,7 @@ class EntityResultImpl<E> implements EntityResult<E> {
 			AssemblerCreationState creationState) {
 		return new EntityInitializerImpl(
 				this,
-				getResultVariable(),
+				resultAlias,
 				identifierFetch,
 				discriminatorFetch,
 				null,
@@ -136,7 +142,7 @@ class EntityResultImpl<E> implements EntityResult<E> {
 
 	@Override
 	public String getResultVariable() {
-		return "";
+		return resultAlias;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/jpa/TupleResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/jpa/TupleResultImpl.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Tuple;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
+import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.graph.InitializerParent;
 import org.hibernate.sql.results.internal.TupleImpl;
 import org.hibernate.sql.results.internal.TupleMetadata;
@@ -15,6 +16,7 @@ import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 import org.hibernate.type.descriptor.java.JavaType;
 
 import java.util.BitSet;
+import java.util.function.BiConsumer;
 
 /**
  * @author Steve Ebersole
@@ -38,7 +40,7 @@ public record TupleResultImpl(
 	public TupleAssembler createResultAssembler(
 			InitializerParent<?> parent,
 			AssemblerCreationState creationState) {
-		final DomainResultAssembler<?>[] elementAssemblers = new DomainResultAssembler<?>[elementResults.length];
+		final var elementAssemblers = new DomainResultAssembler<?>[elementResults.length];
 		for ( int i = 0; i < elementResults.length; i++ ) {
 			elementAssemblers[i] = elementResults[i].createResultAssembler( parent, creationState );
 		}
@@ -47,13 +49,13 @@ public record TupleResultImpl(
 
 	@Override
 	public void collectValueIndexesToCache(BitSet valueIndexes) {
-
 	}
 
 	public record TupleAssembler(
 			JavaType<Tuple> resultType,
 			TupleMetadata tupleMetadata,
-			DomainResultAssembler<?>[] elementAssemblers) implements DomainResultAssembler<Tuple> {
+			DomainResultAssembler<?>[] elementAssemblers)
+					implements DomainResultAssembler<Tuple> {
 
 		@Override
 		public JavaType<Tuple> getAssembledJavaType() {
@@ -62,11 +64,25 @@ public record TupleResultImpl(
 
 		@Override
 		public Tuple assemble(RowProcessingState rowProcessingState) {
-			final Object[] row = new Object[elementAssemblers.length];
+			final var row = new Object[elementAssemblers.length];
 			for ( int i = 0; i < elementAssemblers.length; i++ ) {
 				row[i] = elementAssemblers[i].assemble( rowProcessingState );
 			}
 			return new TupleImpl( tupleMetadata, row );
+		}
+
+		@Override
+		public void resolveState(RowProcessingState rowProcessingState) {
+			for ( var elementAssembler : elementAssemblers ) {
+				elementAssembler.resolveState( rowProcessingState );
+			}
+		}
+
+		@Override
+		public <X> void forEachResultAssembler(BiConsumer<Initializer<?>, X> consumer, X arg) {
+			for ( var elementAssembler : elementAssemblers ) {
+				elementAssembler.forEachResultAssembler( consumer, arg );
+			}
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/CountProjectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/CountProjectionSpecificationImpl.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.query.specification.internal;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.TypedQueryReference;
@@ -20,9 +22,10 @@ import org.hibernate.query.specification.SimpleProjectionSpecification;
 import org.hibernate.query.spi.JpaTypedQueryReference;
 import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * @author Gavin King
@@ -83,41 +86,49 @@ public class CountProjectionSpecificationImpl<T> implements SimpleProjectionSpec
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}
 
 	@Override
+	@Nonnull
 	public Class<Long> getResultType() {
 		return Long.class;
 	}
 
 	@Override
+	@Nullable
 	public String getEntityGraphName() {
 		return null;
 	}
 
 	@Override
+	@Nonnull
 	public Map<String, Object> getHints() {
-		return Collections.emptyMap();
+		return emptyMap();
 	}
 
 	@Override
+	@Nonnull
 	public List<Class<?>> getParameterTypes() {
 		return List.of();
 	}
 
 	@Override
+	@Nonnull
 	public List<String> getParameterNames() {
 		return List.of();
 	}
 
 	@Override
+	@Nonnull
 	public List<Object> getArguments() {
 		return List.of();
 	}
 
 	@Override
+	@Nullable
 	public Timeout getTimeout() {
 		return null;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/ExistsProjectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/ExistsProjectionSpecificationImpl.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.query.specification.internal;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.TypedQueryReference;
@@ -83,41 +85,49 @@ public class ExistsProjectionSpecificationImpl<T> implements SimpleProjectionSpe
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}
 
 	@Override
+	@Nonnull
 	public Class<Boolean> getResultType() {
 		return Boolean.class;
 	}
 
 	@Override
+	@Nullable
 	public String getEntityGraphName() {
 		return null;
 	}
 
 	@Override
+	@Nonnull
 	public Map<String, Object> getHints() {
 		return Collections.emptyMap();
 	}
 
 	@Override
+	@Nonnull
 	public List<Class<?>> getParameterTypes() {
 		return List.of();
 	}
 
 	@Override
+	@Nonnull
 	public List<String> getParameterNames() {
 		return List.of();
 	}
 
 	@Override
+	@Nonnull
 	public List<Object> getArguments() {
 		return List.of();
 	}
 
 	@Override
+	@Nullable
 	public Timeout getTimeout() {
 		return null;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.query.specification.internal;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Statement;
 import jakarta.persistence.StatementReference;
@@ -113,11 +115,13 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T>, J
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return statementReference == null ? null : statementReference.getName();
 	}
 
 	@Override
+	@Nonnull
 	public Map<String,Object> getHints() {
 		return statementReference == null ? emptyMap() : statementReference.getHints();
 	}
@@ -130,21 +134,25 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T>, J
 	}
 
 	@Override
+	@Nullable
 	public List<Class<?>> getParameterTypes() {
 		return statementReference == null ? null : statementReference.getParameterTypes();
 	}
 
 	@Override
+	@Nullable
 	public List<String> getParameterNames() {
 		return statementReference == null ? null : statementReference.getParameterNames();
 	}
 
 	@Override
+	@Nullable
 	public List<Object> getArguments() {
 		return statementReference == null ? null : statementReference.getArguments();
 	}
 
 	@Override
+	@Nonnull
 	public Set<Statement.Option> getOptions() {
 		return statementReference == null ? emptySet() : statementReference.getOptions();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/ProjectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/ProjectionSpecificationImpl.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.query.specification.internal;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.TypedQueryReference;
@@ -28,11 +30,11 @@ import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 import org.hibernate.query.sqm.tree.select.SqmSelection;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import static java.util.Collections.emptyMap;
 import static org.hibernate.internal.util.type.PrimitiveWrappers.cast;
 
 /**
@@ -115,18 +117,21 @@ public class ProjectionSpecificationImpl<T> implements ProjectionSpecification<T
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}
 
 	@Override
+	@Nonnull
 	public Class<Object[]> getResultType() {
 		return Object[].class;
 	}
 
 	@Override
+	@Nonnull
 	public Map<String, Object> getHints() {
-		return Collections.emptyMap();
+		return emptyMap();
 	}
 
 	@Override
@@ -135,7 +140,8 @@ public class ProjectionSpecificationImpl<T> implements ProjectionSpecification<T
 	}
 
 	@Override
+	@Nullable
 	public String getEntityGraphName() {
-		return "";
+		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SelectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SelectionSpecificationImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query.specification.internal;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.TypedQuery;
@@ -94,36 +95,43 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T>,
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return typedQueryReference == null ? null : typedQueryReference.getName();
 	}
 
 	@Override
+	@Nonnull
 	public Class<T> getResultType() {
 		return resultType;
 	}
 
 	@Override
+	@Nonnull
 	public Map<String,Object> getHints() {
 		return typedQueryReference == null ? emptyMap() : typedQueryReference.getHints();
 	}
 
 	@Override
+	@Nullable
 	public List<Class<?>> getParameterTypes() {
 		return typedQueryReference == null ? null : typedQueryReference.getParameterTypes();
 	}
 
 	@Override
+	@Nullable
 	public List<String> getParameterNames() {
 		return typedQueryReference == null ? null : typedQueryReference.getParameterNames();
 	}
 
 	@Override
+	@Nullable
 	public List<Object> getArguments() {
 		return typedQueryReference == null ? null : typedQueryReference.getArguments();
 	}
 
 	@Override
+	@Nonnull
 	public Set<TypedQuery.Option> getOptions() {
 		return typedQueryReference == null ? emptySet() : typedQueryReference.getOptions();
 	}
@@ -472,6 +480,7 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T>,
 //	}
 
 	@Override
+	@Nullable
 	public Timeout getTimeout() {
 		return typedQueryReference instanceof JpaTypedQueryReference<?> jpaTypedQueryReference
 				? jpaTypedQueryReference.getTimeout()
@@ -479,6 +488,7 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T>,
 	}
 
 	@Override
+	@Nullable
 	public String getEntityGraphName() {
 		return typedQueryReference == null ? "" : typedQueryReference.getEntityGraphName();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SimpleProjectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SimpleProjectionSpecificationImpl.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.query.specification.internal;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.TypedQueryReference;
@@ -100,11 +102,13 @@ public class SimpleProjectionSpecificationImpl<T,X> implements SimpleProjectionS
 	}
 
 	@Override
+	@Nullable
 	public String getName() {
 		return null;
 	}
 
 	@Override
+	@Nonnull
 	public Class<X> getResultType() {
 		if ( path != null ) {
 			return path.getType();
@@ -118,6 +122,7 @@ public class SimpleProjectionSpecificationImpl<T,X> implements SimpleProjectionS
 	}
 
 	@Override
+	@Nonnull
 	public Map<String, Object> getHints() {
 		return Collections.emptyMap();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/JpaStatementReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/JpaStatementReference.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.query.spi;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.StatementReference;
 import jakarta.persistence.Statement;
 
@@ -22,24 +24,28 @@ public interface JpaStatementReference<T> extends JpaReference, StatementReferen
 
 	/// {@inheritDoc}
 	@Override
+	@Nullable
 	default List<Class<?>> getParameterTypes() {
 		return null;
 	}
 
 	/// {@inheritDoc}
 	@Override
+	@Nullable
 	default List<String> getParameterNames() {
 		return null;
 	}
 
 	/// {@inheritDoc}
 	@Override
+	@Nullable
 	default List<Object> getArguments() {
 		return null;
 	}
 
 	/// {@inheritDoc}
 	@Override
+	@Nonnull
 	default Set<Statement.Option> getOptions() {
 		return Set.of();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/JpaTypedQueryReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/JpaTypedQueryReference.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.query.spi;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.TypedQuery;
@@ -21,6 +23,7 @@ public interface JpaTypedQueryReference<R> extends JpaReference, TypedQueryRefer
 
 	/// {@inheritDoc}
 	@Override
+	@Nullable
 	default List<Class<?>> getParameterTypes() {
 		return null;
 	}
@@ -39,6 +42,7 @@ public interface JpaTypedQueryReference<R> extends JpaReference, TypedQueryRefer
 
 	/// {@inheritDoc}
 	@Override
+	@Nonnull
 	default Set<TypedQuery.Option> getOptions() {
 		return Set.of();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.metamodel.SingularAttribute;
 import jakarta.persistence.metamodel.Type;
+import jakarta.persistence.sql.EntityMapping;
 import jakarta.annotation.Nullable;
 import org.hibernate.CacheMode;
 import org.hibernate.HibernateException;
@@ -69,7 +70,6 @@ import org.hibernate.query.results.internal.ResultSetMappingImpl;
 import org.hibernate.query.results.internal.dynamic.DynamicResultBuilderBasicStandard;
 import org.hibernate.query.results.internal.dynamic.DynamicResultBuilderEntityStandard;
 import org.hibernate.query.results.internal.dynamic.DynamicResultBuilderInstantiation;
-import org.hibernate.query.results.internal.jpa.JpaMappingHelper;
 import org.hibernate.query.results.spi.ResultBuilder;
 import org.hibernate.query.results.spi.ResultSetMapping;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
@@ -78,6 +78,7 @@ import org.hibernate.query.spi.NonSelectQueryPlan;
 import org.hibernate.query.spi.ParameterMetadataImplementor;
 import org.hibernate.query.spi.QueryInterpretationCache;
 import org.hibernate.query.spi.QueryOptions;
+import org.hibernate.query.spi.QueryParameterBinding;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.spi.SelectQueryPlan;
 import org.hibernate.query.spi.SelectionQueryImplementor;
@@ -120,6 +121,7 @@ import static org.hibernate.internal.util.collections.CollectionHelper.makeCopy;
 import static org.hibernate.internal.util.type.PrimitiveWrappers.canonicalize;
 import static org.hibernate.jpa.HibernateHints.HINT_NATIVE_LOCK_MODE;
 import static org.hibernate.query.results.internal.Builders.resultClassBuilder;
+import static org.hibernate.query.results.internal.jpa.JpaMappingHelper.toHibernateMapping;
 import static org.hibernate.query.results.spi.ResultSetMapping.resolveResultSetMapping;
 import static org.hibernate.query.sqm.internal.SqmUtil.isResultTypeAlwaysAllowed;
 import static org.hibernate.sql.ast.internal.ParameterMarkerStrategyStandard.isStandardRenderer;
@@ -156,6 +158,7 @@ public class NativeQueryImpl<R>
 	 */
 	public NativeQueryImpl(String incomingSqlString, SharedSessionContractImplementor session) {
 		super( session );
+		final var factory = session.getFactory();
 
 		originalSqlString = incomingSqlString;
 		querySpaces = new HashSet<>();
@@ -164,12 +167,12 @@ public class NativeQueryImpl<R>
 		sqlString = parameterInterpretation.getAdjustedSqlString();
 		parameterMetadata = parameterInterpretation.toParameterMetadata( session );
 		parameterOccurrences = parameterInterpretation.getOrderedParameterOccurrences();
-		parameterBindings = parameterMetadata.createBindings( session.getFactory() );
+		parameterBindings = parameterMetadata.createBindings( factory );
 
 		// We don't know (yet).  Create an "implicit" ResultSetMapping...
 		resultType = null;
-		var resultSetMappingProducer = session.getFactory().getJdbcValuesMappingProducerProvider();
-		resultSetMapping = resultSetMappingProducer.buildResultSetMapping( sqlString, true, session.getFactory() );
+		var resultSetMappingProducer = factory.getJdbcValuesMappingProducerProvider();
+		resultSetMapping = resultSetMappingProducer.buildResultSetMapping( sqlString, true, factory );
 		resultMappingSuppliedToCtor = false;
 	}
 
@@ -425,6 +428,7 @@ public class NativeQueryImpl<R>
 			jakarta.persistence.sql.ResultSetMapping<R> resultSetMapping,
 			SharedSessionContractImplementor session) {
 		super( session );
+		final var factory = session.getFactory();
 		originalSqlString = sql;
 		startsWithSelect = true;
 		querySpaces = new HashSet<>();
@@ -433,9 +437,29 @@ public class NativeQueryImpl<R>
 		sqlString = parameterInterpretation.getAdjustedSqlString();
 		parameterMetadata = parameterInterpretation.toParameterMetadata( session );
 		parameterOccurrences = parameterInterpretation.getOrderedParameterOccurrences();
-		parameterBindings = parameterMetadata.createBindings( session.getFactory() );
+		parameterBindings = parameterMetadata.createBindings( factory );
 
-		this.resultSetMapping = JpaMappingHelper.toHibernateMapping( resultSetMapping, session.getSessionFactory() );
+		this.resultSetMapping = toHibernateMapping( resultSetMapping, factory );
+		resultMappingSuppliedToCtor = true;
+		resultType = resultSetMapping.type();
+	}
+
+	private NativeQueryImpl(
+			NativeQueryImpl<?> original,
+			jakarta.persistence.sql.ResultSetMapping<R> resultSetMapping) {
+		super( original.session, original.queryOptions );
+		final var factory = session.getFactory();
+		originalSqlString = original.originalSqlString;
+		sqlString = original.sqlString;
+		startsWithSelect = true;
+		querySpaces = makeCopy( original.querySpaces );
+
+		parameterMetadata = original.parameterMetadata;
+		parameterOccurrences = original.parameterOccurrences;
+		parameterBindings = parameterMetadata.createBindings( factory );
+		original.getQueryParameterBindings().visitBindings( this::setBindValues );
+
+		this.resultSetMapping = toHibernateMapping( resultSetMapping, factory );
 		resultMappingSuppliedToCtor = true;
 		resultType = resultSetMapping.type();
 	}
@@ -446,6 +470,7 @@ public class NativeQueryImpl<R>
 			Class<R> resultClass,
 			SharedSessionContractImplementor session) {
 		super( session );
+		final var factory = session.getFactory();
 		originalSqlString = sql;
 		startsWithSelect = true;
 		querySpaces = new HashSet<>();
@@ -454,18 +479,18 @@ public class NativeQueryImpl<R>
 		sqlString = parameterInterpretation.getAdjustedSqlString();
 		parameterMetadata = parameterInterpretation.toParameterMetadata( session );
 		parameterOccurrences = parameterInterpretation.getOrderedParameterOccurrences();
-		parameterBindings = parameterMetadata.createBindings( session.getFactory() );
+		parameterBindings = parameterMetadata.createBindings( factory );
 
 		resultType = resultClass;
 		if ( resultSetMappingMemento != null ) {
-			resultSetMapping = session.getFactory().getJdbcValuesMappingProducerProvider()
-					.buildResultSetMapping( null, true, session.getFactory() );
+			resultSetMapping = factory.getJdbcValuesMappingProducerProvider()
+					.buildResultSetMapping( null, true, factory );
 			resultSetMappingMemento.resolve( resultSetMapping, this::addSynchronizedQuerySpace, this );
 			resultMappingSuppliedToCtor = true;
 			handleExplicitResultSetMapping();
 		}
 		else {
-			resultSetMapping = resolveResultSetMapping( sql, true, session.getFactory() );
+			resultSetMapping = resolveResultSetMapping( sql, true, factory );
 			resultMappingSuppliedToCtor = false;
 			handleImplicitResultSetMapping( session );
 		}
@@ -843,8 +868,21 @@ public class NativeQueryImpl<R>
 
 	@Override
 	@Nonnull
-	public <T> SelectionQueryImplementor<T> withResultSetMapping(@Nonnull jakarta.persistence.sql.ResultSetMapping<T> mapping) {
-		throw new UnsupportedOperationException( "Not implemented yet" );
+	public <T> SelectionQueryImplementor<T> withResultSetMapping(
+			@Nonnull jakarta.persistence.sql.ResultSetMapping<T> mapping) {
+		errorIfNotSelectForSure();
+		final var query = new NativeQueryImpl<>( this, mapping );
+		query.applyEntityMappingLockMode( mapping );
+		return query;
+	}
+
+	private void applyEntityMappingLockMode(jakarta.persistence.sql.ResultSetMapping<?> mapping) {
+		if ( mapping instanceof EntityMapping<?> entityMapping ) {
+			final var lockMode = LockMode.fromJpaLockMode( entityMapping.lockMode() );
+			if ( lockMode.greaterThan( LockMode.READ ) ) {
+				setHibernateLockMode( lockMode );
+			}
+		}
 	}
 
 	@Override
@@ -2072,6 +2110,33 @@ public class NativeQueryImpl<R>
 
 	private static boolean constructorParameterMatches(ResultBuilder resultBuilder, Class<?> paramType) {
 		return resultBuilder.getJavaType() == canonicalize( paramType );
+	}
+
+	private <T> void setBindValues(QueryParameter<?> parameter, QueryParameterBinding<T> binding) {
+		final var parameterBinding = parameterBindings.getBinding( binding.getQueryParameter() );
+		parameterBinding.setType( binding.getType() );
+		if ( !binding.isBound() ) {
+			return;
+		}
+		final var explicitTemporalPrecision = binding.getExplicitTemporalPrecision();
+		if ( explicitTemporalPrecision != null ) {
+			if ( binding.isMultiValued() ) {
+				parameterBinding.setBindValues( binding.getBindValues(), explicitTemporalPrecision );
+			}
+			else {
+				parameterBinding.setBindValue( binding.getBindValue(), explicitTemporalPrecision );
+			}
+		}
+		else {
+			final var bindType = binding.getBindType();
+			if ( binding.isMultiValued() ) {
+				parameterBinding.setBindValues( binding.getBindValues(), bindType );
+			}
+			else {
+				parameterBinding.setBindValue( binding.getBindValue(), bindType );
+			}
+		}
+		parameterBinding.setType( binding.getType() );
 	}
 
 	protected <T> void setTupleTransformerForResultType(Class<T> resultClass) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/options/Jpa4OptionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/options/Jpa4OptionsTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.Entity;
@@ -173,7 +175,7 @@ class Jpa4OptionsTest {
 			final var book = entityManager.find( Book.class, 2L, (Map<String, Object>) null );
 
 			assertEquals( "before", book.title );
-			assertEquals( book, entityManager.find( Book.class, 2L, LockModeType.NONE, (Map<String, Object>) null ) );
+			assertEquals( book, entityManager.find( Book.class, 2L, LockModeType.NONE, null ) );
 			entityManager.lock( book, LockModeType.NONE, (Map<String, Object>) null );
 
 			entityManager.createStatement( "update Book b set b.title = 'after' where b.id = :id" )
@@ -185,7 +187,7 @@ class Jpa4OptionsTest {
 			entityManager.createStatement( "update Book b set b.title = 'again' where b.id = :id" )
 					.setParameter( "id", 2L )
 					.execute();
-			entityManager.refresh( book, LockModeType.NONE, (Map<String, Object>) null );
+			entityManager.refresh( book, LockModeType.NONE, null );
 			assertEquals( "again", book.title );
 			entityManager.getTransaction().commit();
 		}
@@ -298,41 +300,49 @@ class Jpa4OptionsTest {
 			Class<R> resultType,
 			Set<TypedQuery.Option> options) implements TypedQueryReference<R> {
 		@Override
+		@Nonnull
 		public String getName() {
 			return name;
 		}
 
 		@Override
+		@Nonnull
 		public Class<? extends R> getResultType() {
 			return resultType;
 		}
 
 		@Override
+		@Nullable
 		public List<Class<?>> getParameterTypes() {
 			return null;
 		}
 
 		@Override
+		@Nullable
 		public List<String> getParameterNames() {
 			return null;
 		}
 
 		@Override
+		@Nullable
 		public List<Object> getArguments() {
 			return null;
 		}
 
 		@Override
+		@Nonnull
 		public Map<String, Object> getHints() {
 			return Map.of();
 		}
 
 		@Override
+		@Nonnull
 		public Set<TypedQuery.Option> getOptions() {
 			return options;
 		}
 
 		@Override
+		@Nullable
 		public String getEntityGraphName() {
 			return null;
 		}
@@ -346,26 +356,31 @@ class Jpa4OptionsTest {
 		}
 
 		@Override
+		@Nullable
 		public List<Class<?>> getParameterTypes() {
 			return null;
 		}
 
 		@Override
+		@Nullable
 		public List<String> getParameterNames() {
 			return null;
 		}
 
 		@Override
+		@Nullable
 		public List<Object> getArguments() {
 			return null;
 		}
 
 		@Override
+		@Nonnull
 		public Map<String, Object> getHints() {
 			return Map.of();
 		}
 
 		@Override
+		@Nonnull
 		public Set<jakarta.persistence.Statement.Option> getOptions() {
 			return options;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/dynamic/SimpleResultSetMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/dynamic/SimpleResultSetMappingTests.java
@@ -57,6 +57,28 @@ public class SimpleResultSetMappingTests {
 		} );
 	}
 
+	@Test
+	void testWithResultSetMapping(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var query =
+					session.createNativeQuery( "select id, name from books where id = :id" )
+							.setParameter( "id", 1 );
+			var mapping = ResultSetMapping.constructor(
+					DropDownItem.class,
+					ResultSetMapping.column( "id", Integer.class ),
+					ResultSetMapping.column( "name", String.class )
+			);
+
+			var result =
+					query.withResultSetMapping( mapping )
+							.getSingleResult();
+
+			assertThat( result )
+					.extracting( "key", "text" )
+					.containsExactly( 1, "The Fellowship of the Ring" );
+		} );
+	}
+
 	/// @see NamedToDynamicTests#testConstructorConversions
 	@Test
 	void testConstructorMappings(SessionFactoryScope factoryScope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/dynamic/SimpleResultSetMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/dynamic/SimpleResultSetMappingTests.java
@@ -202,6 +202,81 @@ public class SimpleResultSetMappingTests {
 	}
 
 	@Test
+	void testTupleMappingWithColumnAliases(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var idMapping = ResultSetMapping.column( "id", Integer.class ).withAlias( "bookId" );
+			var nameMapping = ResultSetMapping.column( "name", String.class ).withAlias( "bookTitle" );
+			var mapping = ResultSetMapping.tuple( idMapping, nameMapping );
+			var result = session.createNativeQuery( "select id, name from books", mapping ).list();
+			assertThat( result ).hasSize( 1 );
+
+			final Tuple tuple = result.get( 0 );
+			assertThat( tuple.getElements() ).extracting( "alias" )
+					.containsExactly( "bookId", "bookTitle" );
+			assertThat( tuple.get( idMapping ) ).isEqualTo( 1 );
+			assertThat( tuple.get( nameMapping ) ).isEqualTo( "The Fellowship of the Ring" );
+			assertThat( tuple.get( "bookId", Integer.class ) ).isEqualTo( 1 );
+			assertThat( tuple.get( "bookTitle", String.class ) ).isEqualTo( "The Fellowship of the Ring" );
+			assertThat( tuple.get( 0, Integer.class ) ).isEqualTo( 1 );
+			assertThat( tuple.get( 1, String.class ) ).isEqualTo( "The Fellowship of the Ring" );
+			assertThat( tuple.toArray() ).containsExactly( 1, "The Fellowship of the Ring" );
+		} );
+	}
+
+	@Test
+	void testTupleMappingWithConstructorAlias(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var itemMapping = ResultSetMapping.constructor(
+					DropDownItem.class,
+					ResultSetMapping.column( "id", Integer.class ),
+					ResultSetMapping.column( "name", String.class )
+			).withAlias( "item" );
+			var isbnMapping = ResultSetMapping.column( "isbn", String.class ).withAlias( "bookIsbn" );
+			var mapping = ResultSetMapping.tuple( itemMapping, isbnMapping );
+			var result = session.createNativeQuery( "select id, name, isbn from books", mapping ).list();
+			assertThat( result ).hasSize( 1 );
+
+			final Tuple tuple = result.get( 0 );
+			assertThat( tuple.getElements() ).extracting( "alias" )
+					.containsExactly( "item", "bookIsbn" );
+			assertThat( tuple.get( itemMapping ) ).isInstanceOf( DropDownItem.class );
+			assertThat( tuple.get( "item", DropDownItem.class ) )
+					.extracting( "key", "text" )
+					.containsExactly( 1, "The Fellowship of the Ring" );
+			assertThat( tuple.get( isbnMapping ) ).isEqualTo( "123-456" );
+			assertThat( tuple.get( "bookIsbn", String.class ) ).isEqualTo( "123-456" );
+		} );
+	}
+
+	@Test
+	void testTupleMappingWithEntityAlias(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var bookMapping = ResultSetMapping.entity(
+					Book.class,
+					ResultSetMapping.field( Book_.id, "id" ),
+					ResultSetMapping.field( Book_.name, "name" ),
+					ResultSetMapping.field( Book_.isbn, "isbn" ),
+					ResultSetMapping.field( Book_.published, "published" )
+			).withAlias( "book" );
+			var labelMapping = ResultSetMapping.column( "label", String.class ).withAlias( "label" );
+			var mapping = ResultSetMapping.tuple( bookMapping, labelMapping );
+			var result = session.createNativeQuery(
+					"select id, name, isbn, published, name as label from books",
+					mapping
+			).list();
+			assertThat( result ).hasSize( 1 );
+
+			final Tuple tuple = result.get( 0 );
+			assertThat( tuple.getElements() ).extracting( "alias" )
+					.containsExactly( "book", "label" );
+			assertThat( tuple.get( bookMapping ) ).isInstanceOf( Book.class );
+			assertThat( tuple.get( "book", Book.class ) ).isInstanceOf( Book.class );
+			assertThat( tuple.get( labelMapping ) ).isEqualTo( "The Fellowship of the Ring" );
+			assertThat( tuple.get( "label", String.class ) ).isEqualTo( "The Fellowship of the Ring" );
+		} );
+	}
+
+	@Test
 	void testCompoundMapping(SessionFactoryScope factoryScope) {
 		factoryScope.inTransaction( (session) -> {
 			var mapping = ResultSetMapping.compound(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/dynamic/SimpleResultSetMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/dynamic/SimpleResultSetMappingTests.java
@@ -7,9 +7,11 @@ package org.hibernate.orm.test.query.resultmapping.dynamic;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.sql.ResultSetMapping;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -297,6 +299,8 @@ public class SimpleResultSetMappingTests {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = SQLServerDialect.class,
+			reason = "FOR UPDATE clause allowed only for DECLARE CURSOR")
 	void testCompoundEntityMappingWithLockMode(SessionFactoryScope factoryScope) {
 		factoryScope.inTransaction( (session) -> {
 			var bookMapping = ResultSetMapping.entity(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/dynamic/SimpleResultSetMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/dynamic/SimpleResultSetMappingTests.java
@@ -5,6 +5,7 @@
 package org.hibernate.orm.test.query.resultmapping.dynamic;
 
 import jakarta.persistence.Tuple;
+import jakarta.persistence.LockModeType;
 import jakarta.persistence.sql.ResultSetMapping;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -140,6 +141,23 @@ public class SimpleResultSetMappingTests {
 	}
 
 	@Test
+	void testEntityMappingWithLockMode(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var mapping = ResultSetMapping.entity(
+					Book.class,
+					ResultSetMapping.field( Book_.id, "id" ),
+					ResultSetMapping.field( Book_.name, "name" ),
+					ResultSetMapping.field( Book_.isbn, "isbn" ),
+					ResultSetMapping.field( Book_.published, "published" )
+			).withLockMode( LockModeType.PESSIMISTIC_WRITE );
+			var result = session.createNativeQuery( "select * from books where id = 1", mapping )
+					.getSingleResult();
+
+			assertThat( session.getLockMode( result ) ).isEqualTo( LockModeType.PESSIMISTIC_WRITE );
+		} );
+	}
+
+	@Test
 	void testTupleMapping(SessionFactoryScope factoryScope) {
 		factoryScope.inTransaction( (session) -> {
 			var mapping = ResultSetMapping.tuple(
@@ -200,6 +218,32 @@ public class SimpleResultSetMappingTests {
 			assertThat( row[0] ).isEqualTo( 1 );
 			// should be the name
 			assertThat( row[1] ).isEqualTo( "The Fellowship of the Ring" );
+		} );
+	}
+
+	@Test
+	void testCompoundEntityMappingWithLockMode(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var bookMapping = ResultSetMapping.entity(
+					Book.class,
+					ResultSetMapping.field( Book_.id, "id" ),
+					ResultSetMapping.field( Book_.name, "name" ),
+					ResultSetMapping.field( Book_.isbn, "isbn" ),
+					ResultSetMapping.field( Book_.published, "published" )
+			).withLockMode( LockModeType.PESSIMISTIC_WRITE );
+			var mapping = ResultSetMapping.compound(
+					bookMapping,
+					ResultSetMapping.column( "label", String.class )
+			);
+
+			var result = session.createNativeQuery(
+					"select id, name, isbn, published, name as label from books where id = 1 for update",
+					mapping
+			).getSingleResult();
+
+			assertThat( result[0] ).isInstanceOf( Book.class );
+			assertThat( result[1] ).isEqualTo( "The Fellowship of the Ring" );
+			assertThat( session.getLockMode( result[0] ) ).isEqualTo( LockModeType.PESSIMISTIC_WRITE );
 		} );
 	}
 }


### PR DESCRIPTION
1. implement `withResultSetMapping()`
2. propagate nullability annotations down `Reference` hierarchy

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
