### PR TITLE
Update the insert statement for PURCHASE_ORDER in a TCK runner config

### DIFF
--- a/hibernate-tck-runner/hibernate-tck-runner.gradle
+++ b/hibernate-tck-runner/hibernate-tck-runner.gradle
@@ -63,11 +63,10 @@ test {
             "vehicle"                                        : "standalone",
             "user.dir"                                       : userdir,
             "db.supports.sequence"                           : "true",
-            "Insert_Jpa_Purchase_Order"                      : "INSERT INTO PURCHASE_ORDER(ID, TOTAL, DESCRIPTION) VALUES(?, ?, null)",
+            "Insert_Jpa_Purchase_Order"                      : "INSERT INTO PURCHASE_ORDER(ID, TOTAL) VALUES(?, ?)",
             "Select_Jpa_Purchase_Order"                      : "SELECT ID, TOTAL FROM PURCHASE_ORDER WHERE ID=?",
             "log.file.location"                              : tckLogs,
             "jdbc.db"                                        : "postgresql",
-            "hibernate.show_sql"                             : "true"
     ]
 
     testLogging {


### PR DESCRIPTION
since `PURCHASE_ORDER` doesn't have the `DESCRIPTION` column ... at least not in the tests where that insert statement is used.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
