### PR TITLE
HHH-20348 Handle primitive array aggregate element types

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/DdlTypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/DdlTypeHelper.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 
 import org.hibernate.engine.jdbc.Size;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.metamodel.mapping.SqlTypedMapping;
 import org.hibernate.metamodel.model.domain.DomainType;
@@ -15,6 +16,7 @@ import org.hibernate.metamodel.model.domain.ReturnableType;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.java.BasicPluralJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.sql.DdlType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.internal.ParameterizedTypeImpl;
@@ -31,10 +33,28 @@ public class DdlTypeHelper {
 		return arrayJavaType.resolveType(
 				typeConfiguration,
 				typeConfiguration.getCurrentBaseSqlTypeIndicators().getDialect(),
-				(BasicType<Object>) elementType,
+				resolveElementBasicType( elementType, typeConfiguration ),
 				null,
 				typeConfiguration.getCurrentBaseSqlTypeIndicators()
 		);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static BasicType<Object> resolveElementBasicType(
+			DomainType<?> elementType,
+			TypeConfiguration typeConfiguration) {
+		if ( elementType instanceof BasicType<?> basicType ) {
+			return (BasicType<Object>) basicType;
+		}
+		else if ( elementType instanceof JdbcMapping jdbcMapping ) {
+			return typeConfiguration.getBasicTypeRegistry().resolve(
+					(JavaType<Object>) elementType.getExpressibleJavaType(),
+					jdbcMapping.getJdbcType()
+			);
+		}
+		else {
+			return (BasicType<Object>) elementType;
+		}
 	}
 
 	@SuppressWarnings("unchecked")
@@ -50,7 +70,7 @@ public class DdlTypeHelper {
 		return arrayJavaType.resolveType(
 				typeConfiguration,
 				typeConfiguration.getCurrentBaseSqlTypeIndicators().getDialect(),
-				(BasicType<Object>) elementType,
+				resolveElementBasicType( elementType, typeConfiguration ),
 				null,
 				typeConfiguration.getCurrentBaseSqlTypeIndicators()
 		);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayAggregateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayAggregateTest.java
@@ -39,7 +39,6 @@ import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
-import org.hibernate.testing.orm.junit.Jira;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,9 +95,12 @@ public class ArrayAggregateTest {
 		scope.inTransaction( em -> {
 			final EntityOfBasics e1 = new EntityOfBasics( 1 );
 			e1.setTheString( "abc" );
+			e1.setTheInt( 2 );
 			final EntityOfBasics e2 = new EntityOfBasics( 2 );
 			e2.setTheString( "def" );
+			e2.setTheInt( 1 );
 			final EntityOfBasics e3 = new EntityOfBasics( 3 );
+			e3.setTheInt( 3 );
 			em.persist( e1 );
 			em.persist( e2 );
 			em.persist( e3 );
@@ -173,6 +175,20 @@ public class ArrayAggregateTest {
 					.getResultList();
 			assertEquals( 1, results.size() );
 			assertArrayEquals( new Integer[]{ 1, 2, 3 }, results.get( 0 ) );
+		} );
+	}
+
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-20348")
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsArrayToString.class)
+	public void testArrayToStringArrayAggPrimitive(SessionFactoryScope scope) {
+		scope.inSession( em -> {
+			List<String> results = em.createQuery(
+					"select array_to_string(array_agg(e.theInt) within group (order by e.theInt), ',') from EntityOfBasics e",
+					String.class
+			).getResultList();
+			assertEquals( 1, results.size() );
+			assertEquals( "1,2,3", results.get( 0 ) );
 		} );
 	}
 


### PR DESCRIPTION
## Summary

- Resolve array aggregate element types through the basic type registry when the SQM domain type is a JDBC mapping but not an `org.hibernate.type.BasicType`
- Add a regression test for `array_to_string(array_agg(...))` over a primitive `int` attribute

## Testing

- `./gradlew :hibernate-core:test --tests 'org.hibernate.orm.test.function.array.ArrayAggregateTest.testArrayToStringArrayAggPrimitive' --no-daemon`
- `./gradlew :hibernate-core:test --tests 'org.hibernate.orm.test.function.array.ArrayAggregateTest' --no-daemon`

https://hibernate.atlassian.net/browse/HHH-20348

---

<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20348 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

<!-- Hibernate GitHub Bot task list end -->

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
