### PR TITLE
Use Google Maven mirror for GitHub builds / move mirror definition to a helper class for reuse / Add an option to enable maven local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
         shell: bash
         env:
           RDBMS: ${{ matrix.rdbms }}
+          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
           POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
@@ -244,6 +245,7 @@ jobs:
       - name: Run build script
         env:
           RDBMS: ${{ matrix.rdbms }}
+          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
           RUNID: ${{ github.run_number }}
           TESTPILOT_CONNECTION_STRING_SUFFIX: ${{ steps.create_database.outputs.connection_string_suffix }}
           TESTPILOT_PASSWORD: ${{ steps.create_database.outputs.database_password }}
@@ -376,6 +378,7 @@ jobs:
         shell: bash
         env:
           RDBMS: ${{ matrix.rdbms }}
+          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
           POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
@@ -473,6 +476,7 @@ jobs:
       - name: Run build script
         run: ./gradlew formatChecks
         env:
+          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
           POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
@@ -561,6 +565,8 @@ jobs:
 
       - name: Merge Jacoco Reports
         run: ./gradlew mergeCodeCoverageReport copyDependenciesSonar --no-parallel
+        env:
+          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
 
       - name: Store build info for Sonar scanning
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,11 @@ To do so, set the `MAVEN_MIRROR` environment variable to the URL of your mirror,
 e.g. `http://something-on-aws.com/path/to/repo`.
 Alternatively, you can pass `-DMAVEN_MIRROR=...` to the `gradle` command.
 
+To pick up locally built dependencies (e.g. a local Jakarta Persistence build),
+pass `-DenableMavenLocalRepo=true` to the `gradle` command.
+This adds `mavenLocal()` as a repository, which is disabled by default
+to ensure reproducible builds on CI.
+
 ### GitHub Actions workflows
 
 TODO: describe the workflows available.

--- a/hibernate-tck-runner/README.adoc
+++ b/hibernate-tck-runner/README.adoc
@@ -22,6 +22,22 @@ To run the Jakarta Persistence TCK from the terminal execute:
 Make sure to include the `pgsql_ci` database parameter!
 ====
 
+== Testing with a locally built Jakarta Persistence
+
+If you are developing changes to the Jakarta Persistence and want to test them against the TCK
+without publishing upstream, you can install the Jakarta Persistence artifacts to your local Maven repository
+(`mvn clean install -DskipTests` in the Jakarta Persistence project) and then run the TCK with:
+
+[source,bash]
+----
+./gradlew :hibernate-tck-runner:test -Pdb=pgsql_ci -Pruntck=true -DenableMavenLocalRepo=true
+----
+
+The `-DenableMavenLocalRepo=true` system property adds `mavenLocal()` as a repository so that
+locally built artifacts are picked up. This flag works for the main build as well, not just the TCK runner.
+
+== Testing from the IDE
+
 Tests can be executed from the IDE as well. The steps below are specific to Intellij IDEA,
 but should be applicable to any other IDE.
 

--- a/hibernate-tck-runner/hibernate-tck-runner.gradle
+++ b/hibernate-tck-runner/hibernate-tck-runner.gradle
@@ -27,7 +27,8 @@ repositories {
             includeGroup "jakarta.persistence"
         }
     }
