### PR TITLE
HHH-20502 preserve Validator constraints in history table / audit log

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/TypeSafeActivator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/TypeSafeActivator.java
@@ -48,6 +48,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SingleTableSubclass;
 
+import org.hibernate.mapping.Table;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 
 import jakarta.validation.Validation;
@@ -219,9 +220,28 @@ class TypeSafeActivator {
 							dialect,
 							constraintCompositionTypeCache
 					);
+					synchronizeAuxiliaryTables( persistentClass );
 				}
 				catch (Exception e) {
 					BEAN_VALIDATION_LOGGER.unableToApplyConstraints( className, e );
+				}
+			}
+		}
+	}
+
+	private static void synchronizeAuxiliaryTables(PersistentClass persistentClass) {
+		synchronizeTable( persistentClass.getAuxiliaryTable(), persistentClass.getTable() );
+		for ( var join : persistentClass.getJoins() ) {
+			synchronizeTable( join.getAuxiliaryTable(), join.getTable() );
+		}
+	}
+
+	private static void synchronizeTable(Table auxiliaryTable, Table sourceTable) {
+		if ( auxiliaryTable != null && auxiliaryTable != sourceTable ) {
+			for ( var sourceColumn : sourceTable.getColumns() ) {
+				final var targetColumn = auxiliaryTable.getColumn( sourceColumn );
+				if ( targetColumn != null ) {
+					targetColumn.copy( sourceColumn );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AuditHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AuditHelper.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import org.hibernate.MappingException;
 import org.hibernate.annotations.Audited;
 import org.hibernate.annotations.Changelog;
@@ -312,15 +313,8 @@ public final class AuditHelper {
 
 		// Table name: @Audited.CollectionTable name, or {OwnerJpaEntityName}_{ChildJpaEntityName}_AUD
 		final var referencedEntity = collector.getEntityBinding( referencedEntityName );
-		final String auditTableName;
-		if ( collectionAuditTable != null && !isBlank( collectionAuditTable.name() ) ) {
-			auditTableName = collectionAuditTable.name();
-		}
-		else {
-			final String ownerSimpleName = collection.getOwner().getJpaEntityName();
-			final String childSimpleName = referencedEntity.getJpaEntityName();
-			auditTableName = ownerSimpleName + "_" + childSimpleName + DEFAULT_TABLE_SUFFIX;
-		}
+		final String auditTableName =
+				auditTableName( collection, collectionAuditTable, referencedEntity );
 
 		final String auditSchema;
 		final String auditCatalog;
@@ -338,12 +332,14 @@ public final class AuditHelper {
 			csIdColumnName = DEFAULT_CHANGESET_ID_COLUMN_NAME;
 			modTypeColumnName = DEFAULT_MODIFICATION_TYPE_COLUMN_NAME;
 		}
-		final String schema = collectionAuditTable != null && !isBlank( collectionAuditTable.schema() )
-				? collectionAuditTable.schema()
-				: !isBlank( auditSchema ) ? auditSchema : ownerTable.getSchema();
-		final String catalog = collectionAuditTable != null && !isBlank( collectionAuditTable.catalog() )
-				? collectionAuditTable.catalog()
-				: !isBlank( auditCatalog ) ? auditCatalog : ownerTable.getCatalog();
+		final String schema =
+				collectionAuditTable != null && !isBlank( collectionAuditTable.schema() )
+						? collectionAuditTable.schema()
+						: !isBlank( auditSchema ) ? auditSchema : ownerTable.getSchema();
+		final String catalog =
+				collectionAuditTable != null && !isBlank( collectionAuditTable.catalog() )
+						? collectionAuditTable.catalog()
+						: !isBlank( auditCatalog ) ? auditCatalog : ownerTable.getCatalog();
 		final var middleAuditTable = collector.addTable(
 				schema,
 				catalog,
@@ -357,19 +353,11 @@ public final class AuditHelper {
 			final var keyColumns = new ArrayList<Column>();
 			// Copy the FK columns (parent key) from the collection's key
 			for ( var column : collection.getKey().getColumns() ) {
-				final var copy = column.clone();
-				copy.setUnique( false );
-				copy.setUniqueKeyName( null );
-				middleAuditTable.addColumn( copy );
-				keyColumns.add( copy );
+				keyColumns.add( copyColumnRemovingUnique( column, middleAuditTable ) );
 			}
 			// Copy the child identifier columns from the referenced entity
 			for ( var column : referencedEntity.getKey().getColumns() ) {
-				final var copy = column.clone();
-				copy.setUnique( false );
-				copy.setUniqueKeyName( null );
-				middleAuditTable.addColumn( copy );
-				keyColumns.add( copy );
+				keyColumns.add( copyColumnRemovingUnique( column, middleAuditTable ) );
 			}
 			// Audit columns
 			final var changesetIdColumn = createAuditColumn(
@@ -391,6 +379,21 @@ public final class AuditHelper {
 			enableAudit( collection, middleAuditTable, changesetIdColumn, modificationTypeColumn );
 			addTransactionEndColumns( auditTable, collection, middleAuditTable, context );
 		} );
+	}
+
+	@Nonnull
+	private static String auditTableName(
+			Collection collection,
+			@Nullable Audited.CollectionTable collectionAuditTable,
+			PersistentClass referencedEntity) {
+		if ( collectionAuditTable != null && !isBlank( collectionAuditTable.name() ) ) {
+			return collectionAuditTable.name();
+		}
+		else {
+			final String ownerSimpleName = collection.getOwner().getJpaEntityName();
+			final String childSimpleName = referencedEntity.getJpaEntityName();
+			return ownerSimpleName + "_" + childSimpleName + DEFAULT_TABLE_SUFFIX;
+		}
 	}
 
 	static void bindChangelog(
@@ -532,19 +535,18 @@ public final class AuditHelper {
 			String revTimestampName,
 			MetadataBuildingContext context) {
 		final var entityBinding = context.getMetadataCollector().getEntityBinding( entityName );
-		if ( entityBinding == null ) {
-			return;
-		}
-		final var revNumberProperty = requireBasicProperty(
-				entityBinding,
-				revNumberName,
-				"@Changelog.ChangesetId"
-		);
-		requireBasicProperty( entityBinding, revTimestampName, "@Changelog.Timestamp" );
-		// Add unique constraint on non-ID @ChangesetId
-		if ( revNumberProperty != entityBinding.getIdentifierProperty() ) {
-			for ( var column : revNumberProperty.getColumns() ) {
-				column.setUnique( true );
+		if ( entityBinding != null ) {
+			final var revNumberProperty = requireBasicProperty(
+					entityBinding,
+					revNumberName,
+					"@Changelog.ChangesetId"
+			);
+			requireBasicProperty( entityBinding, revTimestampName, "@Changelog.Timestamp" );
+			// Add unique constraint on non-ID @ChangesetId
+			if ( revNumberProperty != entityBinding.getIdentifierProperty() ) {
+				for ( var column : revNumberProperty.getColumns() ) {
+					column.setUnique( true );
+				}
 			}
 		}
 	}
@@ -631,14 +633,37 @@ public final class AuditHelper {
 	private static void copyTableColumns(Table sourceTable, Table targetTable, Set<String> excludedColumns) {
 		for ( var column : sourceTable.getColumns() ) {
 			if ( !excludedColumns.contains( column.getCanonicalName() ) ) {
-				final var copy = column.clone();
-				// Audit tables must not inherit unique constraints from the source,
-				// since the same value can appear at different revisions
-				copy.setUnique( false );
-				copy.setUniqueKeyName( null );
-				targetTable.addColumn( copy );
+				copyColumnRemovingUnique( column, targetTable );
 			}
 		}
+	}
+
+	private static Column copyColumnRemovingUnique(Column sourceColumn, Table auditTable) {
+		final var auditColumn = copyColumn( auditTable, sourceColumn );
+		removeUniqueConstraint( auditColumn );
+		return auditColumn;
+	}
+
+	@Nonnull
+	private static Column copyColumn(Table targetTable, Column column) {
+		final var targetColumn = targetTable.getColumn( column );
+		if ( targetColumn == null ) {
+			final var columnCopy = column.clone();
+			columnCopy.copy( column );
+			targetTable.addColumn( columnCopy );
+			return columnCopy;
+		}
+		else {
+			targetColumn.copy( column );
+			return targetColumn;
+		}
+	}
+
+	private static void removeUniqueConstraint(Column column) {
+		// Audit tables must not inherit unique constraints from the source,
+		// since the same value can appear at different revisions
+		column.setUnique( false );
+		column.setUniqueKeyName( null );
 	}
 
 	private static Column createAuditColumn(
@@ -654,7 +679,8 @@ public final class AuditHelper {
 		basicValue.addColumn( column );
 
 		final var database = context.getMetadataCollector().getDatabase();
-		setColumnName( columnName, column, database, context.getBuildingOptions().getPhysicalNamingStrategy() );
+		setColumnName( columnName, column, database,
+				context.getBuildingOptions().getPhysicalNamingStrategy() );
 		setTemporalColumnType( column, database, javaType );
 
 		return column;
@@ -693,19 +719,18 @@ public final class AuditHelper {
 			AuxiliaryTableHolder holder,
 			Table auditTable,
 			MetadataBuildingContext context) {
-		if ( !isValidityStrategy( context ) ) {
-			return;
+		if ( isValidityStrategy( context ) ) {
+			final var revEndColumn =
+					createAuditColumn(
+							auditTableAnnotation == null
+									? DEFAULT_INVALIDATING_CHANGESET_ID_COLUMN_NAME
+									: auditTableAnnotation.invalidatingChangesetIdColumn(),
+							getChangesetIdType( context ), auditTable, context );
+			revEndColumn.setNullable( true );
+			auditTable.addColumn( revEndColumn );
+			holder.addAuxiliaryColumn( INVALIDATING_CHANGESET_ID, revEndColumn );
+			createChangesetForeignKey( auditTable, revEndColumn, context );
 		}
-		final var revEndColumn =
-				createAuditColumn(
-						auditTableAnnotation != null
-								? auditTableAnnotation.invalidatingChangesetIdColumn()
-								: DEFAULT_INVALIDATING_CHANGESET_ID_COLUMN_NAME,
-						getChangesetIdType( context ), auditTable, context );
-		revEndColumn.setNullable( true );
-		auditTable.addColumn( revEndColumn );
-		holder.addAuxiliaryColumn( INVALIDATING_CHANGESET_ID, revEndColumn );
-		createChangesetForeignKey( auditTable, revEndColumn, context );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TemporalHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TemporalHelper.java
@@ -175,7 +175,19 @@ public class TemporalHelper {
 
 	private static void copyTableColumns(Table sourceTable, Table targetTable) {
 		for ( var column : sourceTable.getColumns() ) {
-			targetTable.addColumn( column.clone() );
+			copyColumn( targetTable, column );
+		}
+	}
+
+	private static void copyColumn(Table targetTable, Column column) {
+		final var targetColumn = targetTable.getColumn( column );
+		if ( targetColumn == null ) {
+			final var columnCopy = column.clone();
+			columnCopy.copy( column );
+			targetTable.addColumn( columnCopy );
+		}
+		else {
+			targetColumn.copy( column );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
@@ -752,6 +752,34 @@ public sealed class Column
 		this.options = options;
 	}
 
+	@Internal
+	public void copy(Column source) {
+		nullable = source.nullable;
+		length = source.length;
+		precision = source.precision;
+		scale = source.scale;
+		temporalPrecision = source.temporalPrecision;
+		arrayLength = source.arrayLength;
+		comment = source.comment;
+		collation = source.collation;
+		defaultValue = source.defaultValue;
+		generatedAs = source.generatedAs;
+		assignmentExpression = source.assignmentExpression;
+		customRead = source.customRead;
+		customWrite = source.customWrite;
+		options = source.options;
+
+		if ( source.getSqlType() != null ) {
+			setSqlType( source.getSqlType() );
+		}
+		if ( source.getSqlTypeCode() != null ) {
+			setSqlTypeCode( source.getSqlTypeCode() );
+		}
+		for ( var checkConstraint : source.getCheckConstraints() ) {
+			addCheckConstraint( checkConstraint );
+		}
+	}
+
 	/**
 	 * Shallow copy, the value is not copied
 	 */

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/FinalModifierEnhancementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/FinalModifierEnhancementTest.java
@@ -5,7 +5,6 @@
 package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -13,7 +12,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/hibernate-core/src/test/java/org/hibernate/temporal/TemporalHistoryTableBeanValidationDDLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/temporal/TemporalHistoryTableBeanValidationDDLTest.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.temporal;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+
+import org.hibernate.annotations.Temporal;
+import org.hibernate.cfg.StateManagementSettings;
+import org.hibernate.cfg.ValidationSettings;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Table;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SessionFactory
+@DomainModel(annotatedClasses = {
+		TemporalHistoryTableBeanValidationDDLTest.Parent.class,
+		TemporalHistoryTableBeanValidationDDLTest.TemporalEntity.class
+})
+@ServiceRegistry(settings = {
+		@Setting(name = StateManagementSettings.TEMPORAL_TABLE_STRATEGY, value = "HISTORY_TABLE"),
+		@Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "DDL")
+})
+class TemporalHistoryTableBeanValidationDDLTest {
+	@BeforeAll
+	static void beforeAll(SessionFactoryScope scope) {
+		// Build the SessionFactory before inspecting the boot model so Bean Validation DDL integration has run.
+		scope.getSessionFactory();
+	}
+
+	@Test
+	void beanValidationNotNullPropagatesToHistoryTable(SessionFactoryScope scope) {
+		final PersistentClass entityBinding =
+				scope.getMetadataImplementor().getEntityBinding( TemporalEntity.class.getName() );
+		final Table historyTable = entityBinding.getAuxiliaryTable();
+
+		assertHistoryColumnIsNotNull( entityBinding, historyTable, "status" );
+		assertHistoryColumnIsNotNull( entityBinding, historyTable, "parent" );
+	}
+
+	private static void assertHistoryColumnIsNotNull(
+			PersistentClass entityBinding,
+			Table historyTable,
+			String propertyName) {
+		final Column sourceColumn = entityBinding.getProperty( propertyName ).getColumns().get( 0 );
+		final Column historyColumn = historyTable.getColumn( sourceColumn );
+
+		assertThat( sourceColumn.isNullable() ).isFalse();
+		assertThat( historyColumn ).isNotNull();
+		assertThat( historyColumn.isNullable() ).isFalse();
+	}
+
+	enum Status {
+		ACTIVE,
+		INACTIVE
+	}
+
+	@Entity(name = "TemporalHistoryValidationParent")
+	static class Parent {
+		@Id
+		Long id;
+	}
+
+	@Temporal
+	@Entity(name = "TemporalHistoryValidationEntity")
+	static class TemporalEntity {
+		@Id
+		Long id;
+
+		@NotNull
+		@Enumerated(EnumType.STRING)
+		Status status;
+
+		@NotNull
+		@ManyToOne
+		Parent parent;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/temporal/audit/AuditAuxiliaryTableBeanValidationDDLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/temporal/audit/AuditAuxiliaryTableBeanValidationDDLTest.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.temporal.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SecondaryTable;
+import jakarta.validation.constraints.NotNull;
+
+import org.hibernate.SharedSessionContract;
+import org.hibernate.annotations.Audited;
+import org.hibernate.cfg.StateManagementSettings;
+import org.hibernate.cfg.ValidationSettings;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Table;
+import org.hibernate.temporal.spi.ChangesetIdentifierSupplier;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SessionFactory
+@DomainModel(annotatedClasses = {
+		AuditAuxiliaryTableBeanValidationDDLTest.Parent.class,
+		AuditAuxiliaryTableBeanValidationDDLTest.AuditedEntity.class
+})
+@ServiceRegistry(settings = {
+		@Setting(name = StateManagementSettings.CHANGESET_ID_SUPPLIER,
+				value = "org.hibernate.temporal.audit.AuditAuxiliaryTableBeanValidationDDLTest$TxIdSupplier"),
+		@Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "DDL")
+})
+class AuditAuxiliaryTableBeanValidationDDLTest {
+	@Test
+	void beanValidationNotNullPropagatesToAuditTables(SessionFactoryScope scope) {
+		scope.getSessionFactory();
+
+		final PersistentClass entityBinding =
+				scope.getMetadataImplementor().getEntityBinding( AuditedEntity.class.getName() );
+
+		assertAuxiliaryColumnIsNotNull( entityBinding, entityBinding.getAuxiliaryTable(), "status" );
+		assertAuxiliaryColumnIsNotNull( entityBinding, entityBinding.getAuxiliaryTable(), "parent" );
+		assertAuxiliaryColumnIsNotNull( entityBinding, secondaryAuditTable( entityBinding, "secondaryStatus" ),
+				"secondaryStatus" );
+		assertAuxiliaryColumnIsNotNull( entityBinding, secondaryAuditTable( entityBinding, "secondaryParent" ),
+				"secondaryParent" );
+		assertAuxiliaryColumnIsAbsent( entityBinding, entityBinding.getAuxiliaryTable(), "excluded" );
+	}
+
+	private static Table secondaryAuditTable(PersistentClass entityBinding, String propertyName) {
+		final var sourceColumn = entityBinding.getProperty( propertyName ).getColumns().get( 0 );
+		for ( var join : entityBinding.getJoins() ) {
+			if ( join.getTable().getColumn( sourceColumn ) != null ) {
+				return join.getAuxiliaryTable();
+			}
+		}
+		throw new AssertionError( "No secondary audit table found for property " + propertyName );
+	}
+
+	private static void assertAuxiliaryColumnIsNotNull(
+			PersistentClass entityBinding,
+			Table auxiliaryTable,
+			String propertyName) {
+		final var sourceColumn = entityBinding.getProperty( propertyName ).getColumns().get( 0 );
+		final var auxiliaryColumn = auxiliaryTable.getColumn( sourceColumn );
+
+		assertThat( sourceColumn.isNullable() ).isFalse();
+		assertThat( auxiliaryColumn ).isNotNull();
+		assertThat( auxiliaryColumn.isNullable() ).isFalse();
+	}
+
+	private static void assertAuxiliaryColumnIsAbsent(
+			PersistentClass entityBinding,
+			Table auxiliaryTable,
+			String propertyName) {
+		final var sourceColumn = entityBinding.getProperty( propertyName ).getColumns().get( 0 );
+
+		assertThat( sourceColumn.isNullable() ).isFalse();
+		assertThat( auxiliaryTable.getColumn( sourceColumn ) ).isNull();
+	}
+
+	public static class TxIdSupplier implements ChangesetIdentifierSupplier<Integer> {
+		@Override
+		public Integer generateIdentifier(SharedSessionContract session) {
+			return 1;
+		}
+	}
+
+	enum Status {
+		ACTIVE,
+		INACTIVE
+	}
+
+	@Audited
+	@Entity(name = "AuditValidationParent")
+	static class Parent {
+		@Id
+		Long id;
+	}
+
+	@Audited
+	@Entity(name = "AuditValidationEntity")
+	@SecondaryTable(name = "audit_validation_details")
+	static class AuditedEntity {
+		@Id
+		Long id;
+
+		@NotNull
+		@Enumerated(EnumType.STRING)
+		Status status;
+
+		@NotNull
+		@ManyToOne
+		Parent parent;
+
+		@NotNull
+		@Column(table = "audit_validation_details")
+		@Enumerated(EnumType.STRING)
+		Status secondaryStatus;
+
+		@NotNull
+		@ManyToOne
+		@JoinColumn(table = "audit_validation_details")
+		Parent secondaryParent;
+
+		@Audited.Excluded
+		@NotNull
+		String excluded;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20502 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20502
<!-- Hibernate GitHub Bot issue links end -->