### PR TITLE
HHH-20551 Release jdbc resources after scrollable result stream is closed when no transaction is active

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.engine.jdbc.internal;
 
-import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.HibernateException;
 import org.hibernate.TransactionException;
 import org.hibernate.engine.jdbc.batch.spi.Batch;
@@ -328,12 +327,12 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 
 	@Override
 	public void afterStatementExecution() {
-		final var connectionReleaseMode = connectionReleaseMode();
+		final var connectionReleaseMode = getLogicalConnection().resolvedConnectionReleaseMode();
 		if ( TRACE_ENABLED ) {
 			JDBC_LOGGER.statementExecutionComplete( connectionReleaseMode, hashCode() );
 		}
 		if ( connectionReleaseMode == AFTER_STATEMENT ) {
-			if ( ! releasesEnabled ) {
+			if ( !releasesEnabled ) {
 				JDBC_LOGGER.skippingAggressiveRelease( "manually disabled" );
 			}
 			else if ( hasRegisteredResources() ) {
@@ -363,16 +362,12 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 	@Override
 	public void afterTransaction() {
 		transactionTimeOutInstant = -1;
-		switch ( connectionReleaseMode() ) {
+		switch ( logicalConnection.resolvedConnectionReleaseMode() ) {
 			case AFTER_STATEMENT:
 			case AFTER_TRANSACTION:
 			case BEFORE_TRANSACTION_COMPLETION:
 				logicalConnection.afterTransaction();
 		}
-	}
-
-	private ConnectionReleaseMode connectionReleaseMode() {
-		return getLogicalConnection().getConnectionHandlingMode().getReleaseMode();
 	}
 
 	private boolean hasRegisteredResources() {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
@@ -1727,12 +1727,7 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 
 	protected void afterQuery(boolean success) {
 		afterQuery();
-
-		final var session = getSession();
-		if ( !session.isTransactionInProgress() ) {
-			session.getJdbcCoordinator().getLogicalConnection().afterTransaction();
-		}
-		session.afterOperation( success );
+		getSession().afterOperation( success );
 	}
 
 	protected void afterQuery() {

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.ResourceClosedException;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
@@ -23,6 +24,7 @@ import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 
 import static org.hibernate.ConnectionAcquisitionMode.IMMEDIATELY;
 import static org.hibernate.ConnectionReleaseMode.AFTER_STATEMENT;
+import static org.hibernate.ConnectionReleaseMode.AFTER_TRANSACTION;
 import static org.hibernate.ConnectionReleaseMode.BEFORE_TRANSACTION_COMPLETION;
 import static org.hibernate.ConnectionReleaseMode.ON_CLOSE;
 import static org.hibernate.resource.jdbc.internal.LogicalConnectionLogging.CONNECTION_LOGGER;
@@ -138,7 +140,7 @@ public class LogicalConnectionManagedImpl extends AbstractLogicalConnectionImple
 	@Override
 	public void afterStatement() {
 		super.afterStatement();
-		if ( connectionHandlingMode.getReleaseMode() == AFTER_STATEMENT ) {
+		if ( resolvedConnectionReleaseMode() == AFTER_STATEMENT ) {
 			if ( getResourceRegistry().hasRegisteredResources() ) {
 				CONNECTION_LOGGER.skipConnectionReleaseAfterStatementDueToResources( hashCode() );
 			}
@@ -152,7 +154,7 @@ public class LogicalConnectionManagedImpl extends AbstractLogicalConnectionImple
 	@Override
 	public void beforeTransactionCompletion() {
 		super.beforeTransactionCompletion();
-		if ( connectionHandlingMode.getReleaseMode() == BEFORE_TRANSACTION_COMPLETION ) {
+		if ( resolvedConnectionReleaseMode() == BEFORE_TRANSACTION_COMPLETION ) {
 			CONNECTION_LOGGER.initiatingConnectionReleaseBeforeTransactionCompletion( hashCode() );
 			releaseConnectionIfNeeded();
 		}
@@ -161,7 +163,7 @@ public class LogicalConnectionManagedImpl extends AbstractLogicalConnectionImple
 	@Override
 	public void afterTransaction() {
 		super.afterTransaction();
-		if ( connectionHandlingMode.getReleaseMode() != ON_CLOSE ) {
+		if ( resolvedConnectionReleaseMode() != ON_CLOSE ) {
 			// NOTE: we check for !ON_CLOSE here (rather than AFTER_TRANSACTION) to also catch:
 			// - AFTER_STATEMENT cases that were circumvented due to held resources
 			// - BEFORE_TRANSACTION_COMPLETION cases that were circumvented because a rollback occurred
@@ -317,5 +319,18 @@ public class LogicalConnectionManagedImpl extends AbstractLogicalConnectionImple
 	@Nonnull
 	public ResourceRegistry getResourceRegistry() {
 		return resourceRegistry;
+	}
+
+	public @Nonnull ConnectionReleaseMode resolvedConnectionReleaseMode() {
+		final var releaseMode = connectionHandlingMode.getReleaseMode();
+		if ( releaseMode == AFTER_TRANSACTION
+			&& !jdbcSessionOwner.getTransactionCoordinator().isTransactionActive() ) {
+			// means we've autocommitted and the transaction ended after the statement
+			// hence we should treat it as if "after statement":
+			return AFTER_STATEMENT;
+		}
+		else {
+			return releaseMode;
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionProvidedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionProvidedImpl.java
@@ -44,7 +44,7 @@ public class LogicalConnectionProvidedImpl extends AbstractLogicalConnectionImpl
 	}
 
 	@Override
-	public PhysicalConnectionHandlingMode getConnectionHandlingMode() {
+	public @Nonnull PhysicalConnectionHandlingMode getConnectionHandlingMode() {
 		return IMMEDIATE_ACQUISITION_AND_HOLD;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/LogicalConnectionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/LogicalConnectionImplementor.java
@@ -8,6 +8,9 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.sql.Connection;
 
+import jakarta.annotation.Nonnull;
+import org.hibernate.ConnectionReleaseMode;
+import org.hibernate.Incubating;
 import org.hibernate.resource.jdbc.LogicalConnection;
 
 /**
@@ -25,7 +28,13 @@ public interface LogicalConnectionImplementor extends LogicalConnection {
 	 */
 	Connection getPhysicalConnection();
 
+	@Nonnull
 	PhysicalConnectionHandlingMode getConnectionHandlingMode();
+
+	@Incubating
+	default @Nonnull ConnectionReleaseMode resolvedConnectionReleaseMode() {
+		return getConnectionHandlingMode().getReleaseMode();
+	}
 
 	/**
 	 * Notification indicating a JDBC statement has been executed, to trigger

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/InflaterInputStreamBlobTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/InflaterInputStreamBlobTest.java
@@ -67,7 +67,7 @@ class InflaterInputStreamBlobTest {
 				}
 		);
 
-		scope.inStatelessSession( session -> {
+		scope.inStatelessTransaction( session -> {
 			final var entity = session.get( TestEntity.class, 1L );
 			try {
 				final var blob = entity.getData();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stream/basic/StreamConnectionReleaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stream/basic/StreamConnectionReleaseTest.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.stream.basic;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {StreamConnectionReleaseTest.MyEntity.class})
+@SessionFactory
+@ServiceRegistry(settings = {
+		// We want to make sure that the release mode is set to "after transaction"
+		// but at the same time we are running things without an actual transaction.
+		// Resources should be still released in this case ...
+		@Setting(name = AvailableSettings.CONNECTION_HANDLING,
+				value = "DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION")
+})
+public class StreamConnectionReleaseTest {
+
+	@BeforeEach
+	void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			for ( int i = 0; i < 5; i++ ) {
+				MyEntity e = new MyEntity();
+				e.id = i;
+				e.name = "Entity #" + i;
+				session.persist( e );
+			}
+		} );
+	}
+
+	@AfterEach
+	void dropTestData(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	void testConnectionReleasedAfterStreamCloseOutsideTransaction(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should not be acquired before the query" )
+					.isFalse();
+
+			try (Stream<MyEntity> stream = session.createQuery( "from MyEntity", MyEntity.class ).getResultStream()) {
+				stream.forEach( e -> assertThat( e.name ).isNotNull() );
+				assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+						.as( "we are still holding the connection because the stream is opened" )
+						.isTrue();
+			}
+
+			assertThat(
+					session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().hasRegisteredResources() )
+					.as( "resources should be released after stream close" )
+					.isFalse();
+
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should be released after stream close outside a transaction" )
+					.isFalse();
+		} );
+	}
+
+	@Test
+	void testConnectionReleasedAfterStatementOutsideTransaction(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should not be acquired before the query" )
+					.isFalse();
+
+			List<MyEntity> list = session.createQuery( "from MyEntity", MyEntity.class ).getResultList();
+			list.forEach( e -> assertThat( e.name ).isNotNull() );
+
+			assertThat(
+					session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry()
+							.hasRegisteredResources() )
+					.as( "no resources were requested by this query" )
+					.isFalse();
+
+			assertThat( session.getJdbcCoordinator().getLogicalConnection().isPhysicallyConnected() )
+					.as( "connection should be released after the statement" )
+					.isFalse();
+		} );
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity {
+		@Id
+		public Integer id;
+		public String name;
+	}
+}

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -65,6 +65,44 @@ This section describes changes to contracts (classes, interfaces, methods, etc.)
 
 This section describes changes in behavior that applications should be aware of.
 
+[[jdbc-resource-release-autocommit]]
+=== JDBC resource release in autocommit mode
+
+When no transaction is active (autocommit), Hibernate now correctly releases the connection after statement
+execution if the configured `ConnectionReleaseMode` is set to `AFTER_TRANSACTION`.
+Previously, with `DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION` connection handling mode, JDBC resources
+and the physical connection were held until an explicit call to `afterTransaction()` or closing the session,
+even though in autocommit mode each statement is effectively its own transaction.
+
+This change ensures that JDBC connections are promptly returned to the pool after each statement when there
+is no active transaction, preventing potential resource leaks.
+
+As a consequence, accessing LOB locators (i.e. `java.sql.Blob` or `java.sql.Clob` typed attributes) outside of
+an active transaction will no longer work and result in an exception on most dialects.
+Previously this appeared to work only because the connection happened to remain open; however, there were no
+transactional isolation guarantees — the data read from the LOB could have already been modified by another
+transaction.
+
+Note that this only affects entity attributes mapped as `java.sql.Blob` or `java.sql.Clob`, since these types
+rely on a JDBC locator that requires a live connection. Attributes mapped as `byte[]` or `String` are always
+eagerly materialized when the result set is read, and are not affected by this change. Similarly, some dialects
+that always use materialized LOB access are also unaffected.
+
+Applications that use `Blob` or `Clob` typed attributes must access them within an active transaction:
+
+[source,java]
+----
+// Before (assuming no active transaction, may have accidentally worked, but with no isolation guarantees):
+session.get(MyEntity.class, id);
+entity.getData().getBinaryStream(); // may now fail — connection already released
+
+// After (correct):
+session.getTransaction().begin();
+session.get(MyEntity.class, id);
+entity.getData().getBinaryStream(); // works — connection held by the transaction
+session.getTransaction().commit();
+----
+
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // XSD changes


### PR DESCRIPTION
replaces previous attempts 🙈:
* https://github.com/hibernate/hibernate-orm/pull/12721
* https://github.com/hibernate/hibernate-orm/pull/12709

we don't have that extra check in the `AbstractCommonQueryContract` and simply rely on afterstatement to do the right thing. Since we resolve the release mode in the logicalconnection when can "downgrade" it to statement if we know it was actually an autocommit. 

Failing test for lobs was relying on an unreleased connection, but that wasn't good ... if we want to read something after the initial statement we better do it within the same transaction..

H2/Postgresql worked ... let's see if others will pass too

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20551 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20551
<!-- Hibernate GitHub Bot issue links end -->