### PR TITLE
HHH-20582 Walk superclass auditing data when resolving @OneToOne mappedBy

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ToOneRelationMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ToOneRelationMetadataGenerator.java
@@ -10,7 +10,9 @@ import org.hibernate.envers.boot.EnversMappingException;
 import org.hibernate.envers.boot.model.AttributeContainer;
 import org.hibernate.envers.boot.spi.EnversMetadataBuildingContext;
 import org.hibernate.envers.RelationTargetNotFoundAction;
+import org.hibernate.envers.configuration.internal.ClassesAuditingData;
 import org.hibernate.envers.configuration.internal.metadata.reader.AuditedPropertiesHolder;
+import org.hibernate.envers.configuration.internal.metadata.reader.ClassAuditingData;
 import org.hibernate.envers.configuration.internal.metadata.reader.ComponentAuditingData;
 import org.hibernate.envers.configuration.internal.metadata.reader.PropertyAuditingData;
 import org.hibernate.envers.internal.entities.EntityConfiguration;
@@ -23,6 +25,7 @@ import org.hibernate.envers.internal.entities.mapper.relation.OneToOnePrimaryKey
 import org.hibernate.envers.internal.entities.mapper.relation.ToOneIdMapper;
 import org.hibernate.envers.internal.tools.MappingTools;
 import org.hibernate.mapping.OneToOne;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.Value;
 
@@ -159,14 +162,14 @@ public final class ToOneRelationMetadataGenerator extends AbstractMetadataGenera
 		);
 	}
 
-	private static void checkMappedByAudited(
+	private void checkMappedByAudited(
 			String entityName,
 			String associationName,
 			String referencedEntityName,
 			String referencedPropertyName,
 			AuditedPropertiesHolder propertiesHolder) {
 		final var split = referencedPropertyName.split( "\\.", 2 );
-		final var auditingData = propertiesHolder.getPropertyAuditingData( split[0] );
+		final var auditingData = resolveAuditedProperty( propertiesHolder, split[0] );
 		if ( auditingData == null ) {
 			throw new EnversMappingException( String.format(
 					Locale.ROOT,
@@ -182,6 +185,29 @@ public final class ToOneRelationMetadataGenerator extends AbstractMetadataGenera
 			// mapped by is a nested component property
 			checkMappedByAudited( entityName, associationName, referencedEntityName, split[1], (ComponentAuditingData) auditingData );
 		}
+	}
+
+	private PropertyAuditingData resolveAuditedProperty(AuditedPropertiesHolder propertiesHolder, String propertyName) {
+		PropertyAuditingData auditingData = propertiesHolder.getPropertyAuditingData( propertyName );
+		if ( auditingData != null ) {
+			return auditingData;
+		}
+
+		if ( propertiesHolder instanceof ClassAuditingData classAuditingData ) {
+			final ClassesAuditingData classesAuditingData = getMetadataBuildingContext().getClassesAuditingData();
+			PersistentClass superclass = classAuditingData.getPersistentClass().getSuperclass();
+			while ( superclass != null ) {
+				auditingData = classesAuditingData
+						.getClassAuditingData( superclass.getEntityName() )
+						.getPropertyAuditingData( propertyName );
+				if ( auditingData != null ) {
+					return auditingData;
+				}
+				superclass = superclass.getSuperclass();
+			}
+		}
+
+		return null;
 	}
 
 	void addOneToOnePrimaryKeyJoinColumn(

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/onetoone/bidirectional/MappedByOnSuperclassOneToOneTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/onetoone/bidirectional/MappedByOnSuperclassOneToOneTest.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.onetoone.bidirectional;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.envers.Audited;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JiraKey("HHH-20582")
+public class MappedByOnSuperclassOneToOneTest {
+	@Test
+	public void testBootstrapSucceedsWhenMappedByTargetsSuperclassProperty() {
+		final Configuration cfg = new Configuration().addAnnotatedClasses(
+				Account.class,
+				Credential.class,
+				PasswordCredential.class,
+				User.class
+		);
+		ServiceRegistryUtil.applySettings( cfg.getStandardServiceRegistryBuilder() );
+		try (SessionFactory sessionFactory = cfg.buildSessionFactory()) {
+			assertThat( sessionFactory ).isNotNull();
+		}
+	}
+
+	@Entity
+	@Audited
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "type")
+	public abstract static class Account {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+	}
+
+	@Entity
+	@Audited
+	@Table(name = "credential")
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "type")
+	public abstract static class Credential {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+
+		@ManyToOne(optional = false)
+		@JoinColumn(name = "account_id", updatable = false)
+		private Account account;
+
+		protected Credential() {}
+
+		protected Credential(Account account) {
+			this.account = account;
+		}
+	}
+
+	@Entity
+	@Audited
+	@DiscriminatorValue("PWD")
+	public static class PasswordCredential extends Credential {
+
+		protected PasswordCredential() {}
+
+		public PasswordCredential(Account account) {
+			super( account );
+		}
+	}
+
+	@Entity
+	@Audited
+	@DiscriminatorValue("U")
+	public static class User extends Account {
+
+		@OneToOne(mappedBy = "account", optional = false, cascade = CascadeType.ALL)
+		private PasswordCredential credential;
+
+		protected User() {}
+
+		public User(PasswordCredential credential) {
+			this.credential = credential;
+		}
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/onetoone/bidirectional/MappedByOnSuperclassOneToOneTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/onetoone/bidirectional/MappedByOnSuperclassOneToOneTest.java
@@ -4,12 +4,14 @@
  */
 package org.hibernate.orm.test.envers.integration.onetoone.bidirectional;
 
-import org.hibernate.SessionFactory;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.envers.Audited;
-
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.testing.envers.junit.EnversTest;
+import org.hibernate.testing.orm.junit.BeforeClassTemplate;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.hibernate.testing.orm.junit.Jpa;
+
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
@@ -17,7 +19,6 @@ import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
@@ -26,36 +27,70 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @JiraKey("HHH-20582")
+@EnversTest
+@Jpa(annotatedClasses = {
+		MappedByOnSuperclassOneToOneTest.Account.class,
+		MappedByOnSuperclassOneToOneTest.Credential.class,
+		MappedByOnSuperclassOneToOneTest.PasswordCredential.class,
+		MappedByOnSuperclassOneToOneTest.User.class
+})
 public class MappedByOnSuperclassOneToOneTest {
-	@Test
-	public void testBootstrapSucceedsWhenMappedByTargetsSuperclassProperty() {
-		final Configuration cfg = new Configuration().addAnnotatedClasses(
-				Account.class,
-				Credential.class,
-				PasswordCredential.class,
-				User.class
-		);
-		ServiceRegistryUtil.applySettings( cfg.getStandardServiceRegistryBuilder() );
-		try (SessionFactory sessionFactory = cfg.buildSessionFactory()) {
-			assertThat( sessionFactory ).isNotNull();
-		}
+	private Integer userId;
+	private Integer credentialId;
+
+	@BeforeClassTemplate
+	public void initData(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			final User user = new User();
+			final PasswordCredential credential = new PasswordCredential( user );
+			user.setCredential( credential );
+			em.persist( user );
+
+			this.userId = user.getId();
+			this.credentialId = credential.getId();
+		} );
 	}
 
-	@Entity
+	@Test
+	public void testRevisionCounts(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			final var auditReader = AuditReaderFactory.get( em );
+			assertEquals( 1, auditReader.getRevisions( User.class, userId ).size() );
+			assertEquals( 1, auditReader.getRevisions( PasswordCredential.class, credentialId ).size() );
+		} );
+	}
+
+	@Test
+	public void testRevisionHistory(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			final var auditReader = AuditReaderFactory.get( em );
+			final User userRev = auditReader.find( User.class, userId, 1 );
+			assertNotNull( userRev.getCredential() );
+			final PasswordCredential credentialRev = auditReader.find( PasswordCredential.class, credentialId, 1 );
+			assertNotNull( credentialRev.getAccount() );
+		} );
+	}
+
+	@Entity(name = "Account")
 	@Audited
 	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 	@DiscriminatorColumn(name = "type")
 	public abstract static class Account {
 
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
-		private Long id;
+		@GeneratedValue
+		private Integer id;
+
+		public Integer getId() {
+			return id;
+		}
 	}
 
