### PR TITLE
Renamed Quarkus Data package

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
@@ -106,7 +106,7 @@ public final class Context {
 
 	private boolean usesQuarkusOrm = false;
 	private boolean usesQuarkusReactive = false;
-	private boolean usesQuarkusPanache2 = false;
+	private boolean usesQuarkusDataHibernate = false;
 	private boolean usesQuarkusReactiveCommon = false;
 
 	private String[] includes = {"*"};
@@ -487,12 +487,12 @@ public final class Context {
 		return usesQuarkusReactive;
 	}
 
-	public void setUsesQuarkusPanache2(boolean b) {
-		usesQuarkusPanache2 = b;
+	public void setUsesQuarkusDataHibernate(boolean b) {
+		usesQuarkusDataHibernate = b;
 	}
 
-	public boolean usesQuarkusPanache2() {
-		return usesQuarkusPanache2;
+	public boolean usesQuarkusDataHibernate() {
+		return usesQuarkusDataHibernate;
 	}
 
 	public void setUsesQuarkusReactiveCommon(boolean b) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
@@ -12,6 +12,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+
+import org.hibernate.processor.spi.QuarkusDataTypeNames;
+
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -108,6 +111,8 @@ public final class Context {
 	private boolean usesQuarkusReactive = false;
 	private boolean usesQuarkusDataHibernate = false;
 	private boolean usesQuarkusReactiveCommon = false;
+
+	private QuarkusDataTypeNames quarkusDataTypeNames;
 
 	private String[] includes = {"*"};
 	private String[] excludes = {};
@@ -493,6 +498,14 @@ public final class Context {
 
 	public boolean usesQuarkusDataHibernate() {
 		return usesQuarkusDataHibernate;
+	}
+
+	public void setQuarkusDataTypeNames(QuarkusDataTypeNames quarkusDataTypeNames) {
+		this.quarkusDataTypeNames = quarkusDataTypeNames;
+	}
+
+	public QuarkusDataTypeNames quarkusDataTypeNames() {
+		return quarkusDataTypeNames;
 	}
 
 	public void setUsesQuarkusReactiveCommon(boolean b) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -9,6 +9,8 @@ import org.hibernate.processor.annotation.AnnotationMetaEntity;
 import org.hibernate.processor.annotation.AnnotationMetaPackage;
 import org.hibernate.processor.annotation.NonManagedMetamodel;
 import org.hibernate.processor.model.Metamodel;
+import org.hibernate.processor.spi.DefaultQuarkusDataTypeNames;
+import org.hibernate.processor.spi.QuarkusDataTypeNames;
 import org.hibernate.processor.util.Constants;
 import org.hibernate.processor.xml.JpaDescriptorParser;
 
@@ -37,6 +39,8 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -283,9 +287,11 @@ public class HibernateProcessor extends AbstractProcessor {
 		var quarkusOrmPanachePackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "io.quarkus.hibernate.orm.panache" );
+		final var quarkusDataTypeNames = loadQuarkusDataTypeNames();
+		context.setQuarkusDataTypeNames( quarkusDataTypeNames );
 		var quarkusDataHibernatePackage =
 				context.getProcessingEnvironment().getElementUtils()
-						.getPackageElement( "io.quarkus.data.hibernate" );
+						.getPackageElement( quarkusDataTypeNames.packageName() );
 		var quarkusReactivePanachePackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "io.quarkus.hibernate.reactive.panache" );
@@ -358,6 +364,16 @@ public class HibernateProcessor extends AbstractProcessor {
 		return pack != null
 			//HHH-18019 ecj always returns a non-null PackageElement
 			&& !pack.getEnclosedElements().isEmpty();
+	}
+
+	private static QuarkusDataTypeNames loadQuarkusDataTypeNames() {
+		final Iterator<QuarkusDataTypeNames> iterator =
+				ServiceLoader.load( QuarkusDataTypeNames.class, QuarkusDataTypeNames.class.getClassLoader() )
+						.iterator();
+		if ( iterator.hasNext() ) {
+			return iterator.next();
+		}
+		return new DefaultQuarkusDataTypeNames();
 	}
 
 	@Override
@@ -584,7 +600,7 @@ public class HibernateProcessor extends AbstractProcessor {
 	}
 
 	private boolean isImplicitRepository(TypeElement typeElement) {
-		if ( AnnotationMetaEntity.isQuarkusDataRepository( typeElement ) ) {
+		if ( AnnotationMetaEntity.isQuarkusDataRepository( typeElement, context.quarkusDataTypeNames() ) ) {
 			return true;
 		}
 		for ( var member : typeElement.getEnclosedElements() ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -283,9 +283,9 @@ public class HibernateProcessor extends AbstractProcessor {
 		var quarkusOrmPanachePackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "io.quarkus.hibernate.orm.panache" );
-		var quarkusPanache2Package =
+		var quarkusDataHibernatePackage =
 				context.getProcessingEnvironment().getElementUtils()
-						.getPackageElement( "io.quarkus.hibernate.panache" );
+						.getPackageElement( "io.quarkus.data.hibernate" );
 		var quarkusReactivePanachePackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "io.quarkus.hibernate.reactive.panache" );
@@ -321,7 +321,7 @@ public class HibernateProcessor extends AbstractProcessor {
 		context.setUsesQuarkusReactive( packagePresent(quarkusReactivePanachePackage) );
 		context.setSpringInjection( packagePresent(springBeansPackage) );
 		context.setAddComponentAnnotation( packagePresent(springStereotypePackage) );
-		context.setUsesQuarkusPanache2( packagePresent(quarkusPanache2Package) );
+		context.setUsesQuarkusDataHibernate( packagePresent(quarkusDataHibernatePackage) );
 		context.setUsesQuarkusReactiveCommon( packagePresent(quarkusReactivePanacheCommonPackage) );
 
 		final var options = environment.getOptions();
@@ -584,7 +584,7 @@ public class HibernateProcessor extends AbstractProcessor {
 	}
 
 	private boolean isImplicitRepository(TypeElement typeElement) {
-		if ( AnnotationMetaEntity.isPanache2Repository( typeElement ) ) {
+		if ( AnnotationMetaEntity.isQuarkusDataRepository( typeElement ) ) {
 			return true;
 		}
 		for ( var member : typeElement.getEnclosedElements() ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -16,6 +16,7 @@ import org.hibernate.processor.ImportContextImpl;
 import org.hibernate.processor.ProcessLaterException;
 import org.hibernate.processor.model.ImportContext;
 import org.hibernate.processor.model.MetaAttribute;
+import org.hibernate.processor.spi.QuarkusDataTypeNames;
 import org.hibernate.processor.model.Metamodel;
 import org.hibernate.processor.util.AccessTypeInformation;
 import org.hibernate.processor.util.Constants;
@@ -653,6 +654,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	}
 
 	private void addRepositoryMembers(TypeElement element) {
+		final QuarkusDataTypeNames typeNames = context.quarkusDataTypeNames();
 		Element managedBlockingRepository = null;
 		Element statelessBlockingRepository = null;
 		Element managedReactiveRepository = null;
@@ -666,19 +668,19 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 					continue;
 				}
 				if ( implementsInterface( (TypeElement) enclosedElement,
-						Constants.QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE ) ) {
+						typeNames.managedBlockingRepositoryBase() ) ) {
 					managedBlockingRepository = enclosedElement;
 				}
 				else if ( implementsInterface( (TypeElement) enclosedElement,
-						Constants.QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE ) ) {
+						typeNames.statelessBlockingRepositoryBase() ) ) {
 					statelessBlockingRepository = enclosedElement;
 				}
 				else if ( implementsInterface( (TypeElement) enclosedElement,
-						Constants.QUARKUS_DATA_MANAGED_REACTIVE_REPOSITORY_BASE ) ) {
+						typeNames.managedReactiveRepositoryBase() ) ) {
 					managedReactiveRepository = enclosedElement;
 				}
 				else if ( implementsInterface( (TypeElement) enclosedElement,
-						Constants.QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE ) ) {
+						typeNames.statelessReactiveRepositoryBase() ) ) {
 					statelessReactiveRepository = enclosedElement;
 				}
 			}
@@ -687,15 +689,15 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			// FIXME: perhaps import id type?
 			final var idType = findIdType();
 			addAccessors( managedBlockingRepository, idType, "managedBlocking",
-					QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE, nestedRepositories );
+					typeNames.managedBlockingRepositoryBase(), nestedRepositories );
 			addAccessors( statelessBlockingRepository, idType, "statelessBlocking",
-					QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE, nestedRepositories );
+					typeNames.statelessBlockingRepositoryBase(), nestedRepositories );
 			// Only add those if HR is in the classpath, otherwise it causes a compilation issue
 			if ( context.usesQuarkusReactiveCommon() ) {
 				addAccessors( managedReactiveRepository, idType, "managedReactive",
-						QUARKUS_DATA_MANAGED_REACTIVE_REPOSITORY_BASE, nestedRepositories );
+						typeNames.managedReactiveRepositoryBase(), nestedRepositories );
 				addAccessors( statelessReactiveRepository, idType, "statelessReactive",
-						QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE, nestedRepositories );
+						typeNames.statelessReactiveRepositoryBase(), nestedRepositories );
 			}
 		}
 	}
