### PR TITLE
Backport selected main commits to 8.0

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Querying.adoc
+++ b/documentation/src/main/asciidoc/introduction/Querying.adoc
@@ -315,7 +315,7 @@ When all else fails, and sometimes even before that, we're left with the option 
 [[native-queries]]
 === Native SQL queries
 
-HQL is a powerful language which helps reduce the verbosity of SQL, and significantly increases portability of queries between databases.
+HQL is a powerful language that helps reduce the verbosity of SQL, and significantly increases the portability of queries between databases.
 But ultimately, the true value of ORM is not in avoiding SQL, but in alleviating the pain involved in dealing with SQL result sets once we get them back to our Java program.
 As we said <<introduction,right up front>>, Hibernate's generated SQL is meant to be used in conjunction with handwritten SQL, and native SQL queries are one of the facilities we provide to make that easy.
 

--- a/documentation/src/main/asciidoc/introduction/Tuning.adoc
+++ b/documentation/src/main/asciidoc/introduction/Tuning.adoc
@@ -120,7 +120,7 @@ However, there are a couple of exceptions to this and for the offending drivers 
 | link:{doc-javadoc-url}/org/hibernate/cfg/JdbcSettings.html#STATEMENT_FETCH_SIZE[`hibernate.jdbc.fetch_size`] | The default JDBC fetch size
 |===
 
-The default fetch size can be overridden for a given query by calling link:{doc-javadoc-url}/org/hibernate/query/SelectionQuery.html#setFetchSize(int)[`setFetchSize()`], but this is rarely necessary.
+The default fetch size can be overridden for a given query by using the link:{doc-javadoc-url}/org/hibernate/query/QueryOption.JdbcFetchSize.html[`JdbcFetchSize`] option, but this is rarely necessary.
 
 [WARNING]
 ====
@@ -770,16 +770,26 @@ The query cache must be enabled explicitly:
 | link:{doc-javadoc-url}org/hibernate/cfg/CacheSettings.html#USE_QUERY_CACHE[`hibernate.cache.use_query_cache`] | `true` to enable the query cache
 |===
 
-To cache the results of a query, call `SelectionQuery.setCacheable(true)`:
+To cache the results of a query, use the link:{doc-javadoc-url}org/hibernate/query/QueryOption.ResultSetCache.html[`ResultSetCache`] option:
 
 [source,java]
 ----
+import org.hibernate.query.QueryOption.ResultSetCache;
+...
 entityManager.createQuery("from Product where discontinued = false")
-    .ofType(Product.class)
-    .unwrap(SelectionQuery.class)
-    .setCacheable(true)
-    .getResultList();
+             .ofType(Product.class)
+             .addOption(new ResultSetCache(null))
+             .getResultList();
 ----
+//
+// [source,java]
+// ----
+// entityManager.createQuery("from Product where discontinued = false")
+//     .ofType(Product.class)
+//     .unwrap(SelectionQuery.class)
+//     .setCacheable(true)
+//     .getResultList();
+// ----
 
 By default, the query result set is stored in a cache region named `default-query-results-region`.
 Since different queries should have different caching policies, it's common to explicitly specify a region name:
@@ -787,11 +797,9 @@ Since different queries should have different caching policies, it's common to e
 [source,java]
 ----
 entityManager.createQuery("from Product where discontinued = false")
-    .ofType(Product.class)
-    .unwrap(SelectionQuery.class)
-    .setCacheable(true)
-    .setCacheRegion("ProductCatalog")
-    .getResultList();
+             .ofType(Product.class)
+             .addOption(new ResultSetCache("all-active-products"))
+             .getResultList();
 ----
 
 A result set is cached together with a _logical timestamp_.
@@ -1143,7 +1151,7 @@ long failedVersionChecks =
 long publisherCacheMissCount =
         sessionFactory.getStatistics()
             .getEntityStatistics(Publisher.class.getName())
-                .getCacheMissCount()
+                .getCacheMissCount();
 ----
 
 :micrometer: https://quarkus.io/guides/micrometer
@@ -1155,7 +1163,7 @@ Both {micrometer}[Micrometer] and {smallrye-metrics}[SmallRye Metrics] are capab
 [[jfr]]
 === Using Java Flight Recorder
 
