### PR TITLE
HHH-20551 Release JDBC resources after scrollable result stream is closed when no transaction is active

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/scrollable/AbstractScrollableResults.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/scrollable/AbstractScrollableResults.java
@@ -93,6 +93,9 @@ public abstract class AbstractScrollableResults<R> implements ScrollableResults<
 			rowReader.finishUp( rowProcessingState );
 			jdbcValues.finishUp( persistenceContext );
 			getPersistenceContext().getJdbcCoordinator().afterStatementExecution();
+			if ( !getPersistenceContext().isTransactionInProgress() ) {
+				getPersistenceContext().getJdbcCoordinator().getLogicalConnection().afterTransaction();
+			}
 			closed = true;
 		}
 		// noop if already closed

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stream/basic/StreamConnectionReleaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stream/basic/StreamConnectionReleaseTest.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.stream.basic;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {StreamConnectionReleaseTest.MyEntity.class})
+@SessionFactory
+@ServiceRegistry(settings = {
+		// We want to make sure that the release mode is set to "after transaction"
+		// but at the same time we are running things without an actual transaction.
+		// Resources should be still released in this case ...
+		@Setting(name = AvailableSettings.CONNECTION_HANDLING,
+				value = "DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION")
+})
+public class StreamConnectionReleaseTest {
+
+	@BeforeEach
+	void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			for ( int i = 0; i < 5; i++ ) {
+				MyEntity e = new MyEntity();
+				e.id = i;
+				e.name = "Entity #" + i;
+				session.persist( e );
+			}
+		} );
+	}
+
+	@AfterEach
+	void dropTestData(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	void testConnectionReleasedAfterStreamCloseOutsideTransaction(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should not be acquired before the query" )
+					.isFalse();
+
+			try (Stream<MyEntity> stream = session.createQuery( "from MyEntity", MyEntity.class ).getResultStream()) {
+				stream.forEach( e -> assertThat( e.name ).isNotNull() );
+				assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+						.as( "we are still holding the connection because the stream is opened" )
+						.isTrue();
+			}
+
+			assertThat(
+					session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().hasRegisteredResources() )
+					.as( "resources should be released after stream close" )
+					.isFalse();
+
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should be released after stream close outside a transaction" )
+					.isFalse();
+		} );
+	}
+
+	@Test
+	void testConnectionReleasedAfterStatementOutsideTransaction(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should not be acquired before the query" )
+					.isFalse();
+
+			List<MyEntity> list = session.createQuery( "from MyEntity", MyEntity.class ).getResultList();
+			list.forEach( e -> assertThat( e.name ).isNotNull() );
+
+			assertThat(
+					session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry()
+							.hasRegisteredResources() )
+					.as( "no resources were requested by this query" )
+					.isFalse();
+
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should be released after the statement" )
+					.isFalse();
+		} );
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity {
+		@Id
+		public Integer id;
+		public String name;
+	}
+}


### PR DESCRIPTION
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20551
<!-- Hibernate GitHub Bot issue links end -->

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20551 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->