### PR TITLE
HHH-20550 - Copy CTEs in SqmSelectStatement.createCountQuery()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/spi/select/SqmSelectStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/spi/select/SqmSelectStatement.java
@@ -594,6 +594,7 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T>
 			if ( subquery.getFetch() == null && subquery.getOffset() == null ) {
 				subquery.getQueryPart().setOrderByClause( null );
 			}
+			query.addCteStatements( copy.getCteStatementMap() );
 			return query;
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CountQueryTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CountQueryTests.java
@@ -12,6 +12,7 @@ import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaQuery;
+import org.hibernate.query.criteria.JpaCteCriteria;
 import org.hibernate.query.criteria.JpaParameterExpression;
 import org.hibernate.query.criteria.JpaRoot;
 
@@ -310,6 +311,33 @@ public class CountQueryTests {
 			final Long count = session.createQuery( union.createCountQuery() ).getSingleResult();
 			final List<String> resultList = session.createQuery( union ).getResultList();
 			assertEquals( 2L, count );
+			assertEquals( resultList.size(), count.intValue() );
+		} );
+	}
+
+	@Test
+	@JiraKey("HHH-20550")
+	public void testCteQuery(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final HibernateCriteriaBuilder cb = session.getCriteriaBuilder();
+
+			final JpaCriteriaQuery<Integer> cteQuery = cb.createQuery( Integer.class );
+			final JpaRoot<Contact> cteRoot = cteQuery.from( Contact.class );
+			cteQuery.select( cteRoot.<Integer>get( "id" ).alias( "id" ) )
+					.where( cb.equal( cteRoot.get( "name" ).get( "last" ), "Doe" ) );
+
+			final JpaCriteriaQuery<String> cq = cb.createQuery( String.class );
+			final JpaRoot<Contact> root = cq.from( Contact.class );
+			final JpaCteCriteria<Integer> cteContactIds = cq.with( "cte_contact_ids", cteQuery );
+			cq.select( root.get( "name" ).get( "first" ) )
+					.where( root.get( "id" ).in( cq.from( cteContactIds ).get( "id" ) ) );
+			cq.distinct( true );
+
+			final Boolean exists = session.createQuery( cq.createExistsQuery() ).getSingleResult();
+			final Long count = session.createQuery( cq.createCountQuery() ).getSingleResult();
+			final List<String> resultList = session.createQuery( cq ).getResultList();
+			assertTrue( exists );
+			assertEquals( 8L, count );
 			assertEquals( resultList.size(), count.intValue() );
 		} );
 	}


### PR DESCRIPTION
Currently `createCountQuery()` fails when trying to count a query with CTE statements and has groupings/is distinct. We now copy the statements to match the `createExistsQuery()` implementation.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20550 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20550
<!-- Hibernate GitHub Bot issue links end -->