### PR TITLE
HHH-20540 Upgrade antlr from 4.13.0 to 4.13.2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -83,7 +83,7 @@ dependencyResolutionManagement {
             version "maxSupportedBytecode", "22"
         }
         libs {
-            def antlrVersion = version "antlr", "4.13.0"
+            def antlrVersion = version "antlr", "4.13.2"
             // WARNING: When upgrading to a version of bytebuddy that supports a new bytecode version,
             // make sure to remove the now unnecessary net.bytebuddy.experimental=true in relevant CI jobs (Jenkinsfile).
             def byteBuddyVersion = version "byteBuddy", "1.17.8"


### PR DESCRIPTION
Partial backport of 985740ecb937eb8ec2d6a4b6f8afbf40006bf081, which unfortunately didn't have a Jira, so we'll continue that way...

EDIT: Created https://hibernate.atlassian.net/browse/HHH-20540 to not have an empty changelog...