### PR TITLE
HHH-20578 - Deprecate SessionFactoryBuilder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -10,6 +10,7 @@ import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
 import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
+import org.hibernate.Remove;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.StatementObserver;
@@ -39,7 +40,10 @@ import jakarta.persistence.criteria.Nulls;
  * @since 5.0
  *
  * @see Metadata#getSessionFactoryBuilder()
+ *
+ * @apiNote This will be removed in 9.0.
  */
+@Remove
 public interface SessionFactoryBuilder {
 	/**
 	 * Specifies a Bean Validation {@link jakarta.validation.ValidatorFactory}.

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
@@ -9,6 +9,7 @@ import java.util.function.Supplier;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
 import org.hibernate.Interceptor;
+import org.hibernate.Remove;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.StatementObserver;
@@ -37,7 +38,10 @@ import jakarta.persistence.criteria.Nulls;
  *
  * @param <T> The specific subclass; Allows subclasses to narrow the return type of the contract methods
  *            to a specialization of {@link MetadataBuilderImplementor}.
+ *
+ * @apiNote This will be removed in 9.0.
  */
+@Remove
 public abstract class AbstractDelegatingSessionFactoryBuilder<T extends SessionFactoryBuilder> implements SessionFactoryBuilder {
 	private final SessionFactoryBuilder delegate;
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilderImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilderImplementor.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.boot.spi;
 
+import org.hibernate.Remove;
+
 /**
  * Convenience base class for custom implementors of {@link SessionFactoryBuilderImplementor}, using delegation
  *
@@ -11,7 +13,10 @@ package org.hibernate.boot.spi;
  *
  * @param <T> The specific subclass; Allows subclasses to narrow the return type of the contract methods
  *            to a specialization of {@link MetadataBuilderImplementor}.
+ *
+ * @apiNote This will be removed in 9.0.
  */
+@Remove
 public abstract class AbstractDelegatingSessionFactoryBuilderImplementor<T extends SessionFactoryBuilderImplementor>
 		extends AbstractDelegatingSessionFactoryBuilder<T> implements SessionFactoryBuilderImplementor {
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryBuilderFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryBuilderFactory.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.boot.spi;
 
+import org.hibernate.Remove;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.service.JavaServiceLoadable;
 
@@ -12,8 +13,11 @@ import org.hibernate.service.JavaServiceLoadable;
  * is built. Intended as a "discoverable service" ({@link java.util.ServiceLoader}). There can
  * be at most one implementation discovered that returns a non-null {@link SessionFactoryBuilder}.
  *
+ * @apiNote This will be removed in 9.0.
+ *
  * @author Steve Ebersole
  */
+@Remove
 @JavaServiceLoadable
 public interface SessionFactoryBuilderFactory {
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryBuilderImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryBuilderImplementor.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.boot.spi;
 
+import org.hibernate.Remove;
 import org.hibernate.boot.SessionFactoryBuilder;
 
 /**
@@ -11,7 +12,10 @@ import org.hibernate.boot.SessionFactoryBuilder;
  * implementors of {@link SessionFactoryBuilderFactory}.
  *
  * @author Steve Ebersole
+ *
+ * @apiNote This will be removed in 9.0.
  */
+@Remove
 public interface SessionFactoryBuilderImplementor extends SessionFactoryBuilder {
 
 	/**


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

HHH-20578 - Deprecate SessionFactoryBuilder
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20578 (Deprecation):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20578
<!-- Hibernate GitHub Bot issue links end -->