### PR TITLE
HHH-20513 XML entity mapping ignores `<mutable>false</mutable>` configuration

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
@@ -221,6 +221,12 @@ public class XmlAnnotationHelper {
 		if ( isNotEmpty( jaxbEntity.getName() ) ) {
 			entityAnn.name( jaxbEntity.getName() );
 		}
+		if ( jaxbEntity.isMutable() != null && !jaxbEntity.isMutable() ) {
+			classDetails.applyAnnotationUsage(
+					HibernateAnnotations.IMMUTABLE,
+					xmlDocumentContext.getModelBuildingContext()
+			);
+		}
 	}
 
 	public static void applyColumn(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/immutable/ImmutableEntityXmlMappingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/immutable/ImmutableEntityXmlMappingTest.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.immutable;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		xmlMappings = "org/hibernate/orm/test/immutable/entitywithmutablecollection/inverse/ImmutableEntity.xml"
+)
+@SessionFactory
+@JiraKey( "HHH-20513" )
+public class ImmutableEntityXmlMappingTest {
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					TestEntity entity = new TestEntity( 1L, "initial" );
+					session.persist( entity );
+				}
+		);
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testImmutableEntityFromXmlMapping(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					TestEntity entity = session.find( TestEntity.class, 1L );
+					entity.setName( "updated" );
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					TestEntity entity = session.find( TestEntity.class, 1L );
+					assertThat( entity.getName() ).isEqualTo( "initial" );
+				}
+		);
+
+	}
+
+	public static class TestEntity {
+		private Long id;
+		private String name;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/immutable/entitywithmutablecollection/inverse/ImmutableEntity.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/immutable/entitywithmutablecollection/inverse/ImmutableEntity.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping"
+                 version="8.0">
+    <package>org.hibernate.orm.test.immutable</package>
+    <entity class="ImmutableEntityXmlMappingTest$TestEntity" metadata-complete="true">
+
+        <table name="test_entity"/>
+        <mutable>false</mutable>
+        <attributes>
+            <id name="id"/>
+            <basic name="name"/>
+        </attributes>
+    </entity>
+</entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20513

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
