### PR TITLE
HHH-20586 Add XML query hints to global named query registrations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/GlobalRegistrationsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/GlobalRegistrationsImpl.java
@@ -1379,6 +1379,7 @@ public class GlobalRegistrationsImpl implements GlobalRegistrations, GlobalRegis
 			final var hint = JpaAnnotations.QUERY_HINT.createUsage( sourceModelContext );
 			hint.name( jaxbHint.getName() );
 			hint.value( jaxbHint.getValue() );
+			hints.add( hint );
 		}
 		return hints;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/XmlProcessingSmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/XmlProcessingSmokeTests.java
@@ -13,6 +13,8 @@ import org.hibernate.boot.jaxb.spi.Binding;
 import org.hibernate.boot.models.internal.DomainModelCategorizationCollector;
 import org.hibernate.boot.models.internal.GlobalRegistrationsImpl;
 import org.hibernate.boot.models.spi.FilterDefRegistration;
+import org.hibernate.boot.models.spi.NamedNativeQueryRegistration;
+import org.hibernate.boot.models.spi.NamedQueryRegistration;
 import org.hibernate.boot.models.xml.internal.XmlDocumentContextImpl;
 import org.hibernate.boot.models.xml.internal.XmlDocumentImpl;
 import org.hibernate.boot.models.xml.internal.XmlPreProcessingResultImpl;
@@ -166,6 +168,61 @@ public class XmlProcessingSmokeTests {
 				.isEqualTo( org.hibernate.type.YesNoConverter.class );
 
 		validateFilterDefs( globalRegistrations.getFilterDefRegistrations() );
+	}
+
+	@Test
+	@ServiceRegistry
+	void testGlobalNamedQueryHints(ServiceRegistryScope scope) {
+		final ModelsContext buildingContext = SourceModelTestHelper.createBuildingContext( StringTypeDescriptor.class );
+		final XmlPreProcessingResultImpl collectedXmlResources = new XmlPreProcessingResultImpl();
+
+		final JaxbEntityMappingsImpl xmlMapping = XmlHelper.loadMapping(
+				"mappings/models/named-query-hints.xml",
+				SIMPLE_CLASS_LOADING
+		);
+		final Binding<JaxbEntityMappingsImpl> binding = new Binding<>(
+				xmlMapping,
+				new Origin( SourceType.RESOURCE, "mappings/models/named-query-hints.xml" )
+		);
+		collectedXmlResources.addDocument( binding );
+
+		final DomainModelCategorizationCollector collector = new DomainModelCategorizationCollector(
+				new GlobalRegistrationsImpl( buildingContext, new BootstrapContextImpl() ),
+				buildingContext
+		);
+		collectedXmlResources.getDocuments().forEach( xmlDocument -> {
+			final XmlDocumentContextImpl xmlDocumentContext = new XmlDocumentContextImpl(
+					xmlDocument,
+					new RootMappingDefaults(
+							new MetadataBuilderImpl.MappingDefaultsImpl( scope.getRegistry() ),
+							collectedXmlResources.getPersistenceUnitMetadata()
+					),
+					buildingContext,
+					new BootstrapContextImpl()
+			);
+			collector.apply( xmlMapping, xmlDocumentContext );
+		} );
+
+		final GlobalRegistrationsImpl globalRegistrations = collector.getGlobalRegistrations();
+
+		final NamedQueryRegistration namedQuery = globalRegistrations.getNamedQueryRegistrations().get( "global.findAll" );
+		assertThat( namedQuery ).isNotNull();
+		assertThat( namedQuery.getQueryHints() ).containsEntry( "org.hibernate.timeout", "200" );
+
+		final NamedNativeQueryRegistration nativeQuery =
+				globalRegistrations.getNamedNativeQueryRegistrations().get( "global.findAllNative" );
+		assertThat( nativeQuery ).isNotNull();
+		assertThat( nativeQuery.getQueryHints() ).containsEntry( "org.hibernate.timeout", "300" );
+
+		assertThat( globalRegistrations.getNamedStoredProcedureQueryRegistrations().get( "global.proc" ) )
+				.isNotNull()
+				.extracting( registration -> registration.configuration().hints() )
+				.satisfies( hints -> assertThat( hints )
+						.hasSize( 1 )
+						.anySatisfy( hint -> {
+							assertThat( hint.name() ).isEqualTo( "org.hibernate.timeout" );
+							assertThat( hint.value() ).isEqualTo( "400" );
+						} ) );
 	}
 
 	private void validateFilterDefs(Map<String, FilterDefRegistration> filterDefRegistrations) {

--- a/hibernate-core/src/test/resources/mappings/models/named-query-hints.xml
+++ b/hibernate-core/src/test/resources/mappings/models/named-query-hints.xml
@@ -1,0 +1,21 @@
+
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 version="8.0">
+    <named-query name="global.findAll">
+        <query>from SimpleEntity</query>
+        <entity-graph/>
+        <hint name="org.hibernate.timeout" value="200"/>
+    </named-query>
+    <named-native-query name="global.findAllNative">
+        <query>select * from simple_entity</query>
+        <hint name="org.hibernate.timeout" value="300"/>
+    </named-native-query>
+    <named-stored-procedure-query name="global.proc" procedure-name="p1">
+        <hint name="org.hibernate.timeout" value="400"/>
+    </named-stored-procedure-query>
+</entity-mappings>


### PR DESCRIPTION
Fixes XML query hint registration (ignored by GlobalRegistrationsImpl).

Addresses https://hibernate.atlassian.net/browse/HHH-20586

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20586 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->