### PR TITLE
HHH-20514 XML mapping does not apply optimistic-lock attribute for <many-to-many> associations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ManyToManyAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ManyToManyAttributeProcessing.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.boot.models.xml.internal.attr;
 
+import jakarta.persistence.AccessType;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.XmlAnnotations;
@@ -17,11 +18,10 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.MutableClassDetails;
 import org.hibernate.models.spi.MutableMemberDetails;
 
-import jakarta.persistence.AccessType;
-
 import static org.hibernate.boot.models.xml.internal.attr.CommonAttributeProcessing.applyAccess;
 import static org.hibernate.boot.models.xml.internal.attr.CommonAttributeProcessing.applyAttributeAccessor;
 import static org.hibernate.boot.models.xml.internal.attr.CommonAttributeProcessing.applyFetching;
+import static org.hibernate.boot.models.xml.internal.attr.CommonAttributeProcessing.applyOptimisticLock;
 import static org.hibernate.boot.models.xml.internal.attr.CommonPluralAttributeProcessing.applyPluralAttributeStructure;
 import static org.hibernate.internal.util.NullnessHelper.coalesce;
 
@@ -68,11 +68,15 @@ public class ManyToManyAttributeProcessing {
 
 		TableProcessing.transformJoinTable( jaxbManyToMany.getJoinTable(), memberDetails, xmlDocumentContext );
 
-		XmlAnnotationHelper.applySqlJoinTableRestriction( jaxbManyToMany.getSqlJoinTableRestriction(), memberDetails, xmlDocumentContext );
+		XmlAnnotationHelper.applySqlJoinTableRestriction( jaxbManyToMany.getSqlJoinTableRestriction(), memberDetails,
+				xmlDocumentContext );
 
-		XmlAnnotationHelper.applyJoinTableFilters( jaxbManyToMany.getJoinTableFilters(), memberDetails, xmlDocumentContext );
+		XmlAnnotationHelper.applyJoinTableFilters( jaxbManyToMany.getJoinTableFilters(), memberDetails,
+				xmlDocumentContext );
 
 		XmlAnnotationHelper.applyNotFound( jaxbManyToMany, memberDetails, xmlDocumentContext );
+
+		applyOptimisticLock( jaxbManyToMany, memberDetails, xmlDocumentContext );
 
 		return memberDetails;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/ManyToManyTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/ManyToManyTests.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.attr;
+
+import java.util.Set;
+
+import org.hibernate.annotations.OptimisticLock;
+import org.hibernate.boot.model.process.spi.ManagedResources;
+import org.hibernate.boot.model.source.internal.annotations.AdditionalManagedResourcesImpl;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.models.spi.ClassDetails;
+import org.hibernate.models.spi.ClassDetailsRegistry;
+import org.hibernate.models.spi.FieldDetails;
+import org.hibernate.models.spi.ModelsContext;
+
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.boot.models.SourceModelTestHelper.createBuildingContext;
+
+@ServiceRegistry
+public class ManyToManyTests {
+	@Test
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	void testSimpleManyToMany(ServiceRegistryScope scope) {
+		final StandardServiceRegistry serviceRegistry = scope.getRegistry();
+		final ManagedResources managedResources = new AdditionalManagedResourcesImpl.Builder()
+				.addXmlMappings( "mappings/models/attr/many-to-many/simple.xml" )
+				.build();
+
+		final ModelsContext modelsContext = createBuildingContext( managedResources, serviceRegistry );
+		final ClassDetailsRegistry classDetailsRegistry = modelsContext.getClassDetailsRegistry();
+
+		final ClassDetails classDetails = classDetailsRegistry.getClassDetails( SimpleEntity.class.getName() );
+
+		final FieldDetails othersField = classDetails.findFieldByName( "others" );
+		final ManyToMany manyToManyAnn = othersField.getDirectAnnotationUsage( ManyToMany.class );
+		assertThat( manyToManyAnn ).isNotNull();
+
+		final OptimisticLock optLockAnn = othersField.getDirectAnnotationUsage( OptimisticLock.class );
+		assertThat( optLockAnn ).isNotNull();
+		assertThat( optLockAnn.excluded() ).isFalse();
+	}
+
+	@SuppressWarnings("unused")
+	@Entity(name = "SYYimpleEntity")
+	@Table(name = "SimpleEntity")
+	public static class SimpleEntity {
+		@Id
+		private Integer id;
+		private String name;
+		private Set<SimpleEntity> others;
+	}
+}

--- a/hibernate-core/src/test/resources/mappings/models/attr/many-to-many/simple.xml
+++ b/hibernate-core/src/test/resources/mappings/models/attr/many-to-many/simple.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 version="8.0">
+    <entity class="org.hibernate.orm.test.boot.models.xml.attr.ManyToManyTests$SimpleEntity" metadata-complete="true" access="FIELD">
+        <attributes>
+            <id name="id"/>
+            <basic name="name"/>
+            <many-to-many name="others"
+                         target-entity="org.hibernate.orm.test.boot.models.xml.attr.ManyToManyTests$SimpleEntity"
+                         optimistic-lock="true">
+                <join-table name="entity_others"/>
+            </many-to-many>
+        </attributes>
+    </entity>
+</entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20514

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20514 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->