### PR TITLE
HHH-4451 Serialize lazy attribute interceptor state for enhanced entities

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
@@ -4,6 +4,9 @@
  */
 package org.hibernate.bytecode.enhance.spi.interceptor;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -12,6 +15,7 @@ import org.hibernate.LockMode;
 import org.hibernate.bytecode.enhance.spi.CollectionTracker;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.EntityHolder;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
 
@@ -206,6 +210,33 @@ public class LazyAttributeLoadingInterceptor
 		initializedLazyFields = null;
 	}
 
+	public void serialize(ObjectOutputStream oos) throws IOException {
+		entityMeta.serialize( oos );
+		if ( initializedLazyFields == null ) {
+			oos.writeInt( -1 );
+		}
+		else {
+			oos.writeInt( initializedLazyFields.size() );
+			for ( String field : initializedLazyFields ) {
+				oos.writeUTF( field );
+			}
+		}
+	}
+
+	public static LazyAttributeLoadingInterceptor deserialize(
+			ObjectInputStream ois,
+			EntityHolder holder,
+			SharedSessionContractImplementor session) throws IOException {
+		final EntityRelatedState entityMeta = EntityRelatedState.deserialize( ois, holder );
+		final var interceptor = new LazyAttributeLoadingInterceptor(
+				entityMeta, holder.getEntityKey().getIdentifier(), session );
+		final int size = ois.readInt();
+		for ( int i = 0; i < size; i++ ) {
+			interceptor.attributeInitialized( ois.readUTF() );
+		}
+		return interceptor;
+	}
+
 	/**
 	 * This is an helper object to group all state which relates to a particular entity type,
 	 * and which is needed for this interceptor.
@@ -230,6 +261,37 @@ public class LazyAttributeLoadingInterceptor
 		}
 		private EntityRelatedState toNonSharedMutableState() {
 			return new EntityRelatedState( entityName, new HashSet<>( lazyFields ), false );
+		}
+
+		private void serialize(ObjectOutputStream oos) throws IOException {
+			if ( shared ) {
+				oos.writeInt( -1 );
+			}
+			else {
+				oos.writeInt( lazyFields.size() );
+				for ( String field : lazyFields ) {
+					oos.writeUTF( field );
+				}
+			}
+		}
+
+		private static EntityRelatedState deserialize(ObjectInputStream ois, EntityHolder holder) throws IOException {
+			final var persister = holder.getDescriptor();
+			final String entityName = persister.getEntityName();
+			final int size = ois.readInt();
+			if ( size == -1 ) {
+				return new EntityRelatedState(
+						entityName,
+						persister.getBytecodeEnhancementMetadata()
+								.getLazyAttributesMetadata().getLazyAttributeNames() );
+			}
+			else {
+				final Set<String> lazyFields = new HashSet<>( size );
+				for ( int i = 0; i < size; i++ ) {
+					lazyFields.add( ois.readUTF() );
+				}
+				return new EntityRelatedState( entityName, lazyFields, false );
+			}
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -32,6 +32,7 @@ import org.hibernate.NonUniqueObjectException;
 import org.hibernate.UnmanagedObjectException;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
+import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.AssociationKey;
 import org.hibernate.engine.spi.BatchFetchQueue;
@@ -1830,6 +1831,7 @@ class StatefulPersistenceContext implements PersistenceContext {
 			stream.writeObject( holder.entity );
 			stream.writeObject( holder.proxy );
 			stream.writeObject( holder.state );
+			writeLazyAttributeInterceptorState( holder, stream );
 		} );
 		writeMapToStream(
 				collectionsByKey,
@@ -1893,6 +1895,24 @@ class StatefulPersistenceContext implements PersistenceContext {
 			PERSISTENCE_CONTEXT_LOGGER.startingSerializationOfEntries( size, keysName );
 			for ( E entry : collection ) {
 				serializer.serialize( entry, oos );
+			}
+		}
+	}
+
+	private static void writeLazyAttributeInterceptorState(EntityHolderImpl holder, ObjectOutputStream stream)
+			throws IOException {
+		final var enhancementMetadata = holder.descriptor.getBytecodeEnhancementMetadata();
+		if ( enhancementMetadata.isEnhancedForLazyLoading() ) {
+			if ( holder.state != EntityHolderState.ENHANCED_PROXY ) {
+				if ( isPersistentAttributeInterceptable( holder.entity )
+						&& asPersistentAttributeInterceptable( holder.entity ).$$_hibernate_getInterceptor()
+								instanceof LazyAttributeLoadingInterceptor interceptor ) {
+					stream.writeBoolean( true );
+					interceptor.serialize( stream );
+				}
+				else {
+					stream.writeBoolean( false );
+				}
 			}
 		}
 	}
@@ -1977,6 +1997,28 @@ class StatefulPersistenceContext implements PersistenceContext {
 							// otherwise, the proxy was pruned during the serialization process
 							if ( traceEnabled ) {
 								PERSISTENCE_CONTEXT_LOGGER.encounteredPrunedProxy();
+							}
+						}
+					}
+					final var enhancementMetadata = persister.getBytecodeEnhancementMetadata();
+					if ( enhancementMetadata.isEnhancedForLazyLoading() ) {
+						if ( state == EntityHolderState.ENHANCED_PROXY ) {
+							if ( isPersistentAttributeInterceptable( entity ) ) {
+								enhancementMetadata.injectEnhancedEntityAsProxyInterceptor( entity, entityKey,
+										session );
+							}
+						}
+						else {
+							final var interceptor = ois.readBoolean()
+									? LazyAttributeLoadingInterceptor.deserialize( ois, holder, session )
+									: null;
+							if ( isPersistentAttributeInterceptable( entity ) ) {
+								if ( interceptor != null ) {
+									enhancementMetadata.injectInterceptor( entity, interceptor, session );
+								}
+								else {
+									enhancementMetadata.injectInterceptor( entity, entityKey.getIdentifier(), session );
+								}
 							}
 						}
 					}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/serialization/EnhancedEntityProxySerializationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/serialization/EnhancedEntityProxySerializationTest.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.serialization;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@BytecodeEnhanced
+@EnhancementOptions(lazyLoading = true, inlineDirtyChecking = true)
+@DomainModel(annotatedClasses = {
+		EnhancedEntityProxySerializationTest.SimpleEntity.class, EnhancedEntityProxySerializationTest.ChildEntity.class
+})
+@SessionFactory
+@JiraKey("HHH-4451")
+public class EnhancedEntityProxySerializationTest {
+
+	@BeforeEach
+	public void setup(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			// idempotent across tests: data is committed once and only read afterwards
+			final Number count = (Number) session.createQuery( "SELECT count(id) FROM SimpleEntity" ).getSingleResult();
+			if ( count.longValue() > 0L ) {
+				return;
+			}
+			final SimpleEntity entity = new SimpleEntity();
+			entity.setId( 1L );
+			entity.setName( "TheParent" );
+
+			final ChildEntity c1 = new ChildEntity();
+			c1.setId( 1L );
+			c1.setParent( entity );
+			c1.setDescription( "ChildOne" );
+
+			final ChildEntity c2 = new ChildEntity();
+			c2.setId( 2L );
+			c2.setParent( entity );
+
+			session.persist( entity );
+			session.persist( c1 );
+			session.persist( c2 );
+		} );
+	}
+
+	@Test
+	public void testDeserialization(SessionFactoryScope scope) {
+		byte[] serialized = scope.fromSession( session -> {
+			// Load entity and proxy into session
+			ChildEntity child = session.find( ChildEntity.class, 1L );
+			assertFalse( Hibernate.isInitialized( child.parent ) );
+
+			//fake the in container work
+			session.getJdbcCoordinator().getLogicalConnection().manualDisconnect();
+			return SerializationHelper.serialize( session );
+		} );
+
+		final SessionImplementor deserializedSession = (SessionImplementor) SerializationHelper.deserialize( serialized );
+		scope.inTransaction( deserializedSession, session -> {
+			final ChildEntity deserializedChild = session.find( ChildEntity.class, 1L );
+
+			// ENHANCED_PROXY branch: stub parent's interceptor reinjected
+			assertFalse( Hibernate.isInitialized( deserializedChild.parent ) );
+			assertEquals( "TheParent", deserializedChild.parent.getName() );
+
+			// INITIALIZED branch: child's lazy basic attribute interceptor reinjected
+			assertFalse( Hibernate.isPropertyInitialized( deserializedChild, "description" ) );
+			assertEquals( "ChildOne", deserializedChild.getDescription() );
+		} );
+	}
+
+	@Test
+	public void testInitializedLazyFieldsPreserved(SessionFactoryScope scope) {
+		final byte[] serialized = scope.fromSession( session -> {
+			final ChildEntity child = session.find( ChildEntity.class, 1L );
+			// Force-initialize the lazy @Basic attribute: the interceptor records "description"
+			// in its initializedLazyFields set.
+			child.getDescription();
+			assertTrue( Hibernate.isPropertyInitialized( child, "description" ) );
+
+			//fake the in container work
+			session.getJdbcCoordinator().getLogicalConnection().manualDisconnect();
+			return SerializationHelper.serialize( session );
+		} );
+
+		final SessionImplementor deserializedSession = (SessionImplementor) SerializationHelper.deserialize( serialized );
+		scope.inTransaction( deserializedSession, session -> {
+			final ChildEntity deserializedChild = session.find( ChildEntity.class, 1L );
+
+			assertTrue( Hibernate.isPropertyInitialized( deserializedChild, "description" ) );
+			assertEquals( "ChildOne", deserializedChild.getDescription() );
+		} );
+	}
+
+	@Entity(name = "SimpleEntity")
+	static class SimpleEntity implements Serializable {
+		private Long id;
+
+		private String name;
+
+		Set<ChildEntity> children = new HashSet<>();
+
+		@Id
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(final Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(final String name) {
+			this.name = name;
+		}
+
+		@OneToMany(targetEntity = ChildEntity.class, mappedBy = "parent")
+		@Fetch(FetchMode.SELECT)
+		public Set<ChildEntity> getChildren() {
+			return children;
+		}
+
+		public void setChildren(final Set<ChildEntity> children) {
+			this.children = children;
+		}
+	}
+
+	@Entity(name = "ChildEntity")
+	public static class ChildEntity implements Serializable {
+		private Long id;
+
+		private SimpleEntity parent;
+		private String description;
+
+		@Id
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(final Long id) {
+			this.id = id;
+		}
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn
+		public SimpleEntity getParent() {
+			return parent;
+		}
+		public void setParent(final SimpleEntity parent) {
+			this.parent = parent;
+		}
+
+		@Basic(fetch = FetchType.LAZY)
+		public String getDescription(){
+			return description;
+		}
+		public void setDescription(final String description){
+			this.description = description;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

## issue

The `entityMeta` and `initializedLazyFields` reachable only through the entity's
transient `attributeInterceptor` field are neither serialized nor deserialized,
so the lazy-loading state is lost.

## fix

### EntityRelatedState

Add a `serialize` helper.

For `shared=true`, write `-1` instead of serializing the fields — signaling they
are rebuilt from the persister on read.

For `shared=false`, write the size of `lazyFields` and then serialize them.

Add a `deserialize` helper doing the reverse.

During entity-meta deserialization, when it hits the `size = -1` sentinel it does
not deserialize the fields; it builds the entity meta from the persister's
information instead (the `shared=true` meta).

### LazyAttributeLoadingInterceptor.java

Add a `serialize` helper: serialize the entity meta first, then `initializedLazyFields`.

Add a `deserialize` helper doing the reverse.

### StatefulPersistenceContext.java

#### Serialization (writeLazyAttributeInterceptorState)

Write nothing when the entity is not enhanced for lazy loading, or is an `ENHANCED_PROXY`.

If the entity's current interceptor is a `LazyAttributeLoadingInterceptor`, write a
`true` flag and serialize the interceptor.

Otherwise, write a `false` flag; nothing else is serialized.

#### Deserialization

For `ENHANCED_PROXY`, inject the proxy interceptor.

Otherwise read the flag: if `true`, restore the interceptor via its `deserialize`
helper and inject it; if `false`, create and inject a new id-based interceptor.

---

https://hibernate.atlassian.net/browse/HHH-4451

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-4451 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->