### PR TITLE
HHH-20595 Make VersionJavaType not directly depend on SharedSessionContractImplementor

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
@@ -7,6 +7,7 @@ package org.hibernate.engine.internal;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.EntityVersionMapping;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.VersionJavaType;
 
 
@@ -42,7 +43,7 @@ public final class Versioning {
 						? versionMapping.getTemporalPrecision()
 						: versionMapping.getPrecision(),
 				versionMapping.getScale(),
-				session
+				(WrapperOptions) session
 		);
 		VersionLogger.INSTANCE.seed( seed );
 		return seed;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/spi/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/spi/BaseSqmToSqlAstConverter.java
@@ -957,12 +957,12 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 										length,
 										precision,
 										scale,
-										null
+										persister.getFactory().getWrapperOptions()
 								),
 								length,
 								precision,
 								scale,
-								null
+								persister.getFactory().getWrapperOptions()
 						),
 						versionType
 				),

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/VersionTypeSeedParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/VersionTypeSeedParameterSpecification.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import org.hibernate.metamodel.mapping.EntityVersionMapping;
 import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
  * Parameter bind specification used for optimistic lock version seeding (from insert statements).
@@ -47,7 +48,7 @@ public class VersionTypeSeedParameterSpecification extends AbstractJdbcParameter
 						executionContext.getSession()
 				),
 				startPosition,
-				executionContext.getSession()
+				(WrapperOptions) executionContext.getSession()
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteJavaType.java
@@ -208,4 +208,13 @@ public class ByteJavaType extends AbstractClassJavaType<Byte>
 		return ZERO;
 	}
 
+	@Override
+	public Byte seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return ZERO;
+	}
+
+	@Override
+	public Byte next(Byte current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return (byte) ( current + 1 );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
@@ -192,4 +192,14 @@ public class CalendarJavaType extends AbstractTemporalJavaType<Calendar> impleme
 	public Calendar seed(Long length, Integer precision, Integer scale, SharedSessionContractImplementor session) {
 		return GregorianCalendar.from( ZonedDateTime.now( ClockHelper.forPrecision( precision, session, 3 ) ) );
 	}
+
+	@Override
+	public Calendar seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return GregorianCalendar.from( ZonedDateTime.now( ClockHelper.forPrecision( precision, options.getSessionFactory(), 3 ) ) );
+	}
+
+	@Override
+	public Calendar next(Calendar current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return seed( length, precision, scale, options );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClockHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClockHelper.java
@@ -7,6 +7,7 @@ package org.hibernate.type.descriptor.java;
 import java.time.Clock;
 import java.time.Duration;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.internal.CurrentTimestampGeneration;
 
@@ -33,13 +34,20 @@ public class ClockHelper {
 	}
 
 	public static Clock forPrecision(Integer precision, SharedSessionContractImplementor session, int maxPrecision) {
+		return forPrecision( precision, session.getSessionFactory(), maxPrecision );
+	}
+
+	public static Clock forPrecision(Integer precision, SessionFactoryImplementor factory) {
+		return forPrecision( precision, factory, 9 );
+	}
+
+	public static Clock forPrecision(Integer precision, SessionFactoryImplementor factory, int maxPrecision) {
 		final int resolvedPrecision =
 				precision == null
-						? session.getJdbcServices().getDialect().getDefaultTimestampPrecision()
+						? factory.getJdbcServices().getDialect().getDefaultTimestampPrecision()
 						: precision;
 		final var baseClock = (Clock)
-				session.getFactory().getProperties()
-						.get( CurrentTimestampGeneration.CLOCK_SETTING_NAME );
+				factory.getProperties().get( CurrentTimestampGeneration.CLOCK_SETTING_NAME );
 		return forPrecision( baseClock, resolvedPrecision, maxPrecision );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
@@ -227,6 +227,16 @@ public class DateJavaType extends AbstractTemporalJavaType<Date> implements Vers
 		return Timestamp.from( ClockHelper.forPrecision( precision, session ).instant() );
 	}
 
+	@Override
+	public Date seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return Timestamp.from( ClockHelper.forPrecision( precision, options.getSessionFactory() ).instant() );
+	}
+
+	@Override
+	public Date next(Date current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return seed( length, precision, scale, options );
+	}
+
 	private static Timestamp toTimestamp(Date date) {
 		return date instanceof Timestamp timestamp
 				? timestamp

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaType.java
@@ -214,7 +214,16 @@ public class InstantJavaType extends AbstractTemporalJavaType<Instant>
 			Integer precision,
 			Integer scale,
 			SharedSessionContractImplementor session) {
-		return Instant.now( ClockHelper.forPrecision( precision, session ) );
+		return seed( length, precision, scale, session );
 	}
 
