### PR TITLE
HHH-20340 Prevent unnecessary DDL execution when there are no actions to perform

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
@@ -778,12 +778,25 @@ public class SchemaManagementToolCoordinator {
 
 		public static Set<ActionGrouping> interpret(Metadata metadata, Map<?, ?> configuration) {
 			Set<String> contributors = metadata.getContributors();
-			if ( contributors.isEmpty() ) {
-				// even with no contributors (e.g. no entities), schema actions
-				// such as import.sql execution should still be processed
-				contributors = Set.of( "orm" );
+			if ( !contributors.isEmpty() ) {
+				return interpret( contributors, configuration );
 			}
-			return interpret( contributors, configuration );
+
+			final Action rootDatabaseAction =
+					determineJpaDbActionSetting( configuration, null, null );
+			final Action rootScriptAction =
+					determineJpaScriptActionSetting( configuration, null, null );
+			final Action rootAutoAction =
+					determineAutoSettingImpliedAction( configuration, null, null );
+
+			if ( rootDatabaseAction == null && rootScriptAction == null && rootAutoAction == null ) {
+				// no entities and no schema actions configured, skip DDL pipeline
+				return Set.of();
+			}
+
+			// even with no contributors (e.g. no entities), configured schema actions
+			// such as import.sql execution should still be processed
+			return interpret( Set.of( "orm" ), configuration );
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/NoEntitiesNoScriptsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/NoEntitiesNoScriptsTest.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.tool.schema;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.hibernate.tool.schema.SourceType;
+import org.hibernate.tool.schema.TargetType;
+import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
+import org.hibernate.tool.schema.spi.CommandAcceptanceException;
+import org.hibernate.tool.schema.spi.ContributableMatcher;
+import org.hibernate.tool.schema.spi.ExceptionHandler;
+import org.hibernate.tool.schema.spi.ExecutionOptions;
+import org.hibernate.tool.schema.spi.ScriptSourceInput;
+import org.hibernate.tool.schema.spi.ScriptTargetOutput;
+import org.hibernate.tool.schema.spi.SourceDescriptor;
+import org.hibernate.tool.schema.spi.TargetDescriptor;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Jira("https://hibernate.atlassian.net/browse/HHH-20340")
+public class NoEntitiesNoScriptsTest {
+
+	@Test
+	public void noEntitiesNoScriptsShouldSkipDDL() {
+		try ( StandardServiceRegistry serviceRegistry = ServiceRegistryUtil.serviceRegistryBuilder().build() ) {
+			TargetDescriptorImpl targetDescriptor = new TargetDescriptorImpl();
+
+			createSchema( serviceRegistry, targetDescriptor, Map.of() );
+
+			TestScriptTargetOutput targetOutput = (TestScriptTargetOutput) targetDescriptor.getScriptTargetOutput();
+
+			assertThat( targetOutput.getCommands().size() ).isEqualTo( 0 );
+		}
+	}
+
+
+	@Test
+	public void noEntitiesEmptyImportFilesShouldSkipDDL() {
+		try ( StandardServiceRegistry serviceRegistry = ServiceRegistryUtil.serviceRegistryBuilder().build() ) {
+			TargetDescriptorImpl targetDescriptor = new TargetDescriptorImpl();
+
+			Map<String, Object> options = new HashMap<>();
+			options.put( AvailableSettings.HBM2DDL_IMPORT_FILES, "   " );
+			createSchema( serviceRegistry, targetDescriptor, options );
+
+			TestScriptTargetOutput targetOutput = (TestScriptTargetOutput) targetDescriptor.getScriptTargetOutput();
+
+			assertThat( targetOutput.getInsertCommands().size() ).isEqualTo( 0 );
+		}
+	}
+
+	private void createSchema(StandardServiceRegistry serviceRegistry, TargetDescriptorImpl targetDescriptor, Map<String, Object> options) {
+		final Metadata mappings = buildMappings( serviceRegistry );
+
+		assertThat( mappings.getEntityBindings().isEmpty() ).isTrue();
+		assertThat( mappings.getContributors().isEmpty() ).isTrue();
+
+		final SchemaCreatorImpl schemaCreator = new SchemaCreatorImpl( serviceRegistry );
+
+		schemaCreator.doCreation(
+				mappings,
+				new ExecutionOptionsTestImpl( options ),
+				ContributableMatcher.ALL,
+				SourceDescriptorImpl.INSTANCE,
+				targetDescriptor
+		);
+	}
+
+
+	private Metadata buildMappings(StandardServiceRegistry registry) {
+		return new MetadataSources( registry ).buildMetadata();
+	}
+
+	public class ExecutionOptionsTestImpl implements ExecutionOptions, ExceptionHandler {
+		Map<String, Object> configValues;
+
+		public ExecutionOptionsTestImpl(Map<String, Object> configValues) {
+			this.configValues = configValues;
+		}
+
+		@Override
+		public Map<String, Object> getConfigurationValues() {
+			return configValues;
+		}
+
+		@Override
+		public boolean shouldManageNamespaces() {
+			return true;
+		}
+
+		@Override
+		public ExceptionHandler getExceptionHandler() {
+			return this;
+		}
+
+		@Override
+		public void handleException(CommandAcceptanceException exception) {
+			throw exception;
+		}
+	}
+
+	private static class SourceDescriptorImpl implements SourceDescriptor {
+		public static final SourceDescriptorImpl INSTANCE = new SourceDescriptorImpl();
+
+		@Override
+		public SourceType getSourceType() {
+			return SourceType.METADATA;
+		}
+
+		@Override
+		public ScriptSourceInput getScriptSourceInput() {
+			return null;
+		}
+	}
+
+	private static class TargetDescriptorImpl implements TargetDescriptor {
+		private final TestScriptTargetOutput targetOutput = new TestScriptTargetOutput();
+
+		@Override
+		public EnumSet<TargetType> getTargetTypes() {
+			return EnumSet.of( TargetType.SCRIPT );
+		}
+
+		@Override
+		public TestScriptTargetOutput getScriptTargetOutput() {
+			return targetOutput;
+		}
+	}
+
+	private static class TestScriptTargetOutput implements ScriptTargetOutput {
+		private final List<String> commands = new ArrayList<>();
+		private final List<String> insertCommands = new ArrayList<>();
+
+		@Override
+		public void prepare() {
+		}
+
+		@Override
+		public void accept(String command) {
+			commands.add( command );
+			if ( command.toLowerCase().startsWith( "insert" ) ) {
+				insertCommands.add( command );
+			}
+		}
+
+		@Override
+		public void release() {
+		}
+
+		public List<String> getCommands() {
+			return commands;
+		}
+
+		public List<String> getInsertCommands() {
+			return insertCommands;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[This change skips such unnecessary DDL execution when it is known that there are no entities and no import.sql to process. This reduces redundant database interactions.]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20340 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20340
<!-- Hibernate GitHub Bot issue links end -->