-    mavenCentral()
+    // See MavenMirror and settings.gradle for more info on the mirror configuration
+    org.hibernate.orm.env.MavenMirror.maybeAddMavenCentral(it)
 }
 
 configurations {

--- a/hibernate-tck-runner/hibernate-tck-runner.gradle
+++ b/hibernate-tck-runner/hibernate-tck-runner.gradle
@@ -11,14 +11,8 @@ plugins {
 description = 'Hibernate ORM\'s Jakarta Persistence TCK runner'
 
 repositories {
-    if ( project.hasProperty('enableMavenLocalRepo') ) {
-        // Useful for local development when you want to write a TCK test and run it,
-        // disabled otherwise
-        mavenLocal() {
-            content {
-                includeGroup "jakarta.persistence"
-            }
-        }
+    org.hibernate.orm.env.MavenMirror.maybeAddMavenLocal(it) { content ->
+        content.includeGroup "jakarta.persistence"
     }
     maven {
         name = "Central Portal Snapshots"

--- a/local-build-plugins/src/main/java/org/hibernate/orm/env/MavenMirror.java
+++ b/local-build-plugins/src/main/java/org/hibernate/orm/env/MavenMirror.java
@@ -4,7 +4,9 @@
  */
 package org.hibernate.orm.env;
 
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 
 /**
  * Configures Maven Central or a mirror of it, based on the {@code MAVEN_MIRROR} environment
@@ -14,6 +16,26 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler;
  * @see <a href="https://blog.gradle.org/maven-central-mirror">Gradle Maven Central Mirror</a>
  */
 public class MavenMirror {
+
+	/**
+	 * Adds a {@code mavenLocal()} repository if the {@code enableMavenLocalRepo} system property is set.
+	 * Useful for local development to pick up locally built artifacts.
+	 *
+	 * @param contentFilter optional content filter, e.g. {@code c -> c.includeGroup("jakarta.persistence")}
+	 */
+	public static void maybeAddMavenLocal(RepositoryHandler repositories, Action<RepositoryContentDescriptor> contentFilter) {
+		if ( "true".equalsIgnoreCase( resolve( "enableMavenLocalRepo" ) ) ) {
+			repositories.mavenLocal( repo -> {
+				if ( contentFilter != null ) {
+					repo.content( contentFilter );
+				}
+			} );
+		}
+	}
+
+	public static void maybeAddMavenLocal(RepositoryHandler repositories) {
+		maybeAddMavenLocal( repositories, null );
+	}
 
 	/**
 	 * @return {@code true} if a mirror was configured, {@code false} if plain Maven Central was added

--- a/local-build-plugins/src/main/java/org/hibernate/orm/env/MavenMirror.java
+++ b/local-build-plugins/src/main/java/org/hibernate/orm/env/MavenMirror.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.env;
+
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
+
+/**
+ * Configures Maven Central or a mirror of it, based on the {@code MAVEN_MIRROR} environment
+ * variable or system property. Optionally supports authentication via
+ * {@code MAVEN_MIRROR_USERNAME} and {@code MAVEN_MIRROR_PASSWORD}.
+ *
+ * @see <a href="https://blog.gradle.org/maven-central-mirror">Gradle Maven Central Mirror</a>
+ */
+public class MavenMirror {
+
+	/**
+	 * @return {@code true} if a mirror was configured, {@code false} if plain Maven Central was added
+	 */
+	public static boolean maybeAddMavenCentral(RepositoryHandler repositories) {
+		String mirror = resolve( "MAVEN_MIRROR" );
+		if ( mirror != null ) {
+			repositories.maven( repo -> {
+				repo.setUrl( mirror );
+				String username = resolve( "MAVEN_MIRROR_USERNAME" );
+				if ( username != null ) {
+					repo.credentials( creds -> {
+						creds.setUsername( username );
+						String password = resolve( "MAVEN_MIRROR_PASSWORD" );
+						if ( password != null ) {
+							creds.setPassword( password );
+						}
+					} );
+				}
+			} );
+			return true;
+		}
+		else {
+			repositories.mavenCentral();
+			return false;
+		}
+	}
+
+	private static String resolve(String key) {
+		String value = System.getProperty( key );
+		if ( value != null && !value.isEmpty() ) {
+			return value;
+		}
+		value = System.getenv( key );
+		if ( value != null && !value.isEmpty() ) {
+			return value;
+		}
+		return null;
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,7 @@ dependencyResolutionManagement {
         // See MAINTAINERS.md for documentation.
         // TODO Move to infra overrides instead;
         //  see https://blog.gradle.org/maven-central-mirror#overriding-the-urls-for-maven-central-and-the-plugin-portal-repositories
+        org.hibernate.orm.env.MavenMirror.maybeAddMavenLocal(it)
         if ( !org.hibernate.orm.env.MavenMirror.maybeAddMavenCentral(it) ) {
             // temporary for 4.0 snapshot testing
             maven {

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,22 +27,7 @@ dependencyResolutionManagement {
         // See MAINTAINERS.md for documentation.
         // TODO Move to infra overrides instead;
         //  see https://blog.gradle.org/maven-central-mirror#overriding-the-urls-for-maven-central-and-the-plugin-portal-repositories
-        if ( System.getProperty( 'MAVEN_MIRROR' ) ?: System.env['MAVEN_MIRROR'] ) {
-            maven {
-                url System.getProperty( 'MAVEN_MIRROR' ) ?: System.env['MAVEN_MIRROR']
-                if ( System.getProperty( 'MAVEN_MIRROR_USERNAME' ) || System.env['MAVEN_MIRROR_USERNAME'] ) {
-                    credentials {
-                        username = System.getProperty( 'MAVEN_MIRROR_USERNAME' ) ?: System.env['MAVEN_MIRROR_USERNAME']
-                        if ( System.getProperty( 'MAVEN_MIRROR_PASSWORD' ) || System.env['MAVEN_MIRROR_PASSWORD'] ) {
-                            password = System.getProperty( 'MAVEN_MIRROR_PASSWORD' ) ?: System.env['MAVEN_MIRROR_PASSWORD']
-                        }
-                    }
-                }
-            }
-        }
-        else {
-            mavenCentral()
-
+        if ( !org.hibernate.orm.env.MavenMirror.maybeAddMavenCentral(it) ) {
             // temporary for 4.0 snapshot testing
             maven {
                 url "https://central.sonatype.com/repository/maven-snapshots/"


### PR DESCRIPTION
I noticed that on GH we sometimes get
```
> Could not create task ':hibernate-core:javadoc'.
   > Could not create task ':hibernate-core:unpackTheme'.
      > Could not resolve all files for configuration ':hibernate-core:themezip'.
         > Could not resolve org.hibernate.infra:hibernate-asciidoctor-theme:6.1.2.Final.
           Required by:
               project ':hibernate-core'
            > Could not resolve org.hibernate.infra:hibernate-asciidoctor-theme:6.1.2.Final.
               > Could not get resource 'https://repo.maven.apache.org/maven2/org/hibernate/infra/hibernate-asciidoctor-theme/6.1.2.Final/hibernate-asciidoctor-theme-6.1.2.Final.pom'.
                  > Could not GET 'https://repo.maven.apache.org/maven2/org/hibernate/infra/hibernate-asciidoctor-theme/6.1.2.Final/hibernate-asciidoctor-theme-6.1.2.Final.pom'. Received status code 403 from server: Forbidden
```

So let's try using the Google mirror instead of Central ?

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
