### PR TITLE
Backport HHH-20568 to branch 8.0 - Make hibernate-micrometer dependency to Micrometer provided (compileOnly)

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -271,7 +271,8 @@ asciidoctorj {
             'html-outdated-content-project-key': 'orm',
             'html-meta-description': 'Hibernate ORM, relational persistence for idiomatic Java',
             'html-meta-keywords': 'hibernate, orm, hibernate orm, database, db, jpa, sql',
-            'html-meta-version-family': ormBuildDetails.hibernateVersion.family
+            'html-meta-version-family': ormBuildDetails.hibernateVersion.family,
+            micrometerVersion: libs.versions.micrometer.get().split('\\.')[0..1].join('.')
 
     options logDocuments: true
 

--- a/documentation/src/main/asciidoc/introduction/Tuning.adoc
+++ b/documentation/src/main/asciidoc/introduction/Tuning.adoc
@@ -1152,6 +1152,13 @@ long publisherCacheMissCount =
 Hibernate's statistics enable observability.
 Both {micrometer}[Micrometer] and {smallrye-metrics}[SmallRye Metrics] are capable of exposing these metrics.
 
+[NOTE]
+====
+To use the Micrometer integration, the application must include `org.hibernate.orm:hibernate-micrometer` on the classpath,
+as well as an appropriate version of `io.micrometer:micrometer-core`.
+This version of Hibernate ORM is compatible with Micrometer {micrometerVersion}.
+====
+
 [[jfr]]
 === Using Java Flight Recorder
 

--- a/hibernate-micrometer/hibernate-micrometer.gradle
+++ b/hibernate-micrometer/hibernate-micrometer.gradle
@@ -7,9 +7,10 @@ description = 'Integration for Micrometer metrics into Hibernate as a metrics co
 
 dependencies {
     implementation project( ':hibernate-core' )
-    implementation libs.micrometer
+    compileOnly libs.micrometer
 
     testImplementation project( ':hibernate-testing' )
+    testImplementation libs.micrometer
 
     testAnnotationProcessor project( ':hibernate-processor' )
     testCompileOnly libs.jakarta.annotation

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -735,3 +735,9 @@ No DDL changes are needed. The default `REV`/`REVTYPE` column names and encoding
 == Changes in Dependencies
 
 This section describes changes to dependencies used by Hibernate ORM.
+
+[[dependency-changes-micrometer]]
+=== Micrometer dependency is now provided
+
+The `hibernate-micrometer` module no longer pulls `io.micrometer:micrometer-core` as a transitive runtime dependency.
+Applications using this module must now explicitly add `io.micrometer:micrometer-core` to their classpath.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20568

Backport of #12747

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20568 (Remove Feature):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->