### PR TITLE
HHH-20510 - Bring back hibernate-ucp module

### DIFF
--- a/documentation/src/main/asciidoc/quickstart/guides/obtaining.adoc
+++ b/documentation/src/main/asciidoc/quickstart/guides/obtaining.adoc
@@ -52,6 +52,7 @@ transitive dependencies based on the features being used or not.
 |hibernate-agroal| Support for https://agroal.github.io/[Agroal] connection pooling
 |hibernate-c3p0| Support for https://www.mchange.com/projects/c3p0/[C3P0] connection pooling
 |hibernate-hikaricp| Support for https://github.com/brettwooldridge/HikariCP/[HikariCP] connection pooling
+|hibernate-ucp| Support for https://docs.oracle.com/en/database/oracle/oracle-database/26/jjucp/intro.html[Oracle Universal Connection Pool] connection pooling
 |hibernate-jcache| Integration with https://jcp.org/en/jsr/detail?id=107$$[JCache], allowing any compliant implementation as a second-level cache provider
 |hibernate-graalvm| Experimental extension to make it easier to compile applications as a https://www.graalvm.org/[GraalVM] native image
 |hibernate-micrometer| Integration with https://micrometer.io[Micrometer] metrics

--- a/documentation/src/main/asciidoc/userguide/chapters/jdbc/Database_Access.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/jdbc/Database_Access.adoc
@@ -18,8 +18,9 @@ Hibernate will internally determine which `ConnectionProvider` to use based on t
 3. else if any setting prefixed by `hibernate.c3p0.` is set -> <<database-connectionprovider-c3p0>>
 4. else if any setting prefixed by `hibernate.hikari.` is set -> <<database-connectionprovider-hikari>>
 5. else if any setting prefixed by `hibernate.agroal.` is set -> <<database-connectionprovider-agroal>>
-6. else if `hibernate.connection.url` is set -> <<database-connectionprovider-drivermanager>>
-7. else -> <<database-connectionprovider-provided>>
+6. else if any setting prefixed by `hibernate.ucp.` is set -> <<database-connectionprovider-oracleucp>>
+7. else if `hibernate.connection.url` is set -> <<database-connectionprovider-drivermanager>>
+8. else -> <<database-connectionprovider-provided>>
 
 [[database-connectionprovider-datasource]]
 === Using DataSources
@@ -109,6 +110,41 @@ Additionally, this `ConnectionProvider` will pick up the following Hibernate-spe
 `hibernate.connection.password`:: Mapped to Agroal's `credential` setting
 `hibernate.connection.isolation`:: Mapped to Agroal's `jdbcTransactionIsolation` setting. See <<ConnectionProvider support for transaction isolation setting>>.
 `hibernate.connection.autocommit`:: Mapped to Agroal's `autoCommit` setting
