### PR TITLE
HHH-20467 Exclude abstract converters from global registrations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -134,7 +134,7 @@ public class DomainModelCategorizationCollector {
 
 	private static boolean isConverter(ClassDetails classDetails) {
 		return classDetails.getClassName() != null && classDetails.isImplementor( AttributeConverter.class )
-			|| classDetails.hasDirectAnnotationUsage( Converter.class );
+			&& !classDetails.isAbstract() || classDetails.hasDirectAnnotationUsage( Converter.class );
 	}
 
 	private static boolean isLifecycleEventHandler(ClassDetails classDetails) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/convert/GenericConverterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/convert/GenericConverterTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.convert;
+
+import jakarta.persistence.AttributeConverter;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * @author Yanming Zhou
+ */
+class GenericConverterTest {
+
+	@JiraKey( "HHH-20467" )
+	@Test
+	void extendsFromAbstractConverterWithUnboundGenerics() {
+		assertDoesNotThrow( () -> {
+			try ( SessionFactory sf = new MetadataSources( new StandardServiceRegistryBuilder().build() )
+					.addAnnotatedClass( StringConverter.class )
+					.buildMetadata()
+					.buildSessionFactory() ) {
+			}
+		} );
+	}
+
+	static class StringConverter extends AbstractMiddleConverter<String> {
+
+		@Override
+		public String convertToDatabaseColumn(String attribute) {
+			return "";
+		}
+
+		@Override
+		public String convertToEntityAttribute(String dbData) {
+			return "";
+		}
+	}
+
+	abstract static class AbstractMiddleConverter<T> extends AbstractBaseConverter<T> {
+
+	}
+
+	abstract static class AbstractBaseConverter<T> implements AttributeConverter<T, String> {
+
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20467 (Bug):
- [x] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20467
<!-- Hibernate GitHub Bot issue links end -->