### PR TITLE
HHH-20594 Make NonSelectQueryPlan overridable

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -1292,11 +1292,16 @@ public class NativeQueryImpl<R>
 		}
 
 		final String sqlString = expandParameterLists( 1 );
-		final var queryPlan = new NativeNonSelectQueryPlanImpl( sqlString, querySpaces, parameterOccurrences );
+		final var queryPlan = createNonSelectQueryPlan( sqlString, querySpaces, parameterOccurrences );
 		if ( cacheKey != null ) {
 			getInterpretationCache().cacheNonSelectQueryPlan( cacheKey, queryPlan );
 		}
 		return queryPlan;
+	}
+
+	// Used by Hibernate Reactive to create its own instance of NonSelectQueryPlan
+	protected NonSelectQueryPlan createNonSelectQueryPlan(String sqlString, Set<String> querySpaces, List<ParameterOccurrence> parameterOccurrences) {
+		return new NativeNonSelectQueryPlanImpl( sqlString, querySpaces, parameterOccurrences );
 	}
 
 	protected NonSelectInterpretationsKey generateNonSelectInterpretationsKey() {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Hibernate Reactive can now override which implementation is created in NativeQueryImpl

Hibernate Reactive need a way to pass its own instance of NonSelectQueryPlan

Same as https://github.com/hibernate/hibernate-orm/pull/12823 (but for `main`)
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20594
<!-- Hibernate GitHub Bot issue links end -->