### PR TITLE
FetchBatchSize and PreferredFetchMethod don't apply to stateless sessions [8.0]

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SessionCreationOption.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionCreationOption.java
@@ -96,7 +96,7 @@ public interface SessionCreationOption {
 	/// @see Session#setFetchBatchSize(int)
 	/// @see org.hibernate.cfg.FetchSettings#DEFAULT_BATCH_FETCH_SIZE
 	record FetchBatchSize(int batchSize)
-			implements EntityManager.CreationOption, EntityAgent.CreationOption {
+			implements EntityManager.CreationOption {
 	}
 
 	/// Enables or disables the use of [subselect fetching][FetchMethod#BY_SUBQUERY].
@@ -104,7 +104,7 @@ public interface SessionCreationOption {
 	/// @see org.hibernate.Session#setSubselectFetchingEnabled(boolean)
 	/// @see org.hibernate.cfg.FetchSettings#USE_SUBSELECT_FETCH
 	enum PreferredFetchMethod
-			implements EntityManager.CreationOption, EntityAgent.CreationOption {
+			implements EntityManager.CreationOption {
 		/// Enables [subselect fetching][FetchMethod#BY_SUBQUERY]
 		BY_SUBQUERY,
 		/// Disables [subselect fetching][FetchMethod#BY_SUBQUERY]

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/OptionsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/OptionsHelper.java
@@ -152,12 +152,6 @@ public final class OptionsHelper {
 		else if ( option instanceof CacheRetrieveMode cacheRetrieveMode ) {
 			options.cacheRetrieveMode( cacheRetrieveMode );
 		}
-		else if ( option instanceof SessionCreationOption.FetchBatchSize fetchBatchSize ) {
-			options.defaultBatchFetchSize( fetchBatchSize.batchSize() );
-		}
-		else if ( option instanceof SessionCreationOption.PreferredFetchMethod preferredFetchMethod ) {
-			options.subselectFetchEnabled( preferredFetchMethod == SessionCreationOption.PreferredFetchMethod.BY_SUBQUERY );
-		}
 		else if ( option instanceof SessionCreationOption.TenantId tenantId ) {
 			options.tenantIdentifier( tenantId.value() );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pc/EntityHandlerOptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pc/EntityHandlerOptionTests.java
@@ -102,11 +102,6 @@ public class EntityHandlerOptionTests {
 			assertThat( em.unwrap( StatelessSessionImplementor.class ).getLoadQueryInfluencers().getBatchSize() )
 					.isEqualTo( defaultBatchFetchSize );
 		}
-
-		try (var em = sf.createEntityAgent( new SessionCreationOption.FetchBatchSize( 10 ) )) {
-			assertThat( em.unwrap( StatelessSessionImplementor.class ).getLoadQueryInfluencers().getBatchSize() )
-					.isEqualTo( 10 );
-		}
 	}
 
 	@Test


### PR DESCRIPTION
…

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
