### PR TITLE
[8.0] HHH-20561 Fix queries not inheriting session cache modes 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
@@ -65,6 +65,7 @@ import java.util.Set;
 
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Locale.ROOT;
+import static org.hibernate.CacheMode.fromJpaModes;
 import static org.hibernate.internal.log.DeprecationLogger.DEPRECATION_LOGGER;
 import static org.hibernate.internal.util.StringHelper.isNotEmpty;
 import static org.hibernate.jpa.HibernateHints.HINT_CACHEABLE;
@@ -97,8 +98,9 @@ import static org.hibernate.jpa.SpecHints.HINT_SPEC_FETCH_GRAPH;
 import static org.hibernate.jpa.SpecHints.HINT_SPEC_LOAD_GRAPH;
 import static org.hibernate.jpa.SpecHints.HINT_SPEC_LOCK_TIMEOUT;
 import static org.hibernate.jpa.SpecHints.HINT_SPEC_QUERY_TIMEOUT;
+import org.hibernate.jpa.internal.util.ConfigurationHelper;
+
 import static org.hibernate.jpa.internal.util.ConfigurationHelper.getBoolean;
-import static org.hibernate.jpa.internal.util.ConfigurationHelper.getCacheMode;
 import static org.hibernate.jpa.internal.util.ConfigurationHelper.getInteger;
 import static org.hibernate.query.QueryLogging.QUERY_MESSAGE_LOGGER;
 import static org.hibernate.query.internal.QueryArguments.areInstances;
@@ -282,18 +284,25 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 		return flushMode == null ? getSession().getHibernateFlushMode() : flushMode;
 	}
 
+	@Nonnull
+	protected CacheMode getCacheMode() {
+		final var cacheMode = queryOptions.getCacheMode();
+		return cacheMode != null ? cacheMode : getSession().getCacheMode();
+	}
+
 	@Override
 	@SuppressWarnings("removal")
 	@Nonnull
 	public CacheRetrieveMode getCacheRetrieveMode() {
-		return queryOptions.getCacheRetrieveMode();
+		final var mode = queryOptions.getCacheRetrieveMode();
+		return mode != null ? mode : getCacheMode().getJpaRetrieveMode();
 	}
 
 	@Override
 	@Nonnull
 	public CommonQueryContractImplementor setCacheRetrieveMode(@Nonnull CacheRetrieveMode cacheRetrieveMode) {
 		session.checkOpen();
-		queryOptions.setCacheRetrieveMode( cacheRetrieveMode );
+		queryOptions.setCacheMode( fromJpaModes( cacheRetrieveMode, getCacheMode().getJpaStoreMode() ) );
 		return this;
 	}
 
@@ -301,14 +310,15 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 	@SuppressWarnings("removal")
 	@Nonnull
 	public CacheStoreMode getCacheStoreMode() {
-		return queryOptions.getCacheStoreMode();
+		final var mode = queryOptions.getCacheStoreMode();
+		return mode != null ? mode : getCacheMode().getJpaStoreMode();
 	}
 
 	@Override
 	@Nonnull
 	public CommonQueryContractImplementor setCacheStoreMode(@Nonnull CacheStoreMode cacheStoreMode) {
 		session.checkOpen();
-		queryOptions.setCacheStoreMode( cacheStoreMode );
+		queryOptions.setCacheMode( fromJpaModes( getCacheMode().getJpaRetrieveMode(), cacheStoreMode ) );
 		return this;
 	}
 