-Hibernate JFR is a separate module which reports events to link:https://developers.redhat.com/blog/2020/08/25/get-started-with-jdk-flight-recorder-in-openjdk-8u[Java Flight Recorder].
+Hibernate JFR is a separate module that reports events to link:https://developers.redhat.com/blog/2020/08/25/get-started-with-jdk-flight-recorder-in-openjdk-8u[Java Flight Recorder].
 This is different to reporting aggregated <<statistics,metrics>> via a tool like Micrometer, since JFR records information about the timing and duration of each discrete event, along with a stack trace.
 If anything, the information reported by JFR is a little _too_ detailed to make it really useful for performance tuning--it's perhaps more useful for _troubleshooting_.
 
@@ -1182,7 +1190,7 @@ When `hibernate.use_sql_comments` is enabled, the text of the HQL query is prepe
 
 The comment text may be customized:
 
-- by calling `Query.setComment(comment)` or `Query.setHint(AvailableHints.HINT_COMMENT,comment)`, or
+- using the link:{doc-javadoc-url}/org/hibernate/query/QueryOption.Comment.html[`Comment`] option, or
 - via the `@NamedQuery` annotation.
 
 [TIP]

--- a/hibernate-core/src/main/java/org/hibernate/FindMultipleOption.java
+++ b/hibernate-core/src/main/java/org/hibernate/FindMultipleOption.java
@@ -21,14 +21,14 @@ public interface FindMultipleOption extends FindOption {
 	/// - By default, the batch sizing strategy is determined by the
 	///   [SQL Dialect][org.hibernate.dialect.Dialect#getBatchLoadSizingStrategy],
 	///   but
-	/// - if some `batchSize>1` is specified as an argument to this method, then that
-	///   batch size will be used.
+	/// - if some `batchSize>1` is specified using this option, then that batch size
+	///   is used.
 	///
 	/// If an explicit batch size is set manually, care should be taken to not exceed
 	/// the capabilities of the underlying database.
 	///
 	/// The performance impact of setting a batch size depends on whether a SQL array
-	///  may be used to pass the list of identifiers to the database:
+	/// may be used to pass the list of identifiers to the database:
 	///
 	/// - for databases which support standard SQL arrays, a smaller batch size might
 	///   be extremely inefficient compared to a very large batch size or no batching

--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -11,6 +11,8 @@ import java.util.function.UnaryOperator;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
 import org.hibernate.cfg.StateManagementSettings;
 import org.hibernate.engine.creation.CommonBuilder;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
@@ -180,7 +182,19 @@ public interface SessionBuilder extends CommonBuilder {
 
 	@Override
 	@Nonnull
+	SessionBuilder jdbcBatchSize(int batchSize);
+
+	@Override
+	@Nonnull
 	SessionBuilder initialCacheMode(@Nonnull CacheMode cacheMode);
+
+	@Override
+	@Nonnull
+	SessionBuilder cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode);
+
+	@Override
+	@Nonnull
+	SessionBuilder cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode);
 
 	/**
 	 * Add one or more {@link SessionEventListener} instances to the list of

--- a/hibernate-core/src/main/java/org/hibernate/SessionCreationOption.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionCreationOption.java
@@ -110,4 +110,21 @@ public interface SessionCreationOption {
 		/// Disables subselect fetching.
 		DISABLED
 	}
+
+	/**
+	 * Enables JDBC statement batching and specifies a batch size.
+	 *
+	 * @param batchSize The batch size for JDBC batch updates
+	 *
+	 * @see Session#setJdbcBatchSize(Integer)
+	 * @see org.hibernate.cfg.BatchSettings#STATEMENT_BATCH_SIZE
+	 *
+	 * @apiNote Not defined as an {@link EntityAgent.CreationOption}
+	 * because JDBC batching at the session level results in a sort
+	 * of write-behind behavior which is foreign to the nature of
+	 * the stateless programming model.
+	 */
+	record JdbcBatchSize(int batchSize)
+			implements EntityManager.CreationOption {
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/SessionCreationOption.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionCreationOption.java
@@ -76,14 +76,14 @@ public interface SessionCreationOption {
 	/// - By default, the batch sizing strategy is determined by the
 	///   [SQL Dialect][org.hibernate.dialect.Dialect#getBatchLoadSizingStrategy],
 	///   but
-	/// - if some `batchSize>1` is specified as an argument to this method, then that
-	///   batch size will be used.
+	/// - if some `batchSize>1` is specified using this option, then that batch size
+	///   is used.
 	///
 	/// If an explicit batch size is set manually, care should be taken to not exceed
 	/// the capabilities of the underlying database.
 	///
 	/// The performance impact of setting a batch size depends on whether a SQL array
-	///  may be used to pass the list of identifiers to the database:
+	/// may be used to pass the list of identifiers to the database:
 	///
 	/// - for databases which support standard SQL arrays, a smaller batch size might
 	///   be extremely inefficient compared to a very large batch size or no batching

--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
@@ -6,6 +6,8 @@ package org.hibernate;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
 import org.hibernate.engine.creation.CommonSharedBuilder;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
@@ -168,7 +170,19 @@ public interface SharedSessionBuilder extends SessionBuilder, CommonSharedBuilde
 
 	@Override
 	@Nonnull
+	SharedSessionBuilder jdbcBatchSize(int batchSize);
+
+	@Override
+	@Nonnull
 	SharedSessionBuilder initialCacheMode(@Nonnull CacheMode cacheMode);
+
+	@Override
+	@Nonnull
+	SharedSessionBuilder cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode);
+
+	@Override
+	@Nonnull
+	SharedSessionBuilder cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode);
 
 	@Override
 	@Nonnull

