### PR TITLE
HHH-20583 Spurious HHH90010101/HHH90010108 warnings on bulk operations under container-managed JTA

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -392,7 +392,18 @@ public class SessionImpl
 			// E.g. When we are in the JTA context, the session can get closed while the
 			// transaction is still active and JTA will call the AfterCompletion itself.
 			// Hence, we don't want to clear out the action queue callbacks at this point:
+			//
+			// HHH-20583: In a container-managed JTA context the session is frequently closed
+			// during the JTA afterCompletion dispatch window -- after the transaction is no longer
+			// "active" but BEFORE Hibernate's own RegisteredSynchronization has fired (it runs as a
+			// regular synchronization, while the container closes the session from an interposed one,
+			// which the JTA contract dispatches first). In that window isTransactionActive() is
+			// already false, so this guard would force-execute and log HHH90010108, even though the
+			// pending synchronization processes these callbacks moments later. isJoined() (a
+			// RegisteredSynchronization is still registered) tells us the afterCompletion is still
+			// pending; defer to it instead of warning.
 			if ( !getTransactionCoordinator().isTransactionActive()
+					&& !getTransactionCoordinator().isJoined()
 					&& actionQueue.hasAfterTransactionActions() ) {
 				SESSION_LOGGER.closingSessionWithUnprocessedBulkOperations();
 				actionQueue.executePendingBulkOperationCleanUpActions();
@@ -422,6 +433,11 @@ public class SessionImpl
 
 	@Override
 	protected void checkBeforeClosingJdbcCoordinator() {
+		// HHH-20583: do not warn when a JTA afterCompletion is still pending (isJoined()); the
+		// registered synchronization fires shortly after this close and processes the callbacks.
+		if ( getTransactionCoordinator().isJoined() ) {
+			return;
+		}
 		final var actionQueue = getActionQueue();
 		if ( actionQueue.hasBeforeTransactionActions() || actionQueue.hasAfterTransactionActions() ) {
 			SESSION_LOGGER.closingSharedSessionWithUnprocessedTxCompletions();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/JtaSessionCloseBulkCleanupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/JtaSessionCloseBulkCleanupTest.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.actionqueue;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionManager;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.orm.test.jpa.transaction.JtaPlatformSettingProvider;
+
+import org.hibernate.testing.jta.TestingJtaPlatformImpl;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Logger;
+import org.hibernate.testing.orm.junit.MessageKeyInspection;
+import org.hibernate.testing.orm.junit.MessageKeyWatcher;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * In a container-managed JTA context the session is closed from within an <em>interposed</em>
+ * {@link Synchronization#afterCompletion(int)} (e.g. WildFly's
+ * {@code TransactionUtil$SessionSynchronization}). Per the JTA contract interposed
+ * {@code afterCompletion} callbacks run before regular ones, while Hibernate registers its own
+ * callback-processing synchronization as a regular one. So the session is closed while the
+ * transaction is no longer active but before Hibernate has processed the bulk-operation cleanup
+ * callbacks; {@code SessionImpl}'s close guard then force-executes them and logs HHH90010101 /
+ * HHH90010108, even though the (regular) synchronization processes them moments later.
+ *
+ * @see <a href="https://hibernate.atlassian.net/browse/HHH-20583">HHH-20583</a>
+ */
+@Jpa(
+		annotatedClasses = JtaSessionCloseBulkCleanupTest.Author.class,
+		settingProviders = @SettingProvider(
+				settingName = AvailableSettings.JTA_PLATFORM,
+				provider = JtaPlatformSettingProvider.class
+		),
+		integrationSettings = {
+				@Setting(name = AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, value = "jta"),
+				@Setting(name = AvailableSettings.ALLOW_JTA_TRANSACTION_ACCESS, value = "true"),
+				@Setting(name = AvailableSettings.JPA_TRANSACTION_COMPLIANCE, value = "true"),
+				@Setting(name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true"),
+				@Setting(
+						name = AvailableSettings.CACHE_REGION_FACTORY,
+						value = "org.hibernate.testing.cache.CachingRegionFactory"
+				)
+		}
+)
+@MessageKeyInspection(
+		messageKey = "HHH90010108",
+		logger = @Logger(loggerName = "org.hibernate.orm.session")
+)
+public class JtaSessionCloseBulkCleanupTest {
+
+	@Test
+	void bulkNativeUpdateClosedDuringAfterCompletionDoesNotWarn(
+			EntityManagerFactoryScope scope,
+			MessageKeyWatcher watcher) throws Exception {
+
+		final SessionFactory sessionFactory = scope.getEntityManagerFactory().unwrap( SessionFactory.class );
+		final TransactionManager tm = TestingJtaPlatformImpl.INSTANCE.getTransactionManager();
+
+		tm.begin();
+		final Session session = sessionFactory.openSession();
+
+		// No synchronized query spaces -> the bulk cleanup is treated as affecting all cacheable
+		// entities, so it is non-empty and registers an after-completion callback.
+		session.createNativeMutationQuery( "update AUTHORS set NAME = NAME" ).executeUpdate();
+
+		// Mimic the container: close the session from an interposed afterCompletion (runs before
+		// Hibernate's own regular synchronization).
+		TestingJtaPlatformImpl.synchronizationRegistry().registerInterposedSynchronization( new Synchronization() {
+			@Override
+			public void beforeCompletion() {
+			}
+
+			@Override
+			public void afterCompletion(int status) {
+				session.close();
+			}
+		} );
+
+		tm.commit();
+
+		assertFalse(
+				watcher.wasTriggered(),
+				"Spurious unprocessed-completion warning(s): " + watcher.getTriggeredMessages()
+		);
+	}
+
+	@Entity(name = "Author")
+	@Table(name = "AUTHORS")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	static class Author {
+		@Id
+		Long id;
+		@Column(name = "NAME")
+		String name;
+	}
+}


### PR DESCRIPTION
Issue: https://hibernate.atlassian.net/browse/HHH-20583

## Problem

Since 7.3, applications running on a container-managed JTA `EntityManager` (e.g. WildFly, Payara) log two warnings on **every** bulk operation (`createNativeQuery(...).executeUpdate()`, HQL/Criteria `UPDATE`/`DELETE`):

```
HHH90010101: Closing shared session with unprocessed transaction completion actions
HHH90010108: Closing session with unprocessed clean up bulk operations, forcing their execution
```

The warnings are spurious — the after-transaction-completion callbacks they complain about are processed correctly by the JTA `afterCompletion` a moment later — but they flood the log on write-heavy applications. 6.6 scheduled the same callbacks but had no close-time diagnostic, so the condition was silent.

## Cause

Under a container-managed persistence context the container closes the session from an **interposed** `Synchronization.afterCompletion` (e.g. WildFly's `TransactionUtil$SessionSynchronization`, registered via `registerInterposedSynchronization`). Per the JTA contract interposed `afterCompletion` callbacks run **before** regular ones, and Hibernate registers its own callback-processing synchronization (`RegisteredSynchronization`) as a **regular** one. So the session is closed while the transaction is no longer active but **before** Hibernate has processed the bulk-operation cleanup callbacks; the close-time guards in `SessionImpl` (`closeWithoutOpenChecks` and `checkBeforeClosingJdbcCoordinator`) then conclude the callbacks are orphaned, force-execute them, and warn — even though the pending synchronization processes them moments later.

## Fix

- `SessionImpl`: defer (don't warn / force-execute) when `getTransactionCoordinator().isJoined()` — a `RegisteredSynchronization` is still registered, i.e. the JTA `afterCompletion` is still pending and will process the callbacks. For non-JTA / resource-local coordinators `isJoined()` is already `false` once the transaction completes, so their behavior is unchanged.
- `BulkOperationCleanupAction`: return `null` from `getAfterTransactionCompletionProcess()` when all cleanup sets are empty, so no no-op after-completion callback is registered (query-space cache invalidation is unaffected — that is driven by `getPropertySpaces()`).

## Test

`org.hibernate.orm.test.actionqueue.JtaSessionCloseBulkCleanupTest` reproduces the interposed-`afterCompletion` close over a non-empty bulk cleanup and asserts (via `@MessageKeyInspection`) that `HHH90010108` is no longer logged. It fails before this change and passes after.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20583 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->