### PR TITLE
HHH-20518 Do not exclude plexus-utils and add missing xml-utils for the maven test runtime

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,6 +97,7 @@ maven = "3.9.14"
 mavenPluginTools = "3.15.1"
 mavenFileManagement = "3.2.0"
 mavenTransport = "1.9.24"
+mavenPlexusXml = "4.1.1"
 
 #Buildscript
 forbiddenapis = "3.8"
@@ -247,6 +248,7 @@ maven-embedder = { group = "org.apache.maven", name = "maven-embedder", version.
 maven-compat = { group = "org.apache.maven", name = "maven-compat", version.ref = "maven" }
 maven-resolverHttp = { group = "org.apache.maven.resolver", name = "maven-resolver-transport-http", version.ref = "mavenTransport" }
 maven-resolverBasic = { group = "org.apache.maven.resolver", name = "maven-resolver-connector-basic", version.ref = "mavenTransport" }
+maven-plexusXml = { group = "org.codehaus.plexus", name = "plexus-xml", version.ref = "mavenPlexusXml" }
 
 # Buildscript
 buildscript-forbiddenapis = { group = "de.thetaphi", name = "forbiddenapis", version.ref = "forbiddenapis" }

--- a/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
+++ b/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
@@ -32,11 +32,7 @@ dependencies {
     implementation(libs.maven.pluginApi) {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    implementation(libs.maven.fileManagement) {
-        // file-management 3.2.0 pulls in plexus-utils 4.x (via maven-parent:44) which is
-        // incompatible with Maven 3's runtime; exclude it so the 3.x version from maven-core wins
-        exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
-    }
+    implementation(libs.maven.fileManagement)
 
     compileOnly libs.maven.pluginToolsAnnotations
 
@@ -48,6 +44,7 @@ dependencies {
     intTestRuntimeOnly libs.maven.resolverBasic
     intTestRuntimeOnly libs.test.logbackClassic
     intTestRuntimeOnly libs.maven.resolverHttp
+    intTestRuntimeOnly libs.maven.plexusXml
     intTestRuntimeOnly libs.jdbc.h2
 }
 


### PR DESCRIPTION
turns out that those plexus utils might actually be fine, and problem is more that we are running the tests with maven embedder which was pulling it's own dependencies and wanted some extra XML bits that were removed from plexus-utils 4 ..

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20518
<!-- Hibernate GitHub Bot issue links end -->