+	@Override
+	public Instant seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return Instant.now( ClockHelper.forPrecision( precision, options.getSessionFactory() ) );
+	}
+
+	@Override
+	public Instant next(Instant current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return seed( length, precision, scale, options );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
@@ -220,4 +220,13 @@ public class IntegerJavaType extends AbstractClassJavaType<Integer>
 		return current + 1;
 	}
 
+	@Override
+	public Integer seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return ZERO;
+	}
+
+	@Override
+	public Integer next(Integer current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return current + 1;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
@@ -270,6 +270,15 @@ public class JdbcTimestampJavaType extends AbstractTemporalJavaType<Timestamp>
 		return Timestamp.from( ClockHelper.forPrecision( precision, session ).instant() );
 	}
 
+	@Override
+	public Timestamp seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return Timestamp.from( ClockHelper.forPrecision( precision, options.getSessionFactory() ).instant() );
+	}
+
+	@Override
+	public Timestamp next(Timestamp current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return seed( length, precision, scale, options );
+	}
 
 	public static class TimestampMutabilityPlan extends MutableMutabilityPlan<Timestamp> {
 		public static final TimestampMutabilityPlan INSTANCE = new TimestampMutabilityPlan();

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
@@ -189,7 +189,16 @@ public class LocalDateTimeJavaType extends AbstractTemporalJavaType<LocalDateTim
 			Integer precision,
 			Integer scale,
 			SharedSessionContractImplementor session) {
-		return LocalDateTime.now( ClockHelper.forPrecision( precision, session ) );
+		return seed( length, precision, scale, session );
 	}
 
+	@Override
+	public LocalDateTime seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return LocalDateTime.now( ClockHelper.forPrecision( precision, options.getSessionFactory() ) );
+	}
+
+	@Override
+	public LocalDateTime next(LocalDateTime current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return seed( length, precision, scale, options );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongJavaType.java
@@ -225,4 +225,13 @@ public class LongJavaType extends AbstractClassJavaType<Long>
 		return ZERO;
 	}
 
+	@Override
+	public Long seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return ZERO;
+	}
+
+	@Override
+	public Long next(Long current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return current + 1L;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
@@ -255,7 +255,16 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 			Integer precision,
 			Integer scale,
 			SharedSessionContractImplementor session) {
-		return OffsetDateTime.now( ClockHelper.forPrecision( precision, session ) );
+		return seed( length, precision, scale, session );
 	}
 
+	@Override
+	public OffsetDateTime seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return OffsetDateTime.now( ClockHelper.forPrecision( precision, options.getSessionFactory() ) );
+	}
+
+	@Override
+	public OffsetDateTime next(OffsetDateTime current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return seed( length, precision, scale, options );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveByteArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveByteArrayJavaType.java
@@ -193,6 +193,20 @@ public class PrimitiveByteArrayJavaType extends AbstractClassJavaType<byte[]>
 		return current;
 	}
 
+	@Override
+	public byte[] seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		// Note: simply returns null for seed() and next() as the only known
+		// 		application of binary types for versioning is for use with the
+		// 		TIMESTAMP datatype supported by Sybase and SQL Server, which
+		// 		are completely db-generated values...
+		return null;
+	}
+
+	@Override
+	public byte[] next(byte[] current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return current;
+	}
+
 	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<byte[]> {
 		@Override
 		protected byte[] deepCopyNotNull(byte[] value) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortJavaType.java
@@ -214,4 +214,13 @@ public class ShortJavaType extends AbstractClassJavaType<Short>
 		return (short) ( current + 1 );
 	}
 