@@ -1145,7 +1147,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 					repository = true;
 					sessionType = addRepositoryConstructor( getter );
 				}
-				else if ( !isQuarkusDataRepository( element ) && !isQuarkusDataType( element ) ) {
+				else if ( !isQuarkusDataRepository( element, context.quarkusDataTypeNames() ) && !isQuarkusDataType( element ) ) {
 					// For Panache 1 subtypes, we look at the session type, but no DAO,
 					// we want static methods
 					sessionType = fullReturnType( getter );
@@ -1305,15 +1307,16 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	}
 
 	private boolean isQuarkusDataType(TypeElement type) {
-		return implementsInterface( type, QUARKUS_DATA_ENTITY_MARKER )
-			|| isQuarkusDataRepository( type );
+		final QuarkusDataTypeNames typeNames = context.quarkusDataTypeNames();
+		return implementsInterface( type, typeNames.entityMarker() )
+			|| isQuarkusDataRepository( type, typeNames );
 	}
 
-	public static boolean isQuarkusDataRepository(TypeElement type) {
-		return implementsInterface( type, QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE )
-			|| implementsInterface( type, QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE )
-			|| implementsInterface( type, QUARKUS_DATA_MANAGED_REACTIVE_REPOSITORY_BASE )
-			|| implementsInterface( type, QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE );
+	public static boolean isQuarkusDataRepository(TypeElement type, QuarkusDataTypeNames typeNames) {
+		return implementsInterface( type, typeNames.managedBlockingRepositoryBase() )
+			|| implementsInterface( type, typeNames.statelessBlockingRepositoryBase() )
+			|| implementsInterface( type, typeNames.managedReactiveRepositoryBase() )
+			|| implementsInterface( type, typeNames.statelessReactiveRepositoryBase() );
 	}
 
 	/**
@@ -1366,8 +1369,9 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	private String setupQuarkusRepositoryConstructor(@Nullable ExecutableElement getter, @Nullable TypeElement element) {
 		// FIXME: probably go in this branch if we have a getter too?
 		if ( isBlockingFavored( element ) ) {
-			final var name = quarkusSessionGetterName( getter, element );
-			final var sessionType = quarkusSessionType( getter, element );
+			final var typeNames = context.quarkusDataTypeNames();
+			final var name = quarkusSessionGetterName( getter, element, typeNames );
+			final var sessionType = quarkusSessionType( getter, element, typeNames );
 			putMember( name,
 					new RepositoryConstructor(
 							this,
@@ -1388,7 +1392,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		else {
 			importType( Constants.QUARKUS_SESSION_OPERATIONS );
 			// use this getter to get the method, do not generate an injection point for its type
-			if ( element != null && isQuarkusDataStatelessReactiveRepository( element ) ) {
+			if ( element != null && isQuarkusDataStatelessReactiveRepository( element, context.quarkusDataTypeNames() ) ) {
 				sessionGetter = "SessionOperations.getStatelessSession()";
 				return UNI_MUTINY_STATELESS_SESSION;
 			}
@@ -1399,11 +1403,12 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		}
 	}
 
-	private static String quarkusSessionGetterName(@Nullable ExecutableElement getter, @Nullable TypeElement element) {
+	private static String quarkusSessionGetterName(@Nullable ExecutableElement getter, @Nullable TypeElement element,
+			QuarkusDataTypeNames typeNames) {
 		if ( getter != null ) {
 			return getter.getSimpleName().toString();
 		}
-		else if ( element != null && isQuarkusDataStatelessBlockingRepository( element ) ) {
+		else if ( element != null && isQuarkusDataStatelessBlockingRepository( element, typeNames ) ) {
 			return "getStatelessSession";
 		}
 		else { // good default
@@ -1411,11 +1416,12 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		}
 	}
 
-	private String quarkusSessionType(@Nullable ExecutableElement getter, @Nullable TypeElement element) {
+	private String quarkusSessionType(@Nullable ExecutableElement getter, @Nullable TypeElement element,
+			QuarkusDataTypeNames typeNames) {
 		if ( getter != null ) {
 			return fullReturnType( getter );
 		}
-		else if ( element != null && isQuarkusDataStatelessBlockingRepository( element ) ) {
+		else if ( element != null && isQuarkusDataStatelessBlockingRepository( element, typeNames ) ) {
 			return HIB_STATELESS_SESSION;
 		}
 		else { // good default
@@ -1425,9 +1431,10 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 	private boolean isBlockingFavored(@Nullable TypeElement element) {
 		if ( element != null ) {
+			final QuarkusDataTypeNames typeNames = context.quarkusDataTypeNames();
 			if ( context.usesQuarkusDataHibernate()
-					&& isQuarkusDataRepository( element ) ) {
-				return isQuarkusDataBlockingRepository( element );
+					&& isQuarkusDataRepository( element, typeNames ) ) {
+				return isQuarkusDataBlockingRepository( element, typeNames );
 			}
 			else {
 				// look for any annotated method, see if they return a Uni
@@ -1442,17 +1449,17 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		return context.usesQuarkusOrm();
 	}
 
-	private static boolean isQuarkusDataBlockingRepository(@Nonnull TypeElement element) {
-		return implementsInterface( element, QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE )
-			|| implementsInterface( element, QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE );
+	private static boolean isQuarkusDataBlockingRepository(@Nonnull TypeElement element, QuarkusDataTypeNames typeNames) {
+		return implementsInterface( element, typeNames.managedBlockingRepositoryBase() )
+			|| implementsInterface( element, typeNames.statelessBlockingRepositoryBase() );
 	}
 
-	private static boolean isQuarkusDataStatelessReactiveRepository(@Nonnull TypeElement element) {
-		return implementsInterface( element, QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE );
+	private static boolean isQuarkusDataStatelessReactiveRepository(@Nonnull TypeElement element, QuarkusDataTypeNames typeNames) {
+		return implementsInterface( element, typeNames.statelessReactiveRepositoryBase() );
 	}
 
-	private static boolean isQuarkusDataStatelessBlockingRepository(@Nonnull TypeElement element) {
-		return implementsInterface( element, QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE );
+	private static boolean isQuarkusDataStatelessBlockingRepository(@Nonnull TypeElement element, QuarkusDataTypeNames typeNames) {
+		return implementsInterface( element, typeNames.statelessBlockingRepositoryBase() );
 	}
 
 	/**

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -594,7 +594,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 			addIdClassIfNeeded( fieldsOfClass, gettersAndSettersOfClass );
 
-			if ( hasAnnotation( element, ENTITY ) && isPanache2Type( element ) && !jakartaDataStaticModel ) {
+			if ( hasAnnotation( element, ENTITY ) && isQuarkusDataType( element ) && !jakartaDataStaticModel ) {
 				addRepositoryMembers( element );
 			}
 		}
@@ -666,19 +666,19 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 					continue;
 				}
 				if ( implementsInterface( (TypeElement) enclosedElement,
-						Constants.PANACHE2_MANAGED_BLOCKING_REPOSITORY_BASE ) ) {
+						Constants.QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE ) ) {
 					managedBlockingRepository = enclosedElement;
 				}
 				else if ( implementsInterface( (TypeElement) enclosedElement,
-						Constants.PANACHE2_STATELESS_BLOCKING_REPOSITORY_BASE ) ) {
+						Constants.QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE ) ) {
 					statelessBlockingRepository = enclosedElement;
 				}
 				else if ( implementsInterface( (TypeElement) enclosedElement,
-						Constants.PANACHE2_MANAGED_REACTIVE_REPOSITORY_BASE ) ) {
+						Constants.QUARKUS_DATA_MANAGED_REACTIVE_REPOSITORY_BASE ) ) {
 					managedReactiveRepository = enclosedElement;
 				}
 				else if ( implementsInterface( (TypeElement) enclosedElement,
-						Constants.PANACHE2_STATELESS_REACTIVE_REPOSITORY_BASE ) ) {
+						Constants.QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE ) ) {
 					statelessReactiveRepository = enclosedElement;
 				}
 			}
@@ -687,15 +687,15 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			// FIXME: perhaps import id type?
 			final var idType = findIdType();
 			addAccessors( managedBlockingRepository, idType, "managedBlocking",
-					PANACHE2_MANAGED_BLOCKING_REPOSITORY_BASE, nestedRepositories );
+					QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE, nestedRepositories );
 			addAccessors( statelessBlockingRepository, idType, "statelessBlocking",
-					PANACHE2_STATELESS_BLOCKING_REPOSITORY_BASE, nestedRepositories );
+					QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE, nestedRepositories );
 			// Only add those if HR is in the classpath, otherwise it causes a compilation issue
 			if ( context.usesQuarkusReactiveCommon() ) {
 				addAccessors( managedReactiveRepository, idType, "managedReactive",
-						PANACHE2_MANAGED_REACTIVE_REPOSITORY_BASE, nestedRepositories );
+						QUARKUS_DATA_MANAGED_REACTIVE_REPOSITORY_BASE, nestedRepositories );
 				addAccessors( statelessReactiveRepository, idType, "statelessReactive",
-						PANACHE2_STATELESS_REACTIVE_REPOSITORY_BASE, nestedRepositories );
+						QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE, nestedRepositories );
 			}
 		}
 	}
@@ -1141,11 +1141,11 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			final var getter = findSessionGetter( element );
 			if ( getter != null ) {
 				// Never make a DAO for Panache subtypes
-				if ( !isPanacheType( element ) && !isPanache2Type( element ) ) {
+				if ( !isPanacheType( element ) && !isQuarkusDataType( element ) ) {
 					repository = true;
 					sessionType = addRepositoryConstructor( getter );
 				}
-				else if ( !isPanache2Repository( element ) && !isPanache2Type( element ) ) {
+				else if ( !isQuarkusDataRepository( element ) && !isQuarkusDataType( element ) ) {
 					// For Panache 1 subtypes, we look at the session type, but no DAO,
 					// we want static methods
 					sessionType = fullReturnType( getter );
@@ -1158,7 +1158,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			}
 			else if ( element.getKind() == ElementKind.INTERFACE
 					&& !jakartaDataRepository
-					&& (context.usesQuarkusOrm() || context.usesQuarkusReactive() || context.usesQuarkusPanache2()) ) {
+					&& (context.usesQuarkusOrm() || context.usesQuarkusReactive() || context.usesQuarkusDataHibernate()) ) {
 				// if we don't have a getter, and not a JD repository, but we're in Quarkus,
 				// we know how to find the default sessions
 				repository = true;
@@ -1304,16 +1304,16 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			|| extendsClass( type, PANACHE_REACTIVE_ENTITY_BASE );
 	}
 
-	private boolean isPanache2Type(TypeElement type) {
-		return implementsInterface( type, PANACHE2_ENTITY_MARKER )
-			|| isPanache2Repository( type );
+	private boolean isQuarkusDataType(TypeElement type) {
+		return implementsInterface( type, QUARKUS_DATA_ENTITY_MARKER )
+			|| isQuarkusDataRepository( type );
 	}
 
-	public static boolean isPanache2Repository(TypeElement type) {
-		return implementsInterface( type, PANACHE2_MANAGED_BLOCKING_REPOSITORY_BASE )
-			|| implementsInterface( type, PANACHE2_STATELESS_BLOCKING_REPOSITORY_BASE )
-			|| implementsInterface( type, PANACHE2_MANAGED_REACTIVE_REPOSITORY_BASE )
-			|| implementsInterface( type, PANACHE2_STATELESS_REACTIVE_REPOSITORY_BASE );
+	public static boolean isQuarkusDataRepository(TypeElement type) {
+		return implementsInterface( type, QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE )
+			|| implementsInterface( type, QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE )
+			|| implementsInterface( type, QUARKUS_DATA_MANAGED_REACTIVE_REPOSITORY_BASE )
+			|| implementsInterface( type, QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE );
 	}
 
 	/**
@@ -1388,7 +1388,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		else {
 			importType( Constants.QUARKUS_SESSION_OPERATIONS );
 			// use this getter to get the method, do not generate an injection point for its type
-			if ( element != null && isPanache2StatelessReactiveRepository( element ) ) {
+			if ( element != null && isQuarkusDataStatelessReactiveRepository( element ) ) {
 				sessionGetter = "SessionOperations.getStatelessSession()";
 				return UNI_MUTINY_STATELESS_SESSION;
 			}
@@ -1403,7 +1403,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		if ( getter != null ) {
 			return getter.getSimpleName().toString();
 		}
-		else if ( element != null && isPanache2StatelessBlockingRepository( element ) ) {
+		else if ( element != null && isQuarkusDataStatelessBlockingRepository( element ) ) {
 			return "getStatelessSession";
 		}
 		else { // good default
@@ -1415,7 +1415,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		if ( getter != null ) {
 			return fullReturnType( getter );
 		}
-		else if ( element != null && isPanache2StatelessBlockingRepository( element ) ) {
+		else if ( element != null && isQuarkusDataStatelessBlockingRepository( element ) ) {
 			return HIB_STATELESS_SESSION;
 		}
 		else { // good default
@@ -1425,9 +1425,9 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 	private boolean isBlockingFavored(@Nullable TypeElement element) {
 		if ( element != null ) {
-			if ( context.usesQuarkusPanache2()
-					&& isPanache2Repository( element ) ) {
-				return isPanache2BlockingRepository( element );
+			if ( context.usesQuarkusDataHibernate()
+					&& isQuarkusDataRepository( element ) ) {
+				return isQuarkusDataBlockingRepository( element );
 			}
 			else {
 				// look for any annotated method, see if they return a Uni
@@ -1442,17 +1442,17 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		return context.usesQuarkusOrm();
 	}
 
-	private static boolean isPanache2BlockingRepository(@Nonnull TypeElement element) {
-		return implementsInterface( element, PANACHE2_MANAGED_BLOCKING_REPOSITORY_BASE )
-			|| implementsInterface( element, PANACHE2_STATELESS_BLOCKING_REPOSITORY_BASE );
+	private static boolean isQuarkusDataBlockingRepository(@Nonnull TypeElement element) {
+		return implementsInterface( element, QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE )
+			|| implementsInterface( element, QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE );
 	}
 
-	private static boolean isPanache2StatelessReactiveRepository(@Nonnull TypeElement element) {
-		return implementsInterface( element, PANACHE2_STATELESS_REACTIVE_REPOSITORY_BASE );
+	private static boolean isQuarkusDataStatelessReactiveRepository(@Nonnull TypeElement element) {
+		return implementsInterface( element, QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE );
 	}
 
-	private static boolean isPanache2StatelessBlockingRepository(@Nonnull TypeElement element) {
-		return implementsInterface( element, PANACHE2_STATELESS_BLOCKING_REPOSITORY_BASE );
+	private static boolean isQuarkusDataStatelessBlockingRepository(@Nonnull TypeElement element) {
+		return implementsInterface( element, QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE );
 	}
 
 	/**

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/spi/DefaultQuarkusDataTypeNames.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/spi/DefaultQuarkusDataTypeNames.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.spi;
+
+/**
+ * Default implementation returning the original Panache Next type names.
+ */
+public class DefaultQuarkusDataTypeNames implements QuarkusDataTypeNames {
+
+	@Override
+	public String packageName() {
+		return "io.quarkus.hibernate.panache";
+	}
+
+	@Override
+	public String entityMarker() {
+		return "io.quarkus.hibernate.panache.PanacheEntityMarker";
+	}
+
+	@Override
+	public String managedBlockingRepositoryBase() {
+		return "io.quarkus.hibernate.panache.managed.blocking.PanacheManagedBlockingRepositoryBase";
+	}
+
+	@Override
+	public String statelessBlockingRepositoryBase() {
+		return "io.quarkus.hibernate.panache.stateless.blocking.PanacheStatelessBlockingRepositoryBase";
+	}
+
+	@Override
+	public String managedReactiveRepositoryBase() {
+		return "io.quarkus.hibernate.panache.managed.reactive.PanacheManagedReactiveRepositoryBase";
+	}
+
+	@Override
+	public String statelessReactiveRepositoryBase() {
+		return "io.quarkus.hibernate.panache.stateless.reactive.PanacheStatelessReactiveRepositoryBase";
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/spi/QuarkusDataTypeNames.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/spi/QuarkusDataTypeNames.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.spi;
+
+/**
+ * SPI for providing the type names used by the Quarkus Data / Panache framework.
+ * <p>
+ * Implementations are discovered via {@link java.util.ServiceLoader}. When no
+ * implementation is found, {@link DefaultQuarkusDataTypeNames} is used, which
+ * returns the original Panache Next type names.
+ */
+public interface QuarkusDataTypeNames {
+
+	String packageName();
+
+	String entityMarker();
+
+	String managedBlockingRepositoryBase();
+
+	String statelessBlockingRepositoryBase();
+
+	String managedReactiveRepositoryBase();
+
+	String statelessReactiveRepositoryBase();
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
@@ -238,11 +238,11 @@ public final class Constants {
 	public static final String SPRING_STATELESS_SESSION_PROVIDER = SPRING_OBJECT_PROVIDER + "<" + HIB_STATELESS_SESSION + ">";
 	public static final String SPRING_COMPONENT = "org.springframework.stereotype.Component";
 
-	public static final String PANACHE2_ENTITY_MARKER = "io.quarkus.hibernate.panache.PanacheEntityMarker";
-	public static final String PANACHE2_MANAGED_BLOCKING_REPOSITORY_BASE = "io.quarkus.hibernate.panache.managed.blocking.PanacheManagedBlockingRepositoryBase";
-	public static final String PANACHE2_STATELESS_BLOCKING_REPOSITORY_BASE = "io.quarkus.hibernate.panache.stateless.blocking.PanacheStatelessBlockingRepositoryBase";
-	public static final String PANACHE2_MANAGED_REACTIVE_REPOSITORY_BASE = "io.quarkus.hibernate.panache.managed.reactive.PanacheManagedReactiveRepositoryBase";
-	public static final String PANACHE2_STATELESS_REACTIVE_REPOSITORY_BASE = "io.quarkus.hibernate.panache.stateless.reactive.PanacheStatelessReactiveRepositoryBase";
+	public static final String QUARKUS_DATA_ENTITY_MARKER = "io.quarkus.data.hibernate.EntitySwitcher";
+	public static final String QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE = "io.quarkus.data.hibernate.managed.blocking.PanacheManagedBlockingRepositoryBase";
+	public static final String QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE = "io.quarkus.data.hibernate.stateless.blocking.PanacheStatelessBlockingRepositoryBase";
+	public static final String QUARKUS_DATA_MANAGED_REACTIVE_REPOSITORY_BASE = "io.quarkus.data.hibernate.managed.reactive.PanacheManagedReactiveRepositoryBase";
+	public static final String QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE = "io.quarkus.data.hibernate.stateless.reactive.PanacheStatelessReactiveRepositoryBase";
 
 	public static final Map<String, String> COLLECTIONS = Map.of(
 			COLLECTION, COLLECTION_ATTRIBUTE,

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
@@ -238,12 +238,6 @@ public final class Constants {
 	public static final String SPRING_STATELESS_SESSION_PROVIDER = SPRING_OBJECT_PROVIDER + "<" + HIB_STATELESS_SESSION + ">";
 	public static final String SPRING_COMPONENT = "org.springframework.stereotype.Component";
 
-	public static final String QUARKUS_DATA_ENTITY_MARKER = "io.quarkus.data.hibernate.EntitySwitcher";
-	public static final String QUARKUS_DATA_MANAGED_BLOCKING_REPOSITORY_BASE = "io.quarkus.data.hibernate.managed.blocking.PanacheManagedBlockingRepositoryBase";
-	public static final String QUARKUS_DATA_STATELESS_BLOCKING_REPOSITORY_BASE = "io.quarkus.data.hibernate.stateless.blocking.PanacheStatelessBlockingRepositoryBase";
-	public static final String QUARKUS_DATA_MANAGED_REACTIVE_REPOSITORY_BASE = "io.quarkus.data.hibernate.managed.reactive.PanacheManagedReactiveRepositoryBase";
-	public static final String QUARKUS_DATA_STATELESS_REACTIVE_REPOSITORY_BASE = "io.quarkus.data.hibernate.stateless.reactive.PanacheStatelessReactiveRepositoryBase";
-
 	public static final Map<String, String> COLLECTIONS = Map.of(
 			COLLECTION, COLLECTION_ATTRIBUTE,
 			SET, SET_ATTRIBUTE,


### PR DESCRIPTION
This renames the types and packages used by Quarkus Data (formerly Panache Next) and is required by https://github.com/quarkusio/quarkus/pull/54610

I'll need a backport to 7.4 if possible, please :)

https://hibernate.atlassian.net/browse/HHH-20642

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
