### PR TITLE
HHH-20580  HbmXmlTransformer should not add a table attribute  for entities mapped to a <subselect>

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1122,7 +1122,7 @@ public class HbmXmlTransformer {
 			String tableName) {
 		if ( tableName != null
 				&& currentBaseTable != null
-				&& currentBaseTable.isPhysicalTable()
+				&& ( currentBaseTable.isPhysicalTable() || currentBaseTable.isSubselect() )
 				&& currentBaseTable.getName().equals( tableName ) ) {
 			tableName = null;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -251,6 +251,37 @@ public class HbmTransformationJaxbTests {
 		} );
 	}
 
+	@Test
+	public void testSubselectEntityTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/subselect-entity/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl viewEntity = transformed.getEntities().stream()
+					.filter( e -> "SubselectView".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( viewEntity.getTableExpression() )
+					.as( "Subselect entity should have a table-expression" )
+					.isNotNull();
+			assertThat( viewEntity.getTableExpression() ).contains( "select id, name, value from base_table" );
+			assertThat( viewEntity.getTable() )
+					.as( "Subselect entity should not have a regular table" )
+					.isNull();
+			assertThat( viewEntity.getSynchronizeTables() ).hasSize( 1 );
+			assertThat( viewEntity.getSynchronizeTables().get( 0 ).getTable() ).isEqualTo( "base_table" );
+			assertThat( viewEntity.isMutable() ).isFalse();
+
+			for ( JaxbBasicImpl basic : viewEntity.getAttributes().getBasicAttributes() ) {
+				if ( basic.getColumn() != null ) {
+					assertThat( basic.getColumn().getTable() )
+							.as( "Column for property '%s' should not have a table attribute on a subselect entity", basic.getName() )
+							.isNull();
+				}
+			}
+		} );
+	}
+
 	private void transformAndVerify(
 			String resourceName,
 			ServiceRegistryScope scope,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubselectBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubselectBase.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class SubselectBase {
+	private Long id;
+	private String name;
+	private String value;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubselectView.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubselectView.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class SubselectView {
+	private Long id;
+	private String name;
+	private String value;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/subselect-entity/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/subselect-entity/hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="SubselectBase" table="base_table">
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name"/>
+        <property name="value"/>
+    </class>
+
+    <class name="SubselectView" mutable="false">
+        <subselect>select id, name, value from base_table</subselect>
+        <synchronize table="base_table"/>
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name"/>
+        <property name="value" column="value"/>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20580

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20580 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->