### PR TITLE
Backport query projection fixes to 8.0

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/basic/DataTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/basic/DataTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
 import static org.hibernate.processor.test.util.TestUtil.assertNoMetamodelClassGeneratedFor;
 import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -164,16 +165,27 @@ class DataTest {
 			);
 			assertFalse( task.call() );
 		}
-		final String messages = diagnostics.getDiagnostics()
+		final var errorMessages = diagnostics.getDiagnostics()
 				.stream()
 				.filter( diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR )
 				.map( diagnostic -> diagnostic.getMessage( Locale.ROOT ) )
-				.collect( Collectors.joining( "\n" ) );
+				.toList();
+		final String messages = errorMessages.stream().collect( Collectors.joining( "\n" ) );
 
 		assertTrue( messages.contains(
 				"positional query parameters must be numbered sequentially starting at ?1" ) );
 		assertTrue( messages.contains(
 				"query parameters must be either all named or all positional" ) );
+		assertEquals( 1, countMessagesContaining( errorMessages,
+				"positional query parameters must be numbered sequentially starting at ?1" ) );
+		assertEquals( 1, countMessagesContaining( errorMessages,
+				"query parameters must be either all named or all positional" ) );
+	}
+
+	private static long countMessagesContaining(List<String> messages, String text) {
+		return messages.stream()
+				.filter( message -> message.contains( text ) )
+				.count();
 	}
 
 	private static File sourceFile(Class<?> type) {

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/DataRestrictionTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/DataRestrictionTest.java
@@ -78,14 +78,20 @@ class DataRestrictionTest {
 	})
 	void queryRootEntitySupportsProjectionRestrictionsWithoutPrimaryEntity() {
 		final String repository = getMetaModelSourceAsString( ExplicitQueryRestrictionRepository.class, true );
+		final String queryMetamodel = getMetaModelSourceAsString( ExplicitQueryRestrictionRepository.class );
 		System.out.println( repository );
+		System.out.println( queryMetamodel );
 
 		assertTrue( repository.contains(
 				"List<Summary> books(@Nonnull Restriction<DataRestrictionBook> restriction)" ) );
 		assertTrue( repository.contains(
+				"var _reference = _builder.augment(ExplicitQueryRestrictionRepository_.books(), Summary.class, _query -> {" ) );
+		assertTrue( repository.contains(
 				"var _entity = (Root<DataRestrictionBook>) _query.getRootList().get(0);" ) );
 		assertTrue( repository.contains( "restriction.apply(_query, _entity);" ) );
 		assertTrue( repository.contains( "_builder.construct(Summary.class" ) );
+		assertTrue( queryMetamodel.contains( "TypedQueryReference<DataRestrictionBook> books()" ) );
+		assertTrue( queryMetamodel.contains( "DataRestrictionBook.class" ) );
 	}
 
 	@Test

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/DataRestrictionTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/DataRestrictionTest.java
@@ -71,6 +71,24 @@ class DataRestrictionTest {
 	}
 
 	@Test
+	@WithClasses({
+			DataRestrictionBook.class,
+			DataRestrictionPublisher.class,
+			ExplicitQueryRestrictionRepository.class
+	})
+	void queryRootEntitySupportsProjectionRestrictionsWithoutPrimaryEntity() {
+		final String repository = getMetaModelSourceAsString( ExplicitQueryRestrictionRepository.class, true );
+		System.out.println( repository );
+
+		assertTrue( repository.contains(
+				"List<Summary> books(@Nonnull Restriction<DataRestrictionBook> restriction)" ) );
+		assertTrue( repository.contains(
+				"var _entity = (Root<DataRestrictionBook>) _query.getRootList().get(0);" ) );
+		assertTrue( repository.contains( "restriction.apply(_query, _entity);" ) );
+		assertTrue( repository.contains( "_builder.construct(Summary.class" ) );
+	}
+
+	@Test
 	void invalidAutomaticDeleteUsesMeaningfulDiagnostics() throws Exception {
 		final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
 		final var compiler = ToolProvider.getSystemJavaCompiler();

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/DataRestrictionTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/DataRestrictionTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.Charset.defaultCharset;
 import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -119,11 +120,12 @@ class DataRestrictionTest {
 			);
 			assertFalse( task.call() );
 		}
-		final String messages = diagnostics.getDiagnostics()
+		final var errorMessages = diagnostics.getDiagnostics()
 				.stream()
 				.filter( diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR )
 				.map( diagnostic -> diagnostic.getMessage( Locale.ROOT ) )
-				.collect( Collectors.joining( "\n" ) );
+				.toList();
+		final String messages = errorMessages.stream().collect( Collectors.joining( "\n" ) );
 
 		assertTrue( messages.contains(
 				"parameter of type 'jakarta.data.Limit' is not allowed on an automatic '@Delete' method" ) );
