### PR TITLE
HHH-20590  HbmXmlTransformer does not transfer optimistic-lock attribute on collections

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1902,6 +1902,7 @@ public class HbmXmlTransformer {
 		);
 		target.setFetchMode( convert( source.getFetch(), source.getOuterJoin() ) );
 		target.setFetch( convert( source.getLazy() ) );
+		target.setOptimisticLock( source.isOptimisticLock() );
 		target.setMutable( source.isMutable() );
 
 		if ( isNotEmpty( source.getCollectionType() ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -315,6 +315,37 @@ public class HbmTransformationJaxbTests {
 		} );
 	}
 
+	@Test
+	@JiraKey( "HHH-20590" )
+	public void testCollectionOptimisticLockTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/collection-optimistic-lock/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 3 );
+
+			final JaxbEntityImpl ownerEntity = transformed.getEntities().stream()
+					.filter( e -> "Owner".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( ownerEntity.getAttributes().getOneToManyAttributes() ).hasSize( 2 );
+
+			final JaxbOneToManyImpl lockedItems = ownerEntity.getAttributes().getOneToManyAttributes().stream()
+					.filter( a -> "lockedItems".equals( a.getName() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( lockedItems.isOptimisticLock() )
+					.as( "lockedItems should have optimistic-lock=true (default)" )
+					.isTrue();
+
+			final JaxbOneToManyImpl unlockedItems = ownerEntity.getAttributes().getOneToManyAttributes().stream()
+					.filter( a -> "unlockedItems".equals( a.getName() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( unlockedItems.isOptimisticLock() )
+					.as( "unlockedItems should have optimistic-lock=false" )
+					.isFalse();
+		} );
+	}
+
 	private void transformAndVerify(
 			String resourceName,
 			ServiceRegistryScope scope,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionoptimisticlock/LockedItem.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionoptimisticlock/LockedItem.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.collectionoptimisticlock;
+
+public class LockedItem {
+	private Long id;
+	private String name;
+	private Owner owner;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Owner getOwner() {
+		return owner;
+	}
+
+	public void setOwner(Owner owner) {
+		this.owner = owner;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionoptimisticlock/Owner.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionoptimisticlock/Owner.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.collectionoptimisticlock;
+
+import java.util.List;
+
+public class Owner {
+	private Long id;
+	private List lockedItems;
+	private List unlockedItems;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public List getLockedItems() {
+		return lockedItems;
+	}
+
+	public void setLockedItems(List lockedItems) {
+		this.lockedItems = lockedItems;
+	}
+
+	public List getUnlockedItems() {
+		return unlockedItems;
+	}
+
+	public void setUnlockedItems(List unlockedItems) {
+		this.unlockedItems = unlockedItems;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionoptimisticlock/UnlockedItem.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionoptimisticlock/UnlockedItem.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.collectionoptimisticlock;
+
+public class UnlockedItem {
+	private Long id;
+	private String name;
+	private Owner owner;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Owner getOwner() {
+		return owner;
+	}
+
+	public void setOwner(Owner owner) {
+		this.owner = owner;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-optimistic-lock/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-optimistic-lock/hbm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.collectionoptimisticlock">
+	<class name="Owner">
+		<id name="id" type="long">
+			<generator class="native"/>
+		</id>
+		<bag name="lockedItems" inverse="true" cascade="all">
+			<key column="locked_owner_id"/>
+			<one-to-many class="LockedItem"/>
+		</bag>
+		<bag name="unlockedItems" inverse="true" cascade="all" optimistic-lock="false">
+			<key column="unlocked_owner_id"/>
+			<one-to-many class="UnlockedItem"/>
+		</bag>
+	</class>
+	<class name="LockedItem">
+		<id name="id" type="long">
+			<generator class="native"/>
+		</id>
+		<property name="name"/>
+		<many-to-one name="owner" column="locked_owner_id"/>
+	</class>
+	<class name="UnlockedItem">
+		<id name="id" type="long">
+			<generator class="native"/>
+		</id>
+		<property name="name"/>
+		<many-to-one name="owner" column="unlocked_owner_id"/>
+	</class>
+</hibernate-mapping>


### PR DESCRIPTION
backport of https://github.com/hibernate/hibernate-orm/pull/12813 for 8.0
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20590 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20590
<!-- Hibernate GitHub Bot issue links end -->