+
+[[database-connectionprovider-oracleucp]]
+=== Using Oracle Universal Connection Pool
+
+[IMPORTANT]
+====
+To use the Oracle Universal Connection Pool (aka UCP) integration, the application must include the `hibernate-ucp` module jar (as well as its dependencies) on the classpath.
+====
+
+Hibernate also provides support for applications using https://docs.oracle.com/en/database/oracle/oracle-database/26/jjucp/intro.html[Oracle Universal Connection Pool].
+
+UCP settings may be supplied by prefixing the setting name with `hibernate.ucp.`.
+Additionally, the UCP `ConnectionProvider` understands the following standard properties:
+
+`jakarta.persistence.jdbc.url` or `hibernate.connection.url`:: Mapped to UCP `URL` setting
+`jakarta.persistence.jdbc.user` or `hibernate.connection.username`:: Mapped to UCP `user` setting
+`jakarta.persistence.jdbc.password` or `hibernate.connection.password`:: Mapped to UCP `password` setting
+`hibernate.connection.isolation`:: Used to initialize the `Connection` retrieved from UCP. See <<ConnectionProvider support for transaction isolation setting>>.
+`hibernate.connection.autocommit`:: Used to initialize the `Connection` retrieved from UCP.
+Any other setting prefixed with `hibernate.ucp.`:: The `hibernate.ucp.` prefix is stripped and the remaining text is passed to UCP (for example, `hibernate.ucp.loginTimeout 5000`).
+
+[IMPORTANT]
+====
+You can pass further properties to the `Connection` provided by UCP by using the `hibernate.ucp.connectionProperties` property in the following manner:
+
+`hibernate.ucp.connectionProperties=oracle.jdbc.thinForceDNSLoadBalancing=true,oracle.jdbc.fanEnabled=true,oracle.jdbc.defaultConnectionValidation=SOCKET,oracle.jdbc.implicitStatementCacheSize=50,oracle.jdbc.loginTimeout=5000`
+
+You can find the exhaustive list of the supported `Connection` properties https://docs.oracle.com/en/database/oracle/oracle-database/26/jajdb/oracle/jdbc/OracleConnection.html[here].
+
+====
+
+The Hibernate property `hibernate.ucp.connectionFactoryClassName` selects between:
+
+. a standard connection pool: `oracle.jdbc.pool.OracleDataSource`
+. a _replay_ connection pool: `oracle.jdbc.replay.OracleDataSourceImpl` which allows using https://docs.oracle.com/en/database/oracle/oracle-database/26/jjdbc/application-continuity.html[Application Continuity] capabilities to mask planned and unplanned downtimes. Note that the `OracleDialect` knows  if Application Continuity is enabled by using the `isApplicationContinuity()` function.
 
 [[database-connectionprovider-drivermanager]]
 === Using Hibernate's built-in (and unsupported) pooling

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -154,6 +154,7 @@ graalvmSdk = { group = "org.graalvm.sdk", name = "graal-sdk", version.ref = "gra
 commonsCollections = { group = "org.apache.commons", name = "commons-collections4", version.ref = "commonsCollections" }
 eclipseJdtCore = { group = "org.eclipse.jdt", name = "org.eclipse.jdt.core", version.ref = "eclipseJdtCore" }
 freemarker = { group = "org.freemarker", name = "freemarker", version.ref = "freemarker" }
+oracleucp = { group = "com.oracle.database.jdbc", name = "ucp17", version.ref = "oracle" }
 
 # Jakarta
 jakarta-jpa = { group = "jakarta.persistence", name = "jakarta.persistence-api", version.ref = "jpa" }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/UCPSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/UCPSettings.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.cfg;
+
+/**
+ * Oracle Universal Connection Pool settings.
+ *
+ * @author Loïc Lefèvre
+ */
+public interface UCPSettings {
+	/**
+	 * A setting prefix used to indicate settings that target the {@code hibernate-ucp} integration.
+	 */
+	String UCP_CONFIG_PREFIX = "hibernate.ucp";
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionProviderInitiator.java
@@ -30,6 +30,7 @@ import static java.sql.Connection.TRANSACTION_SERIALIZABLE;
 import static org.hibernate.cfg.AgroalSettings.AGROAL_CONFIG_PREFIX;
 import static org.hibernate.cfg.C3p0Settings.C3P0_CONFIG_PREFIX;
 import static org.hibernate.cfg.HikariCPSettings.HIKARI_CONFIG_PREFIX;
+import static org.hibernate.cfg.UCPSettings.UCP_CONFIG_PREFIX;
 import static org.hibernate.cfg.JdbcSettings.CONNECTION_PREFIX;
 import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER;
 import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT;
@@ -51,6 +52,7 @@ import static org.hibernate.internal.util.StringHelper.nullIfBlank;
  * @author Gavin King
  * @author Steve Ebersole
  * @author Brett Meyer
+ * @author Loïc Lefèvre
  */
 public class ConnectionProviderInitiator implements StandardServiceInitiator<ConnectionProvider> {
 
@@ -73,6 +75,11 @@ public class ConnectionProviderInitiator implements StandardServiceInitiator<Con
 	 * The strategy for agroal connection pooling
 	 */
 	public static final String AGROAL_STRATEGY = "agroal";
+
+	/**
+	 * The strategy for oracle ucp connection pooling
+	 */
+	public static final String UCP_STRATEGY = "ucp";
 
 	@Override
 	public Class<ConnectionProvider> getServiceInitiated() {
@@ -154,6 +161,9 @@ public class ConnectionProviderInitiator implements StandardServiceInitiator<Con
 		}
 		else if ( hasConfiguration( configurationValues, AGROAL_CONFIG_PREFIX ) ) {
 			return instantiateProvider( strategySelector, AGROAL_STRATEGY );
+		}
+		else if ( hasConfiguration( configurationValues, UCP_CONFIG_PREFIX ) ) {
+			return instantiateProvider( strategySelector, UCP_STRATEGY );
 		}
 		else if ( configurationValues.containsKey( URL ) ) {
 			return new DriverManagerConnectionProvider();

--- a/hibernate-platform/hibernate-platform.gradle
+++ b/hibernate-platform/hibernate-platform.gradle
@@ -30,6 +30,8 @@ dependencies {
         api "org.hibernate:hibernate-c3p0:$version"
         api project( ":hibernate-hikaricp" )
         api "org.hibernate:hibernate-hikaricp:$version"
+        api project( ":hibernate-ucp" )
+        api "org.hibernate:hibernate-ucp:$version"
 
         api project( ":hibernate-jcache" )
         api "org.hibernate:hibernate-jcache:$version"

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/GradleParallelTestingResolver.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/GradleParallelTestingResolver.java
@@ -4,7 +4,7 @@
  */
 package org.hibernate.testing.jdbc;
 
-import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.JdbcSettings;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,10 +46,19 @@ public class GradleParallelTestingResolver {
 				connectionProps.put( JDBC_USER_CONNECTION_PROPERTY,
 						user.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
 			}
-			final String url = connectionProps.getProperty( AvailableSettings.URL );
-			if ( url != null && url.contains( GRADLE_WORKER_PATTERN ) ) {
-				connectionProps.put( AvailableSettings.URL,
-						url.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+			if( connectionProps.containsKey( JdbcSettings.URL ) ) {
+				final String url = connectionProps.getProperty( JdbcSettings.URL );
+				if ( url != null && url.contains( GRADLE_WORKER_PATTERN ) ) {
+					connectionProps.put( JdbcSettings.URL,
+							url.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
+			}
+			else {
+				final String url = connectionProps.getProperty( JdbcSettings.JAKARTA_JDBC_URL );
+				if ( url != null && url.contains( GRADLE_WORKER_PATTERN ) ) {
+					connectionProps.put( JdbcSettings.JAKARTA_JDBC_URL,
+							url.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
 			}
 		}
 	}
@@ -57,15 +66,34 @@ public class GradleParallelTestingResolver {
 	public static void resolveFromSettings(final Properties settingsProps) {
 		if ( settingsProps != null ) {
 			// If Gradle parallel testing is enabled (maxParallelForks > 1)
-			final String user = settingsProps.getProperty( AvailableSettings.USER );
-			if ( user != null && user.contains( GRADLE_WORKER_PATTERN ) ) {
-				settingsProps.put( AvailableSettings.USER,
-						user.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+			if( settingsProps.containsKey( JdbcSettings.USER ) ) {
+				final String user = settingsProps.getProperty( JdbcSettings.USER );
+				if ( user != null && user.contains( GRADLE_WORKER_PATTERN ) ) {
+					settingsProps.put( JdbcSettings.USER,
+							user.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
 			}
-			final String url = settingsProps.getProperty( AvailableSettings.URL );
-			if ( url != null && url.contains( GRADLE_WORKER_PATTERN ) ) {
-				settingsProps.put( AvailableSettings.URL,
-						url.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+			else {
+				final String user = settingsProps.getProperty( JdbcSettings.JAKARTA_JDBC_USER );
+				if ( user != null && user.contains( GRADLE_WORKER_PATTERN ) ) {
+					settingsProps.put( JdbcSettings.JAKARTA_JDBC_USER,
+							user.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
+			}
+
+			if( settingsProps.containsKey( JdbcSettings.URL ) ) {
+				final String url = settingsProps.getProperty( JdbcSettings.URL );
+				if ( url != null && url.contains( GRADLE_WORKER_PATTERN ) ) {
+					settingsProps.put( JdbcSettings.URL,
+							url.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
+			}
+			else {
+				final String url = settingsProps.getProperty( JdbcSettings.JAKARTA_JDBC_URL );
+				if ( url != null && url.contains( GRADLE_WORKER_PATTERN ) ) {
+					settingsProps.put( JdbcSettings.JAKARTA_JDBC_URL,
+							url.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
 			}
 		}
 	}
@@ -73,15 +101,33 @@ public class GradleParallelTestingResolver {
 	public static void resolveFromSettings(final Map<String, Object> settingsProps) {
 		if ( settingsProps != null ) {
 			// If Gradle parallel testing is enabled (maxParallelForks > 1)
-			final String user = (String) settingsProps.get( AvailableSettings.USER );
-			if ( user != null && user.contains( GRADLE_WORKER_PATTERN ) ) {
-				settingsProps.put( AvailableSettings.USER,
-						user.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+			if( settingsProps.containsKey( JdbcSettings.USER ) ) {
+				final String user = (String) settingsProps.get( JdbcSettings.USER );
+				if ( user != null && user.contains( GRADLE_WORKER_PATTERN ) ) {
+					settingsProps.put( JdbcSettings.USER,
+							user.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
 			}
-			final String url = (String) settingsProps.get( AvailableSettings.URL );
-			if ( url != null && url.contains( GRADLE_WORKER_PATTERN ) ) {
-				settingsProps.put( AvailableSettings.URL,
-						url.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+			else {
+				final String user = (String) settingsProps.get( JdbcSettings.JAKARTA_JDBC_USER );
+				if ( user != null && user.contains( GRADLE_WORKER_PATTERN ) ) {
+					settingsProps.put( JdbcSettings.JAKARTA_JDBC_USER,
+							user.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
+			}
+			if( settingsProps.containsKey(  JdbcSettings.URL ) ) {
+				final String url = (String) settingsProps.get( JdbcSettings.URL );
+				if ( url != null && url.contains( GRADLE_WORKER_PATTERN ) ) {
+					settingsProps.put( JdbcSettings.URL,
+							url.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
+			}
+			else {
+				final String url = (String) settingsProps.get( JdbcSettings.JAKARTA_JDBC_URL );
+				if ( url != null && url.contains( GRADLE_WORKER_PATTERN ) ) {
+					settingsProps.put( JdbcSettings.JAKARTA_JDBC_URL,
+							url.replace( GRADLE_WORKER_PATTERN, String.valueOf( getWorkerID() ) ) );
+				}
 			}
 		}
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectContext.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectContext.java
@@ -46,11 +46,17 @@ public final class DialectContext {
 	static void init() {
 		final Properties properties = Environment.getProperties();
 		final String driverClassName = properties.getProperty( Environment.DRIVER );
-		final String jdbcUrl = resolveUrl( properties.getProperty( Environment.URL ) );
+		final String jdbcUrl = resolveUrl( properties.containsKey( Environment.URL )
+				? properties.getProperty( Environment.URL )
+				: properties.getProperty( Environment.JAKARTA_JDBC_URL ) );
 		final Properties props = new Properties();
 		resolveFromSettings(properties);
-		props.setProperty( "user", properties.getProperty( Environment.USER ) );
-		props.setProperty( "password", properties.getProperty( Environment.PASS ) );
+		props.setProperty( "user", properties.containsKey( Environment.USER )
+				? properties.getProperty( Environment.USER )
+				: properties.getProperty( Environment.JAKARTA_JDBC_USER ) );
+		props.setProperty( "password", properties.containsKey( Environment.PASS )
+				? properties.getProperty( Environment.PASS )
+				: properties.getProperty( Environment.JAKARTA_JDBC_PASSWORD ) );
 		final Class<? extends Dialect> dialectClass = getDialectClass();
 		final Constructor<? extends Dialect> constructor;
 		try {

--- a/hibernate-ucp/hibernate-ucp.gradle
+++ b/hibernate-ucp/hibernate-ucp.gradle
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+
+plugins {
+    id "local.publishing-java-module"
+    id "local.publishing-group-relocation"
+}
+
+description = 'Integration for Oracle Universal Connection Pool within Hibernate ORM'
+
+dependencies {
+    implementation project( ':hibernate-core' )
+    implementation libs.oracleucp
+    implementation libs.jdbc.oracle
+
+    testImplementation project( ':hibernate-testing' )
+}

--- a/hibernate-ucp/src/main/java/org/hibernate/ucp/internal/StrategyRegistrationProviderImpl.java
+++ b/hibernate-ucp/src/main/java/org/hibernate/ucp/internal/StrategyRegistrationProviderImpl.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.ucp.internal;
+
+import org.hibernate.boot.registry.selector.SimpleStrategyRegistrationImpl;
+import org.hibernate.boot.registry.selector.StrategyRegistration;
+import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+
+import static java.util.Collections.singleton;
+
+/**
+ * Provides the {@link UCPConnectionProvider} to the
+ * {@link org.hibernate.boot.registry.selector.spi.StrategySelector} service.
+ *
+ * @author Loïc Lefèvre
+ */
+public class StrategyRegistrationProviderImpl implements StrategyRegistrationProvider {
+	@Override
+	public Iterable<StrategyRegistration<?>> getStrategyRegistrations() {
+		return singleton( new SimpleStrategyRegistrationImpl<>(
+				ConnectionProvider.class,
+				UCPConnectionProvider.class,
+				"ucp",
+				"oracleucp",
+				UCPConnectionProvider.class.getSimpleName(),
+				// for consistency's sake
+				"org.hibernate.connection.UCPConnectionProvider"
+		) );
+	}
+}

--- a/hibernate-ucp/src/main/java/org/hibernate/ucp/internal/UCPConnectionProvider.java
+++ b/hibernate-ucp/src/main/java/org/hibernate/ucp/internal/UCPConnectionProvider.java
@@ -1,0 +1,295 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.ucp.internal;
+
+import oracle.ucp.UniversalConnectionPool;
+import oracle.ucp.UniversalConnectionPoolAdapter;
+import oracle.ucp.UniversalConnectionPoolException;
+import oracle.ucp.UniversalConnectionPoolLifeCycleState;
+import oracle.ucp.admin.UniversalConnectionPoolManager;
+import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
+import oracle.ucp.jdbc.PoolDataSource;
+import oracle.ucp.jdbc.PoolDataSourceFactory;
+import oracle.ucp.jdbc.PoolDataSourceImpl;
+import org.hibernate.HibernateException;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.JdbcSettings;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.connections.internal.ConnectionProviderInitiator;
+import org.hibernate.engine.jdbc.connections.internal.DatabaseConnectionInfoImpl;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.jdbc.connections.spi.DatabaseConnectionInfo;
+import org.hibernate.exception.JDBCConnectionException;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.service.UnknownUnwrapTypeException;
+import org.hibernate.service.spi.Configurable;
+import org.hibernate.service.spi.Stoppable;
+
+import javax.sql.DataSource;
+import java.io.Serial;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hibernate.cfg.UCPSettings.UCP_CONFIG_PREFIX;
+import static org.hibernate.engine.jdbc.connections.internal.ConnectionProviderInitiator.toIsolationNiceName;
+import static org.hibernate.engine.jdbc.connections.internal.DatabaseConnectionInfoImpl.getFetchSize;
+import static org.hibernate.engine.jdbc.connections.internal.DatabaseConnectionInfoImpl.getIsolation;
+import static org.hibernate.engine.jdbc.connections.internal.DatabaseConnectionInfoImpl.hasCatalog;
+import static org.hibernate.engine.jdbc.connections.internal.DatabaseConnectionInfoImpl.hasSchema;
+import static org.hibernate.internal.log.ConnectionInfoLogger.CONNECTION_INFO_LOGGER;
+
+/**
+ * {@link ConnectionProvider} based on the Oracle Universal Connection Pool.
+ * <p>
+ * To force the use of this {@code ConnectionProvider}, set
+ * {@value org.hibernate.cfg.JdbcSettings#CONNECTION_PROVIDER}
+ * to {@code ucp} or {@code oracleucp}.
+ *
+ * @author Loïc Lefèvre
+ */
+public class UCPConnectionProvider implements ConnectionProvider, Configurable, Stoppable {
+
+	@Serial
+	private static final long serialVersionUID = 1L;
+
+	public static final String CONFIG_PREFIX = UCP_CONFIG_PREFIX + ".";
+
+	private PoolDataSource ucpDS;
+
+	private boolean autoCommit;
+
+	private Integer isolation;
+
+	@Override
+	public void configure(Map<String, Object> props) throws HibernateException {
+		try {
+			CONNECTION_INFO_LOGGER.configureConnectionPool( "UCP" );
+
+			isolation = ConnectionProviderInitiator.extractIsolation( props );
+			autoCommit = ConfigurationHelper.getBoolean( JdbcSettings.AUTOCOMMIT, props );
+
+			UniversalConnectionPoolManager poolManager = UniversalConnectionPoolManagerImpl.
+					getUniversalConnectionPoolManager();
+			ucpDS = PoolDataSourceFactory.getPoolDataSource();
+			Properties ucpProps = getConfiguration( props );
+			configureDataSource( ucpDS, ucpProps );
+			poolManager.createConnectionPool((UniversalConnectionPoolAdapter)ucpDS);
+			poolManager.startConnectionPool( ucpDS.getConnectionPoolName() );
+		}
+		catch (Exception e) {
+			CONNECTION_INFO_LOGGER.unableToInstantiateConnectionPool( e );
+			throw new HibernateException( e );
+		}
+	}
+
+	private void configureDataSource(PoolDataSource ucpDS, Properties ucpProps) {
+		List<Method> methods = Arrays.asList( PoolDataSourceImpl.class.getDeclaredMethods() );
+
+		for ( String propName : ucpProps.stringPropertyNames() ) {
+			String value = ucpProps.getProperty( propName );
+
+			final String methodName = "set" + propName.substring( 0, 1 )
+					.toUpperCase( Locale.ENGLISH ) + propName.substring( 1 );
+			Method writeMethod = methods.stream()
+					.filter( m -> m.getName().equals( methodName ) && m.getParameterCount() == 1 ).findFirst()
+					.orElse( null );
+			if ( writeMethod == null ) {
+				// skip properties whenever there is no related UCP DataSource property to be set
+				continue;
+			}
+
+			try {
+				Class<?> paramClass = writeMethod.getParameterTypes()[0];
+				if ( paramClass == int.class ) {
+					writeMethod.invoke( ucpDS, Integer.parseInt( value ) );
+				}
+				else if ( paramClass == long.class ) {
+					writeMethod.invoke( ucpDS, Long.parseLong( value ) );
+				}
+				else if ( paramClass == boolean.class || paramClass == Boolean.class ) {
+					writeMethod.invoke( ucpDS, Boolean.parseBoolean( value ) );
+				}
+				else if ( paramClass == String.class ) {
+					writeMethod.invoke( ucpDS, value );
+				}
+				else {
+					if ( propName.equals( "connectionProperties" ) ||
+						propName.equals( "connectionFactoryProperties" ) ) {
+						if ( value != null ) {
+							Properties connProps = new Properties();
+
+							// The Properties string is in the following format:
+							// {prop1=val1, prop2=val2, ..., propN=valN}
+							String[] propStrs = value.substring( 1, value.length() - 1 ).split( ", " );
+							for ( String onePropStr : propStrs ) {
+								// Separate the name and value strings for each property
+								String[] nvPair = onePropStr.split( "=" );
+								connProps.setProperty( nvPair[0], nvPair[1] );
+							}
+
+							writeMethod.invoke( ucpDS, connProps );
+						}
+					}
+					else {
+						writeMethod.invoke( ucpDS, value );
+					}
+				}
+			}
+			catch (Exception e) {
+				throw new RuntimeException( e );
+			}
+		}
+	}
+
+	private Properties getConfiguration(Map<String, Object> props) {
+		final Properties ucpProps = ConnectionProviderInitiator.getConnectionProperties( props );
+
+		copyProperty( AvailableSettings.URL, props, "URL", ucpProps );
+		copyProperty( AvailableSettings.USER, props, "user", ucpProps );
+		copyProperty( AvailableSettings.PASS, props, "password", ucpProps );
+
+		for ( Object keyObject : props.keySet() ) {
+			if ( keyObject instanceof String key ) {
+				if ( key.startsWith( CONFIG_PREFIX ) ) {
+					ucpProps.setProperty( key.substring( CONFIG_PREFIX.length() ), (String) props.get( key ) );
+				}
+			}
+		}
+
+		return ucpProps;
+	}
+
+	@SuppressWarnings("rawtypes")
+	private static void copyProperty(String srcKey, Map src, String dstKey, Properties dst) {
+		if ( src.containsKey( srcKey ) ) {
+			dst.setProperty( dstKey, (String) src.get( srcKey ) );
+		}
+	}
+
+	// *************************************************************************
+	// ConnectionProvider
+	// *************************************************************************
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		Connection conn = null;
+
+		try {
+			if ( ucpDS != null ) {
+				UniversalConnectionPoolManager poolManager = UniversalConnectionPoolManagerImpl.
+						getUniversalConnectionPoolManager();
+				UniversalConnectionPool ucp = poolManager.getConnectionPool( ucpDS.getConnectionPoolName() );
+				UniversalConnectionPoolLifeCycleState lifeCycleState = ucp.getLifeCycleState();
+
+				if( lifeCycleState == UniversalConnectionPoolLifeCycleState.LIFE_CYCLE_RUNNING) {
+					conn = ucpDS.getConnection();
+					if ( isolation != null && isolation != conn.getTransactionIsolation() ) {
+						conn.setTransactionIsolation( isolation );
+					}
+
+					if ( conn.getAutoCommit() != autoCommit ) {
+						conn.setAutoCommit( autoCommit );
+					}
+				}
+				else if(lifeCycleState == UniversalConnectionPoolLifeCycleState.LIFE_CYCLE_FAILED ||
+						lifeCycleState == UniversalConnectionPoolLifeCycleState.LIFE_CYCLE_STOPPED ||
+						lifeCycleState == UniversalConnectionPoolLifeCycleState.LIFE_CYCLE_STOPPING) {
+					throw new SQLException("UCP connection pool " + this + " has been destroyed.");
+				}
+			}
+		}
+		catch (UniversalConnectionPoolException ucpe) {
+			throw new SQLException( ucpe );
+		}
+
+		return conn;
+	}
+
+	@Override
+	public void closeConnection(Connection conn) throws SQLException {
+		conn.close();
+	}
+
+	@Override
+	public boolean supportsAggressiveRelease() {
+		return false;
+	}
+
+	@Override
+	public DatabaseConnectionInfo getDatabaseConnectionInfo(Dialect dialect) {
+		try (var connection = ucpDS.getConnection()) {
+			final var info = new DatabaseConnectionInfoImpl(
+					UCPConnectionProvider.class,
+					ucpDS.getURL(),
+					ucpDS.getConnectionFactoryClassName(),
+					dialect.getClass(),
+					dialect.getVersion(),
+					hasSchema( connection ),
+					hasCatalog( connection ),
+					ucpDS.getUser(),
+					ucpDS.getUser(),
+					Boolean.toString( autoCommit ),
+					isolation != null
+							? ConnectionProviderInitiator.toIsolationConnectionConstantName( isolation )
+							: toIsolationNiceName( getIsolation( connection ) ),
+					ucpDS.getMinIdle(),
+					ucpDS.getMaxPoolSize(),
+					getFetchSize( connection )
+			);
+			if ( !connection.getAutoCommit() ) {
+				connection.rollback();
+			}
+			return info;
+		}
+		catch (SQLException e) {
+			throw new JDBCConnectionException( "Could not create connection", e );
+		}
+	}
+
+	@Override
+	@SuppressWarnings("rawtypes")
+	public boolean isUnwrappableAs(Class unwrapType) {
+		return ConnectionProvider.class.equals( unwrapType )
+			|| UCPConnectionProvider.class.isAssignableFrom( unwrapType )
+			|| DataSource.class.isAssignableFrom( unwrapType );
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T unwrap(Class<T> unwrapType) {
+		if ( ConnectionProvider.class.equals( unwrapType ) ||
+			UCPConnectionProvider.class.isAssignableFrom( unwrapType ) ) {
+			return (T) this;
+		}
+		else if ( DataSource.class.isAssignableFrom( unwrapType ) ) {
+			return (T) ucpDS;
+		}
+		else {
+			throw new UnknownUnwrapTypeException( unwrapType );
+		}
+	}
+
+	@Override
+	public void stop() {
+		if ( this.ucpDS != null && ucpDS.getConnectionPoolName() != null ) {
+			CONNECTION_INFO_LOGGER.cleaningUpConnectionPool( UCP_CONFIG_PREFIX + " [" + ucpDS.getConnectionPoolName() + "]" );
+			try {
+				UniversalConnectionPoolManager poolManager = UniversalConnectionPoolManagerImpl.
+						getUniversalConnectionPoolManager();
+				poolManager.stopConnectionPool( ucpDS.getConnectionPoolName() );
+				poolManager.destroyConnectionPool( ucpDS.getConnectionPoolName() );
+			}
+			catch (UniversalConnectionPoolException e) {
+				CONNECTION_INFO_LOGGER.unableToDestroyConnectionPool( e );
+			}
+		}
+	}
+}

--- a/hibernate-ucp/src/main/java/org/hibernate/ucp/internal/package-info.java
+++ b/hibernate-ucp/src/main/java/org/hibernate/ucp/internal/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+
+/**
+ * Implementation of the ConnectionProvider using
+ * the Oracle Universal Connection Pool.
+ */
+package org.hibernate.ucp.internal;

--- a/hibernate-ucp/src/main/resources/META-INF/services/org.hibernate.boot.registry.selector.StrategyRegistrationProvider
+++ b/hibernate-ucp/src/main/resources/META-INF/services/org.hibernate.boot.registry.selector.StrategyRegistrationProvider
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Red Hat Inc. and Hibernate Authors
+#
+org.hibernate.ucp.internal.StrategyRegistrationProviderImpl
+

--- a/hibernate-ucp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/hibernate-ucp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<blueprint  default-activation="eager"
+            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <bean id="strategyRegistrationProvider" class="org.hibernate.ucp.internal.StrategyRegistrationProviderImpl"/>
+  <service ref="strategyRegistrationProvider" interface="org.hibernate.boot.registry.selector.StrategyRegistrationProvider"/>
+  
+</blueprint>
+

--- a/hibernate-ucp/src/test/java/org/hibernate/test/ucp/UCPConnectionProviderTest.java
+++ b/hibernate-ucp/src/test/java/org/hibernate/test/ucp/UCPConnectionProviderTest.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.test.ucp;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.ConnectionProviderJdbcConnectionAccess;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.hibernate.ucp.internal.UCPConnectionProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.orm.junit.ExtraAssertions.assertTyping;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author Loïc Lefèvre
+ */
+@SuppressWarnings("JUnitMalformedDeclaration")
+@SkipForDialect(dialectClass = SybaseDialect.class, matchSubTypes = true, reason = "The jTDS driver doesn't implement Connection#isValid so this fails")
+@ServiceRegistry
+@SessionFactory
+public class UCPConnectionProviderTest {
+
+	@Test
+	public void testUCPConnectionProvider(SessionFactoryScope factoryScope) throws Exception {
+		var serviceRegistry = factoryScope.getSessionFactory().getServiceRegistry();
+		var jdbcServices = serviceRegistry.requireService( JdbcServices.class );
+		var connectionAccess = assertTyping(
+				ConnectionProviderJdbcConnectionAccess.class,
+				jdbcServices.getBootstrapJdbcConnectionAccess()
+		);
+		var ucpProvider = assertTyping(
+				UCPConnectionProvider.class,
+				connectionAccess.getConnectionProvider()
+		);
+
+		// For simplicity's sake, using the following in hibernate.properties:
+		// hibernate.ucp.minimumPoolSize 2
+		// hibernate.ucp.maximumPoolSize 2
+		final List<Connection> conns = new ArrayList<>();
+		for ( int i = 0; i < 2; i++ ) {
+			Connection conn = ucpProvider.getConnection();
+			assertThat( conn ).isNotNull();
+			assertThat( conn.isClosed() ).isFalse();
+			conns.add( conn );
+		}
+
+		try {
+			ucpProvider.getConnection();
+			fail( "SQLException expected -- no more connections should have been available in the pool." );
+		}
+		catch (SQLException e) {
+			// expected "UCP-29: Failed to get a connection"
+			assertThat( e.getMessage() ).contains( "UCP-29" );
+		}
+
+		for ( Connection conn : conns ) {
+			ucpProvider.closeConnection( conn );
+			assertThat( conn.isClosed() ).isTrue();
+		}
+
+		// NOTE : The JUnit 5 infrastructure versus the JUnit 4 infrastructure causes the
+		//		StandardServiceRegistry (the SF registry's parent) to be created with auto-closure disabled.
+		//		That is not the normal process.
+		//		So here we explicitly close the parent.
+		factoryScope.getSessionFactory().close();
+		serviceRegistry.destroy();
+		assert serviceRegistry.getParentServiceRegistry() != null : "Expecting parent service registry";
+		( (ServiceRegistryImplementor) serviceRegistry.getParentServiceRegistry() ).destroy();
+
+
+		try {
+			ucpProvider.getConnection();
+			fail( "Exception expected -- the pool should have been shutdown." );
+		}
+		catch (Exception e) {
+			// expected
+			assertThat( e.getMessage() ).containsAnyOf(
+					"UCP-45351: Universal Connection Pool not found in Universal Connection Pool Manager",
+					"has been destroyed"
+			);
+		}
+	}
+}

--- a/hibernate-ucp/src/test/java/org/hibernate/test/ucp/UCPTransactionIsolationConfigTest.java
+++ b/hibernate-ucp/src/test/java/org/hibernate/test/ucp/UCPTransactionIsolationConfigTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.test.ucp;
+
+import org.hibernate.test.ucp.util.GradleParallelTestingUCPConnectionProvider;
+import org.hibernate.community.dialect.AltibaseDialect;
+import org.hibernate.community.dialect.GaussDBDialect;
+import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.community.dialect.TiDBDialect;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+
+import org.hibernate.testing.orm.common.BaseTransactionIsolationConfigTest;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+
+/**
+ * @author Loïc Lefèvre
+ */
+
+@SkipForDialect(dialectClass = SybaseDialect.class,
+		matchSubTypes = true,
+		reason = "The jTDS driver doesn't implement Connection#getNetworkTimeout() so this fails")
+@SkipForDialect(dialectClass = TiDBDialect.class,
+		reason = "Doesn't support SERIALIZABLE isolation")
+@SkipForDialect(dialectClass = AltibaseDialect.class,
+		reason = "Altibase cannot change isolation level in autocommit mode")
+@SkipForDialect(dialectClass = GaussDBDialect.class,
+		reason = "GaussDB does not support SERIALIZABLE isolation")
+public class UCPTransactionIsolationConfigTest extends BaseTransactionIsolationConfigTest {
+	@Override
+	protected ConnectionProvider getConnectionProviderUnderTest(ServiceRegistryScope registryScope) {
+		return new GradleParallelTestingUCPConnectionProvider();
+	}
+}

--- a/hibernate-ucp/src/test/java/org/hibernate/test/ucp/util/GradleParallelTestingUCPConnectionProvider.java
+++ b/hibernate-ucp/src/test/java/org/hibernate/test/ucp/util/GradleParallelTestingUCPConnectionProvider.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.test.ucp.util;
+
+import org.hibernate.HibernateException;
+import org.hibernate.ucp.internal.UCPConnectionProvider;
+
+import java.util.Map;
+
+import static org.hibernate.testing.jdbc.GradleParallelTestingResolver.resolveFromSettings;
+
+/**
+ * @author Loïc Lefèvre
+ */
+public class GradleParallelTestingUCPConnectionProvider extends UCPConnectionProvider {
+	@Override
+	public void configure(Map<String, Object> properties) throws HibernateException {
+		resolveFromSettings( properties );
+		super.configure( properties );
+	}
+}

--- a/hibernate-ucp/src/test/resources/hibernate.properties
+++ b/hibernate-ucp/src/test/resources/hibernate.properties
@@ -1,0 +1,22 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Red Hat Inc. and Hibernate Authors
+#
+hibernate.dialect @db.dialect@
+hibernate.connection.driver_class @jdbc.driver@
+hibernate.connection.url @jdbc.url@
+hibernate.connection.username @jdbc.user@
+hibernate.connection.password @jdbc.pass@
+hibernate.connection.init_sql @connection.init_sql@
+
+# Used for Gradle Parallel Testing
+hibernate.connection.provider_class=org.hibernate.test.ucp.util.GradleParallelTestingUCPConnectionProvider
+
+hibernate.jdbc.fetch_size 100
+hibernate.jdbc.batch_size 10
+
+hibernate.ucp.connectionFactoryClassName @jdbc.datasource@
+hibernate.ucp.minPoolSize 2
+hibernate.ucp.maxPoolSize 2
+hibernate.ucp.connectionPoolName TestUCPPool
+hibernate.ucp.loginTimeout 5000

--- a/hibernate-ucp/src/test/resources/log4j2.properties
+++ b/hibernate-ucp/src/test/resources/log4j2.properties
@@ -1,0 +1,17 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Red Hat Inc. and Hibernate Authors
+#
+appender.stdout.type=Console
+appender.stdout.name=STDOUT
+appender.stdout.layout.type=PatternLayout
+appender.stdout.layout.pattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+
+
+rootLogger.level=info
+rootLogger.appenderRef.stdout.ref=STDOUT
+
+logger.hbm2ddl.name=org.hibernate.tool.hbm2ddl
+logger.hbm2ddl.level=debug
+logger.testing-cache.name=org.hibernate.testing.cache
+logger.testing-cache.level=debug

--- a/settings.gradle
+++ b/settings.gradle
@@ -154,6 +154,7 @@ include 'hibernate-vector'
 include 'hibernate-c3p0'
 include 'hibernate-hikaricp'
 include 'hibernate-agroal'
+include 'hibernate-ucp'
 
 include 'hibernate-jcache'
 


### PR DESCRIPTION
This PR brings back the `hibernate-ucp` module within Hibernate ORM.

Remark: UCP stands for Oracle Universal Connection Pool

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20510 (New Feature):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20510
<!-- Hibernate GitHub Bot issue links end -->