--- a/hibernate-core/src/main/java/org/hibernate/SharedStatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedStatelessSessionBuilder.java
@@ -6,9 +6,12 @@ package org.hibernate;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
 import org.hibernate.engine.creation.CommonSharedBuilder;
 
 import java.sql.Connection;
+import java.time.Instant;
 import java.util.TimeZone;
 import java.util.function.UnaryOperator;
 
@@ -109,7 +112,19 @@ public interface SharedStatelessSessionBuilder extends StatelessSessionBuilder, 
 
 	@Override
 	@Nonnull
+	SharedStatelessSessionBuilder jdbcBatchSize(int batchSize);
+
+	@Override
+	@Nonnull
 	SharedStatelessSessionBuilder initialCacheMode(@Nonnull CacheMode cacheMode);
+
+	@Override
+	@Nonnull
+	SharedStatelessSessionBuilder cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode);
+
+	@Override
+	@Nonnull
+	SharedStatelessSessionBuilder cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode);
 
 	@Override
 	@Nonnull
@@ -122,4 +137,12 @@ public interface SharedStatelessSessionBuilder extends StatelessSessionBuilder, 
 	@Override
 	@Nonnull
 	SharedStatelessSessionBuilder jdbcTimeZone(@Nullable TimeZone timeZone);
+
+	@Override
+	@Nonnull
+	SharedStatelessSessionBuilder asOf(@Nullable Instant instant);
+
+	@Override
+	@Nonnull
+	SharedStatelessSessionBuilder atChangeset(@Nullable Object changesetId);
 }

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -11,6 +11,8 @@ import java.util.function.UnaryOperator;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
 import org.hibernate.cfg.StateManagementSettings;
 import org.hibernate.engine.creation.CommonBuilder;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
@@ -46,6 +48,18 @@ public interface StatelessSessionBuilder extends CommonBuilder {
 
 	@Override
 	@Nonnull
+	StatelessSessionBuilder interceptor(@Nullable Interceptor interceptor);
+
+	@Override
+	@Nonnull
+	StatelessSessionBuilder noInterceptor();
+
+	@Override
+	@Nonnull
+	StatelessSessionBuilder noSessionInterceptorCreation();
+
+	@Override
+	@Nonnull
 	StatelessSessionBuilder tenantIdentifier(Object tenantIdentifier);
 
 	@Incubating
@@ -56,11 +70,28 @@ public interface StatelessSessionBuilder extends CommonBuilder {
 	@Incubating
 	@Override
 	@Nonnull
+	StatelessSessionBuilder jdbcBatchSize(int batchSize);
+
+	@Incubating
+	@Override
+	@Nonnull
 	StatelessSessionBuilder initialCacheMode(@Nonnull CacheMode cacheMode);
 
 	@Override
 	@Nonnull
+	StatelessSessionBuilder cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode);
+
+	@Override
+	@Nonnull
+	StatelessSessionBuilder cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode);
+
+	@Override
+	@Nonnull
 	StatelessSessionBuilder statementInspector(@Nullable UnaryOperator<String> operator);
+
+	@Override
+	@Nonnull
+	StatelessSessionBuilder noStatementInspector();
 
 	@Override
 	@Nonnull