-	@Entity
+	@Entity(name = "Credential")
 	@Audited
 	@Table(name = "credential")
 	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
@@ -63,8 +98,8 @@ public class MappedByOnSuperclassOneToOneTest {
 	public abstract static class Credential {
 
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
-		private Long id;
+		@GeneratedValue
+		private Integer id;
 
 		@ManyToOne(optional = false)
 		@JoinColumn(name = "account_id", updatable = false)
@@ -75,9 +110,17 @@ public class MappedByOnSuperclassOneToOneTest {
 		protected Credential(Account account) {
 			this.account = account;
 		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public Account getAccount() {
+			return account;
+		}
 	}
 
-	@Entity
+	@Entity(name = "PasswordCredential")
 	@Audited
 	@DiscriminatorValue("PWD")
 	public static class PasswordCredential extends Credential {
@@ -89,7 +132,7 @@ public class MappedByOnSuperclassOneToOneTest {
 		}
 	}
 
-	@Entity
+	@Entity(name = "User")
 	@Audited
 	@DiscriminatorValue("U")
 	public static class User extends Account {
@@ -99,8 +142,12 @@ public class MappedByOnSuperclassOneToOneTest {
 
 		protected User() {}
 
-		public User(PasswordCredential credential) {
+		public void setCredential(PasswordCredential credential) {
 			this.credential = credential;
+		}
+
+		public PasswordCredential getCredential() {
+			return credential;
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://hibernate.atlassian.net/browse/HHH-20582

Envers `ToOneRelationMetadataGenerator.checkMappedByAudited` (added in HHH-19897 / PR #11175)
validates that the owning side of an inverse `@OneToOne` is audited, but only inspects the
concrete referenced entity's `ClassAuditingData`. `CollectionMappedByResolver` was updated in
the same change to walk superclasses; this brings `@OneToOne` inverse resolution in line.
Adds `MappedByOnSuperclassOneToOneTest` reproducing bootstrap failure when `mappedBy` targets
a property declared on a parent `@Entity` in a `SINGLE_TABLE` hierarchy.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20582 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->