### PR TITLE
HHH-20593 HbmXmlTransformer does not convert one-to-one property-ref to mapped-by when the referenced property is a back-reference association

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -164,6 +164,7 @@ import org.hibernate.mapping.Component;
 import org.hibernate.mapping.Formula;
 import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.ManyToOne;
+import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.OneToMany;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
@@ -1673,8 +1674,13 @@ public class HbmXmlTransformer {
 		oneToOne.setForeignKey( new JaxbForeignKeyImpl() );
 		oneToOne.getForeignKey().setName( hbmOneToOne.getForeignKey() );
 		if ( isNotEmpty( hbmOneToOne.getPropertyRef() ) ) {
-			oneToOne.setPropertyRef( new JaxbPropertyRefImpl() );
-			oneToOne.getPropertyRef().setName( hbmOneToOne.getPropertyRef() );
+			if ( isPropertyRefBackReference( hbmOneToOne, propertyInfo ) ) {
+				oneToOne.setMappedBy( hbmOneToOne.getPropertyRef() );
+			}
+			else {
+				oneToOne.setPropertyRef( new JaxbPropertyRefImpl() );
+				oneToOne.getPropertyRef().setName( hbmOneToOne.getPropertyRef() );
+			}
 		}
 		for ( String formula : hbmOneToOne.getFormula() ) {
 			oneToOne.getJoinColumnOrJoinFormula().add( formula );
@@ -1690,6 +1696,26 @@ public class HbmXmlTransformer {
 		transferFetchable( hbmOneToOne.getLazy(), hbmOneToOne.getFetch(), hbmOneToOne.getOuterJoin(), hbmOneToOne.isConstrained(), oneToOne );
 
 		attributes.getOneToOneAttributes().add( oneToOne );
+	}
+
+	private boolean isPropertyRefBackReference(JaxbHbmOneToOneType hbmOneToOne, PropertyInfo propertyInfo) {
+		final String targetEntityName = isNotEmpty( hbmOneToOne.getEntityName() )
+				? hbmOneToOne.getEntityName()
+				: hbmOneToOne.getClazz();
+		final var targetEntityInfo = transformationState.getEntityInfoByName().get( targetEntityName );
+		if ( targetEntityInfo == null ) {
+			return false;
+		}
+		final var refPropertyInfo = targetEntityInfo.propertyInfoMap().get( hbmOneToOne.getPropertyRef() );
+		if ( refPropertyInfo == null ) {
+			return false;
+		}
+		final Value refValue = refPropertyInfo.bootModelProperty().getValue();
+		if ( !( refValue instanceof ToOne refToOne ) ) {
+			return false;
+		}
+		final String declaringEntityName = propertyInfo.bootModelProperty().getPersistentClass().getEntityName();
+		return declaringEntityName.equals( refToOne.getReferencedEntityName() );
 	}
 
 	private void transferManyToOne(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -27,6 +27,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbIdImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToOneImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbOneToManyImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbOneToOneImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbTransientImpl;
 import org.hibernate.boot.jaxb.spi.Binding;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
@@ -312,6 +313,27 @@ public class HbmTransformationJaxbTests {
 					.doesNotContain( "compositeName" )
 					.as( "Mapped properties should not be marked as transient" )
 					.doesNotContain( "id", "name", "anotherCompositeName" );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20593" )
+	public void testCompositePkPropertyRefOneToOneTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/composite-pk-property-ref/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl entityA = transformed.getEntities().stream()
+					.filter( e -> "EntityA".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( entityA.getAttributes().getOneToOneAttributes() ).hasSize( 1 );
+
+			final JaxbOneToOneImpl oneToOne = entityA.getAttributes().getOneToOneAttributes().get( 0 );
+			assertThat( oneToOne.getName() ).isEqualTo( "entityB" );
+			assertThat( oneToOne.getMappedBy() )
+					.as( "mapped-by should resolve to 'entityA' via property-ref on composite-PK entity" )
+					.isEqualTo( "entityA" );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositepkpropertyref/EntityA.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositepkpropertyref/EntityA.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.compositepkpropertyref;
+
+public class EntityA {
+	private Long id;
+	private String name;
+	private Object entityB;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Object getEntityB() {
+		return entityB;
+	}
+
+	public void setEntityB(Object entityB) {
+		this.entityB = entityB;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositepkpropertyref/EntityB.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositepkpropertyref/EntityB.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.compositepkpropertyref;
+
+
+public class EntityB {
+	private Integer code;
+	private String label;
+	private Long refId;
+	private EntityA entityA;
+
+	public Integer getCode() {
+		return code;
+	}
+
+	public void setCode(Integer code) {
+		this.code = code;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+	}
+
+	public Long getRefId() {
+		return refId;
+	}
+
+	public void setRefId(Long refId) {
+		this.refId = refId;
+	}
+
+	public EntityA getEntityA() {
+		return entityA;
+	}
+
+	public void setEntityA(EntityA entityA) {
+		this.entityA = entityA;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-pk-property-ref/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-pk-property-ref/hbm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<!--
+    Reproduces the pattern where entity A has a one-to-one with
+    property-ref pointing at a many-to-one on entity B, and B
+    has a composite PK. The transformer must resolve mapped-by
+    correctly despite B's composite PK spanning more columns
+    than the single-column many-to-one back-reference.
+-->
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.compositepkpropertyref">
+
+	<class name="EntityA" table="CPR_A">
+		<id name="id" column="ID" type="long">
+			<generator class="assigned"/>
+		</id>
+		<property name="name" column="NAME" type="string"/>
+		<one-to-one name="entityB" entity-name="org.hibernate.orm.test.boot.jaxb.mapping.compositepkpropertyref.EntityB"
+					outer-join="auto" property-ref="entityA"/>
+	</class>
+
+	<class name="EntityB" table="CPR_B">
+		<composite-id>
+			<key-property name="code" column="CODE" type="integer"/>
+			<key-property name="label" column="LABEL" type="string"/>
+		</composite-id>
+		<property name="refId" column="REF_ID" type="long"/>
+		<many-to-one name="entityA" class="EntityA" column="REF_ID"
+					 unique="false" insert="false" update="false"/>
+	</class>
+
+</hibernate-mapping>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/12822 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20593 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20593
<!-- Hibernate GitHub Bot issue links end -->