### PR TITLE
HHH-20537 XML embeddable mapping ignores access attribute when processing attributes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/ManagedTypeProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/ManagedTypeProcessor.java
@@ -723,7 +723,7 @@ public class ManagedTypeProcessor {
 			AttributeProcessor.processAttributes(
 					jaxbEmbeddable.getAttributes(),
 					classDetails,
-					AccessType.FIELD,
+					classAccessType != null ? classAccessType : AccessType.FIELD,
 					memberAdjuster,
 					xmlDocumentContext
 			);
@@ -742,12 +742,17 @@ public class ManagedTypeProcessor {
 			classDetails.applyAnnotationUsage( JpaAnnotations.EMBEDDABLE,
 					xmlDocumentContext.getModelBuildingContext() );
 
+			final var classAccessType = coalesce(
+					jaxbEmbeddable.getAccess(),
+					xmlDocumentContext.getEffectiveDefaults().getDefaultPropertyAccessType()
+			);
+
 			final var attributes = jaxbEmbeddable.getAttributes();
 			if ( attributes != null ) {
 				AttributeProcessor.processAttributes(
 						attributes,
 						classDetails,
-						AccessType.FIELD,
+						classAccessType != null ? classAccessType : AccessType.FIELD,
 						ManagedTypeProcessor::adjustNonDynamicTypeMember,
 						xmlDocumentContext
 				);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/transientattr/EmbeddableTransientTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/transientattr/EmbeddableTransientTests.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.attr.transientattr;
+
+import org.hibernate.boot.model.process.spi.ManagedResources;
+import org.hibernate.boot.model.source.internal.annotations.AdditionalManagedResourcesImpl;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.mapping.Component;
+import org.hibernate.mapping.Property;
+import org.hibernate.models.spi.ClassDetails;
+import org.hibernate.models.spi.FieldDetails;
+import org.hibernate.models.spi.MemberDetails;
+import org.hibernate.models.spi.MethodDetails;
+import org.hibernate.models.spi.ModelsContext;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Transient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.boot.models.SourceModelTestHelper.createBuildingContext;
+
+@SuppressWarnings("JUnitMalformedDeclaration")
+public class EmbeddableTransientTests {
+
+	private static final String MAPPING_XML =
+			"mappings/models/attr/transientattr/mapping.xml";
+
+	@ServiceRegistry
+	@Test
+	void testSourceModel(ServiceRegistryScope scope) {
+		final ManagedResources managedResources = new AdditionalManagedResourcesImpl.Builder()
+				.addXmlMappings( MAPPING_XML )
+				.build();
+		final StandardServiceRegistry serviceRegistry = scope.getRegistry();
+		final ModelsContext modelsContext = createBuildingContext( managedResources, serviceRegistry );
+
+		// entity uses access="FIELD", so @Transient is applied to the field
+		final ClassDetails entityDetails = modelsContext.getClassDetailsRegistry()
+				.getClassDetails( EntityWithEmbeddable.class.getName() );
+
+		final FieldDetails nameField = entityDetails.findFieldByName( "name" );
+		assertThat( nameField.getDirectAnnotationUsage( Transient.class ) ).isNull();
+
+		final FieldDetails displayLabelField = entityDetails.findFieldByName( "displayLabel" );
+		assertThat( displayLabelField.getDirectAnnotationUsage( Transient.class ) ).isNotNull();
+
+		// embeddable uses access="PROPERTY", so @Transient is applied to getters
+		final ClassDetails embeddableDetails = modelsContext.getClassDetailsRegistry()
+				.getClassDetails( EmbeddableWithTransient.class.getName() );
+
+		final MemberDetails streetGetter = findGetter( embeddableDetails, "getStreet" );
+		assertThat( streetGetter ).isNotNull();
+		assertThat( streetGetter.getDirectAnnotationUsage( Transient.class ) ).isNull();
+
+		final MemberDetails fullAddressGetter = findGetter( embeddableDetails, "getFullAddress" );
+		assertThat( fullAddressGetter ).isNotNull();
+		assertThat( fullAddressGetter.getDirectAnnotationUsage( Transient.class ) ).isNotNull();
+
+		final MemberDetails componentGetter = findGetter( embeddableDetails, "getComponent" );
+		assertThat( componentGetter ).isNotNull();
+		assertThat( componentGetter.getDirectAnnotationUsage( Transient.class ) ).isNotNull();
+	}
+
+	private static MemberDetails findGetter(ClassDetails classDetails, String getterName) {
+		for ( int i = 0; i < classDetails.getMethods().size(); i++ ) {
+			final MethodDetails method = classDetails.getMethods().get( i );
+			if ( method.getName().equals( getterName ) ) {
+				return method;
+			}
+		}
+		return null;
+	}
+
+	@ServiceRegistry
+	@DomainModel(xmlMappings = MAPPING_XML)
+	@Test
+	void testMappingModel(DomainModelScope domainModelScope) {
+		domainModelScope.withHierarchy( EntityWithEmbeddable.class, (rootClass) -> {
+			// entity: displayLabel is transient, name is persistent
+			assertThat( rootClass.getProperties().stream().map( Property::getName ) )
+					.contains( "name", "address" );
+
+			// embeddable: fullAddress and component are transient
+			final Property addressProperty = rootClass.getProperty( "address" );
+			final Component comp = (Component) addressProperty.getValue();
+
+			assertThat( comp.getProperty( "street" ) ).isNotNull();
+			assertThat( comp.getProperty( "city" ) ).isNotNull();
+
+			assertThat( comp.getProperties().stream().map( Property::getName ) )
+					.containsExactlyInAnyOrder( "street", "city" );
+		} );
+	}
+
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/transientattr/EmbeddableWithTransient.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/transientattr/EmbeddableWithTransient.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.attr.transientattr;
+
+public class EmbeddableWithTransient {
+	private String street;
+	private String city;
+	private String fullAddress;
+	private EmbeddableWithTransient component;
+
+	public String getStreet() {
+		return street;
+	}
+
+	public void setStreet(String street) {
+		this.street = street;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public void setCity(String city) {
+		this.city = city;
+	}
+
+	public String getFullAddress() {
+		return fullAddress;
+	}
+
+	public void setFullAddress(String fullAddress) {
+		this.fullAddress = fullAddress;
+	}
+
+	public EmbeddableWithTransient getComponent() {
+		return component;
+	}
+
+	public void setComponent(EmbeddableWithTransient component) {
+		this.component = component;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/transientattr/EntityWithEmbeddable.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/transientattr/EntityWithEmbeddable.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.attr.transientattr;
+
+public class EntityWithEmbeddable {
+	private Integer id;
+	private String name;
+	private String displayLabel;
+	private EmbeddableWithTransient address;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDisplayLabel() {
+		return displayLabel;
+	}
+
+	public void setDisplayLabel(String displayLabel) {
+		this.displayLabel = displayLabel;
+	}
+
+	public EmbeddableWithTransient getAddress() {
+		return address;
+	}
+
+	public void setAddress(EmbeddableWithTransient address) {
+		this.address = address;
+	}
+}

--- a/hibernate-core/src/test/resources/mappings/models/attr/transientattr/mapping.xml
+++ b/hibernate-core/src/test/resources/mappings/models/attr/transientattr/mapping.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 version="7.0">
+    <package>org.hibernate.orm.test.boot.models.xml.attr.transientattr</package>
+
+    <entity class="EntityWithEmbeddable" metadata-complete="true" access="FIELD">
+        <attributes>
+            <id name="id"/>
+            <basic name="name"/>
+            <embedded name="address"/>
+            <transient name="displayLabel"/>
+        </attributes>
+    </entity>
+
+    <embeddable class="EmbeddableWithTransient" metadata-complete="true" access="PROPERTY">
+        <attributes>
+            <basic name="street"/>
+            <basic name="city"/>
+            <transient name="fullAddress"/>
+            <transient name="component"/>
+        </attributes>
+    </embeddable>
+</entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20537

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20537 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->