### PR TITLE
HHH-20564 HbmXmlTransformer does not transfer the generated attribute on basic properties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1447,6 +1447,8 @@ public class HbmXmlTransformer {
 		);
 		basic.setOptimisticLock( hbmProp.isOptimisticLock() );
 
+		basic.setGenerated( hbmProp.getGenerated() );
+
 		applyBasicTypeMapping(
 				(BasicValue) propertyInfo.bootModelProperty().getValue(),
 				basic,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/ComponentOwnerEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/ComponentOwnerEntity.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class ComponentOwnerEntity {
+	private Long id;
+	private String name;
+	private Component component;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Component getComponent() {
+		return component;
+	}
+
+	public void setComponent(Component component) {
+		this.component = component;
+	}
+
+	public static class Component {
+		private int generated;
+
+		public int getGenerated() {
+			return generated;
+		}
+
+		public void setGenerated(int generated) {
+			this.generated = generated;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -18,6 +18,9 @@ import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping;
 import org.hibernate.boot.jaxb.hbm.transform.HbmXmlTransformer;
 import org.hibernate.boot.jaxb.hbm.transform.UnsupportedFeatureHandling;
 import org.hibernate.boot.jaxb.internal.stax.HbmEventReader;
+import org.hibernate.boot.jaxb.mapping.GenerationTiming;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbBasicImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbIdImpl;
@@ -184,6 +187,22 @@ public class HbmTransformationJaxbTests {
 			assertThat( id.getGenericGenerator().getName() ).isNotNull();
 			assertThat( id.getGenericGenerator().getName() )
 					.isEqualTo( id.getGeneratedValue().getGenerator() );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20564" )
+	public void testComponentGeneratedPropertyTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/component-generated/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 1 );
+			assertThat( transformed.getEmbeddables() ).hasSize( 1 );
+
+			final JaxbEmbeddableImpl embeddable = transformed.getEmbeddables().get( 0 );
+			assertThat( embeddable.getAttributes().getBasicAttributes() ).hasSize( 1 );
+
+			final JaxbBasicImpl basicAttr = embeddable.getAttributes().getBasicAttributes().get( 0 );
+			assertThat( basicAttr.getName() ).isEqualTo( "generated" );
+			assertThat( basicAttr.getGenerated() ).isEqualTo( GenerationTiming.ALWAYS );
 		} );
 	}
 

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/component-generated/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/component-generated/hbm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="ComponentOwnerEntity" table="comp_gen">
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name"/>
+        <component name="component" class="ComponentOwnerEntity$Component">
+            <property name="generated" type="int" generated="always" column="GENED"/>
+        </component>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20564

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20564 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->