### PR TITLE
HHH-20517 Add a flag to disable the support ValueLOB access for the Oracle dialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/DialectSpecificSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/DialectSpecificSettings.java
@@ -68,6 +68,15 @@ public interface DialectSpecificSettings {
 	String ORACLE_OSON_DISABLED = "hibernate.dialect.oracle.oson_format_disabled";
 
 	/**
+	 * Specifies whether {@code lob(column) query as value} should be used in DDL
+	 * for LOB columns on Oracle 23c and above.
+	 *
+	 * @settingDefault {@code true}
+	 * @since 7.4
+	 */
+	String ORACLE_VALUE_LOB_ENABLED = "hibernate.dialect.oracle.value_lob_enabled";
+
+	/**
 	 * Specifies whether the {@code ansinull} setting is enabled on Sybase.
 	 * <p>
 	 * Ignored if Hibernate is able to determine the value of {@code ansinull}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -129,6 +129,7 @@ import static java.lang.String.join;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static org.hibernate.cfg.DialectSpecificSettings.ORACLE_OSON_DISABLED;
 import static org.hibernate.cfg.DialectSpecificSettings.ORACLE_USE_BINARY_FLOATS;
+import static org.hibernate.cfg.DialectSpecificSettings.ORACLE_VALUE_LOB_ENABLED;
 import static org.hibernate.dialect.DialectLogging.DIALECT_LOGGER;
 import static org.hibernate.dialect.type.OracleJdbcHelper.getArrayJdbcTypeConstructor;
 import static org.hibernate.dialect.type.OracleJdbcHelper.getNestedTableJdbcTypeConstructor;
@@ -231,6 +232,7 @@ public class OracleDialect extends Dialect {
 	protected final int driverMajorVersion;
 	protected final int driverMinorVersion;
 	private boolean useBinaryFloat;
+	private boolean useValueLOB; //TODO: if removed or issue fixed update SkipLockedWithLobTest
 
 	public OracleDialect() {
 		this( MINIMUM_VERSION );
@@ -1010,6 +1012,7 @@ public class OracleDialect extends Dialect {
 	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
 		final var configurationService = serviceRegistry.requireService( ConfigurationService.class );
 		useBinaryFloat = configurationService.getSetting( ORACLE_USE_BINARY_FLOATS, StandardConverters.BOOLEAN, true );
+		useValueLOB = configurationService.getSetting( ORACLE_VALUE_LOB_ENABLED, StandardConverters.BOOLEAN, true );
 
 		super.contributeTypes( typeContributions, serviceRegistry );
 		if ( ConfigurationHelper.getPreferredSqlTypeCodeForBoolean( serviceRegistry, this ) == BIT ) {
@@ -1139,7 +1142,9 @@ public class OracleDialect extends Dialect {
 	 * @return {@code true} if LOBs access can be VALUE based.
 	 */
 	@Override
-	public boolean supportsValueLOBAccess() { return getVersion().isSameOrAfter( 23 ); }
+	public boolean supportsValueLOBAccess() {
+		return useValueLOB && getVersion().isSameOrAfter( 23 );
+	}
 
 	@Override
 	public String getValueLOBFragmentForExtraCreateTableInfo(String columnName) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/SkipLockedWithLobTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/SkipLockedWithLobTest.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.locking;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+
+import org.hibernate.LockMode;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Reproducer for ORA-00600 [kollAdjustDuration - compile time VBL, run time RBL]
+ * triggered by SELECT ... FOR UPDATE ... SKIP LOCKED on a table with a LOB column
+ * when the dialect generates {@code lob(col) query as value} DDL (Oracle 23+).
+ *
+ * @see OracleDialect#supportsValueLOBAccess()
+ */
+@RequiresDialect(OracleDialect.class)
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsSkipLocked.class)
+@DomainModel(annotatedClasses = SkipLockedWithLobTest.OutboxEvent.class)
+@SessionFactory
+@ServiceRegistry( // TODO: remove once the issue is fixed on the Oracle side
+		settings = @Setting(
+				name = "hibernate.dialect.oracle.value_lob_enabled",
+				value = "false"
+		)
+)
+public class SkipLockedWithLobTest {
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			for ( int i = 1; i <= 5; i++ ) {
+				OutboxEvent event = new OutboxEvent();
+				event.setId( (long) i );
+				event.setEntityName( "Entity_" + i );
+				event.setPayload( ("payload-" + i).getBytes() );
+				session.persist( event );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	void testSelectForUpdateSkipLockedWithLobColumn(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			List<OutboxEvent> events = session.createQuery(
+							"select e from OutboxEvent e where e.id in (:ids)",
+							OutboxEvent.class
+					)
+					.setParameter( "ids", List.of( 1L, 2L, 3L ) )
+					.setHibernateLockMode( LockMode.UPGRADE_SKIPLOCKED )
+					.getResultList();
+
+			assertEquals( 3, events.size() );
+			for ( OutboxEvent event : events ) {
+				assertNotNull( event.getPayload() );
+			}
+		} );
+	}
+
+	@Entity(name = "OutboxEvent")
+	public static class OutboxEvent {
+
+		@Id
+		private Long id;
+
+		private String entityName;
+
+		@Lob
+		private byte[] payload;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getEntityName() {
+			return entityName;
+		}
+
+		public void setEntityName(String entityName) {
+			this.entityName = entityName;
+		}
+
+		public byte[] getPayload() {
+			return payload;
+		}
+
+		public void setPayload(byte[] payload) {
+			this.payload = payload;
+		}
+	}
+}

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -127,6 +127,36 @@ A unique constraint is now added to the table mapped by an `@ElementCollection` 
 
 A column mapped by a `@CreationTimestamp` or `@UpdateTimestamp` generator now has a `NOT NULL` constraint added automatically.
 