@@ -145,6 +147,51 @@ class DataRestrictionTest {
 		assertTrue( messages.contains(
 				"'@NativeQuery' methods may not declare Order or Sort parameters or '@OrderBy'; "
 						+ "native SQL cannot be augmented with ordering" ) );
+		assertEquals( 1, countMessagesContaining( errorMessages,
+				"'@NativeQuery' methods may not declare Restriction or Range parameters" ) );
+		assertEquals( 1, countMessagesContaining( errorMessages,
+				"'@NativeQuery' methods may not declare Order or Sort parameters or '@OrderBy'" ) );
+	}
+
+	@Test
+	void nonRepositoryNativeQueryWithRestrictionUsesSingleDiagnostic() throws Exception {
+		final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+		final var compiler = ToolProvider.getSystemJavaCompiler();
+		try ( var fileManager = compiler.getStandardFileManager( diagnostics, Locale.ROOT, defaultCharset() ) ) {
+			final var sourceFiles = List.of(
+					sourceFile( DataRestrictionPublisher.class ),
+					sourceFile( DataRestrictionBook.class ),
+					sourceFile( InvalidNativeStaticQuery.class )
+			);
+			final var task = compiler.getTask(
+					null,
+					fileManager,
+					diagnostics,
+					List.of(
+							"-d",
+							TestUtil.getOutBaseDir( DataRestrictionTest.class ).getAbsolutePath(),
+							"-processor",
+							HibernateProcessor.class.getName()
+					),
+					null,
+					fileManager.getJavaFileObjectsFromFiles( sourceFiles )
+			);
+			assertFalse( task.call() );
+		}
+		final var errorMessages = diagnostics.getDiagnostics()
+				.stream()
+				.filter( diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR )
+				.map( diagnostic -> diagnostic.getMessage( Locale.ROOT ) )
+				.toList();
+
+		assertEquals( 1, countMessagesContaining( errorMessages,
+				"'@NativeQuery' methods may not declare Restriction or Range parameters" ) );
+	}
+
+	private static long countMessagesContaining(List<String> messages, String text) {
+		return messages.stream()
+				.filter( message -> message.contains( text ) )
+				.count();
 	}
 
 	private static File sourceFile(Class<?> type) {

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/ExplicitQueryRestrictionRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/ExplicitQueryRestrictionRepository.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.restriction;
+
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+import org.hibernate.query.restriction.Restriction;
+
+import java.util.List;
+
+@Repository
+public interface ExplicitQueryRestrictionRepository {
+	record Summary(String isbn, String title) {
+	}
+
+	@Query("from DataRestrictionBook")
+	List<Summary> books(Restriction<DataRestrictionBook> restriction);
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/InvalidNativeStaticQuery.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/InvalidNativeStaticQuery.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.restriction;
+
+import jakarta.data.restrict.Restriction;
+import jakarta.persistence.EntityAgent;
+import jakarta.persistence.query.JakartaQuery;
+import jakarta.persistence.query.NativeQuery;
+
+import java.util.List;
+
+interface InvalidNativeStaticQuery {
+	record Summary(String isbn, String title) {
+	}
+
+	@JakartaQuery("from DataRestrictionBook")
+	List<DataRestrictionBook> books();
+
+	@JakartaQuery("from DataRestrictionBook")
+	List<Summary> summaries();
+
+	@NativeQuery("select * from data_restriction_book")
+	List<DataRestrictionBook> nat(EntityAgent agent, Restriction<DataRestrictionBook> restriction);
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/select/SelectionTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/select/SelectionTest.java
@@ -39,7 +39,9 @@ class SelectionTest {
 	void generatedRepositorySupportsSelectAndFirst() {
 		final String repository = getMetaModelSourceAsString( SelectionRepository.class, true );
 		final String normalizedRepository = repository.replaceAll( "\\s+", " " );
+		final String queryMetamodel = getMetaModelSourceAsString( SelectionRepository.class );
 		System.out.println( repository );
+		System.out.println( queryMetamodel );
 		assertMetamodelClassGeneratedFor( SelectionBook.class );
 		assertMetamodelClassGeneratedFor( SelectionRepository.class, true );
 
@@ -74,17 +76,25 @@ class SelectionTest {
 		assertFalse( repository.contains( ".setCacheRetrieveMode(CacheRetrieveMode.BYPASS)" ) );
 		assertFalse( repository.contains( ".setHint(\"hint\", \"1\")" ) );
 		assertTrue( repository.contains(
-				"var _reference = _builder.augment(SelectionRepository_.queryTitlesByStatus(status), _query -> {" ) );
+				"var _reference = _builder.augment(SelectionRepository_.queryTitlesByStatus(status), String.class, _query -> {" ) );
 		assertTrue( repository.contains(
-				"var _reference = _builder.augment(SelectionRepository_.queryTitlesWithStringFallback(minPages, status), _query -> {" ) );
+				"var _reference = _builder.augment(SelectionRepository_.queryTitlesWithStringFallback(minPages, status), String.class, _query -> {" ) );
 		assertFalse( repository.contains( ".setParameter(\"status\", status)" ) );
 		assertFalse( repository.contains( ".setParameter(\"minPages\", minPages)" ) );
 		assertTrue( repository.contains(
-				"var _reference = _builder.augment(SelectionRepository_.queryRenamedByStatus(status), _query -> {" ) );
+				"var _reference = _builder.augment(SelectionRepository_.queryRenamedByStatus(status), QueryRenamed.class, _query -> {" )
+				|| repository.contains(
+						"var _reference = _builder.augment(SelectionRepository_.queryRenamedByStatus(status), SelectionRepository.QueryRenamed.class, _query -> {" ) );
 		assertTrue( normalizedRepository.contains(
 				"_query.select(_builder.construct(QueryRenamed.class, _entity.get(SelectionBook_.title), _entity.get(SelectionBook_.pages)));" )
 				|| normalizedRepository.contains(
 						"_query.select(_builder.construct(SelectionRepository.QueryRenamed.class, _entity.get(SelectionBook_.title), _entity.get(SelectionBook_.pages)));" ) );