+	@Override
+	public Short seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return ZERO;
+	}
+
+	@Override
+	public Short next(Short current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return (short) ( current + 1 );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/VersionJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/VersionJavaType.java
@@ -5,6 +5,7 @@
 package org.hibernate.type.descriptor.java;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
  * Additional contract for types which may be used to version (and optimistic lock) data.
@@ -24,8 +25,27 @@ public interface VersionJavaType<T> extends JavaType<T> {
 	 * @param scale The scale of the type
 	 * @param session The session from which this request originates.
 	 * @return an instance of the type
+	 * @deprecated Use {@link #seed(Long, Integer, Integer, WrapperOptions)} instead
 	 */
+	@Deprecated(forRemoval = true, since = "8.0")
 	T seed(Long length, Integer precision, Integer scale, SharedSessionContractImplementor session);
+
+	/**
+	 * Generate an initial version.
+	 * <p>
+	 * Note that this operation is only used when the program sets a null or negative
+	 * number as the value of the entity version field. It is not called when the
+	 * program sets the version field to a sensible-looking version.
+	 *
+	 * @param length The length of the type
+	 * @param precision The precision of the type
+	 * @param scale The scale of the type
+	 * @param options The options.
+	 * @return an instance of the type
+	 */
+	default T seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return seed( length, precision, scale, options.getSession() );
+	}
 
 	/**
 	 * Increment the version.
@@ -36,7 +56,23 @@ public interface VersionJavaType<T> extends JavaType<T> {
 	 * @param scale The scale of the type
 	 * @param session The session from which this request originates.
 	 * @return an instance of the type
+	 * @deprecated Use {@link #next(Object, Long, Integer, Integer, WrapperOptions)} instead
 	 */
+	@Deprecated(forRemoval = true, since = "8.0")
 	T next(T current, Long length, Integer precision, Integer scale, SharedSessionContractImplementor session);
+
+	/**
+	 * Increment the version.
+	 *
+	 * @param current the current version
+	 * @param length The length of the type
+	 * @param precision The precision of the type
+	 * @param scale The scale of the type
+	 * @param options The options.
+	 * @return an instance of the type
+	 */
+	default T next(T current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return next( current, length, precision, scale, options.getSession() );
+	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
@@ -215,7 +215,16 @@ public class ZonedDateTimeJavaType extends AbstractTemporalJavaType<ZonedDateTim
 			Integer precision,
 			Integer scale,
 			SharedSessionContractImplementor session) {
-		return ZonedDateTime.now( ClockHelper.forPrecision( precision, session ) );
+		return seed( length, precision, scale, session );
 	}
 
+	@Override
+	public ZonedDateTime seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return ZonedDateTime.now( ClockHelper.forPrecision( precision, options.getSessionFactory() ) );
+	}
+
+	@Override
+	public ZonedDateTime next(ZonedDateTime current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return seed( length, precision, scale, options );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/UserTypeVersionJavaTypeWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/UserTypeVersionJavaTypeWrapper.java
@@ -6,6 +6,7 @@ package org.hibernate.type.internal;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.CustomType;
+import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.VersionJavaType;
 import org.hibernate.usertype.UserVersionType;
 
@@ -35,5 +36,15 @@ public class UserTypeVersionJavaTypeWrapper<J> extends UserTypeJavaTypeWrapper<J
 			Integer scale,
 			SharedSessionContractImplementor session) {
 		return ( (UserVersionType<J>) userType ).next( current, session );
+	}
+
+	@Override
+	public J seed(Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return ( (UserVersionType<J>) userType ).seed( options );
+	}
+
+	@Override
+	public J next(J current, Long length, Integer precision, Integer scale, WrapperOptions options) {
+		return ( (UserVersionType<J>) userType ).next( current, options );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/usertype/UserVersionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/UserVersionType.java
@@ -7,6 +7,7 @@ package org.hibernate.usertype;
 import java.util.Comparator;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
  * A user type that may be used for a version property
@@ -21,8 +22,20 @@ public interface UserVersionType<T> extends UserType<T>, Comparator<T> {
 	 * null; currently this only happens during startup when trying to determine
 	 * the "unsaved value" of entities.
 	 * @return an instance of the type
+	 * @deprecated Use {@link #seed(WrapperOptions)} instead
 	 */
+	@Deprecated(forRemoval = true, since = "8.0")
 	T seed(SharedSessionContractImplementor session);
+
+	/**
+	 * Generate an initial version.
+	 *
+	 * @param options The options.
+	 * @return an instance of the type
+	 */
+	default T seed(WrapperOptions options) {
+		return seed( options.getSession() );
+	}
 
 	/**
 	 * Increment the version.
@@ -30,6 +43,19 @@ public interface UserVersionType<T> extends UserType<T>, Comparator<T> {
 	 * @param session The session from which this request originates.
 	 * @param current the current version
 	 * @return an instance of the type
+	 * @deprecated Use {@link #next(Object, WrapperOptions)} instead
 	 */
+	@Deprecated(forRemoval = true, since = "8.0")
 	T next(T current, SharedSessionContractImplementor session);
+
+	/**
+	 * Increment the version.
+	 *
+	 * @param current the current version
+	 * @param options The options.
+	 * @return an instance of the type
+	 */
+	default T next(T current, WrapperOptions options) {
+		return next( current, options.getSession() );
+	}
 }


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/12828

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20595 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20595
<!-- Hibernate GitHub Bot issue links end -->