@@ -615,7 +625,7 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 	}
 
 	protected void applyResultCacheModeHint(String hintName, Object value) {
-		queryOptions.setCacheMode( getCacheMode( value ) );
+		queryOptions.setCacheMode( ConfigurationHelper.getCacheMode( value ) );
 	}
 
 	protected void applyResultCachingRetrieveModeHint(String hintName, Object value) {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractQuery.java
@@ -423,7 +423,7 @@ public abstract class AbstractQuery<T> extends AbstractCommonQueryContract imple
 	@Override @SuppressWarnings("removal")
 	@Nonnull
 	public CacheMode getCacheMode() {
-		return queryOptions.getCacheMode();
+		return super.getCacheMode();
 	}
 
 	@Override @SuppressWarnings("removal")

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/SelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/SelectionQueryImpl.java
@@ -524,12 +524,6 @@ public class SelectionQueryImpl<R>
 
 	@Override
 	@Nonnull
-	public CacheMode getCacheMode() {
-		return queryOptions.getCacheMode();
-	}
-
-	@Override
-	@Nonnull
 	public SelectionQueryImplementor<R> setCacheMode(@Nonnull CacheMode cacheMode) {
 		queryOptions.setCacheMode( cacheMode );
 		return this;
@@ -538,26 +532,28 @@ public class SelectionQueryImpl<R>
 	@Override
 	@Nonnull
 	public CacheRetrieveMode getCacheRetrieveMode() {
-		return queryOptions.getCacheRetrieveMode();
+		final var mode = queryOptions.getCacheRetrieveMode();
+		return mode != null ? mode : getCacheMode().getJpaRetrieveMode();
 	}
 
 	@Override
 	@Nonnull
 	public SelectionQueryImplementor<R> setCacheRetrieveMode(@Nonnull CacheRetrieveMode cacheRetrieveMode) {
-		queryOptions.setCacheRetrieveMode( cacheRetrieveMode );
+		super.setCacheRetrieveMode( cacheRetrieveMode );
 		return this;
 	}
 
 	@Override
 	@Nonnull
 	public CacheStoreMode getCacheStoreMode() {
-		return queryOptions.getCacheStoreMode();
+		final var mode = queryOptions.getCacheStoreMode();
+		return mode != null ? mode : getCacheMode().getJpaStoreMode();
 	}
 
 	@Override
 	@Nonnull
 	public SelectionQueryImplementor<R> setCacheStoreMode(@Nonnull CacheStoreMode cacheStoreMode) {
-		queryOptions.setCacheStoreMode( cacheStoreMode );
+		super.setCacheStoreMode( cacheStoreMode );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -1608,7 +1608,7 @@ public class NativeQueryImpl<R>
 	@Nonnull
 	public NativeQueryImplementor<R> setCacheRetrieveMode(@Nonnull CacheRetrieveMode cacheRetrieveMode) {
 		errorIfNotSelectForSure();
-		queryOptions.setCacheRetrieveMode( cacheRetrieveMode );
+		super.setCacheRetrieveMode( cacheRetrieveMode );
 		return this;
 	}
 
@@ -1616,7 +1616,7 @@ public class NativeQueryImpl<R>
 	@Nonnull
 	public NativeQueryImplementor<R> setCacheStoreMode(@Nonnull CacheStoreMode cacheStoreMode) {
 		errorIfNotSelectForSure();
-		queryOptions.setCacheStoreMode( cacheStoreMode );
+		super.setCacheStoreMode( cacheStoreMode );
 		return this;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/options/CacheModeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/options/CacheModeTests.java
@@ -48,4 +48,45 @@ public class CacheModeTests {
 			assertEquals( CacheStoreMode.REFRESH, query.getCacheStoreMode() );
 		} );
 	}
+
+	@Test
+	public void testCacheModeGettersUseInheritedSessionCacheMode(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			session.setCacheMode( CacheMode.GET );
+
+			final var query = session.createQuery( "select c from Contact c" );
+
+			assertEquals( CacheMode.GET, query.getCacheMode() );
+			assertEquals( CacheRetrieveMode.USE, query.getCacheRetrieveMode() );
+			assertEquals( CacheStoreMode.BYPASS, query.getCacheStoreMode() );
+		} );
+	}
+
+	@Test
+	public void testSetJpaCacheRetrieveModeOnQueryInheritingSessionCacheMode(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			session.setCacheMode( CacheMode.NORMAL );
+
+			final var query = session.createQuery( "select c from Contact c" );
+			query.setCacheRetrieveMode( CacheRetrieveMode.BYPASS );
+
+			assertEquals( CacheMode.PUT, query.getCacheMode() );
+			assertEquals( CacheRetrieveMode.BYPASS, query.getCacheRetrieveMode() );
+			assertEquals( CacheStoreMode.USE, query.getCacheStoreMode() );
+		} );
+	}
+
+	@Test
+	public void testSetJpaCacheStoreModeOnQueryInheritingSessionCacheMode(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			session.setCacheMode( CacheMode.NORMAL );
+
+			final var query = session.createQuery( "select c from Contact c" );
+			query.setCacheStoreMode( CacheStoreMode.BYPASS );
+
+			assertEquals( CacheMode.GET, query.getCacheMode() );
+			assertEquals( CacheRetrieveMode.USE, query.getCacheRetrieveMode() );
+			assertEquals( CacheStoreMode.BYPASS, query.getCacheStoreMode() );
+		} );
+	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/12814

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20561 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20561
<!-- Hibernate GitHub Bot issue links end -->