+		assertTrue( queryMetamodel.contains(
+				"TypedQueryReference<SelectionBook> queryTitlesByStatus(SelectionStatus status)" ) );
+		assertTrue( queryMetamodel.contains(
+				"TypedQueryReference<SelectionBook> queryTitlesWithStringFallback(int minPages, SelectionStatus status)" ) );
+		assertTrue( queryMetamodel.contains(
+				"TypedQueryReference<SelectionBook> queryRenamedByStatus(SelectionStatus status)" ) );
 	}
 
 	@Test

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
@@ -99,7 +99,6 @@ public final class Context {
 	private boolean dataEventPackageAvailable;
 
 	// keep track of all classes for which model have been generated
-	private final Set<Metamodel> generatedModelClasses = new HashSet<>();
 	private final Set<String> generatedClassNames = new HashSet<>();
 
 	// keep track of which named queries have been checked
@@ -396,7 +395,6 @@ public final class Context {
 	}
 
 	void markGenerated(Metamodel metamodel) {
-		generatedModelClasses.add( metamodel );
 		generatedClassNames.add( getFullyQualifiedClassName( metamodel ) );
 	}
 
@@ -436,7 +434,7 @@ public final class Context {
 		return persistenceUnitDefaultAccessType;
 	}
 
-	public void setPersistenceUnitDefaultAccessType(AccessType persistenceUnitDefaultAccessType) {
+	public void setPersistenceUnitDefaultAccessType(@Nullable AccessType persistenceUnitDefaultAccessType) {
 		this.persistenceUnitDefaultAccessType = persistenceUnitDefaultAccessType;
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -1907,34 +1907,27 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			boolean isNative) {
 		final var value = getAnnotationValue( mirror );
 		if ( value != null && value.getValue() instanceof String queryString ) {
+			final var validate = shouldValidateStaticQueryMethod( method );
 			final var methodReturnType =
 					unwrappedReturnTypeIfPossible( method, memberMethodType( method ).getReturnType() );
 			final var queryReturnType =
-					staticQueryReturnType( method, methodReturnType, mirror, value, queryString );
+					staticQueryReturnType( method, methodReturnType, mirror, value, queryString, validate );
 			if ( queryReturnType != null ) {
 				final var paramNames = staticQueryParameterNames( method );
 				final var paramTypes = parameterTypes( method );
-				final TypeElement entity;
-				if ( isNative ) {
-					entity = null;
-					if ( !repository || method.isDefault() ) {
-						validateNativeQueryHasNoDynamicAugmentation( method, mirror, paramTypes );
+				final var returnType = queryReturnType.validationReturnType;
+				final var entityType =
+						isNative ? null : querySelectionEntity( method, returnType, mirror, queryString, validate );
+				if ( validate ) {
+					final var type = entityType == null ? returnType : entityType.asType();
+					checkParameters( method, type, paramNames, paramTypes, mirror, value, queryString, isNative );
+					if ( isNative ) {
+						validateSql( method, mirror, queryString, paramNames, value );
 					}
-				}
-				else {
-					entity = querySelectionEntity( method, queryReturnType.validationReturnType, mirror, queryString );
-				}
-				final var validationReturnType = entity == null ? queryReturnType.validationReturnType : entity.asType();
-				final var processedQuery =
-						staticQueryValidationString( validationReturnType, mirror, queryString );
-				checkParameters( method, validationReturnType,
-						paramNames, paramTypes, mirror, value, queryString, isNative );
-				if ( isNative ) {
-					validateSql( method, mirror, queryString, paramNames, value );
-				}
-				else {
-					validateHql( method, validationReturnType,
-							mirror, value, processedQuery, paramNames, paramTypes );
+					else {
+						final var processedQuery = staticQueryValidationString( type, mirror, queryString );
+						validateHql( method, type, mirror, value, processedQuery, paramNames, paramTypes );
+					}
 				}
 				if ( canBindReferenceArguments( queryString, isNative, paramNames, paramTypes ) ) {
 					final var referenceParamNames = queryParameterNames( paramNames, paramTypes );
@@ -1947,12 +1940,12 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									method.getSimpleName().toString(),
 									queryReturnType.statement,
 									isNative,
-									entity == null
+									entityType == null
 											? queryReturnType.resultTypeName
-											: entity.getQualifiedName().toString(),
-									entity == null
+											: entityType.getQualifiedName().toString(),
+									entityType == null
 											? queryReturnType.resultTypeClass
-											: entity.getQualifiedName().toString(),
+											: entityType.getQualifiedName().toString(),
 									paramTypes,
 									referenceParamNames,
 									referenceParamTypes,
@@ -1962,6 +1955,16 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 				}
 			}
 		}
+	}
+
+	/**
+	 * For a repository method validation is done during generation of
+	 * the {@code _Repo} class, and we don't need to duplicate it for
+	 * the {@code Repo_} class which contains only static references.
+	 */
+	private boolean shouldValidateStaticQueryMethod(ExecutableElement method) {
+		return !repositoryQueryMetamodel
+			|| method.isDefault(); //TODO: is this necessary?
 	}
 
 	private String staticQueryValidationString(
@@ -1985,17 +1988,18 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			TypeMirror methodReturnType,
 			AnnotationMirror mirror,
 			AnnotationValue value,
-			String queryString) {
+			String queryString,
+			boolean validate) {
 		final var statement = isMutationStatement( queryString );
 		return switch ( methodReturnType.getKind() ) {
 			case VOID -> statement
 					? new StaticQueryReturnType( true, null, null, methodReturnType )
-					: illegalStaticQueryReturnType( method, mirror, value );
+					: illegalStaticQueryReturnType( method, mirror, value, validate );
 			case BOOLEAN, BYTE, SHORT, INT, LONG, CHAR, FLOAT, DOUBLE -> {
 				if ( statement ) {
 					yield switch ( methodReturnType.getKind() ) {
 						case BOOLEAN, INT, LONG -> new StaticQueryReturnType( true, null, null, methodReturnType );
-						default -> illegalStaticQueryReturnType( method, mirror, value );
+						default -> illegalStaticQueryReturnType( method, mirror, value, validate );
 					};
 				}
 				else {
@@ -2012,7 +2016,9 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 				}
 				else {
 					final var queryResultType = staticQueryResultType( (DeclaredType) methodReturnType );
-					resultType( method, queryResultType, mirror, value );
+					if ( validate ) {
+						resultType( method, queryResultType, mirror, value );
+					}
 					yield new StaticQueryReturnType( false,
 							typeAsString( queryResultType ),
 							returnTypeClass( queryResultType ),
@@ -2026,18 +2032,21 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						returnTypeClass( queryResultType ),
 						queryResultType );
 			}
-			default -> illegalStaticQueryReturnType( method, mirror, value );
+			default -> illegalStaticQueryReturnType( method, mirror, value, validate );
 		};
 	}
 
 	private @Nullable StaticQueryReturnType illegalStaticQueryReturnType(
 			ExecutableElement method,
 			AnnotationMirror mirror,
-			AnnotationValue value) {
-		message( method, mirror, value,
-				"static query method must return a referenceable query result type,"
-				+ " or a legal mutation result type: 'void', 'boolean', 'int', or 'long'",
-				Diagnostic.Kind.ERROR );
+			AnnotationValue value,
+			boolean validate) {
+		if ( validate ) {
+			message( method, mirror, value,
+					"static query method must return a referenceable query result type,"
+					+ " or a legal mutation result type: 'void', 'boolean', 'int', or 'long'",
+					Diagnostic.Kind.ERROR );
+		}
 		return null;
 	}
 
@@ -3114,9 +3123,18 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			@Nullable TypeMirror returnType,
 			AnnotationMirror query,
 			String queryString) {
+		return querySelectionEntity( method, returnType, query, queryString, true );
+	}
+
+	private @Nullable TypeElement querySelectionEntity(
+			ExecutableElement method,
+			@Nullable TypeMirror returnType,
+			AnnotationMirror query,
+			String queryString,
+			boolean validate) {
 		final var explicitMethodSelect = hasSelectAnnotation( method );
 		if ( returnType == null ) {
-			if ( explicitMethodSelect ) {
+			if ( validate && explicitMethodSelect ) {
 				message( method, query,
 						"'@Select' requires a concrete query result type",
 						Diagnostic.Kind.ERROR );
@@ -3124,7 +3142,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			return null;
 		}
 		if ( isMutationStatement( queryString ) ) {
-			if ( explicitMethodSelect ) {
+			if ( validate && explicitMethodSelect ) {
 				message( method, query,
 						"'@Select' may not be used on a mutation query",
 						Diagnostic.Kind.ERROR );
@@ -3136,7 +3154,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		}
 		if ( returnType.getKind() == TypeKind.DECLARED
 				&& containsAnnotation( ((DeclaredType) returnType).asElement(), ENTITY ) ) {
-			if ( explicitMethodSelect ) {
+			if ( validate && explicitMethodSelect ) {
 				message( method, query,
 						"'@Select' may not be used on a '@Query' method that returns entity type '" + returnType + "'",
 						Diagnostic.Kind.ERROR );
@@ -3144,7 +3162,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			return null;
 		}
 		if ( hasSelectClause( queryString ) ) {
-			if ( explicitMethodSelect ) {
+			if ( validate && explicitMethodSelect ) {
 				message( method, query,
 						"'@Select' may not be used on a '@Query' method with an explicit SELECT clause",
 						Diagnostic.Kind.ERROR );
@@ -3152,7 +3170,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			return null;
 		}
 		final var entity = querySelectionEntity( queryString );
-		if ( entity == null ) {
+		if ( validate && entity == null ) {
 			message( method, query,
 					"repository method has no well-defined entity type",
 					Diagnostic.Kind.ERROR );

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -1914,18 +1914,17 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			if ( queryReturnType != null ) {
 				final var paramNames = staticQueryParameterNames( method );
 				final var paramTypes = parameterTypes( method );
-				if ( isNative && ( !repository || method.isDefault() ) ) {
-					validateNativeQueryHasNoDynamicAugmentation( method, mirror, paramTypes );
+				final TypeElement entity;
+				if ( isNative ) {
+					entity = null;
+					if ( !repository || method.isDefault() ) {
+						validateNativeQueryHasNoDynamicAugmentation( method, mirror, paramTypes );
+					}
 				}
-				final var querySelection =
-						!isNative && ( annotationTypeMatches( mirror, JD_QUERY )
-								|| annotationTypeMatches( mirror, JAKARTA_QUERY ) )
-								? querySelection( method, queryReturnType.validationReturnType, mirror, queryString )
-								: null;
-				final var validationReturnType =
-						querySelection == null
-								? queryReturnType.validationReturnType
-								: querySelection.entity().asType();
+				else {
+					entity = querySelectionEntity( method, queryReturnType.validationReturnType, mirror, queryString );
+				}
+				final var validationReturnType = entity == null ? queryReturnType.validationReturnType : entity.asType();
 				final var processedQuery =
 						staticQueryValidationString( validationReturnType, mirror, queryString );
 				checkParameters( method, validationReturnType,
@@ -1948,8 +1947,12 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									method.getSimpleName().toString(),
 									queryReturnType.statement,
 									isNative,
-									queryReturnType.resultTypeName,
-									queryReturnType.resultTypeClass,
+									entity == null
+											? queryReturnType.resultTypeName
+											: entity.getQualifiedName().toString(),
+									entity == null
+											? queryReturnType.resultTypeClass
+											: entity.getQualifiedName().toString(),
 									paramTypes,
 									referenceParamNames,
 									referenceParamTypes,
@@ -3106,7 +3109,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	private record SelectedAttribute(String path, TypeMirror type) {
 	}
 
-	private @Nullable QuerySelection querySelection(
+	private @Nullable TypeElement querySelectionEntity(
 			ExecutableElement method,
 			@Nullable TypeMirror returnType,
 			AnnotationMirror query,
@@ -3155,8 +3158,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 					Diagnostic.Kind.ERROR );
 			return null;
 		}
-		final var resultSelection = resultSelection( method, returnType, entity, true );
-		return resultSelection == null ? null : new QuerySelection( resultSelection, entity );
+		return entity;
 	}
 
 	private @Nullable TypeElement querySelectionEntity(String queryString) {
@@ -3218,9 +3220,6 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			builder.append( identifier.getText() );
 		}
 		return builder.toString();
-	}
-
-	private record QuerySelection(ResultSelection resultSelection, TypeElement entity) {
 	}
 
 	private static boolean isRecordReturn(TypeMirror returnType) {
@@ -4359,15 +4358,20 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			validateNativeQueryHasNoDynamicAugmentation( method, mirror, paramTypes );
 		}
 
-		final var querySelection =
-				!isNative && annotationTypeMatches( mirror, JD_QUERY )
-						? querySelection( method, returnType, mirror, queryString )
-						: null;
-		final var validationReturnType =
-				querySelection == null
-						? returnType
-						: querySelection.entity().asType();
-
+		final TypeElement entity;
+		final ResultSelection querySelection;
+		if ( isNative ) {
+			entity = null;
+			querySelection = null;
+		}
+		else {
+			entity = querySelectionEntity( method, returnType, mirror, queryString );
+			querySelection =
+					returnType == null || entity == null
+							? null
+							: resultSelection( method, returnType, entity, true );
+		}
+		final var validationReturnType = entity == null ? returnType : entity.asType();
 		// now check that the query has a parameter for every method parameter
 		checkParameters( method, validationReturnType, paramNames, paramTypes, mirror, value, queryString, isNative );
 
@@ -4427,10 +4431,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						sessionType[0],
 						sessionType[1],
 						orderBys,
-						querySelection == null ? null : querySelection.resultSelection(),
-						querySelection == null
-								? null
-								: querySelection.entity().getQualifiedName().toString(),
+						querySelection,
+						entity == null ? null : entity.getQualifiedName().toString(),
 						context.addNonnullAnnotation(),
 						jakartaDataRepository,
 						fullReturnType( method ),

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -3174,9 +3174,18 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 	private @Nullable TypeElement entityTypeForEntityName(String entityName) {
 		final var qualifiedName = context.qualifiedNameForEntityName( entityName );
-		final var typeElement =
-				context.getElementUtils()
-						.getTypeElement( qualifiedName == null ? entityName : qualifiedName );
+		final var typeElement = entityType( qualifiedName == null ? entityName : qualifiedName );
+		if ( typeElement != null || entityName.indexOf( '.' ) >= 0 ) {
+			return typeElement;
+		}
+		else {
+			final var packageName = getPackageName();
+			return packageName.isEmpty() ? null : entityType( qualify( packageName, entityName ) );
+		}
+	}
+
+	private @Nullable TypeElement entityType(String qualifiedName) {
+		final var typeElement = context.getElementUtils().getTypeElement( qualifiedName );
 		return typeElement != null
 			&& containsAnnotation( typeElement, ENTITY )
 				? typeElement

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -7,6 +7,7 @@ package org.hibernate.processor.annotation;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.hibernate.AssertionFailure;
+import org.hibernate.grammars.hql.HqlParser;
 import org.hibernate.metamodel.mapping.ordering.OrderByFragmentTranslator;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.processor.Context;
@@ -1922,9 +1923,9 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 								? querySelection( method, queryReturnType.validationReturnType, mirror, queryString )
 								: null;
 				final var validationReturnType =
-						querySelection == null || primaryEntity == null
+						querySelection == null
 								? queryReturnType.validationReturnType
-								: primaryEntity.asType();
+								: querySelection.entity().asType();
 				final var processedQuery =
 						staticQueryValidationString( validationReturnType, mirror, queryString );
 				checkParameters( method, validationReturnType,
@@ -3105,7 +3106,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	private record SelectedAttribute(String path, TypeMirror type) {
 	}
 
-	private @Nullable ResultSelection querySelection(
+	private @Nullable QuerySelection querySelection(
 			ExecutableElement method,
 			@Nullable TypeMirror returnType,
 			AnnotationMirror query,
@@ -3147,13 +3148,79 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			}
 			return null;
 		}
-		if ( primaryEntity == null ) {
+		final var entity = querySelectionEntity( queryString );
+		if ( entity == null ) {
 			message( method, query,
-					"repository method returns a projection, so the repository must have a well-defined primary entity type",
+					"repository method has no well-defined entity type",
 					Diagnostic.Kind.ERROR );
 			return null;
 		}
-		return resultSelection( method, returnType, primaryEntity, true );
+		final var resultSelection = resultSelection( method, returnType, entity, true );
+		return resultSelection == null ? null : new QuerySelection( resultSelection, entity );
+	}
+
+	private @Nullable TypeElement querySelectionEntity(String queryString) {
+		final var rootEntityName = queryRootEntityName( queryString );
+		if ( rootEntityName != null ) {
+			final var rootEntity = entityTypeForEntityName( rootEntityName );
+			if ( rootEntity != null ) {
+				return rootEntity;
+			}
+		}
+		return primaryEntity;
+	}
+
+	private @Nullable TypeElement entityTypeForEntityName(String entityName) {
+		final var qualifiedName = context.qualifiedNameForEntityName( entityName );
+		final var typeElement =
+				context.getElementUtils()
+						.getTypeElement( qualifiedName == null ? entityName : qualifiedName );
+		return typeElement != null
+			&& containsAnnotation( typeElement, ENTITY )
+				? typeElement
+				: null;
+	}
+
+	private static @Nullable String queryRootEntityName(String hql) {
+		try {
+			final var hqlLexer = HqlParseTreeBuilder.INSTANCE.buildHqlLexer( hql );
+			final var hqlParser = HqlParseTreeBuilder.INSTANCE.buildHqlParser( hql, hqlLexer );
+			hqlParser.removeErrorListeners();
+			final var selectStatement = hqlParser.statement().selectStatement();
+			if ( selectStatement == null ) {
+				return null;
+			}
+			final var orderedQueries = selectStatement.queryExpression().orderedQuery();
+			if ( orderedQueries.size() != 1
+					|| !( orderedQueries.get( 0 ) instanceof HqlParser.QuerySpecExpressionContext querySpec ) ) {
+				return null;
+			}
+			final var fromClause = querySpec.query().fromClause();
+			if ( fromClause == null || fromClause.entityWithJoins().size() != 1 ) {
+				return null;
+			}
+			final var fromRoot = fromClause.entityWithJoins( 0 ).fromRoot();
+			return fromRoot instanceof HqlParser.RootEntityContext rootEntity
+					? entityName( rootEntity.entityName() )
+					: null;
+		}
+		catch (RuntimeException ignored) {
+			return null;
+		}
+	}
+
+	private static String entityName(HqlParser.EntityNameContext entityName) {
+		final var builder = new StringBuilder();
+		for ( var identifier : entityName.identifier() ) {
+			if ( !builder.isEmpty() ) {
+				builder.append( '.' );
+			}
+			builder.append( identifier.getText() );
+		}
+		return builder.toString();
+	}
+
+	private record QuerySelection(ResultSelection resultSelection, TypeElement entity) {
 	}
 
 	private static boolean isRecordReturn(TypeMirror returnType) {
@@ -4297,9 +4364,9 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						? querySelection( method, returnType, mirror, queryString )
 						: null;
 		final var validationReturnType =
-				querySelection == null || primaryEntity == null
+				querySelection == null
 						? returnType
-						: primaryEntity.asType();
+						: querySelection.entity().asType();
 
 		// now check that the query has a parameter for every method parameter
 		checkParameters( method, validationReturnType, paramNames, paramTypes, mirror, value, queryString, isNative );
@@ -4360,10 +4427,10 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						sessionType[0],
 						sessionType[1],
 						orderBys,
-						querySelection,
-						querySelection == null || primaryEntity == null
+						querySelection == null ? null : querySelection.resultSelection(),
+						querySelection == null
 								? null
-								: primaryEntity.getQualifiedName().toString(),
+								: querySelection.entity().getQualifiedName().toString(),
 						context.addNonnullAnnotation(),
 						jakartaDataRepository,
 						fullReturnType( method ),

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/QueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/QueryMethod.java
@@ -461,7 +461,10 @@ public class QueryMethod extends AbstractQueryMethod {
 					.append( "\tvar _reference = _builder.augment(" );
 			createQueryReference( declaration );
 			declaration
-					.append( ", _query -> {\n\t" );
+					.append( ", " )
+					// Never null because this is called only when useAugmentedQuery() is true
+					.append( annotationMetaEntity.importType( selection.resultTypeName() ) )
+					.append( ".class, _query -> {\n\t" );
 		}
 		else {
 			declaration

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/InvalidNativeStaticQuery.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/InvalidNativeStaticQuery.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.staticquery;
+
+import jakarta.persistence.EntityAgent;
+import jakarta.persistence.query.NativeQuery;
+import org.hibernate.query.restriction.Restriction;
+
+import java.util.List;
+
+interface InvalidNativeStaticQuery {
+	@NativeQuery("select * from Book")
+	List<Book> nat(EntityAgent agent, Restriction<Book> restriction);
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/NotARepo.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/NotARepo.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.staticquery;
+
+import jakarta.persistence.query.JakartaQuery;
+
+import java.util.List;
+
+public interface NotARepo {
+	record Summary(String isbn, String title) {
+	}
+
+	@JakartaQuery("from Book")
+	List<Book> books();
+
+	@JakartaQuery("from Book")
+	List<Summary> summaries();
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/StaticQueryTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/StaticQueryTest.java
@@ -9,19 +9,26 @@ import jakarta.persistence.QueryFlushMode;
 import jakarta.persistence.StatementReference;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.TypedQueryReference;
+import org.hibernate.processor.HibernateProcessor;
 import org.hibernate.processor.test.util.CompilationTest;
 import org.hibernate.processor.test.util.TestUtil;
 import org.hibernate.processor.test.util.WithClasses;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
+import java.util.Locale;
 
 import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
 import static org.hibernate.processor.test.util.TestUtil.getMethodFromMetamodelFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
 
 @CompilationTest
 class StaticQueryTest {
@@ -93,5 +100,38 @@ class StaticQueryTest {
 				(TypedQueryReference<?>) summaries.invoke( null );
 		assertEquals( NotARepo.class.getName() + "#summaries()", summariesReference.getName() );
 		assertEquals( Book.class, summariesReference.getResultType() );
+	}
+
+	@Test
+	void nonRepositoryNativeStaticQueryReferenceWithRestrictionCompiles() throws Exception {
+		final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+		final var compiler = ToolProvider.getSystemJavaCompiler();
+		try ( var fileManager = compiler.getStandardFileManager( diagnostics, Locale.ROOT, null ) ) {
+			final var sourceFiles = List.of(
+					sourceFile( Book.class ),
+					sourceFile( InvalidNativeStaticQuery.class )
+			);
+			final var task = compiler.getTask(
+					null,
+					fileManager,
+					diagnostics,
+					List.of(
+							"-d",
+							TestUtil.getOutBaseDir( StaticQueryTest.class ).getAbsolutePath(),
+							"-processor",
+							HibernateProcessor.class.getName()
+					),
+					null,
+					fileManager.getJavaFileObjectsFromFiles( sourceFiles )
+			);
+			assertTrue( task.call() );
+		}
+	}
+
+	private static File sourceFile(Class<?> type) {
+		return new File(
+				TestUtil.getSourceBaseDir( type ),
+				type.getName().replace( '.', File.separatorChar ) + ".java"
+		);
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/StaticQueryTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/StaticQueryTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @CompilationTest
 class StaticQueryTest {
 	@Test
-	@WithClasses({ Book.class, Library.class })
+	@WithClasses({ Book.class, Library.class, NotARepo.class })
 	void testStaticQueryReferenceMethods() throws ReflectiveOperationException {
 		System.out.println( TestUtil.getMetaModelSourceAsString( Library.class ) );
 		assertMetamodelClassGeneratedFor( Book.class );
@@ -70,5 +70,28 @@ class StaticQueryTest {
 		assertEquals( List.of(), statementReference.getParameterTypes() );
 		assertEquals( List.of(), statementReference.getParameterNames() );
 		assertEquals( List.of(), statementReference.getArguments() );
+	}
+
+	@Test
+	@WithClasses({ Book.class, NotARepo.class })
+	void nonRepositoryProjectionQueryReferenceUsesExplicitRootEntity() throws ReflectiveOperationException {
+		final var metamodel = TestUtil.getMetaModelSourceAsString( NotARepo.class );
+		assertTrue( metamodel.contains( "TypedQueryReference<Book> summaries()" ) );
+		assertTrue( metamodel.contains( "Book.class" ) );
+
+		final Method books = getMethodFromMetamodelFor( NotARepo.class, "books" );
+		final ParameterizedType booksType = (ParameterizedType) books.getGenericReturnType();
+		assertEquals( TypedQueryReference.class, booksType.getRawType() );
+		assertEquals( Book.class, booksType.getActualTypeArguments()[0] );
+
+		final Method summaries = getMethodFromMetamodelFor( NotARepo.class, "summaries" );
+		final ParameterizedType summariesType = (ParameterizedType) summaries.getGenericReturnType();
+		assertEquals( TypedQueryReference.class, summariesType.getRawType() );
+		assertEquals( Book.class, summariesType.getActualTypeArguments()[0] );
+
+		final TypedQueryReference<?> summariesReference =
+				(TypedQueryReference<?>) summaries.invoke( null );
+		assertEquals( NotARepo.class.getName() + "#summaries()", summariesReference.getName() );
+		assertEquals( Book.class, summariesReference.getResultType() );
 	}
 }


### PR DESCRIPTION
Backports the last four commits from `main` to `8.0`:

- `840ad6d5877` infer entity from @Query annotation for projection repo methods
- `d22fdb051a9` make use of new 3-argument overload of augment() in Processor
- `7dddc3716c8` fix resolution of entity type names for non-repo static query methods
- `1a19433ad82` fix dupe error messages across _X and X_ class generation

The only manual conflict resolution was in `AnnotationMetaEntity.java` while applying the first commit; the final branch is clean and contains four backport commits over `origin/8.0`.

Validation:

- `./gradlew :hibernate-processor:test --tests org.hibernate.processor.test.staticquery.StaticQueryTest`
- `./gradlew :hibernate-processor:jakartaDataTest --tests org.hibernate.processor.test.data.basic.DataTest --tests org.hibernate.processor.test.data.restriction.DataRestrictionTest --tests org.hibernate.processor.test.data.select.SelectionTest`
