### PR TITLE
HHH-20584 HbmXmlTransformer does not generate transient mappings for unmapped entity properties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -8,9 +8,11 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.hibernate.AssertionFailure;
@@ -1278,8 +1280,84 @@ public class HbmXmlTransformer {
 
 			transferJoins( (JaxbHbmRootEntityType) hbmEntity, mappingEntity, bootEntityInfo );
 		}
+		transferTransients( bootEntityInfo, mappingEntity );
 	}
 
+	private void transferTransients(EntityTypeInfo entityInfo, JaxbEntityImpl mappingEntity) {
+		final var persistentClass = entityInfo.getPersistentClass();
+		final var className = persistentClass.getClassName();
+		if ( className == null ) {
+			return;
+		}
+
+		final Set<String> mappedPropertyNames = new HashSet<>();
+		for ( var property : persistentClass.getProperties() ) {
+			mappedPropertyNames.add( property.getName() );
+		}
+		if ( persistentClass.getIdentifierProperty() != null ) {
+			mappedPropertyNames.add( persistentClass.getIdentifierProperty().getName() );
+		}
+		if ( persistentClass instanceof RootClass rootClass && rootClass.getVersion() != null ) {
+			mappedPropertyNames.add( rootClass.getVersion().getName() );
+		}
+
+		try {
+			final var javaClass = persistentClass.getMappedClass();
+			if ( javaClass == null ) {
+				return;
+			}
+
+			final Set<String> transientNames = new HashSet<>();
+
+			if ( "field".equals( hbmXmlBinding.getRoot().getDefaultAccess().toLowerCase( Locale.ROOT ) ) ) {
+				for ( var field : javaClass.getDeclaredFields() ) {
+					final String fieldName = field.getName();
+					if ( !mappedPropertyNames.contains( fieldName ) ) {
+						transientNames.add( fieldName );
+					}
+				}
+			}
+			else {
+				final var setterNames = new HashSet<>();
+				for ( var method : javaClass.getMethods() ) {
+					if ( method.getParameterCount() == 1
+							&& method.getName().startsWith( "set" ) && method.getName().length() > 3 ) {
+						setterNames.add( org.hibernate.internal.util.StringHelper.decapitalize( method.getName().substring( 3 ) ) );
+					}
+				}
+
+				for ( var method : javaClass.getMethods() ) {
+					final String methodName = method.getName();
+					if ( method.getParameterCount() != 0 ) {
+						continue;
+					}
+					String propertyName = null;
+					if ( methodName.startsWith( "get" ) && methodName.length() > 3 ) {
+						propertyName = org.hibernate.internal.util.StringHelper.decapitalize( methodName.substring( 3 ) );
+					}
+					else if ( methodName.startsWith( "is" ) && methodName.length() > 2
+							&& ( method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class ) ) {
+						propertyName = org.hibernate.internal.util.StringHelper.decapitalize( methodName.substring( 2 ) );
+					}
+					if ( propertyName != null
+							&& setterNames.contains( propertyName )
+							&& !mappedPropertyNames.contains( propertyName )
+							&& !propertyName.equals( "class" ) ) {
+						transientNames.add( propertyName );
+					}
+				}
+			}
+
+			for ( var name : transientNames ) {
+				final var transientMapping = new JaxbTransientImpl();
+				transientMapping.setName( name );
+				mappingEntity.getAttributes().getTransients().add( transientMapping );
+			}
+		}
+		catch (Exception e) {
+			// if we can't load the class, skip transient generation
+		}
+	}
 
 	private void transferBaseEntityAttributes(
 			EntityInfo hbmEntity,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -27,6 +27,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbIdImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToOneImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbOneToManyImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbTransientImpl;
 import org.hibernate.boot.jaxb.spi.Binding;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataImplementor;
@@ -248,6 +249,38 @@ public class HbmTransformationJaxbTests {
 					.orElseThrow();
 			assertThat( childEntity.getTable() ).isNotNull();
 			assertThat( childEntity.getTable().getName() ).isEqualTo( "us_child" );
+		} );
+	}
+
+	@Test
+	public void testUnmappedPropertiesAreTransient(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/unmapped-property/hbm.xml", scope, (transformed) -> {
+			final JaxbEntityImpl entity = transformed.getEntities().stream()
+					.filter( e -> e.getClazz() != null && e.getClazz().endsWith( "UnmappedPropEntity" ) )
+					.findFirst()
+					.orElseThrow();
+
+			final var attributes = entity.getAttributes();
+
+			assertThat( attributes.getIdAttributes() )
+					.extracting( JaxbIdImpl::getName )
+					.contains( "id" );
+
+			assertThat( attributes.getBasicAttributes() )
+					.extracting( JaxbBasicImpl::getName )
+					.contains( "name", "anotherCompositeName" )
+					.doesNotContain( "compositeName" );
+
+			final var transients = attributes.getTransients();
+
+			assertThat( transients )
+					.extracting( JaxbTransientImpl::getName )
+					.as( "Unmapped field 'unmappedRef' should be marked as transient" )
+					.contains( "unmappedRef" )
+					.as( "compositeName has no backing field and access is field — should not be transient" )
+					.doesNotContain( "compositeName" )
+					.as( "Mapped properties should not be marked as transient" )
+					.doesNotContain( "id", "name", "anotherCompositeName" );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/UnmappedPropEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/UnmappedPropEntity.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class UnmappedPropEntity {
+	private Long id;
+	private String name;
+	private UnmappedPropTarget unmappedRef;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public UnmappedPropTarget getUnmappedRef() {
+		return unmappedRef;
+	}
+
+	public void setUnmappedRef(UnmappedPropTarget unmappedRef) {
+		this.unmappedRef = unmappedRef;
+	}
+
+	public void setCompositeName(String part1, String part2){
+		this.name = part1 + part2;
+	}
+
+	public String getCompositeName(){
+		return name;
+	}
+
+	public void setAnotherCompositeName(String part1, String part2){
+		this.name = part1 + part2;
+	}
+
+	public String getAnotherCompositeName(){
+		return name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/UnmappedPropTarget.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/UnmappedPropTarget.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class UnmappedPropTarget {
+	private Long id;
+	private String value;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/unmapped-property/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/unmapped-property/hbm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   default-lazy="false" default-access="field">
+    <class name="org.hibernate.orm.test.boot.jaxb.mapping.UnmappedPropEntity" table="unmapped_prop" >
+        <id name="id" type="long" column="id"/>
+        <property name="name" type="string"/>
+        <property name="anotherCompositeName" access="property" />
+    </class>
+    <class name="org.hibernate.orm.test.boot.jaxb.mapping.UnmappedPropTarget" table="unmapped_prop_target">
+        <id name="id" type="long" column="id"/>
+        <property name="value" type="string"/>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20584

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20584 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->