### PR TITLE
HHH-20515 Preserve managed entity state during findMultiple

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
@@ -220,20 +220,27 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			LockOptions lockOptions,
 			List<Object> results, int i,
 			SharedSessionContractImplementor session) {
-		if ( loadOptions.getSessionCheckMode() == FindMultipleOption.SessionCheckMode.ENABLED ) {
+		final boolean sessionCheckEnabled =
+				loadOptions.getSessionCheckMode() == FindMultipleOption.SessionCheckMode.ENABLED;
+		if ( sessionCheckEnabled ) {
 			final var removalsMode = loadOptions.getRemovalsMode();
 			if ( removalsMode == FindMultipleOption.RemovalsMode.EXCLUDE ) {
 				// note, this method is only called from orderedMultiLoad()
 				throw new IllegalArgumentException( "RemovalsMode.EXCLUDE is incompatible with OrderingMode.ORDERED" );
 			}
-			// look for it in the Session first
-			final var entry = loadFromSessionCache( entityKey, lockOptions, GET, session );
-			final Object entity = entry.entity();
-			if ( entity != null ) {
-				// put a null in the results
+		}
+
+		// look for it in the Session first
+		final var entry = loadFromSessionCache( entityKey, lockOptions, GET, session );
+		final Object entity = entry.entity();
+		if ( entity != null ) {
+			if ( entry.isManaged() ) {
+				results.add( i, entity );
+				return true;
+			}
+			else if ( sessionCheckEnabled ) {
 				final Object result =
 						loadOptions.getRemovalsMode() == FindMultipleOption.RemovalsMode.INCLUDE
-							|| entry.isManaged()
 								? entity
 								: null;
 				results.add( i, result );
@@ -243,10 +250,10 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 
 		if ( loadOptions.isSecondLevelCacheCheckingEnabled() ) {
 			// look for it in the second-level cache
-			final Object entity =
+			final Object cachedEntity =
 					loadFromSecondLevelCache( entityKey, lockOptions, session );
-			if ( entity != null ) {
-				results.add( i, entity );
+			if ( cachedEntity != null ) {
+				results.add( i, cachedEntity );
 				return true;
 			}
 		}
@@ -377,28 +384,32 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 
 		// look for it in the Session first
 		final var entry = loadFromSessionCache( entityKey, lockOptions, GET, session );
-		final Object sessionEntity;
-		if ( loadOptions.getSessionCheckMode() == FindMultipleOption.SessionCheckMode.ENABLED ) {
-			sessionEntity = entry.entity();
-			if ( sessionEntity != null && !entry.isManaged() ) {
+		final Object sessionEntity = entry.entity();
+		if ( sessionEntity != null ) {
+			if ( entry.isManaged() ) {
+				//noinspection unchecked
+				resolutionConsumer.consume( i, entityKey, (R) sessionEntity );
+				return unresolvedIds;
+			}
+			else if ( loadOptions.getSessionCheckMode() == FindMultipleOption.SessionCheckMode.ENABLED ) {
 				switch ( loadOptions.getRemovalsMode() ) {
 					case REPLACE :
 						resolutionConsumer.consume( i, entityKey, null );
 						return unresolvedIds;
 					case EXCLUDE:
 						return unresolvedIds;
+					case INCLUDE:
+						//noinspection unchecked
+						resolutionConsumer.consume( i, entityKey, (R) sessionEntity );
+						return unresolvedIds;
 				}
 			}
 		}
-		else {
-			sessionEntity = null;
-		}
 
 		final Object cachedEntity =
-				sessionEntity == null
-					&& loadOptions.isSecondLevelCacheCheckingEnabled()
-						? loadFromSecondLevelCache( entityKey, lockOptions, session )
-						: sessionEntity;
+				loadOptions.isSecondLevelCacheCheckingEnabled()
+					? loadFromSecondLevelCache( entityKey, lockOptions, session )
+					: null;
 
 		if ( cachedEntity != null ) {
 			//noinspection unchecked

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
@@ -230,22 +230,27 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			}
 		}
 
-		// look for it in the Session first
-		final var entry = loadFromSessionCache( entityKey, lockOptions, GET, session );
-		final Object entity = entry.entity();
-		if ( entity != null ) {
-			if ( entry.isManaged() ) {
-				results.add( i, entity );
-				return true;
+		if ( sessionCheckEnabled ) {
+			// look for it in the Session first
+			final var entry = loadFromSessionCache( entityKey, lockOptions, GET, session );
+			final Object entity = entry.entity();
+			if ( entity != null ) {
+				if ( entry.isManaged() ) {
+					results.add( i, entity );
+					return true;
+				}
+				else {
+					final Object result =
+							loadOptions.getRemovalsMode() == FindMultipleOption.RemovalsMode.INCLUDE
+									? entity
+									: null;
+					results.add( i, result );
+					return true;
+				}
 			}
-			else if ( sessionCheckEnabled ) {
-				final Object result =
-						loadOptions.getRemovalsMode() == FindMultipleOption.RemovalsMode.INCLUDE
-								? entity
-								: null;
-				results.add( i, result );
-				return true;
-			}
+		}
+		else if ( session.getPersistenceContextInternal().containsEntity( entityKey ) ) {
+			return false;
 		}
 
 		if ( loadOptions.isSecondLevelCacheCheckingEnabled() ) {
@@ -382,28 +387,35 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			List<Object> unresolvedIds, int i,
 			SharedSessionContractImplementor session) {
 
-		// look for it in the Session first
-		final var entry = loadFromSessionCache( entityKey, lockOptions, GET, session );
-		final Object sessionEntity = entry.entity();
-		if ( sessionEntity != null ) {
-			if ( entry.isManaged() ) {
-				//noinspection unchecked
-				resolutionConsumer.consume( i, entityKey, (R) sessionEntity );
-				return unresolvedIds;
-			}
-			else if ( loadOptions.getSessionCheckMode() == FindMultipleOption.SessionCheckMode.ENABLED ) {
-				switch ( loadOptions.getRemovalsMode() ) {
-					case REPLACE :
-						resolutionConsumer.consume( i, entityKey, null );
-						return unresolvedIds;
-					case EXCLUDE:
-						return unresolvedIds;
-					case INCLUDE:
-						//noinspection unchecked
-						resolutionConsumer.consume( i, entityKey, (R) sessionEntity );
-						return unresolvedIds;
+		final boolean sessionCheckEnabled =
+				loadOptions.getSessionCheckMode() == FindMultipleOption.SessionCheckMode.ENABLED;
+		if ( sessionCheckEnabled ) {
+			// look for it in the Session first
+			final var entry = loadFromSessionCache( entityKey, lockOptions, GET, session );
+			final Object sessionEntity = entry.entity();
+			if ( sessionEntity != null ) {
+				if ( entry.isManaged() ) {
+					//noinspection unchecked
+					resolutionConsumer.consume( i, entityKey, (R) sessionEntity );
+					return unresolvedIds;
+				}
+				else {
+					switch ( loadOptions.getRemovalsMode() ) {
+						case REPLACE :
+							resolutionConsumer.consume( i, entityKey, null );
+							return unresolvedIds;
+						case EXCLUDE:
+							return unresolvedIds;
+						case INCLUDE:
+							//noinspection unchecked
+							resolutionConsumer.consume( i, entityKey, (R) sessionEntity );
+							return unresolvedIds;
+					}
 				}
 			}
+		}
+		else if ( session.getPersistenceContextInternal().containsEntity( entityKey ) ) {
+			return appendUnresolvedId( unresolvedIds, id );
 		}
 
 		final Object cachedEntity =
@@ -414,13 +426,16 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 		if ( cachedEntity != null ) {
 			//noinspection unchecked
 			resolutionConsumer.consume( i, entityKey, (R) cachedEntity );
+			return unresolvedIds;
 		}
-		else {
-			if ( unresolvedIds == null ) {
-				unresolvedIds = new ArrayList<>();
-			}
-			unresolvedIds.add( id );
+		return appendUnresolvedId( unresolvedIds, id );
+	}
+
+	private List<Object> appendUnresolvedId(List<Object> unresolvedIds, Object id) {
+		if ( unresolvedIds == null ) {
+			unresolvedIds = new ArrayList<>();
 		}
+		unresolvedIds.add( id );
 		return unresolvedIds;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderInPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderInPredicate.java
@@ -26,6 +26,7 @@ import org.hibernate.sql.results.spi.ListResultsConsumer;
 import static java.lang.Boolean.TRUE;
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hibernate.engine.spi.SubselectFetch.createRegistrationHandler;
 import static org.hibernate.loader.ast.internal.LoaderSelectBuilder.createSelect;
@@ -169,6 +170,9 @@ public class MultiIdEntityLoaderInPredicate<T> extends AbstractMultiIdEntityLoad
 
 	private List<T> performSingleMultiLoad(Object id, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		final Object entity = getLoadable().getEntityPersister().load( id, null, lockOptions, session );
+		if ( entity == null ) {
+			return emptyList();
+		}
 		@SuppressWarnings("unchecked") T loaded = (T) entity;
 		return singletonList( loaded );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadTest.java
@@ -425,6 +425,41 @@ public class MultiLoadTest {
 	}
 
 	@Test
+	@JiraKey( value = "HHH-20515" )
+	public void testFindMultipleWithManagedEntityFromSecondLevelCache(SessionFactoryScope scope) {
+		scope.getSessionFactory().getCache().evictAll();
+
+		final Statistics statistics = scope.getSessionFactory().getStatistics();
+
+		scope.inTransaction(session -> {
+			assertNotNull( session.find( SimpleEntity.class, 2 ) );
+			assertNotNull( session.find( SimpleEntity.class, 3 ) );
+		} );
+
+		statistics.clear();
+
+		scope.inTransaction(session -> {
+			SimpleEntity entity = session.find( SimpleEntity.class, 2 );
+			assertEquals( "Entity #2", entity.getText() );
+			entity.setText( "updated" );
+
+			statistics.clear();
+
+			final List<SimpleEntity> entities = session.findMultiple(
+					SimpleEntity.class,
+					List.of( 2, 3 ),
+					CacheMode.NORMAL
+			);
+
+			assertEquals( 2, entities.size() );
+			assertSame( entity, entities.get( 0 ) );
+			assertEquals( "updated", entities.get( 0 ).getText() );
+			assertEquals( "Entity #3", entities.get( 1 ).getText() );
+			assertEquals( 1, statistics.getSecondLevelCacheHitCount() );
+		} );
+	}
+
+	@Test
 	@JiraKey(value = "HHH-12944")
 	public void testUnorderedMultiLoadFrom2ndLevelCache(SessionFactoryScope scope) {
 		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();


### PR DESCRIPTION
Summary

- Preserve current managed entity instances from second-level cache assembly while keeping `SessionCheckMode.DISABLED` identifiers in the normal load batch.
- Keep second-level cache use for IDs that are not already associated with the current persistence context.
- Add a regression test for HHH-20515 covering a dirty managed entity plus a separate 2LC hit in the same `findMultiple` call.

The multi-id loader could consult the second-level cache before recognizing that the same entity key was already associated with the current persistence context. Since 2LC assembly can reuse the existing entity holder, cached state could be written into the managed instance and overwrite unflushed in-session changes.

Testing

- `./gradlew :hibernate-core:test --tests 'org.hibernate.orm.test.loading.multiLoad.MultiLoadTest.testFindMultipleWithManagedEntityFromSecondLevelCache'`
- `./gradlew :hibernate-core:test --tests 'org.hibernate.orm.test.loading.multiLoad.MultiLoadLockingTest.testMultiLoadCompositeIdEntityPessimisticReadLockAlreadyInSession' --tests 'org.hibernate.orm.test.loading.multiLoad.MultiLoadLockingTest.testMultiLoadSimpleIdEntityPessimisticWriteLockSomeInL1CAndSomeInL2C'`
- `./gradlew :hibernate-core:test --tests 'org.hibernate.orm.test.loading.multiLoad.MultiLoadTest' --tests 'org.hibernate.orm.test.loading.multiLoad.MultiLoadLockingTest'`
- `git diff --check`

Jira

https://hibernate.atlassian.net/browse/HHH-20515

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20515 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->
