### PR TITLE
Persist+remove in the same flush shouldn't fire post-delete events

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/queue/internal/decompose/entity/DeleteDecomposerStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/queue/internal/decompose/entity/DeleteDecomposerStandard.java
@@ -7,6 +7,7 @@ package org.hibernate.action.queue.internal.decompose.entity;
 import org.hibernate.action.queue.spi.decompose.entity.EntityMutationPlanContributor;
 import org.hibernate.action.queue.spi.decompose.entity.PreDeleteHandling;
 import org.hibernate.action.queue.spi.decompose.entity.PostDeleteHandling;
+import org.hibernate.action.queue.spi.decompose.entity.CancelledInsertPostDeleteHandling;
 
 import org.hibernate.action.internal.EntityDeleteAction;
 import org.hibernate.action.queue.spi.MutationKind;
@@ -102,6 +103,11 @@ public class DeleteDecomposerStandard extends AbstractDecomposer<EntityDeleteAct
 		final Object version = action.getVersion();
 		final Object[] state = action.getState();
 
+		if ( decompositionContext != null && decompositionContext.isBeingInsertedInCurrentFlush( action.getInstance() ) ) {
+			operationConsumer.accept( createCancelledDeleteCallbackCarrier( ordinalBase, action ) );
+			return;
+		}
+
 		final Object naturalIdValues = DeleteNaturalIdHandling.removeLocalResolution( action, session );
 
 		final DeleteCacheHandling.CacheLock cacheLock = DeleteCacheHandling.lockItem( action, session );
@@ -113,11 +119,6 @@ public class DeleteDecomposerStandard extends AbstractDecomposer<EntityDeleteAct
 				naturalIdValues,
 				preDeleteHandling
 		);
-
-		if ( decompositionContext != null && decompositionContext.isBeingInsertedInCurrentFlush( action.getInstance() ) ) {
-			operationConsumer.accept( createNoOpDeleteCallbackCarrier( ordinalBase, preDeleteHandling, postDeleteHandling ) );
-			return;
-		}
 
 		final EntityMutationPlanContributor.DeleteContext context = new EntityMutationPlanContributor.DeleteContext(
 				entityPersister,
@@ -253,6 +254,16 @@ public class DeleteDecomposerStandard extends AbstractDecomposer<EntityDeleteAct
 		);
 		operation.setPreExecutionCallback( preDeleteHandling );
 		return operation;