--- a/hibernate-core/src/main/java/org/hibernate/engine/creation/CommonSharedBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/creation/CommonSharedBuilder.java
@@ -6,6 +6,8 @@ package org.hibernate.engine.creation;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
 import org.hibernate.CacheMode;
 import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.ConnectionReleaseMode;
@@ -13,6 +15,7 @@ import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
 
 import java.sql.Connection;
+import java.time.Instant;
 import java.util.TimeZone;
 import java.util.function.UnaryOperator;
 
@@ -79,7 +82,7 @@ public interface CommonSharedBuilder extends CommonBuilder {
 
 	@Override
 	@Nonnull
-	CommonBuilder connection(@Nonnull Connection connection);
+	CommonSharedBuilder connection(@Nonnull Connection connection);
 
 	@Override
 	@Nonnull
@@ -87,5 +90,25 @@ public interface CommonSharedBuilder extends CommonBuilder {
 
 	@Override
 	@Nonnull
+	CommonSharedBuilder jdbcBatchSize(int batchSize);
+
+	@Override
+	@Nonnull
+	CommonSharedBuilder cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode);
+
+	@Override
+	@Nonnull
+	CommonSharedBuilder cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode);
+
+	@Override
+	@Nonnull
 	CommonSharedBuilder jdbcTimeZone(@Nullable TimeZone timeZone);
+
+	@Override
+	@Nonnull
+	CommonSharedBuilder asOf(@Nullable Instant instant);
+
+	@Override
+	@Nonnull
+	CommonSharedBuilder atChangeset(@Nullable Object changesetId);
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/creation/internal/AbstractCommonBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/creation/internal/AbstractCommonBuilder.java
@@ -98,13 +98,13 @@ public abstract class AbstractCommonBuilder<T extends CommonBuilder> implements 
 	}
 
 	@Override
-	public CommonBuilder cacheStoreMode(CacheStoreMode cacheStoreMode) {
+	public T cacheStoreMode(CacheStoreMode cacheStoreMode) {
 		options.cacheStoreMode( cacheStoreMode );
 		return getThis();
 	}
 
 	@Override
-	public CommonBuilder cacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
+	public T cacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
 		options.cacheRetrieveMode( cacheRetrieveMode );
 		return getThis();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/creation/spi/SessionBuilderImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/creation/spi/SessionBuilderImplementor.java
@@ -7,6 +7,8 @@ package org.hibernate.engine.creation.spi;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.Nonnull;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
 import org.hibernate.CacheMode;
 import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.ConnectionReleaseMode;
@@ -35,6 +37,12 @@ public interface SessionBuilderImplementor extends SessionBuilder {
 	@Override
 	@Nonnull
 	SessionImplementor openSession();
+
+	@Override
+	@Nonnull
+	default SessionImplementor open() {
+		return openSession();
+	}
 
 	@Override
 	@Nonnull
@@ -91,6 +99,18 @@ public interface SessionBuilderImplementor extends SessionBuilder {
 	@Override
 	@Nonnull
 	SessionBuilderImplementor initialCacheMode(@Nonnull CacheMode cacheMode);
+
+	@Override
+	@Nonnull
+	SessionBuilderImplementor jdbcBatchSize(int batchSize);
+
+	@Override
+	@Nonnull
+	SessionBuilderImplementor cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode);
+
+	@Override
+	@Nonnull
+	SessionBuilderImplementor cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode);
 
 	@Override
 	@Nonnull

--- a/hibernate-core/src/main/java/org/hibernate/engine/creation/spi/SharedSessionBuilderImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/creation/spi/SharedSessionBuilderImplementor.java
@@ -6,6 +6,8 @@ package org.hibernate.engine.creation.spi;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
 import org.hibernate.CacheMode;
 import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.ConnectionReleaseMode;
@@ -13,6 +15,7 @@ import org.hibernate.FlushMode;
 import org.hibernate.Interceptor;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SharedSessionBuilder;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 
@@ -27,6 +30,10 @@ import java.util.function.UnaryOperator;
  * @since 7.2
  */
 public interface SharedSessionBuilderImplementor extends SharedSessionBuilder, SessionBuilderImplementor {
+	@Override
+	@Nonnull
+	SessionImplementor open();
+
 	@Override
 	@Nonnull
 	SharedSessionBuilderImplementor interceptor(@Nullable Interceptor interceptor);
@@ -58,6 +65,18 @@ public interface SharedSessionBuilderImplementor extends SharedSessionBuilder, S
 	@Override
 	@Nonnull
 	SharedSessionBuilderImplementor initialCacheMode(@Nonnull CacheMode cacheMode);
+
+	@Override
+	@Nonnull
+	SharedSessionBuilderImplementor jdbcBatchSize(int batchSize);
+
+	@Override
+	@Nonnull
+	SharedSessionBuilderImplementor cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode);
+
+	@Override
+	@Nonnull
+	SharedSessionBuilderImplementor cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode);
 
 	@Override
 	@Nonnull

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
@@ -21,7 +21,6 @@ import org.hibernate.FlushMode;
 import org.hibernate.Interceptor;
 import org.hibernate.SessionBuilder;
 import org.hibernate.SessionEventListener;
