### PR TITLE
HHH-20536  <read> and <write> element inside <attribute-override> are silently ignored in XML mappings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
@@ -205,7 +205,7 @@ public class XmlAnnotationHelper {
 
 	public static void applyColumnTransformation(
 			JaxbColumnImpl jaxbColumn,
-			MutableMemberDetails memberDetails,
+			MutableAnnotationTarget memberDetails,
 			XmlDocumentContext xmlDocumentContext) {
 		if ( isEmpty( jaxbColumn.getRead() )
 				&& isEmpty( jaxbColumn.getWrite() ) ) {
@@ -705,6 +705,9 @@ public class XmlAnnotationHelper {
 		final ColumnJpaAnnotation columnAnn = COLUMN.createUsage( modelBuildingContext );
 		overrideUsage.column( columnAnn );
 		columnAnn.apply( jaxbOverride.getColumn(), xmlDocumentContext );
+		if ( jaxbOverride.getColumn() != null ) {
+			applyColumnTransformation( jaxbOverride.getColumn(), target, xmlDocumentContext );
+		}
 		return overrideUsage;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/column/transform/attributeoverride/AttributeOverrideColumnTransformTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/column/transform/attributeoverride/AttributeOverrideColumnTransformTests.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.column.transform.attributeoverride;
+
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Component;
+import org.hibernate.mapping.Property;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttributeOverrideColumnTransformTests {
+
+	@Test
+	@DomainModel(xmlMappings = "mappings/models/column/transform/attributeoverride/mapping.xml")
+	void testMappingModel(DomainModelScope domainModelScope) {
+		domainModelScope.withHierarchy( Widget.class, (rootClass) -> {
+			final Property measurementProperty = rootClass.getProperty( "measurement" );
+			final Component component = (Component) measurementProperty.getValue();
+			final Property valueProperty = component.getProperty( "valueInInches" );
+			assertThat( valueProperty.getColumns() ).hasSize( 1 );
+			final Column column = valueProperty.getColumns().get( 0 );
+			assertThat( column.getName() ).isEqualTo( "value_centimeters" );
+			assertThat( column.getCustomRead() ).isEqualTo( "value_centimeters / 2.54E0" );
+			assertThat( column.getCustomWrite() ).isEqualTo( "? * 2.54E0" );
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/column/transform/attributeoverride/Measurement.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/column/transform/attributeoverride/Measurement.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.column.transform.attributeoverride;
+
+public class Measurement {
+	private double valueInInches;
+
+	public double getValueInInches() {
+		return valueInInches;
+	}
+
+	public void setValueInInches(double valueInInches) {
+		this.valueInInches = valueInInches;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/column/transform/attributeoverride/Widget.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/column/transform/attributeoverride/Widget.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.column.transform.attributeoverride;
+
+public class Widget {
+	private Integer id;
+	private String name;
+	private Measurement measurement;
+
+	protected Widget() {
+	}
+
+	public Widget(Integer id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Measurement getMeasurement() {
+		return measurement;
+	}
+
+	public void setMeasurement(Measurement measurement) {
+		this.measurement = measurement;
+	}
+}

--- a/hibernate-core/src/test/resources/mappings/models/column/transform/attributeoverride/mapping.xml
+++ b/hibernate-core/src/test/resources/mappings/models/column/transform/attributeoverride/mapping.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 version="7.0">
+    <package>org.hibernate.orm.test.boot.models.xml.column.transform.attributeoverride</package>
+    <entity class="Widget" metadata-complete="true" access="FIELD">
+        <table name="widgets"/>
+        <attributes>
+            <id name="id"/>
+            <basic name="name"/>
+            <embedded name="measurement">
+                <attribute-override name="valueInInches">
+                    <column name="value_centimeters" nullable="false">
+                        <read>value_centimeters / 2.54E0</read>
+                        <write>? * 2.54E0</write>
+                    </column>
+                </attribute-override>
+            </embedded>
+        </attributes>
+    </entity>
+    <embeddable class="Measurement" metadata-complete="true" access="FIELD">
+        <attributes>
+            <basic name="valueInInches"/>
+        </attributes>
+    </embeddable>
+</entity-mappings>


### PR DESCRIPTION
backport of https://github.com/hibernate/hibernate-orm/pull/12648 for 7.4

https://hibernate.atlassian.net/browse/HHH-20536



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20536 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->