### PR TITLE
HHH-20566 HbmXmlTransformer uses wrong inheritance strategy for nested joined-subclass and union-subclass

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -457,7 +457,7 @@ public class HbmXmlTransformer {
 			final var mappingSubclassEntity = transformationState.getMappingEntityByName().get( subclassEntityName );
 			final var subclassEntityInfo = transformationState.getEntityInfoByName().get( subclassEntityName );
 			transferJoinedSubclass( hbmSubclass, mappingSubclassEntity, subclassEntityInfo );
-			defineInheritance( mappingEntity, InheritanceType.TABLE_PER_CLASS );
+			defineInheritance( mappingEntity, InheritanceType.JOINED );
 		}
 
 		for ( var hbmSubclass : hbmClass.getUnionSubclass() ) {
@@ -465,7 +465,7 @@ public class HbmXmlTransformer {
 			final var mappingSubclassEntity = transformationState.getMappingEntityByName().get( subclassEntityName );
 			final var subclassEntityInfo = transformationState.getEntityInfoByName().get( subclassEntityName );
 			transferUnionSubclass( hbmSubclass, mappingSubclassEntity, subclassEntityInfo );
-			defineInheritance( mappingEntity, InheritanceType.JOINED );
+			defineInheritance( mappingEntity, InheritanceType.TABLE_PER_CLASS );
 		}
 
 		for ( var hbmQuery : hbmClass.getQuery() ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -38,6 +38,7 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.ServiceRegistryScope;
 import org.junit.jupiter.api.Test;
 
+import jakarta.persistence.InheritanceType;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 
@@ -203,6 +204,50 @@ public class HbmTransformationJaxbTests {
 			final JaxbBasicImpl basicAttr = embeddable.getAttributes().getBasicAttributes().get( 0 );
 			assertThat( basicAttr.getName() ).isEqualTo( "generated" );
 			assertThat( basicAttr.getGenerated() ).isEqualTo( GenerationTiming.ALWAYS );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20566" )
+	public void testJoinedSubclassInheritanceStrategy(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/joined-subclass/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl baseEntity = transformed.getEntities().stream()
+					.filter( e -> "JoinedSubclassBase".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( baseEntity.getInheritance() ).isNotNull();
+			assertThat( baseEntity.getInheritance().getStrategy() ).isEqualTo( InheritanceType.JOINED );
+
+			final JaxbEntityImpl childEntity = transformed.getEntities().stream()
+					.filter( e -> "JoinedSubclassChild".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( childEntity.getPrimaryKeyJoinColumns() ).isNotEmpty();
+			assertThat( childEntity.getPrimaryKeyJoinColumns().get( 0 ).getName() ).isEqualTo( "base_id" );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20566" )
+	public void testUnionSubclassInheritanceStrategy(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/union-subclass/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl baseEntity = transformed.getEntities().stream()
+					.filter( e -> "UnionSubclassBase".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( baseEntity.getInheritance() ).isNotNull();
+			assertThat( baseEntity.getInheritance().getStrategy() ).isEqualTo( InheritanceType.TABLE_PER_CLASS );
+
+			final JaxbEntityImpl childEntity = transformed.getEntities().stream()
+					.filter( e -> "UnionSubclassChild".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( childEntity.getTable() ).isNotNull();
+			assertThat( childEntity.getTable().getName() ).isEqualTo( "us_child" );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class JoinedSubclassBase {
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class JoinedSubclassChild extends JoinedSubclassBase {
+	private String detail;
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/UnionSubclassBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/UnionSubclassBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class UnionSubclassBase {
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/UnionSubclassChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/UnionSubclassChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class UnionSubclassChild extends UnionSubclassBase {
+	private String detail;
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/joined-subclass/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/joined-subclass/hbm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="JoinedSubclassBase" table="js_base">
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name"/>
+        <joined-subclass name="JoinedSubclassChild" table="js_child">
+            <key column="base_id"/>
+            <property name="detail"/>
+        </joined-subclass>
+    </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/union-subclass/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/union-subclass/hbm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="UnionSubclassBase" table="us_base">
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name"/>
+        <union-subclass name="UnionSubclassChild" table="us_child">
+            <property name="detail"/>
+        </union-subclass>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20566

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20566 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->