### PR TITLE
Enable automatic releases for 7.4 / Update TCK to always run for 7.4 PRs / run Search update job for PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,17 +102,17 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
 	currentBuild.result = 'NOT_BUILT'
   	return
 }
+// This is a limited maintenance branch, so don't run this on pushes to the branch, only on PRs
+if ( !env.CHANGE_ID ) {
+    print "INFO: Build skipped because this job should only run for pull request, not for branch pushes"
+    currentBuild.result = 'NOT_BUILT'
+    return
+}
 
 stage('Build') {
 	Map<String, Closure> executions = [:]
 	Map<String, Map<String, String>> state = [:]
 	environments.each { BuildEnvironment buildEnv ->
-		// Don't build environments for newer JDKs when this is a PR, unless the PR is labelled with 'jdk' or 'jdk-<version>'
-		if ( helper.scmSource.pullRequest &&
-				buildEnv.testJdkVersion && buildEnv.testJdkVersion.toInteger() > DEFAULT_JDK_VERSION.toInteger() &&
-				!pullRequest.labels.contains( 'jdk' ) && !pullRequest.labels.contains( "jdk-${buildEnv.testJdkVersion}" ) ) {
-			return
-		}
 		state[buildEnv.tag] = [:]
 		executions.put(buildEnv.tag, {
 			runBuildOnNode(buildEnv.node ?: NODE_PATTERN_BASE) {
@@ -220,6 +220,9 @@ stage('Build') {
 			}
 		})
 	}
+    executions.put('Hibernate Search Update Dependency', {
+        build job: '/hibernate-search-dependency-update/8.4', propagate: true, parameters: [string(name: 'UPDATE_JOB', value: 'orm7.4'), string(name: 'ORM_REPOSITORY', value: helper.scmSource.remoteUrl), string(name: 'ORM_PULL_REQUEST_ID', value: helper.scmSource.pullRequest.id)]
+    })
 	parallel(executions)
 }
 

--- a/ci/jpa-3.2-tck.Jenkinsfile
+++ b/ci/jpa-3.2-tck.Jenkinsfile
@@ -6,17 +6,11 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
 	currentBuild.result = 'NOT_BUILT'
   	return
 }
-def throttleCount
-// Don't build the TCK on PRs, unless they use the tck label
-if ( env.CHANGE_ID != null ) {
-	if ( !pullRequest.labels.contains( 'tck' ) ) {
-		print "INFO: Build skipped because pull request doesn't have 'tck' label"
-		return
-	}
-	throttleCount = 20
-}
-else {
-	throttleCount = 1
+// This is a limited maintenance branch, so don't run this on pushes to the branch, only on PRs
+if ( !currentBuild.getBuildCauses().toString().contains( 'UserIdCause' ) && !env.CHANGE_ID ) {
+	print "INFO: Build skipped because this job should only run for pull request, not for branch pushes"
+	currentBuild.result = 'NOT_BUILT'
+	return
 }
 
 pipeline {
@@ -25,7 +19,6 @@ pipeline {
         jdk 'OpenJDK 25 Latest'
     }
     options {
-  		rateLimitBuilds(throttle: [count: throttleCount, durationName: 'day', userBoost: true])
         buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
         disableConcurrentBuilds(abortPrevious: true)
     }
@@ -44,7 +37,7 @@ pipeline {
         }
         stage('TCK') {
             agent {
-                label 'LongDuration'
+                label 'Worker&&Containers'
             }
             stages {
                 stage('Build') {

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -15,7 +15,7 @@ import org.hibernate.jenkins.pipeline.helpers.version.Version
 // Global build configuration
 env.PROJECT = "orm"
 env.JIRA_KEY = "HHH"
-def RELEASE_ON_SCHEDULE = false // Set to `true` *only* on branches where you want a scheduled release.
+def RELEASE_ON_SCHEDULE = true // Set to `true` *only* on branches where you want a scheduled release.
 
 print "INFO: env.PROJECT = ${env.PROJECT}"
 print "INFO: env.JIRA_KEY = ${env.JIRA_KEY}"


### PR DESCRIPTION
(mostly because I want a 7.4 release 🫣 🙂)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
