### PR TITLE
HHH-20496 Treat blank string value for APPLY_VALIDATION_CONSTRAINTS as "property not set"

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/ValidationConstraintDdlInfluence.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/ValidationConstraintDdlInfluence.java
@@ -40,8 +40,9 @@ public enum ValidationConstraintDdlInfluence {
 	public static ValidationConstraintDdlInfluence resolve(ServiceRegistry serviceRegistry, Set<ValidationMode> validationModes) {
 		final var configurationService = serviceRegistry.requireService( ConfigurationService.class );
 		final var settings = configurationService.getSettings();
-		if ( settings.containsKey( SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS ) ) {
-			return resolveSettingValue( settings );
+		final var resolvedValue = resolveSettingValue( settings );
+		if ( resolvedValue != null ) {
+			return resolvedValue;
 		}
 		// legacy: treat deprecated ValidationMode.DDL as REQUIRED
 		for ( var mode : validationModes ) {
@@ -58,8 +59,8 @@ public enum ValidationConstraintDdlInfluence {
 
 	private static ValidationConstraintDdlInfluence resolveSettingValue(Map<String, Object> configurationValues) {
 		final Object setting = configurationValues.get( SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS );
-		if ( setting == null ) {
-			return AUTO;
+		if ( setting == null || (setting instanceof String str && str.isBlank()) ) {
+			return null;
 		}
 
 		if ( setting instanceof ValidationConstraintDdlInfluence type ) {

--- a/hibernate-core/src/test/java/org/hibernate/temporal/TemporalHistoryTableBeanValidationDDLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/temporal/TemporalHistoryTableBeanValidationDDLTest.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Temporal;
+import org.hibernate.cfg.SchemaToolingSettings;
 import org.hibernate.cfg.StateManagementSettings;
 import org.hibernate.cfg.ValidationSettings;
 import org.hibernate.mapping.Column;
@@ -35,7 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 })
 @ServiceRegistry(settings = {
 		@Setting(name = StateManagementSettings.TEMPORAL_TABLE_STRATEGY, value = "HISTORY_TABLE"),
-		@Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "DDL")
+		@Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "DDL"),
+		@Setting(name = SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS, value = "")
 })
 class TemporalHistoryTableBeanValidationDDLTest {
 	@BeforeAll

--- a/hibernate-core/src/test/java/org/hibernate/temporal/audit/AuditAuxiliaryTableBeanValidationDDLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/temporal/audit/AuditAuxiliaryTableBeanValidationDDLTest.java
@@ -16,6 +16,7 @@ import jakarta.validation.constraints.NotNull;
 
 import org.hibernate.SharedSessionContract;
 import org.hibernate.annotations.Audited;
+import org.hibernate.cfg.SchemaToolingSettings;
 import org.hibernate.cfg.StateManagementSettings;
 import org.hibernate.cfg.ValidationSettings;
 import org.hibernate.mapping.PersistentClass;
@@ -39,7 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ServiceRegistry(settings = {
 		@Setting(name = StateManagementSettings.CHANGESET_ID_SUPPLIER,
 				value = "org.hibernate.temporal.audit.AuditAuxiliaryTableBeanValidationDDLTest$TxIdSupplier"),
-		@Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "DDL")
+		@Setting(name = ValidationSettings.JAKARTA_VALIDATION_MODE, value = "DDL"),
+		@Setting(name = SchemaToolingSettings.APPLY_VALIDATION_CONSTRAINTS, value = "")
 })
 class AuditAuxiliaryTableBeanValidationDDLTest {
 	@Test


### PR DESCRIPTION
(and update a few more tests that were added after the original patch was committed but not yet merged)

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20496 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20496
<!-- Hibernate GitHub Bot issue links end -->