### PR TITLE
HHH-20528 - Upgrade Oracle Test Pilot Setup GitHub action to v1.0.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-
 
       - id: create_database
-        uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+        uses: oracle-actions/setup-testpilot@aec84678697e1648ddb8e8a480cf3ceda746ce5c # v1.0.24
         with:
           oci-service: ${{ matrix.rdbms }}
           action: create
@@ -267,7 +267,7 @@ jobs:
         run: ./ci/build-github.sh
         shell: bash
 
-      - uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
+      - uses: oracle-actions/setup-testpilot@aec84678697e1648ddb8e8a480cf3ceda746ce5c # v1.0.24
         if: always()
         with:
           oci-service: ${{ matrix.rdbms }}

--- a/local-build-plugins/src/main/groovy/local.databases.gradle
+++ b/local-build-plugins/src/main/groovy/local.databases.gradle
@@ -255,7 +255,9 @@ ext {
                     'jdbc.driver': 'oracle.jdbc.OracleDriver',
                     'jdbc.user'  : 'hibernate_orm_test_$worker_' + runID,
                     'jdbc.pass'  : dbPassword,
-                    'jdbc.url'   : 'jdbc:oracle:thin:@' + dbConnectionStringSuffix + '?oracle.jdbc.enableQueryResultCache=false',
+                    'jdbc.url'   : 'jdbc:oracle:thin:@' + dbConnectionStringSuffix +
+                            (dbConnectionStringSuffix.contains('?') ? '&' : '?') +
+                            'oracle.jdbc.enableQueryResultCache=false',
                     'jdbc.datasource' : 'oracle.jdbc.OracleDriver',
                     'connection.init_sql' : ''
             ],


### PR DESCRIPTION
This PR upgrades the Oracle Test Pilot Setup GitHub action to v1.0.24 and taking care of the existing parameters on the connection strings for Hibernate CI.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20528 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20528
<!-- Hibernate GitHub Bot issue links end -->