+[[oracle-value-lobs]]
+=== Oracle Value-Based LOBs
+
+On Oracle 23c and above, Hibernate now generates `lob(column) query as value` clauses in DDL
+for LOB columns mapped as Java types (e.g. `byte[]`, `String`) rather than JDBC LOB locator types
+(`java.sql.Blob`, `java.sql.Clob`).
+
+Value-based LOB access can improve performance by avoiding the use of LOB locators, allowing the
+database to treat LOB data inline.
+See the https://docs.oracle.com/en/database/oracle/oracle-database/26/adlob/value-based-LOBs.html[Oracle documentation] for more details.
+
+Value-based LOBs use https://docs.oracle.com/en/database/oracle/oracle-database/23/adlob/using-oracle-LOBs-storage.html[SecureFiles] storage,
+which requires a tablespace with Automatic Segment Space Management (ASSM).
+Attempting to create value LOB tables in a tablespace that uses Manual Segment Space Management
+(MSSM), such as the default `SYSTEM` tablespace, will fail with
+https://docs.oracle.com/en/database/oracle/oracle-database/23/errmg/ORA-43750.html[`ORA-43853`].
+Use an application user with a tablespace that supports ASSM (e.g. `USERS`)
+rather than the `SYSTEM` user.
+
+Additionally, some Oracle 23c versions contain a database kernel bug that causes `ORA-00600` internal
+errors when `FOR UPDATE ... SKIP LOCKED` queries are executed against tables with value-based LOBs.
+
+If you encounter either of these errors and cannot change the tablespace or Oracle version,
+the feature can be disabled by setting:
+
+[source,properties]
+----
+hibernate.dialect.oracle.value_lob_enabled=false
+----
+
 [[envers-migration]]
 == Optional: Migrating from Hibernate Envers to core `@Audited`
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20517

cc: @loiclefevre hey 👋🏻 🙂 this seems to be a problem in the DB itself? If you flip the flag to true in the test, you'd be able to reproduce it. ( just in case this wasn't yet reported/fixed)

> ORA-00600: internal error code, arguments: [kollAdjustDuration - compile time VBL, run time RBL], [], [], [], [], [], [], [], [], [], [], []


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20517 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->