### PR TITLE
HHH-20591 HbmXmlTransformer fails to resolve mapped-by for inverse one-to-many when back-reference is a key-many-to-one inside composite-id

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/BootModelPreprocessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/BootModelPreprocessor.java
@@ -57,14 +57,22 @@ public class BootModelPreprocessor {
 		if ( persistentClass instanceof RootClass rootClass ) {
 			if ( persistentClass.getIdentifierProperty() != null ) {
 				if ( persistentClass.getIdentifierProperty().getValue() instanceof Component component ) {
-					final String componentRole = rootClass.getEntityName() + "." + persistentClass.getIdentifierProperty().getName();
+					final String idPropertyName = persistentClass.getIdentifierProperty().getName();
+					final String componentRole = rootClass.getEntityName() + "." + idPropertyName;
 					buildComponentEntries( componentRole, component, transformationState );
+					registerCompositeIdMappableAttributes(
+							rootClass.getEntityName(), idPropertyName, component, transformationState
+					);
 				}
 			}
 			else {
 				assert rootClass.getIdentifier() instanceof Component;
+				final Component component = (Component) rootClass.getIdentifier();
 				final String componentRole = rootClass.getEntityName() + ".id";
-				buildComponentEntries( componentRole, (Component) rootClass.getIdentifier(), transformationState );
+				buildComponentEntries( componentRole, component, transformationState );
+				registerCompositeIdMappableAttributes(
+						rootClass.getEntityName(), "id", component, transformationState
+				);
 			}
 		}
 
@@ -117,6 +125,22 @@ public class BootModelPreprocessor {
 			// could be the target of an inverse mapping, and we will need this information for transforming to mapped-by
 			transformationState.registerMappableAttributesByColumns( entityName, property.getName(), toOne.getSelectables() );
 		}
+	}
+
+	private static void registerCompositeIdMappableAttributes(
+			String entityName,
+			String idPropertyName,
+			Component component,
+			TransformationState transformationState) {
+		component.getProperties().forEach( property -> {
+			if ( property.getValue() instanceof ToOne toOne ) {
+				transformationState.registerMappableAttributesByColumns(
+						entityName,
+						idPropertyName + "." + property.getName(),
+						toOne.getSelectables()
+				);
+			}
+		} );
 	}
 
 	private static void buildComponentEntries(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -346,6 +346,27 @@ public class HbmTransformationJaxbTests {
 		} );
 	}
 
+	@Test
+	@JiraKey( "HHH-20591" )
+	public void testCompositeIdKeyManyToOneMappedByTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/composite-key-many-to-one/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl parentEntity = transformed.getEntities().stream()
+					.filter( e -> "Parent".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( parentEntity.getAttributes().getOneToManyAttributes() ).hasSize( 1 );
+
+			final JaxbOneToManyImpl children = parentEntity.getAttributes().getOneToManyAttributes().get( 0 );
+			assertThat( children.getName() ).isEqualTo( "children" );
+			assertThat( children.getMappedBy() )
+					.as( "mapped-by should resolve to 'id.parent' for key-many-to-one inside composite-id" )
+					.isEqualTo( "id.parent" );
+		} );
+	}
+
 	private void transformAndVerify(
 			String resourceName,
 			ServiceRegistryScope scope,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositekey/Child.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositekey/Child.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.compositekey;
+
+import java.io.Serializable;
+
+public class Child {
+	private Id id;
+
+	public Id getId() {
+		return id;
+	}
+
+	public void setId(Id id) {
+		this.id = id;
+	}
+
+	public static class Id implements Serializable {
+		private Parent parent;
+		private Long number;
+
+		public Parent getParent() {
+			return parent;
+		}
+
+		public void setParent(Parent parent) {
+			this.parent = parent;
+		}
+
+		public Long getNumber() {
+			return number;
+		}
+
+		public void setNumber(Long number) {
+			this.number = number;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositekey/Parent.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositekey/Parent.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.compositekey;
+
+import java.util.List;
+
+public class Parent {
+	private Long id;
+	private String name;
+	private List children;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public List getChildren() {
+		return children;
+	}
+
+	public void setChildren(List children) {
+		this.children = children;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-key-many-to-one/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-key-many-to-one/hbm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.compositekey">
+	<class name="Parent" table="CK_PARENT">
+		<id name="id" column="ID" type="long">
+			<generator class="increment"/>
+		</id>
+		<property name="name" column="NAME" type="string"/>
+		<bag name="children" inverse="true" cascade="all">
+			<key column="PARENT_ID"/>
+			<one-to-many class="Child"/>
+		</bag>
+	</class>
+	<class name="Child" table="CK_CHILD">
+		<composite-id name="id" class="Child$Id">
+			<key-many-to-one name="parent" class="Parent" column="PARENT_ID"/>
+			<key-property name="number" column="CHILD_NUM" type="long"/>
+		</composite-id>
+	</class>
+</hibernate-mapping>


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20591 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20591
<!-- Hibernate GitHub Bot issue links end -->