### PR TITLE
HHH-20551 Release JDBC resources after statement execution when no transaction is active / HHH-20552 Register LOB resources with the resource registry and release them when the connection is closed

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
@@ -40,6 +40,7 @@ import java.sql.Statement;
 import java.util.function.Supplier;
 
 import static org.hibernate.ConnectionReleaseMode.AFTER_STATEMENT;
+import static org.hibernate.ConnectionReleaseMode.AFTER_TRANSACTION;
 import static org.hibernate.engine.jdbc.JdbcLogging.JDBC_LOGGER;
 import static org.hibernate.engine.jdbc.batch.JdbcBatchLogging.BATCH_MESSAGE_LOGGER;
 
@@ -333,15 +334,21 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 			JDBC_LOGGER.statementExecutionComplete( connectionReleaseMode, hashCode() );
 		}
 		if ( connectionReleaseMode == AFTER_STATEMENT ) {
-			if ( ! releasesEnabled ) {
+			if ( !releasesEnabled ) {
 				JDBC_LOGGER.skippingAggressiveRelease( "manually disabled" );
 			}
 			else if ( hasRegisteredResources() ) {
 				JDBC_LOGGER.skippingAggressiveRelease( "registered resources" );
 			}
 			else {
-				getLogicalConnection().afterStatement();
+				getLogicalConnection().afterStatement( false );
 			}
+		}
+		else if ( connectionReleaseMode == AFTER_TRANSACTION
+				&& releasesEnabled
+				&& !hasRegisteredResources()
+				&& !owner.getTransactionCoordinator().isTransactionActive() ) {
+			getLogicalConnection().afterStatement( true );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
@@ -49,6 +49,10 @@ public abstract class AbstractLogicalConnectionImplementor implements LogicalCon
 	}
 
 	@Override
+	public void afterStatement(boolean treatAfterTransactionAsAfterStatement) {
+	}
+
+	@Override
 	public void beforeTransactionCompletion() {
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
@@ -21,6 +21,7 @@ import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 
 import static org.hibernate.ConnectionAcquisitionMode.IMMEDIATELY;
 import static org.hibernate.ConnectionReleaseMode.AFTER_STATEMENT;
+import static org.hibernate.ConnectionReleaseMode.AFTER_TRANSACTION;
 import static org.hibernate.ConnectionReleaseMode.BEFORE_TRANSACTION_COMPLETION;
 import static org.hibernate.ConnectionReleaseMode.ON_CLOSE;
 import static org.hibernate.resource.jdbc.internal.LogicalConnectionLogging.CONNECTION_LOGGER;
@@ -136,6 +137,26 @@ public class LogicalConnectionManagedImpl extends AbstractLogicalConnectionImple
 			else {
 				CONNECTION_LOGGER.initiatingConnectionReleaseAfterStatement( hashCode() );
 				releaseConnectionIfNeeded();
+			}
+		}
+	}
+
+	@Override
+	public void afterStatement(boolean treatAfterTransactionAsAfterStatement) {
+		if ( !treatAfterTransactionAsAfterStatement ) {
+			afterStatement();
+		}
+		else {
+			super.afterStatement(treatAfterTransactionAsAfterStatement);
+			final var releaseMode = connectionHandlingMode.getReleaseMode();
+			if ( releaseMode == AFTER_STATEMENT || releaseMode == AFTER_TRANSACTION  ) {
+				if ( getResourceRegistry().hasRegisteredResources() ) {
+					CONNECTION_LOGGER.skipConnectionReleaseAfterStatementDueToResources( hashCode() );
+				}
+				else {
+					CONNECTION_LOGGER.initiatingConnectionReleaseAfterStatement( hashCode() );
+					releaseConnectionIfNeeded();
+				}
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionProvidedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionProvidedImpl.java
@@ -46,6 +46,11 @@ public class LogicalConnectionProvidedImpl extends AbstractLogicalConnectionImpl
 	}
 
 	@Override
+	public void afterStatement() {
+
+	}
+
+	@Override
 	public boolean isOpen() {
 		return !closed;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/ResourceRegistryStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/ResourceRegistryStandardImpl.java
@@ -15,6 +15,9 @@ import java.util.ArrayList;
 import org.hibernate.JDBCException;
 import org.hibernate.resource.jdbc.ResourceRegistry;
 import org.hibernate.resource.jdbc.spi.JdbcEventHandler;
+import org.hibernate.type.descriptor.java.BlobJavaType;
+import org.hibernate.type.descriptor.java.ClobJavaType;
+import org.hibernate.type.descriptor.java.NClobJavaType;
 
 import static org.hibernate.resource.jdbc.internal.ResourceRegistryLogger.RESOURCE_REGISTRY_LOGGER;
 
@@ -381,13 +384,20 @@ public final class ResourceRegistryStandardImpl implements ResourceRegistry {
 		}
 
 		public void releaseResources() {
-			closeAll( unassociatedResultSets );
-			unassociatedResultSets.clear();
+			if ( unassociatedResultSets != null ) {
+				closeAll( unassociatedResultSets );
+				unassociatedResultSets.clear();
+			}
 
 			if ( blobs != null ) {
 				blobs.forEach( blob -> {
 					try {
-						blob.free();
+						if ( blob instanceof BlobJavaType.ReleasableBlob rb ) {
+							rb.doFree();
+						}
+						else {
+							blob.free();
+						}
 					}
 					catch (SQLException e) {
 						RESOURCE_REGISTRY_LOGGER.unableToFreeLob( Blob.class.getSimpleName(), e.getMessage() );
@@ -400,7 +410,12 @@ public final class ResourceRegistryStandardImpl implements ResourceRegistry {
 			if ( clobs != null ) {
 				clobs.forEach( clob -> {
 					try {
-						clob.free();
+						if ( clob instanceof ClobJavaType.ReleasableClob rb ) {
+							rb.doFree();
+						}
+						else {
+							clob.free();
+						}
 					}
 					catch (SQLException e) {
 						RESOURCE_REGISTRY_LOGGER.unableToFreeLob( Clob.class.getSimpleName(), e.getMessage() );
@@ -412,6 +427,12 @@ public final class ResourceRegistryStandardImpl implements ResourceRegistry {
 			if ( nclobs != null ) {
 				nclobs.forEach( nclob -> {
 					try {
+						if ( nclob instanceof NClobJavaType.ReleasableNClob rb ) {
+							rb.doFree();
+						}
+						else {
+							nclob.free();
+						}
 						nclob.free();
 					}
 					catch (SQLException e) {

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/ResourceRegistryStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/ResourceRegistryStandardImpl.java
@@ -433,7 +433,6 @@ public final class ResourceRegistryStandardImpl implements ResourceRegistry {
 						else {
 							nclob.free();
 						}
-						nclob.free();
 					}
 					catch (SQLException e) {
 						RESOURCE_REGISTRY_LOGGER.unableToFreeLob( NClob.class.getSimpleName(), e.getMessage() );

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/LogicalConnectionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/LogicalConnectionImplementor.java
@@ -35,6 +35,18 @@ public interface LogicalConnectionImplementor extends LogicalConnection {
 	void afterStatement();
 
 	/**
+	 * Notification indicating a JDBC statement has been executed, to trigger
+	 * {@link org.hibernate.ConnectionReleaseMode#AFTER_STATEMENT} releasing
+	 * if needed.
+	 * @param treatAfterTransactionAsAfterStatement whether to consider {@link org.hibernate.ConnectionReleaseMode#AFTER_TRANSACTION}
+	 * as {@link org.hibernate.ConnectionReleaseMode#AFTER_STATEMENT}, useful when you have the after transaction release mode,
+	 * but no actual transactions and still want to release the resources.
+	 */
+	default void afterStatement(boolean treatAfterTransactionAsAfterStatement) {
+		afterStatement();
+	};
+
+	/**
 	 * Notification indicating a transaction is about to be completed, to
 	 * trigger release of the JDBC connection if needed, that is, if
 	 * {@link org.hibernate.ConnectionReleaseMode#BEFORE_TRANSACTION_COMPLETION}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/WrapperOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/WrapperOptions.java
@@ -4,10 +4,12 @@
  */
 package org.hibernate.type.descriptor;
 
+import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.resource.jdbc.ResourceRegistry;
 import org.hibernate.type.format.FormatMapper;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -135,4 +137,16 @@ public interface WrapperOptions {
 	 * @since 7.0
 	 */
 	FormatMapper getJsonFormatMapper();
+
+	/**
+	 * Obtain the resource registry.
+	 *
+	 * @since 8.0
+	 */
+	@Incubating
+	default ResourceRegistry getResourceRegistry() {
+		return getSession().getJdbcCoordinator()
+				.getLogicalConnection()
+				.getResourceRegistry();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BlobJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BlobJavaType.java
@@ -6,6 +6,7 @@ package org.hibernate.type.descriptor.java;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.sql.Blob;
 import java.sql.SQLException;
@@ -16,9 +17,9 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.BlobImplementer;
 import org.hibernate.engine.jdbc.proxy.BlobProxy;
-import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.internal.StreamBackedBinaryStream;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.resource.jdbc.ResourceRegistry;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
@@ -170,30 +171,108 @@ public class BlobJavaType extends AbstractClassJavaType<Blob> {
 			return null;
 		}
 		else {
-			final LobCreator lobCreator = options.getLobCreator();
-			if ( value instanceof Blob blob ) {
-				return lobCreator.wrap( blob );
+			final var result = createLob( value, options );
+			if ( options.getDialect().supportsUnboundedLobLocatorMaterialization() ) {
+				return result;
 			}
-			else if ( value instanceof byte[] bytes ) {
-				return lobCreator.createBlob( bytes );
-			}
-			else if ( value instanceof BinaryStream binaryStream) {
-				return binaryStream.asBlob( lobCreator );
-			}
-			else if ( value instanceof InputStream inputStream ) {
-				// A JDBC Blob object needs to know its length, but
-				// there's no way to get an accurate length from an
-				// InputStream without reading the whole stream
-				return lobCreator.createBlob( extractBytes( inputStream ) );
-			}
-			else {
-				throw unknownWrap( value.getClass() );
-			}
+			final var resourceRegistry = options.getResourceRegistry();
+			final var releasableBlob = new ReleasableBlob( resourceRegistry, result );
+			resourceRegistry.register( releasableBlob );
+			return releasableBlob;
+		}
+	}
+
+	private <X> Blob createLob(X value, WrapperOptions options) {
+		final var lobCreator = options.getLobCreator();
+		if ( value instanceof Blob blob ) {
+			return lobCreator.wrap( blob );
+		}
+		else if ( value instanceof byte[] bytes ) {
+			return lobCreator.createBlob( bytes );
+		}
+		else if ( value instanceof BinaryStream binaryStream ) {
+			return binaryStream.asBlob( lobCreator );
+		}
+		else if ( value instanceof InputStream inputStream ) {
+			// A JDBC Blob object needs to know its length, but
+			// there's no way to get an accurate length from an
+			// InputStream without reading the whole stream
+			return lobCreator.createBlob( extractBytes( inputStream ) );
+		}
+		else {
+			throw unknownWrap( value.getClass() );
 		}
 	}
 
 	@Override
 	public long getDefaultSqlLength(Dialect dialect, JdbcType jdbcType) {
 		return dialect.getDefaultLobLength();
+	}
+
+	public record ReleasableBlob(ResourceRegistry resourceRegistry, Blob blob) implements Blob {
+
+		@Override
+		public InputStream getBinaryStream() throws SQLException {
+			return blob.getBinaryStream();
+		}
+
+		@Override
+		public byte[] getBytes(long pos, int length) throws SQLException {
+			return blob.getBytes( pos, length );
+		}
+
+		@Override
+		public InputStream getBinaryStream(long pos, long length) throws SQLException {
+			return blob.getBinaryStream( pos, length );
+		}
+
+		@Override
+		public long length() throws SQLException {
+			return blob.length();
+		}
+
+		@Override
+		public long position(byte[] pattern, long start) throws SQLException {
+			return blob.position( pattern, start );
+		}
+
+		@Override
+		public long position(Blob pattern, long start) throws SQLException {
+			return blob.position( pattern, start );
+		}
+
+		@Override
+		public int setBytes(long pos, byte[] bytes) throws SQLException {
+			return blob.setBytes( pos, bytes );
+		}
+
+		@Override
+		public int setBytes(long pos, byte[] bytes, int offset, int len) throws SQLException {
+			return blob.setBytes( pos, bytes, offset, len );
+		}
+
+		@Override
+		public OutputStream setBinaryStream(long pos) throws SQLException {
+			return blob.setBinaryStream( pos );
+		}
+
+		@Override
+		public void truncate(long len) throws SQLException {
+			blob.truncate( len );
+		}
+
+		@Override
+		public void free() throws SQLException {
+			try {
+				doFree();
+			}
+			finally {
+				resourceRegistry.release( this );
+			}
+		}
+
+		public void doFree() throws SQLException {
+			blob.free();
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobJavaType.java
@@ -4,8 +4,11 @@
  */
 package org.hibernate.type.descriptor.java;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Serializable;
+import java.io.Writer;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -16,8 +19,8 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.engine.jdbc.ClobImplementer;
 import org.hibernate.engine.jdbc.proxy.ClobProxy;
-import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.resource.jdbc.ResourceRegistry;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -138,22 +141,35 @@ public class ClobJavaType extends AbstractClassJavaType<Clob> {
 			return null;
 		}
 		else {
-			final LobCreator lobCreator = options.getLobCreator();
-			if ( value instanceof Clob clob ) {
-				return lobCreator.wrap( clob );
+			final var result = createLob( value, options );
+
+			if ( options.getDialect().supportsUnboundedLobLocatorMaterialization() ) {
+				return result;
 			}
-			else if ( value instanceof String string ) {
-				return lobCreator.createClob( string );
-			}
-			else if ( value instanceof Reader reader ) {
-				return lobCreator.createClob( extractString( reader ) );
-			}
-			else if ( value instanceof CharacterStream stream ) {
-				return lobCreator.createClob( stream.asReader(), stream.getLength() );
-			}
-			else {
-				throw unknownWrap( value.getClass() );
-			}
+			final var resourceRegistry = options.getResourceRegistry();
+			final var releasableClob = new ReleasableClob( resourceRegistry, result );
+			resourceRegistry.register( releasableClob );
+			return releasableClob;
+		}
+	}
+
+	private <X> Clob createLob(X value, WrapperOptions options) {
+		final var lobCreator = options.getLobCreator();
+
+		if ( value instanceof Clob clob ) {
+			return lobCreator.wrap( clob );
+		}
+		else if ( value instanceof String string ) {
+			return lobCreator.createClob( string );
+		}
+		else if ( value instanceof Reader reader ) {
+			return lobCreator.createClob( extractString( reader ) );
+		}
+		else if ( value instanceof CharacterStream stream ) {
+			return lobCreator.createClob( stream.asReader(), stream.getLength() );
+		}
+		else {
+			throw unknownWrap( value.getClass() );
 		}
 	}
 
@@ -182,6 +198,82 @@ public class ClobJavaType extends AbstractClassJavaType<Clob> {
 
 		public Clob assemble(Serializable cached, SharedSessionContract session) {
 			throw new UnsupportedOperationException( "Clobs are not cacheable" );
+		}
+	}
+
+	public record ReleasableClob(ResourceRegistry resourceRegistry, Clob clob) implements Clob {
+		@Override
+		public long length() throws SQLException {
+			return clob.length();
+		}
+
+		@Override
+		public String getSubString(long pos, int length) throws SQLException {
+			return clob.getSubString( pos, length );
+		}
+
+		@Override
+		public Reader getCharacterStream() throws SQLException {
+			return clob.getCharacterStream();
+		}
+
+		@Override
+		public InputStream getAsciiStream() throws SQLException {
+			return clob.getAsciiStream();
+		}
+
+		@Override
+		public long position(String searchstr, long start) throws SQLException {
+			return clob.position( searchstr, start );
+		}
+
+		@Override
+		public long position(Clob searchstr, long start) throws SQLException {
+			return clob.position( searchstr, start );
+		}
+
+		@Override
+		public int setString(long pos, String str) throws SQLException {
+			return clob.setString( pos, str );
+		}
+
+		@Override
+		public int setString(long pos, String str, int offset, int len) throws SQLException {
+			return clob.setString( pos, str, offset, len );
+		}
+
+		@Override
+		public OutputStream setAsciiStream(long pos) throws SQLException {
+			return clob.setAsciiStream( pos );
+		}
+
+		@Override
+		public Writer setCharacterStream(long pos) throws SQLException {
+			return clob.setCharacterStream( pos );
+		}
+
+		@Override
+		public void truncate(long len) throws SQLException {
+			clob.truncate( len );
+		}
+
+		@Override
+		public void free() throws SQLException {
+			try {
+				doFree();
+			}
+			finally {
+				resourceRegistry.release( this );
+			}
+		}
+
+		public void doFree() throws SQLException {
+			clob.free();
+		}
+
+		@Override
+		public Reader getCharacterStream(long pos, long length) throws SQLException {
+			return clob.getCharacterStream( pos, length );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/NClobJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/NClobJavaType.java
@@ -4,18 +4,22 @@
  */
 package org.hibernate.type.descriptor.java;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Serializable;
+import java.io.Writer;
+import java.sql.Clob;
 import java.sql.NClob;
 import java.sql.SQLException;
 
 import org.hibernate.HibernateException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.CharacterStream;
-import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.NClobImplementer;
 import org.hibernate.engine.jdbc.proxy.NClobProxy;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.resource.jdbc.ResourceRegistry;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 import static org.hibernate.type.descriptor.java.DataHelper.extractString;
@@ -147,22 +151,110 @@ public class NClobJavaType extends AbstractClassJavaType<NClob> {
 			return null;
 		}
 		else {
-			final LobCreator lobCreator = options.getLobCreator();
-			if ( value instanceof NClob clob ) {
-				return lobCreator.wrap( clob );
+			final var result = createLob( value, options );
+			if ( options.getDialect().supportsUnboundedLobLocatorMaterialization() ) {
+				return result;
 			}
-			else if ( value instanceof String string ) {
-				return lobCreator.createNClob( string );
+			final var resourceRegistry = options.getResourceRegistry();
+			final var releasableNClob = new ReleasableNClob( resourceRegistry, result );
+			resourceRegistry.register( releasableNClob );
+			return releasableNClob;
+		}
+	}
+
+	private <X> NClob createLob(X value, WrapperOptions options) {
+		final var lobCreator = options.getLobCreator();
+		if ( value instanceof NClob clob ) {
+			return lobCreator.wrap( clob );
+		}
+		else if ( value instanceof String string ) {
+			return lobCreator.createNClob( string );
+		}
+		else if ( value instanceof Reader reader ) {
+			return lobCreator.createNClob( extractString( reader ) );
+		}
+		else if ( value instanceof CharacterStream stream ) {
+			return lobCreator.createNClob( stream.asReader(), stream.getLength() );
+		}
+		else {
+			throw unknownWrap( value.getClass() );
+		}
+	}
+
+	public record ReleasableNClob(ResourceRegistry resourceRegistry, NClob nClob) implements NClob {
+
+		@Override
+		public long length() throws SQLException {
+			return nClob.length();
+		}
+
+		@Override
+		public String getSubString(long pos, int length) throws SQLException {
+			return nClob.getSubString( pos, length );
+		}
+
+		@Override
+		public Reader getCharacterStream() throws SQLException {
+			return nClob.getCharacterStream();
+		}
+
+		@Override
+		public InputStream getAsciiStream() throws SQLException {
+			return nClob.getAsciiStream();
+		}
+
+		@Override
+		public long position(String searchstr, long start) throws SQLException {
+			return nClob.position( searchstr, start );
+		}
+
+		@Override
+		public long position(Clob searchstr, long start) throws SQLException {
+			return nClob.position( searchstr, start );
+		}
+
+		@Override
+		public int setString(long pos, String str) throws SQLException {
+			return nClob.setString( pos, str );
+		}
+
+		@Override
+		public int setString(long pos, String str, int offset, int len) throws SQLException {
+			return nClob.setString( pos, str, offset, len );
+		}
+
+		@Override
+		public OutputStream setAsciiStream(long pos) throws SQLException {
+			return nClob.setAsciiStream( pos );
+		}
+
+		@Override
+		public Writer setCharacterStream(long pos) throws SQLException {
+			return nClob.setCharacterStream( pos );
+		}
+
+		@Override
+		public void truncate(long len) throws SQLException {
+			nClob.truncate( len );
+		}
+
+		@Override
+		public void free() throws SQLException {
+			try {
+				doFree();
 			}
-			else if ( value instanceof Reader reader ) {
-				return lobCreator.createNClob( extractString( reader ) );
+			finally {
+				resourceRegistry.release( this );
 			}
-			else if ( value instanceof CharacterStream stream ) {
-				return lobCreator.createNClob( stream.asReader(), stream.getLength() );
-			}
-			else {
-				throw unknownWrap( value.getClass() );
-			}
+		}
+
+		public void doFree() throws SQLException {
+			nClob.free();
+		}
+
+		@Override
+		public Reader getCharacterStream(long pos, long length) throws SQLException {
+			return nClob.getCharacterStream( pos, length );
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/java/AbstractDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/java/AbstractDescriptorTest.java
@@ -9,6 +9,8 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.env.internal.NonContextualLobCreator;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.resource.jdbc.ResourceRegistry;
+import org.hibernate.resource.jdbc.internal.ResourceRegistryStandardImpl;
 import org.hibernate.testing.orm.junit.BaseUnitTest;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -107,6 +109,11 @@ public abstract class AbstractDescriptorTest<T> {
 		@Override
 		public FormatMapper getJsonFormatMapper() {
 			return null;
+		}
+
+		@Override
+		public ResourceRegistry getResourceRegistry() {
+			return new ResourceRegistryStandardImpl();
 		}
 	};
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stream/basic/StreamConnectionReleaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stream/basic/StreamConnectionReleaseTest.java
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.stream.basic;
+
+import java.sql.Blob;
+import java.sql.SQLException;
+import java.util.stream.Stream;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.type.descriptor.java.BlobJavaType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@DomainModel(
+		annotatedClasses = {StreamConnectionReleaseTest.MyEntity.class, StreamConnectionReleaseTest.MyBlobEntity.class})
+@SessionFactory
+@ServiceRegistry(settings = {
+		// We want to make sure that the release mode is set to "after transaction"
+		// but at the same time we are running things without an actual transaction.
+		// Resources should be still released in this case ...
+		@Setting(name = AvailableSettings.CONNECTION_HANDLING,
+				value = "DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION")
+})
+public class StreamConnectionReleaseTest {
+
+	@BeforeEach
+	void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			for ( int i = 0; i < 5; i++ ) {
+				MyEntity e = new MyEntity();
+				e.id = i;
+				e.name = "Entity #" + i;
+				session.persist( e );
+
+				MyBlobEntity eb = new MyBlobEntity();
+				eb.id = i;
+				eb.name = "Entity #" + i;
+				eb.blob = BlobJavaType.INSTANCE.fromEncodedString( "aaaaaaaaaaaaaaaaaa" );
+				session.persist( eb );
+			}
+		} );
+	}
+
+	@AfterEach
+	void dropTestData(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	void testConnectionReleasedAfterStreamCloseOutsideTransaction(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should not be acquired before the query" )
+					.isFalse();
+
+			try (Stream<MyEntity> stream = session.createQuery( "from MyEntity", MyEntity.class ).getResultStream()) {
+				stream.forEach( e -> assertThat( e.name ).isNotNull() );
+			}
+
+			assertThat(
+					session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().hasRegisteredResources() )
+					.as( "resources should be released after stream close" )
+					.isFalse();
+
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should be released after stream close outside a transaction" )
+					.isFalse();
+		} );
+	}
+
+	@Test
+	void testConnectionAndBlobsFreed(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should not be acquired before the query" )
+					.isFalse();
+
+			try (Stream<MyBlobEntity> stream = session.createQuery( "from MyBlobEntity", MyBlobEntity.class )
+					.getResultStream()) {
+				stream.forEach( e -> {
+					assertThat( e.name ).isNotNull();
+					try {
+						assertThat( e.blob.length() ).isPositive();
+						e.blob.free();
+					}
+					catch (SQLException ex) {
+						fail( ex );
+					}
+				} );
+			}
+
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().hasRegisteredResources() )
+					.as( "resources should be released after stream close" )
+					.isFalse();
+
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should be released after stream close outside a transaction" )
+					.isFalse();
+		} );
+	}
+
+	@Test
+	void testConnectionAndBlobsDontCallFreeInSessionExplicitly(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should not be acquired before the query" )
+					.isFalse();
+
+			try (Stream<MyBlobEntity> stream = session.createQuery( "from MyBlobEntity", MyBlobEntity.class )
+					.getResultStream()) {
+				stream.forEach( e -> {
+					assertThat( e.name ).isNotNull();
+					try {
+						assertThat( e.blob.length() ).isPositive();
+					}
+					catch (SQLException ex) {
+						fail( ex );
+					}
+				} );
+			}
+
+			if ( scope.getSessionFactory().getJdbcServices()
+					.getDialect().supportsUnboundedLobLocatorMaterialization() ) {
+				// LOBs are not registered with the resource registry when the dialect
+				// supports unbounded LOB locator materialization
+				assertThat( session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().hasRegisteredResources() )
+						.as( "no LOB resources should be registered" )
+						.isFalse();
+				assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+						.as( "connection should be released after stream close outside a transaction" )
+						.isFalse();
+			}
+			else {
+				// because we are not explicitly calling blob.free() all the blobs remain registered.
+				assertThat( session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().hasRegisteredResources() )
+						.as( "LOB resources should still be registered" )
+						.isTrue();
+				assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+						.as( "connection should remain open while LOB resources are registered" )
+						.isTrue();
+			}
+		} );
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity {
+		@Id
+		public Integer id;
+		public String name;
+	}
+
+	@Entity(name = "MyBlobEntity")
+	public static class MyBlobEntity {
+		@Id
+		public Integer id;
+		@Lob
+		private Blob blob;
+		public String name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/sql/StringValueMappingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/sql/StringValueMappingTest.java
@@ -15,6 +15,8 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.env.internal.NonContextualLobCreator;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.resource.jdbc.ResourceRegistry;
+import org.hibernate.resource.jdbc.internal.ResourceRegistryStandardImpl;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -102,6 +104,11 @@ public class StringValueMappingTest {
 		@Override
 		public FormatMapper getJsonFormatMapper() {
 			return null;
+		}
+
+		@Override
+		public ResourceRegistry getResourceRegistry() {
+			return new ResourceRegistryStandardImpl();
 		}
 	};
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20551
https://hibernate.atlassian.net/browse/HHH-20552

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20552 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)

Tasks specific to HHH-20551 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->