### PR TITLE
Allow falling back to Maven Central even if a MAVEN_MIRROR is configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
         env:
           RDBMS: ${{ matrix.rdbms }}
           MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
+          MAVEN_CENTRAL_FALLBACK: "true"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
           POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
@@ -252,6 +253,7 @@ jobs:
         env:
           RDBMS: ${{ matrix.rdbms }}
           MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
+          MAVEN_CENTRAL_FALLBACK: "true"
           RUNID: ${{ github.run_number }}
           TESTPILOT_CONNECTION_STRING_SUFFIX: ${{ steps.create_database.outputs.connection_string_suffix }}
           TESTPILOT_PASSWORD: ${{ steps.create_database.outputs.database_password }}
@@ -388,6 +390,7 @@ jobs:
         env:
           RDBMS: ${{ matrix.rdbms }}
           MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
+          MAVEN_CENTRAL_FALLBACK: "true"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
           POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
@@ -489,6 +492,7 @@ jobs:
         run: ./gradlew formatChecks
         env:
           MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
+          MAVEN_CENTRAL_FALLBACK: "true"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
           POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
@@ -582,6 +586,7 @@ jobs:
         run: ./gradlew mergeCodeCoverageReport copyDependenciesSonar --no-parallel
         env:
           MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
+          MAVEN_CENTRAL_FALLBACK: "true"
 
       - name: Store build info for Sonar scanning
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/local-build-plugins/src/main/java/org/hibernate/orm/env/MavenMirror.java
+++ b/local-build-plugins/src/main/java/org/hibernate/orm/env/MavenMirror.java
@@ -12,6 +12,10 @@ import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
  * Configures Maven Central or a mirror of it, based on the {@code MAVEN_MIRROR} environment
  * variable or system property. Optionally supports authentication via
  * {@code MAVEN_MIRROR_USERNAME} and {@code MAVEN_MIRROR_PASSWORD}.
+ * <p>
+ * When using a mirror, set {@code MAVEN_CENTRAL_FALLBACK} to {@code true} to also add
+ * {@code mavenCentral()} after the mirror — useful when mirrors lag behind on freshly
+ * published artifacts.
  *
  * @see <a href="https://blog.gradle.org/maven-central-mirror">Gradle Maven Central Mirror</a>
  */
@@ -56,6 +60,9 @@ public class MavenMirror {
 					} );
 				}
 			} );
+			if ( "true".equalsIgnoreCase( resolve( "MAVEN_CENTRAL_FALLBACK" ) ) ) {
+				repositories.mavenCentral();
+			}
 			return true;
 		}
 		else {


### PR DESCRIPTION
so we don't wait for 12+ h for a dep to show up on the mirror 😖 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
