### PR TITLE
Fix Javadoc parser errors

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/cid/CompositeIdFkGeneratedValueTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/cid/CompositeIdFkGeneratedValueTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * {@link GenerationType#AUTO} since there are known complications with some {@link Dialect}s (e.g.
  * {@link SQLServerDialect}) and the {@link GenerationType#IDENTITY}
  *
- * @author Jason Pyeron <support@pdinc.us>
+ * @author Jason Pyeron &lt;support&#64;pdinc.us&gt;
  * @see <a href='https://hibernate.atlassian.net/browse/HHH-10956'>HHH-10956</a> Persisting partially-generated
  * composite Ids fails
  * @see <a href='https://hibernate.atlassian.net/browse/HHH-9662'>HHH-9662</a> a related and blocking bug for

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/entities/Bunny.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/entities/Bunny.java
@@ -15,7 +15,7 @@ import jakarta.persistence.OneToMany;
 /**
  * Blown precision on related entity when &#064;JoinColumn is used.
  *
- * @see ANN-748
+ * @see <a href="https://hibernate.atlassian.net/browse/ANN-748">ANN-748</a>
  * @author Andrew C. Oliver andyspam@osintegrators.com
  */
 @Entity

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/entities/PlanetCheatSheet.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/entities/PlanetCheatSheet.java
@@ -14,7 +14,7 @@ import jakarta.persistence.Id;
  * Test entity for enum type as id.
  *
  * @author Hardy Ferentschik
- * @see ANN-744
+ * @see <a href="https://hibernate.atlassian.net/browse/ANN-744">ANN-744</a>
  */
 @Entity
 public class PlanetCheatSheet {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/entities/PointyTooth.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/entities/PointyTooth.java
@@ -15,7 +15,7 @@ import jakarta.persistence.ManyToOne;
  * Blown precision on related entity when &#064;JoinColumn is used.
  * Does not cause an issue on HyperSonic, but replicates nicely on PGSQL.
  *
- * @see ANN-748
+ * @see <a href="https://hibernate.atlassian.net/browse/ANN-748">ANN-748</a>
  * @author Andrew C. Oliver andyspam@osintegrators.com
  */
 @Entity

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/entities/TwinkleToes.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/entities/TwinkleToes.java
@@ -15,7 +15,7 @@ import jakarta.persistence.ManyToOne;
  * Blown precision on related entity when &#064;JoinColumn is used.
  * Does not cause an issue on HyperSonic, but replicates nicely on PGSQL.
  *
- * @see ANN-748
+ * @see <a href="https://hibernate.atlassian.net/browse/ANN-748">ANN-748</a>
  * @author Andrew C. Oliver andyspam@osintegrators.com
  */
 @Entity

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/sequences/entities/Bunny.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/sequences/entities/Bunny.java
@@ -15,7 +15,7 @@ import jakarta.persistence.OneToMany;
 /**
  * Blown precision on related entity when &#064;JoinColumn is used.
  *
- * @see ANN-748
+ * @see <a href="https://hibernate.atlassian.net/browse/ANN-748">ANN-748</a>
  * @author Andrew C. Oliver andyspam@osintegrators.com
  */
 @Entity

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/sequences/entities/PlanetCheatSheet.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/sequences/entities/PlanetCheatSheet.java
@@ -14,7 +14,7 @@ import jakarta.persistence.Id;
  * Test entity for enum type as id.
  *
  * @author Hardy Ferentschik
- * @see ANN-744
+ * @see <a href="https://hibernate.atlassian.net/browse/ANN-744">ANN-744</a>
  */
 @Entity
 public class PlanetCheatSheet {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/sequences/entities/PointyTooth.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/sequences/entities/PointyTooth.java
@@ -15,7 +15,7 @@ import jakarta.persistence.ManyToOne;
  * Blown precision on related entity when &#064;JoinColumn is used.
  * Does not cause an issue on HyperSonic, but replicates nicely on PGSQL.
  *
- * @see ANN-748
+ * @see <a href="https://hibernate.atlassian.net/browse/ANN-748">ANN-748</a>
  * @author Andrew C. Oliver andyspam@osintegrators.com
  */
 @Entity

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/sequences/entities/TwinkleToes.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/id/sequences/entities/TwinkleToes.java
@@ -15,7 +15,7 @@ import jakarta.persistence.ManyToOne;
  * Blown precision on related entity when &#064;JoinColumn is used.
  * Does not cause an issue on HyperSonic, but replicates nicely on PGSQL.
  *
- * @see ANN-748
+ * @see <a href="https://hibernate.atlassian.net/browse/ANN-748">ANN-748</a>
  * @author Andrew C. Oliver andyspam@osintegrators.com
  */
 @Entity

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
@@ -102,7 +102,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *         {@linkplain org.hibernate.testing.orm.junit.DomainModel} or
  *         {@linkplain org.hibernate.testing.orm.junit.SessionFactory} because of the
  *         need to dynamically create these based on the {@linkplain #options() catalog/schema parameters}.
- *         So instead we use {@linkplain ServiceRegistryProducer,
+ *         So instead we use {@linkplain ServiceRegistryProducer},
  *         {@linkplain DomainModelProducer} and {@linkplain SessionFactoryProducer} while
  *         still using the extensions to leverage lifecycle.
  *     </li>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/jakarta/JakartaSchemaToolingSettingPrecedenceTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/jakarta/JakartaSchemaToolingSettingPrecedenceTests.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Make sure {@code `jakarta.persistence.*`} settings have function precedence over
- * the legacy {@link `javax.persistence.*`} counterparts
+ * the legacy {@code `javax.persistence.*`} counterparts
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/procedure/AbstractStoredProcedureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/procedure/AbstractStoredProcedureTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Strong Liu <stliu@hibernate.org>
+ * @author Strong Liu &lt;stliu&#64;hibernate.org&gt;
  */
 public abstract class AbstractStoredProcedureTest {
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationAdvancedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationAdvancedTest.java
@@ -40,10 +40,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Pagination-with-collection-fetch where the root entity uses
- * {@link SecondaryTable @SecondaryTable} or {@link Inheritance(strategy=JOINED)
- * joined inheritance}. Both shapes attach extra {@code TableReferenceJoin}s to
- * the root {@code TableGroup}, so the rewrite has to absorb those tables'
- * columns into the inner derived table — and for joined inheritance the outer
+ * {@link SecondaryTable @SecondaryTable} or
+ * {@link Inheritance @Inheritance(strategy=JOINED) joined inheritance}.
+ * Both shapes attach extra {@code TableReferenceJoin}s to the root
+ * {@code TableGroup}, so the rewrite has to absorb those tables' columns into
+ * the inner derived table — and for joined inheritance the outer
  * SELECT contains a CASE-based discriminator whose internal column references
  * also need rewriting.
  */

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/ConcurrentConcreteSqmSelectQueryPlainTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/ConcurrentConcreteSqmSelectQueryPlainTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.fail;
  *
  * <p>Might cause incorrect SQL to be rendered. In case my MySQL this might cause "limit null,1" statements.
  *
- * @see https://hibernate.atlassian.net/browse/HHH-17742
+ * @see <a href="https://hibernate.atlassian.net/browse/HHH-17742">HHH-17742</a>
  */
 @RequiresDialect(MySQLDialect.class)
 @JiraKey("HHH-17742")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/ConcurrentConcreteSqmSelectQueryPlainTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/ConcurrentConcreteSqmSelectQueryPlainTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.fail;
  *
  * <p>Might cause incorrect SQL to be rendered. In case my MySQL this might cause "limit null,1" statements.
  *
- * @see https://hibernate.atlassian.net/browse/HHH-17742
+ * @see <a href="https://hibernate.atlassian.net/browse/HHH-17742">HHH-17742</a>
  */
 @RequiresDialect(MySQLDialect.class)
 @JiraKey("HHH-17742")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SequenceReadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SequenceReadingTest.java
@@ -31,8 +31,6 @@ import static org.hibernate.cfg.JdbcSettings.DIALECT;
  * Regression test fr a bug in org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl
  *
  * @author Steve Ebersole
- *
- * @see
  */
 @SuppressWarnings("JUnitMalformedDeclaration")
 @JiraKey( value = "HHH-9745" )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SequenceReadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SequenceReadingTest.java
@@ -31,8 +31,6 @@ import static org.hibernate.cfg.JdbcSettings.DIALECT;
  * Regression test for sequence metadata extraction disabled by the Dialect.
  *
  * @author Steve Ebersole
- *
- * @see
  */
 @SuppressWarnings("JUnitMalformedDeclaration")
 @JiraKey( value = "HHH-9745" )


### PR DESCRIPTION
Fix Javadoc comments that are not parsed correctly by Javadoc jdk tool.

The issues were detected while validating Hibernate ORM with the updated Javadoc parsing checks from checkstyle/checkstyle#19963:
https://github.com/checkstyle/checkstyle/pull/19963

Most changes are small Javadoc-only fixes.

Validation performed with Javadoc jdk tool

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-12806 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-12806
<!-- Hibernate GitHub Bot issue links end -->