### PR TITLE
HHH-20527 Modernize CUBRIDDialect for CUBRID 10.2

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
@@ -84,6 +84,11 @@ public class CUBRIDDialect extends Dialect {
 	}
 
 	@Override
+	protected DatabaseVersion getMinimumSupportedVersion() {
+		return MINIMUM_VERSION;
+	}
+
+	@Override
 	protected String columnType(int sqlTypeCode) {
 		return switch ( sqlTypeCode ) {
 			case BOOLEAN -> "bit";
@@ -156,8 +161,7 @@ public class CUBRIDDialect extends Dialect {
 	}
 
 	public CUBRIDDialect(DialectResolutionInfo info) {
-		this( info.makeCopyOrDefault( MINIMUM_VERSION ) );
-		registerKeywords( info );
+		super( info );
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
@@ -11,14 +11,19 @@ import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.community.dialect.identity.CUBRIDIdentityColumnSupport;
 import org.hibernate.community.dialect.sequence.CUBRIDSequenceSupport;
 import org.hibernate.community.dialect.sequence.SequenceInformationExtractorCUBRIDDatabaseImpl;
+import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.NullOrdering;
 import org.hibernate.dialect.OracleDialect;
-import org.hibernate.dialect.SimpleDatabaseVersion;
 import org.hibernate.dialect.TimeZoneSupport;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
+import org.hibernate.dialect.lock.PessimisticLockStyle;
 import org.hibernate.dialect.lock.internal.LockingSupportSimple;
+import org.hibernate.dialect.lock.spi.ConnectionLockTimeoutStrategy;
+import org.hibernate.dialect.lock.spi.LockTimeoutType;
 import org.hibernate.dialect.lock.spi.LockingSupport;
+import org.hibernate.dialect.lock.spi.OuterJoinLockingType;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.LimitLimitHandler;
 import org.hibernate.dialect.sequence.SequenceSupport;
@@ -59,17 +64,23 @@ import static org.hibernate.type.SqlTypes.TINYINT;
 import static org.hibernate.type.SqlTypes.VARBINARY;
 
 /**
- * An SQL dialect for CUBRID (8.3.x and later).
+ * An SQL dialect for CUBRID 10.2 and above.
  *
  * @author Seok Jeong Il
  */
 public class CUBRIDDialect extends Dialect {
 
+	private static final DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 10, 2 );
+
 	/**
 	 * Constructs a CUBRIDDialect
 	 */
 	public CUBRIDDialect() {
-		super( SimpleDatabaseVersion.ZERO_VERSION );
+		this( MINIMUM_VERSION );
+	}
+
+	public CUBRIDDialect(DatabaseVersion version) {
+		super( version );
 	}
 
 	@Override
@@ -91,8 +102,6 @@ public class CUBRIDDialect extends Dialect {
 		super.registerColumnTypes( typeContributions, serviceRegistry );
 		final DdlTypeRegistry ddlTypeRegistry = typeContributions.getTypeConfiguration().getDdlTypeRegistry();
 
-		//precision of a Mimer 'float(p)' represents
-		//decimal digits instead of binary digits
 		ddlTypeRegistry.addDescriptor( new BinaryFloatDdlType( this ) );
 
 		//CUBRID has no 'binary' nor 'varbinary', but 'bit' is
@@ -147,7 +156,7 @@ public class CUBRIDDialect extends Dialect {
 	}
 
 	public CUBRIDDialect(DialectResolutionInfo info) {
-		this();
+		this( info.makeCopyOrDefault( MINIMUM_VERSION ) );
 		registerKeywords( info );
 	}
 
@@ -217,7 +226,7 @@ public class CUBRIDDialect extends Dialect {
 		functionFactory.log2();
 		functionFactory.log10();
 		functionFactory.pi();
-		//rand() returns an integer between 0 and 231 on CUBRID
+		//rand() returns an integer between 0 and 2^31 on CUBRID
 //		functionFactory.rand();
 		functionFactory.radians();
 		functionFactory.degrees();
@@ -233,7 +242,6 @@ public class CUBRIDDialect extends Dialect {
 		functionFactory.bitLength();
 		functionFactory.md5();
 		functionFactory.trunc();
-//		functionFactory.truncate();
 		functionFactory.toCharNumberDateTimestamp();
 		functionFactory.substr();
 		//also natively supports ANSI-style substring()
@@ -265,6 +273,11 @@ public class CUBRIDDialect extends Dialect {
 
 	@Override
 	public boolean supportsColumnCheck() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsTableCheck() {
 		return false;
 	}
 
@@ -313,14 +326,16 @@ public class CUBRIDDialect extends Dialect {
 		return ']';
 	}
 
-	@Override
-	public LockingSupport getLockingSupport() {
-		return LockingSupportSimple.STANDARD_SUPPORT;
-	}
+	private static final LockingSupport LOCKING_SUPPORT = new LockingSupportSimple(
+			PessimisticLockStyle.CLAUSE,
+			LockTimeoutType.NONE,
+			OuterJoinLockingType.FULL,
+			ConnectionLockTimeoutStrategy.NONE
+	);
 
 	@Override
-	public String getForUpdateString() {
-		return "";
+	public LockingSupport getLockingSupport() {
+		return LOCKING_SUPPORT;
 	}
 
 	@Override
@@ -356,6 +371,68 @@ public class CUBRIDDialect extends Dialect {
 	@Override
 	public boolean supportsTemporaryTables() {
 		return false;
+	}
+
+	@Override
+	public boolean supportsWindowFunctions() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsWithClauseInSubquery() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsNestedWithClause() {
+		//pinned false: derives from supportsWithClauseInSubquery(), but CUBRID rejects a with clause nested in another CTE
+		return false;
+	}
+
+	@Override
+	public boolean supportsRecursiveCTE() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsNonQueryWithCTE() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsIsTrue() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsValuesList() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsAlterColumnType() {
+		return true;
+	}
+
+	//CUBRID cannot change only the column type, so emit the full column definition
+	@Override
+	public String getAlterColumnTypeString(String columnName, String columnType, String columnDefinition) {
+		return "modify column " + columnName + " " + columnDefinition.trim();
+	}
+
+	@Override
+	public boolean canCreateSchema() {
+		return false;
+	}
+
+	@Override
+	public int getMaxIdentifierLength() {
+		return 254;
+	}
+
+	@Override
+	public NullOrdering getNullOrdering() {
+		return NullOrdering.SMALLEST;
 	}
 
 	@Override
@@ -522,6 +599,11 @@ public class CUBRIDDialect extends Dialect {
 
 	@Override
 	public boolean supportsRowValueConstructorSyntax() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsRowValueConstructorGtLtSyntax() {
 		return false;
 	}
 
@@ -532,6 +614,11 @@ public class CUBRIDDialect extends Dialect {
 
 	@Override
 	public boolean supportsRowValueConstructorSyntaxInInList() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsRowValueConstructorSyntaxInInSubQuery() {
 		return false;
 	}
 

--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/CUBRIDDialectTestCase.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/CUBRIDDialectTestCase.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@BaseUnitTest
+public class CUBRIDDialectTestCase {
+
+	private final Dialect dialect = new CUBRIDDialect();
+
+	@Test
+	public void testAlterColumnTypeUsesModifyWithFullDefinition() {
+		assertThat( dialect.getAlterColumnTypeString( "age", "integer", "integer not null" ) )
+				.isEqualTo( "modify column age integer not null" );
+	}
+}

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -332,6 +332,20 @@ _Be aware that creating a Cat, with the above model, will result in calls to bot
 that creating a Dog, both `postInsert(Animal)` and `postInsert(Dog)`._
 
 
+[[cubrid-dialect]]
+=== CUBRID dialect
+
+`CUBRIDDialect` now requires CUBRID 10.2 or later, the oldest version still supported by the vendor,
+and declares several capability flags explicitly for 10.2. Two of these are visible at runtime.
+
+`getNullOrdering()` is now `SMALLEST`, which matches CUBRID's native ordering (NULL first when
+ascending and last when descending). Queries that relied on the previous inherited default may order
+NULL values differently.
+
+Pessimistic locking now produces a `FOR UPDATE` clause. The dialect previously returned an empty lock
+string, so `PESSIMISTIC_READ` and `PESSIMISTIC_WRITE` had no effect.
+
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // XSD changes
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

CUBRIDDialect currently builds on `ZERO_VERSION` while its Javadoc documents 8.3 and above. CUBRID 10.1 and all earlier release reached end of life in 2024, and the official Docker images only publish 10.x and later tags, so 10.2 is the oldest version still supported by the vendor. Because the dialect does not target a specific version, several capability flags fall back to inherited defaults that are not accurate for 10.2, and the locking configuration is inconsistent.

This change sets the minimum supported version to 10.2, declares the affected flags explicitly based on the CUBRID 10.2 manual, and fixes the locking configuration.

### Chagnes
- **Minimum version**: the dialect now targets 10.2, using the standard three-constructor pattern.
- **Locking**: removed the empty `getForUpdateString()` override and added a `LockingSupport`. CUBRID emits a `FOR UPDATE` clause, maps `PESSIMISTIC_READ` to `FOR UPDATE` (it has no `FOR SHARE`), and allows locking together with outer joins.
- **CTE and query features**: `supportsRecursiveCTE`, `supportsNonQueryWithCTE`, `supportsWindowFunctions`, `supportsIsTrue`, and `supportsValuesList` are now true. `supportsNestedWithClause` is false, because CUBRID rejects a WITH clause nested inside another CTE.
- **Row value constructors**: CUBRID accepts the `=` and `IN (list)` forms but rejects `<`/`>`, `IN (subquery)`, and quantified comparisons, and the flags now match that.
- **Schema and DDL**: `supportsAlterColumnType` is true, with a matching `getAlterColumnTypeString` that produces a `modify column` clause. `supportsTableCheck` and `canCreateSchema ` are false.
- **Other**: `getNullOrdering` is now `SMALLEST` (CUBRID orders NULL as the smallest value). `getMaxIdentifierLength` is 254.

### Verification
I added a unit test, `CUBRIDDialectTestCase `, for the new `getAlterColumnTypeString ` output. CUBRID is not part of the CI martix, so I verified the flags and behavior against real CUBRID from 10.2 through 11.x with an external Testcontainers suite at https://github.com/Srltas/hibernate-cubrid-e2e, linked here in case you want to reproduce the results.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20527 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20527
<!-- Hibernate GitHub Bot issue links end -->