### PR TITLE
HHH-20576 deprecate @OptimisticLock in favor of @ExcludedFromVersioning

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Entities.adoc
+++ b/documentation/src/main/asciidoc/introduction/Entities.adoc
@@ -480,12 +480,14 @@ LocalDateTime lastUpdated;
 
 Almost every entity which is frequently updated should have a version attribute.
 
+The `@ExcludedFromVersioning` annotation lets us selectively exclude a certain field from optimistic locking, so that modifications to the annotated field do not result in a version increment.
+
 [TIP]
 // .Optimistic locking in Hibernate
 ====
 If an entity doesn't have a version number, which often happens when mapping legacy data, we can still do optimistic locking.
 The link:{doc-javadoc-url}org/hibernate/annotations/OptimisticLocking.html[`@OptimisticLocking`] annotation lets us specify that optimistic locks should be checked by validating the values of `ALL` fields, or only the `DIRTY` fields of the entity.
-And the link:{doc-javadoc-url}org/hibernate/annotations/OptimisticLock.html[`@OptimisticLock`] annotation lets us selectively exclude certain fields from optimistic locking.
+And the `@ExcludedFromVersioning` annotation lets us selectively exclude certain fields from validation.
 ====
 
 The `@Id` and `@Version` attributes we've already seen are just specialized examples of _basic attributes_.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/OptimisticLock.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/OptimisticLock.java
@@ -21,7 +21,10 @@ import java.lang.annotation.Target;
  * the version to be incremented.
  *
  * @author Logi Ragnarsson
+ *
+ * @deprecated Use {@link jakarta.persistence.ExcludedFromVersioning}.
  */
+@Deprecated(since = "8.0", forRemoval = true)
 @Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface OptimisticLock {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/OptimisticLocking.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/OptimisticLocking.java
@@ -32,8 +32,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * root entity, since the optimistic lock checking strategy is inherited
  * by entity subclasses.
  * <p>
- * To exclude a particular attribute from optimistic locking, annotate the
- * attribute {@link OptimisticLock @OptimisticLock(excluded=true)}. Then:
+ * To exclude a particular attribute from optimistic locking, annotate it as
+ * {@link jakarta.persistence.ExcludedFromVersioning @ExcludedFromVersioning}.
+ * Then:
  * <ul>
  * <li>changes to that attribute will never trigger a version increment, and
  * <li>the attribute will not be included in the list of fields checked fields

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -82,7 +82,6 @@ The deprecated `Session.replicate()` methods and the associated `ReplicationMode
 There is no direct replacement.
 For some import or overwrite workflows, consider `StatelessSession#upsert(Object)`.
 
-
 [[stateless]]
 === StatelessSession
 
@@ -94,9 +93,6 @@ Hibernate's `StatelessSession` now implements `EntityAgent`.
 * `fetch()` - `EntityAgent` defines that the fetched value be returned, whereas `StatelessSession` has historically defined a `void` return type.
 
 In both cases, `StatelessSession` has been changed to match the `EntityAgent` signatures.
-
-
-
 
 [[query-api]]
 === Query API
@@ -120,7 +116,6 @@ Another impact is that `@NamedQuery` and `@NamedNativeQuery` (as well as Hiberna
 * `@NamedStatement` - A `MutationQuery` defined using HQL/JPQL
 * `@NamedNativeQuery` - A `SelectionQuery` defined using native SQL
 * `@NamedNativeStatement` - A `MutationQuery` defined using native SQL
-
 
 [[transform-removal]]
 === Removal of `org.hibernate.transform` package
@@ -169,7 +164,6 @@ query.setTupleTransformer( (tuple, aliases) -> {
 } );
 ----
 
-
 [[timeout]]
 === Query and Transaction Timeouts
 
@@ -179,7 +173,6 @@ Starting in 3.2, Jakarta Persistence added a new `Timeout` class which helps all
 Originally this new `Timeout` type was not exposed on any API directly, so there was no impact from an API perspective.
 However, this has changed a bit in 4.0 where `Timeout` *is* now exposed on certain APIs.
 This causes a signature conflict with a few of Hibernate API methods; as part of fixing those conflicts, it was decided to change all exposures of timeout in Hibernate APIs to use `Timeout` as this helps clarify these confusions.
-
 
 [[graph-attr-node]]
 === AttributeNode Subgraphs
@@ -216,13 +209,16 @@ The four enums which are implementors of `org.hibernate.FindMultipleOption` have
 
 These enums were previously incubating, except for `org.hibernate.BatchSize` which is now marked as deprecated.
 
-
 [[generic-generator]]
 === `@GenericGenerator`
 
 The `@GenericGenerator` annotation was deprecated in Hibernate 6.5.
 Instead of removing it completely, we have modernized it and reversed its deprecation.
 Code still using `@GenericGenerator` must adapt to its reworked definition.
+
+=== Deprecated OptimisticLock Annotation
+
+The venerable `@OptimisticLock` annotation was deprecated in favor of the new JPA-standard `@ExcludedFromVersioning` annotation.
 
 
 [[hibernate-processor]]


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20576 (Deprecation):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20576
<!-- Hibernate GitHub Bot issue links end -->