-import org.hibernate.engine.creation.CommonBuilder;
 import org.hibernate.engine.creation.spi.SessionBuilderImplementor;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
@@ -150,21 +149,21 @@ public abstract class AbstractDelegatingSessionBuilder implements SessionBuilder
 
 	@Override
 	@Nonnull
-	public CommonBuilder jdbcBatchSize(int batchSize) {
+	public SessionBuilderImplementor jdbcBatchSize(int batchSize) {
 		delegate.jdbcBatchSize( batchSize );
 		return this;
 	}
 
 	@Override
 	@Nonnull
-	public CommonBuilder cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode) {
+	public SessionBuilderImplementor cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode) {
 		delegate.cacheStoreMode( cacheStoreMode );
 		return this;
 	}
 
 	@Override
 	@Nonnull
-	public CommonBuilder cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode) {
+	public SessionBuilderImplementor cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode) {
 		delegate.cacheRetrieveMode( cacheRetrieveMode );
 		return this;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
@@ -21,7 +21,6 @@ import org.hibernate.Interceptor;
 import org.hibernate.Session;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SharedSessionBuilder;
-import org.hibernate.engine.creation.CommonBuilder;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 
@@ -190,21 +189,21 @@ public abstract class AbstractDelegatingSharedSessionBuilder implements SharedSe
 
 	@Override
 	@Nonnull
-	public CommonBuilder jdbcBatchSize(int batchSize) {
+	public SharedSessionBuilder jdbcBatchSize(int batchSize) {
 		delegate.jdbcBatchSize( batchSize );
 		return this;
 	}
 
 	@Override
 	@Nonnull
-	public CommonBuilder cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode) {
+	public SharedSessionBuilder cacheStoreMode(@Nullable CacheStoreMode cacheStoreMode) {
 		delegate.cacheStoreMode( cacheStoreMode );
 		return this;
 	}
 
 	@Override
 	@Nonnull
-	public CommonBuilder cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode) {
+	public SharedSessionBuilder cacheRetrieveMode(@Nullable CacheRetrieveMode cacheRetrieveMode) {
 		delegate.cacheRetrieveMode( cacheRetrieveMode );
 		return this;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/OptionsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/OptionsHelper.java
@@ -28,6 +28,7 @@ import org.hibernate.engine.creation.internal.options.StatefulOptions;
 import org.hibernate.engine.creation.internal.options.StatelessOptions;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.StatelessSessionImplementor;
+import org.hibernate.query.CommonQueryContract;
 import org.hibernate.query.QueryOption;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.spi.QueryOptions;
@@ -235,6 +236,9 @@ public final class OptionsHelper {
 			selectionQuery.setCacheable( true );
 			selectionQuery.setCacheRegion( resultSetCache.region() );
 		}
+		else if ( option instanceof QueryOption.JdbcFetchSize jdbcFetchSize ) {
+			selectionQuery.setFetchSize( jdbcFetchSize.fetchSize() );
+		}
 		else if ( option instanceof QueryOption.Comment comment ) {
 			selectionQuery.setComment( comment.comment() );
 		}
@@ -268,6 +272,11 @@ public final class OptionsHelper {
 			options.add( new QueryOption.ResultSetCache( queryOptions.getResultCacheRegionName() ) );
 		}
 
+		final Integer fetchSize = queryOptions.getFetchSize();
+		if ( fetchSize != null ) {
+			options.add( new QueryOption.JdbcFetchSize( fetchSize ) );
+		}
+
 		final String comment = queryOptions.getComment();
 		if ( comment != null ) {
 			options.add( new QueryOption.Comment( comment ) );
@@ -289,6 +298,9 @@ public final class OptionsHelper {
 		else if ( option instanceof QueryFlushMode queryFlushMode ) {
 			statement.setQueryFlushMode( queryFlushMode );
 		}
+		else if ( option instanceof QueryOption.Comment comment ) {
+			( (CommonQueryContract) statement ).setComment( comment.comment() );
+		}
 	}
 
 	public static Set<Statement.Option> getStatementOptions(QueryOptions queryOptions) {
@@ -297,6 +309,10 @@ public final class OptionsHelper {
 		final var queryFlushMode = queryFlushModeFromFlushMode( queryOptions.getFlushMode() );
 		if ( queryFlushMode != null && queryFlushMode != QueryFlushMode.DEFAULT ) {
 			options.add( queryFlushMode );
+		}
+		final String comment = queryOptions.getComment();
+		if ( comment != null ) {
+			options.add( new QueryOption.Comment( comment ) );
 		}
 		return options;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/OptionsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/OptionsHelper.java
@@ -70,6 +70,9 @@ public final class OptionsHelper {
 		else if ( option instanceof SessionCreationOption.FetchBatchSize fetchBatchSize ) {
 			options.defaultBatchFetchSize( fetchBatchSize.batchSize() );
 		}
+		else if ( option instanceof SessionCreationOption.JdbcBatchSize jdbcBatchSize ) {
+			options.jdbcBatchSize( jdbcBatchSize.batchSize() );
+		}
 		else if ( option instanceof SessionCreationOption.BulkSelect bulkSelect ) {
 			options.subselectFetchEnabled( bulkSelect == SessionCreationOption.BulkSelect.ENABLED );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryOption.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryOption.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.Statement;
 import org.hibernate.CacheMode;
@@ -34,11 +35,17 @@ public interface QueryOption {
 	/// be explicitly enabled by setting the configuration property
 	/// {@value org.hibernate.cfg.CacheSettings#USE_QUERY_CACHE}.
 	///
-	/// @param region The second-level cache region to use
-	record ResultSetCache(String region) implements TypedQuery.Option {
-		public ResultSetCache {
-			requireNonNull(region, "Region must be specified");
-		}
+	/// @param region The second-level cache region to use, or `null` for
+	///               the default query cache region
+	record ResultSetCache(@Nullable String region) implements TypedQuery.Option {
+	}
+
+	/// Specifies the JDBC fetch size to use for the query.
+	///
+	/// @param fetchSize The JDBC fetch size
+	///
+	/// @see SelectionQuery#setFetchSize(int)
+	record JdbcFetchSize(int fetchSize) implements TypedQuery.Option {
 	}
 
 	/// Specifies a comment for the SQL query.
@@ -53,7 +60,7 @@ public interface QueryOption {
 	/// @param comment The text of the comment
 	record Comment(String comment) implements TypedQuery.Option, Statement.Option {
 		public Comment {
-			requireNonNull(comment, "Comment must be specified");
+			requireNonNull(comment, "Comment text must be specified");
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/options/Jpa4OptionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/options/Jpa4OptionsTest.java
@@ -29,6 +29,9 @@ import jakarta.persistence.StatementReference;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.TypedQueryReference;
+import org.hibernate.query.CommonQueryContract;
+import org.hibernate.query.QueryOption;
+import org.hibernate.query.SelectionQuery;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.junit.jupiter.api.Test;
@@ -210,7 +213,10 @@ class Jpa4OptionsTest {
 							.addOption( CacheRetrieveMode.BYPASS )
 							.addOption( CacheStoreMode.BYPASS )
 							.addOption( LockModeType.PESSIMISTIC_READ )
-							.addOption( PessimisticLockScope.EXTENDED );
+							.addOption( PessimisticLockScope.EXTENDED )
+							.addOption( new QueryOption.ResultSetCache( "book-results" ) )
+							.addOption( new QueryOption.JdbcFetchSize( 42 ) )
+							.addOption( new QueryOption.Comment( "book query" ) );
 
 			assertEquals( 1234, query.getTimeout() );
 			assertEquals( QueryFlushMode.NO_FLUSH, query.getQueryFlushMode() );
@@ -219,12 +225,21 @@ class Jpa4OptionsTest {
 			assertEquals( LockModeType.PESSIMISTIC_READ, query.getLockMode() );
 			assertEquals( PessimisticLockScope.EXTENDED, query.getLockScope() );
 
+			final var hibernateQuery = query.unwrap( SelectionQuery.class );
+			assertTrue( hibernateQuery.isCacheable() );
+			assertEquals( "book-results", hibernateQuery.getCacheRegion() );
+			assertEquals( 42, hibernateQuery.getFetchSize() );
+			assertEquals( "book query", hibernateQuery.getComment() );
+
 			assertTrue( query.getOptions().contains( Timeout.milliseconds( 1234 ) ) );
 			assertTrue( query.getOptions().contains( QueryFlushMode.NO_FLUSH ) );
 			assertTrue( query.getOptions().contains( CacheRetrieveMode.BYPASS ) );
 			assertTrue( query.getOptions().contains( CacheStoreMode.BYPASS ) );
 			assertTrue( query.getOptions().contains( LockModeType.PESSIMISTIC_READ ) );
 			assertTrue( query.getOptions().contains( PessimisticLockScope.EXTENDED ) );
+			assertTrue( query.getOptions().contains( new QueryOption.ResultSetCache( "book-results" ) ) );
+			assertTrue( query.getOptions().contains( new QueryOption.JdbcFetchSize( 42 ) ) );
+			assertTrue( query.getOptions().contains( new QueryOption.Comment( "book query" ) ) );
 		} );
 	}
 
@@ -234,13 +249,16 @@ class Jpa4OptionsTest {
 			final var statement =
 					entityManager.createStatement( "delete from Book" )
 							.addOption( Timeout.milliseconds( 2345 ) )
-							.addOption( QueryFlushMode.NO_FLUSH );
+							.addOption( QueryFlushMode.NO_FLUSH )
+							.addOption( new QueryOption.Comment( "delete books" ) );
 
 			assertEquals( 2345, statement.getTimeout() );
 			assertEquals( QueryFlushMode.NO_FLUSH, statement.getQueryFlushMode() );
+			assertEquals( "delete books", ( (CommonQueryContract) statement ).getComment() );
 
 			assertTrue( statement.getOptions().contains( Timeout.milliseconds( 2345 ) ) );
 			assertTrue( statement.getOptions().contains( QueryFlushMode.NO_FLUSH ) );
+			assertTrue( statement.getOptions().contains( new QueryOption.Comment( "delete books" ) ) );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pc/EntityHandlerOptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pc/EntityHandlerOptionTests.java
@@ -77,6 +77,22 @@ public class EntityHandlerOptionTests {
 	@Test
 	@DomainModel(annotatedClasses = EntityHandlerOptionTests.TestEntity.class)
 	@SessionFactory
+	void testJdbcBatchSizeSession(SessionFactoryScope factoryScope) {
+		var sf = factoryScope.getSessionFactory();
+
+		try (var em = sf.createEntityManager()) {
+			assertThat( em.getJdbcBatchSize() ).isNull();
+		}
+
+		try (var em = sf.createEntityManager( new SessionCreationOption.JdbcBatchSize( 10 ) )) {
+			assertThat( em.getJdbcBatchSize() ).isEqualTo( 10 );
+			assertThat( em.unwrap( SessionImplementor.class ).getConfiguredJdbcBatchSize() ).isEqualTo( 10 );
+		}
+	}
+
+	@Test
+	@DomainModel(annotatedClasses = EntityHandlerOptionTests.TestEntity.class)
+	@SessionFactory
 	void testFetchBatchSizeStateless(SessionFactoryScope factoryScope) {
 		var sf = factoryScope.getSessionFactory();
 		final int defaultBatchFetchSize = sf.getSessionFactoryOptions().getDefaultBatchFetchSize();


### PR DESCRIPTION
Backports the requested commits from `main` to `8.0`:

- `99a6c04d2694` - very minor fix to the jdoc
- `d70b4c9cce6` - HHH-20558 add SessionCreationOption.JdbcBatchSize
- `84eb2b6cf78` - HHH-20563 add missing covariant overrides to subtypes of CommonSharedBuilder
- `9b71c354e3a` - HHH-20559 add Queryoption.JdbcFetchSize
- `b72cd828b3e` - HHH-20559 update doc with new QueryOptions

Resolution note: `84eb2b6cf78` conflicted in `AbstractCommonBuilder`; the backport keeps the 8.0 nullability annotation style while applying the intended covariant return type changes.

Validation:

- `./gradlew :hibernate-core:compileJava :hibernate-core:compileTestJava`

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20558
https://hibernate.atlassian.net/browse/HHH-20559
https://hibernate.atlassian.net/browse/HHH-20563
<!-- Hibernate GitHub Bot issue links end -->