### PR TITLE
Explain why we restored OptionalTableUpdateOperation constructor

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
@@ -71,6 +71,7 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 
 	private final List<JdbcValueDescriptor> jdbcValueDescriptors;
 
+	// Used by Hibernate Reactive
 	@Deprecated(forRemoval = true)
 	public OptionalTableUpdateOperation(
 			MutationTarget mutationTarget,


### PR DESCRIPTION
Follows up on https://github.com/hibernate/hibernate-orm/pull/12659