+	}
+
+	private FlushOperation createCancelledDeleteCallbackCarrier(
+			int ordinalBase,
+			EntityDeleteAction action) {
+		return DecompositionSupport.createNoOpCallbackCarrier(
+				entityPersister.getIdentifierTableDescriptor(),
+				ordinalBase * 1_000,
+				new CancelledInsertPostDeleteHandling( action )
+		);
 	}
 
 	private static int[] getUpdatedAttributeIndexesForDeletedEntity(

--- a/hibernate-core/src/main/java/org/hibernate/action/queue/spi/decompose/entity/CancelledInsertPostDeleteHandling.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/queue/spi/decompose/entity/CancelledInsertPostDeleteHandling.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.action.queue.spi.decompose.entity;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.Incubating;
+import org.hibernate.action.internal.EntityDeleteAction;
+import org.hibernate.action.queue.spi.bind.PostExecutionCallback;
+import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SessionImplementor;
+
+/// Post-execution callback that performs only the essential persistence
+/// context cleanup after a delete action is processed.
+///
+/// This is the base handling used when the entity was never actually
+/// written to the database — for example, when a `persist()` and
+/// `remove()` cancel each other out in the same flush cycle.
+///
+/// The full [PostDeleteHandling] builds on top of this to add cache eviction,
+/// natural ID cleanup, event firing, and statistics.
+///
+/// @see PostDeleteHandling
+/// @see EntityDeleteAction
+///
+/// @since 8.0
+@Incubating
+public class CancelledInsertPostDeleteHandling implements PostExecutionCallback {
+	protected final EntityDeleteAction action;
+
+	public CancelledInsertPostDeleteHandling(EntityDeleteAction action) {
+		this.action = action;
+	}
+
+	@Override
+	public void handle(SessionImplementor session) {
+		final Object instance = action.getInstance();
+		if ( instance != null ) {
+			basicPersistenceContextCleanup( session.getPersistenceContextInternal(), instance );
+		}
+	}
+
+	static void basicPersistenceContextCleanup(PersistenceContext persistenceContext, Object instance) {
+		final var entry = persistenceContext.removeEntry( instance );
+		if ( entry == null ) {
+			throw new AssertionFailure( "possible non-threadsafe access to session" );
+		}
+		entry.postDelete();
+		persistenceContext.removeEntityHolder( entry.getEntityKey() );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/action/queue/spi/decompose/entity/PostDeleteHandling.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/queue/spi/decompose/entity/PostDeleteHandling.java
@@ -13,6 +13,8 @@ import org.hibernate.event.spi.PostDeleteEvent;
 import org.hibernate.event.spi.PostDeleteEventListener;
 import org.hibernate.persister.entity.EntityPersister;
 
+import static org.hibernate.action.queue.spi.decompose.entity.CancelledInsertPostDeleteHandling.basicPersistenceContextCleanup;
+
 /// Post-execution callback for entity delete actions.
 ///
 /// This handles all the finalization work that needs to happen after all table `DELETE`s
@@ -26,6 +28,7 @@ import org.hibernate.persister.entity.EntityPersister;
 /// 	- Firing POST_DELETE event listeners
 /// 	- Updating statistics
 ///
+/// @see CancelledInsertPostDeleteHandling
 /// @see EntityDeleteAction
 ///
 /// @author Steve Ebersole
@@ -83,13 +86,7 @@ public class PostDeleteHandling implements PostExecutionCallback {
 		// exists on the database (needed for identity-column key generation), and
 		// remove it from the session cache
 		final var persistenceContext = session.getPersistenceContextInternal();
-		final var entry = persistenceContext.removeEntry( instance );
-		if ( entry == null ) {
-			throw new AssertionFailure( "possible non-threadsafe access to session" );
-		}
-		entry.postDelete();
-		final var key = entry.getEntityKey();
-		persistenceContext.removeEntityHolder( key );
+		basicPersistenceContextCleanup( persistenceContext, instance );
 		removeCacheItem( session, cacheKey );
 		persistenceContext.getNaturalIdResolutions()
 				.removeSharedResolution( id, naturalIdValues, persister, true );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/events/PersistThenRemoveEventTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/events/PersistThenRemoveEventTest.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.events;
+
+import org.hibernate.IrrelevantEntity;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostInsertEventListener;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@DomainModel(annotatedClasses = IrrelevantEntity.class)
+@SessionFactory
+class PersistThenRemoveEventTest {
+
+	private static final CountingPostInsertListener insertListener = new CountingPostInsertListener();
+	private static final CountingPostDeleteListener deleteListener = new CountingPostDeleteListener();
+
+	@BeforeAll
+	void registerListeners(SessionFactoryScope scope) {
+		final EventListenerRegistry registry = scope.getSessionFactory().getEventListenerRegistry();
+		registry.getEventListenerGroup( EventType.POST_INSERT ).appendListener( insertListener );
+		registry.getEventListenerGroup( EventType.POST_DELETE ).appendListener( deleteListener );
+	}
+
+	@BeforeEach
+	void resetCounters() {
+		insertListener.count = 0;
+		deleteListener.count = 0;
+	}
+
+	@Test
+	public void testPersistThenRemoveBeforeFlush(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			IrrelevantEntity entity = new IrrelevantEntity();
+			entity.setName( "transient" );
+
+			session.persist( entity );
+			session.remove( entity );
+		} );
+
+		assertEquals( 0, insertListener.count,
+				"PostInsertEvent should not fire when persist+remove happens before flush" );
+		assertEquals( 0, deleteListener.count,
+				"PostDeleteEvent should not fire when persist+remove happens before flush" );
+	}
+
+	@Test
+	public void testPersistThenRemoveCleansUpPersistenceContext(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			IrrelevantEntity entity = new IrrelevantEntity();
+			entity.setName( "transient" );
+
+			session.persist( entity );
+			session.remove( entity );
+			session.flush();
+
+			assertFalse( session.contains( entity ),
+					"Entity should not be contained in the session after persist+remove+flush" );
+
+			final var persistenceContext = session.unwrap( org.hibernate.engine.spi.SessionImplementor.class )
+					.getPersistenceContextInternal();
+			assertNull( persistenceContext.getEntry( entity ),
+					"Entity entry should be removed from persistence context after persist+remove" );
+		} );
+	}
+
+	@Test
+	public void testPersistThenRemoveWithExplicitFlush(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			IrrelevantEntity entity = new IrrelevantEntity();
+			entity.setName( "transient" );
+
+			session.persist( entity );
+			session.remove( entity );
+			session.flush();
+		} );
+
+		assertEquals( 0, insertListener.count,
+				"PostInsertEvent should not fire when persist+remove is flushed together" );
+		assertEquals( 0, deleteListener.count,
+				"PostDeleteEvent should not fire when persist+remove is flushed together" );
+	}
+
+	private static class CountingPostInsertListener implements PostInsertEventListener {
+		int count;
+
+		@Override
+		public void onPostInsert(PostInsertEvent event) {
+			count++;
+		}
+
+	}
+
+	private static class CountingPostDeleteListener implements PostDeleteEventListener {
+		int count;
+
+		@Override
+		public void onPostDelete(PostDeleteEvent event) {
+			count++;
+		}
+
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
