### PR TITLE
HHH-20556 Allow generated metamodel constants in @OrderBy

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -123,6 +123,7 @@ import static org.hibernate.query.hql.internal.HqlHelper.*;
 public class AnnotationMetaEntity extends AnnotationMeta {
 
 	private static final String ID_CLASS_MEMBER_NAME = "<ID_CLASS>";
+	private static final String ERROR_ANNOTATION_VALUE = "<error>";
 
 	private final ImportContext importContext;
 	private final @Nullable AnnotationMeta parent;
@@ -1558,19 +1559,20 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		final var annotation =
 				castNonNull( getAnnotationMirror( memberOfClass, ORDER_BY ) );
 		final var annotationValue = getAnnotationValue( annotation );
-		if ( annotationValue != null ) {
-			final var fragment = annotationValue.getValue().toString();
-			if ( !fragment.isBlank() ) {
-				try {
-					OrderByFragmentTranslator.check( fragment );
-				}
-				catch (SyntaxException e) {
-					final var message = "Error in ordering: " + e.getMessage();
-					context.message( memberOfClass, annotation, annotationValue, message, Diagnostic.Kind.ERROR );
-				}
-				catch (Exception ignored) {
-					// do nothing with it
-				}
+		if ( annotationValue == null ) {
+			return;
+		}
+		final var fragment = annotationValue.getValue().toString();
+		if ( !fragment.isBlank() && !ERROR_ANNOTATION_VALUE.equals( fragment ) ) {
+			try {
+				OrderByFragmentTranslator.check( fragment );
+			}
+			catch (SyntaxException e) {
+				final var message = "Error in ordering: " + e.getMessage();
+				context.message( memberOfClass, annotation, annotationValue, message, Diagnostic.Kind.ERROR );
+			}
+			catch (Exception ignored) {
+				// do nothing with it
 			}
 		}
 	}
@@ -1727,8 +1729,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			Element memberOfClass, AnnotationMirror annotation, AnnotationValue annotationVal, TypeElement assocTypeElement) {
 		final var mappedBy = annotationVal.getValue().toString();
 		if ( mappedBy != null && !mappedBy.isEmpty()
-			// this happens for a typesafe ref, e.g. Page_BOOK
-			// TODO: we should queue it to validate it later somehow
+			// typesafe refs such as Page_BOOK are unresolved while the metamodel is generated
 			&& !mappedBy.equals( "<error>" ) ) {
 			if ( mappedBy.indexOf( '.' ) > 0 ) {
 				//we don't know how to handle paths yet

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/orderby/OrderByStaticMetamodelTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/orderby/OrderByStaticMetamodelTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.orderby;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.TestForIssue;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+
+@CompilationTest
+class OrderByStaticMetamodelTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-20556")
+	@WithClasses(value = {}, sources = {
+			"org.hibernate.processor.test.orderby.OrderByParent",
+			"org.hibernate.processor.test.orderby.OrderByChild"
+	})
+	void orderByAcceptsStaticMetamodelConstant() {
+		assertMetamodelClassGeneratedFor( "org.hibernate.processor.test.orderby.OrderByParent" );
+		assertMetamodelClassGeneratedFor( "org.hibernate.processor.test.orderby.OrderByChild" );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-20556")
+	@WithClasses(value = {}, sources = {
+			"org.hibernate.processor.test.orderby.OrderByDefaultParent",
+			"org.hibernate.processor.test.orderby.OrderByChild"
+	})
+	void orderByAcceptsDefaultValue() {
+		assertMetamodelClassGeneratedFor( "org.hibernate.processor.test.orderby.OrderByDefaultParent" );
+		assertMetamodelClassGeneratedFor( "org.hibernate.processor.test.orderby.OrderByChild" );
+	}
+}

--- a/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/orderby/OrderByChild.java
+++ b/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/orderby/OrderByChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.orderby;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class OrderByChild {
+
+	@Id
+	long id;
+
+	int seqNo;
+}

--- a/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/orderby/OrderByDefaultParent.java
+++ b/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/orderby/OrderByDefaultParent.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.orderby;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+
+@Entity
+public class OrderByDefaultParent {
+
+	@Id
+	long id;
+
+	@OneToMany
+	@OrderBy
+	List<OrderByChild> children;
+}

--- a/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/orderby/OrderByParent.java
+++ b/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/orderby/OrderByParent.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.orderby;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+
+@Entity
+public class OrderByParent {
+
+	@Id
+	long id;
+
+	@OneToMany
+	@OrderBy(OrderByChild_.SEQ_NO)
+	List<OrderByChild> children;
+}


### PR DESCRIPTION
HHH-20556

`@OrderBy` validation now skips javac's temporary `<error>` value for generated static-metamodel constants such as `ChildEntity_.SEQ_NO`. This avoids reporting a Hibernate ordering syntax error while the processor is still generating the referenced metamodel class.

The regression test compiles resource-based entities that reference a generated static metamodel constant from `@OrderBy`; before the fix it failed with:

```
Error in ordering: At 1:0 and token '<', extraneous input '<' ... [<error>]
```

Verification:
- `./gradlew --no-daemon :hibernate-processor:test --tests org.hibernate.processor.test.orderby.OrderByStaticMetamodelTest`
- `./gradlew --no-daemon :hibernate-processor:test`
- `git diff --check HEAD^ HEAD`

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20556 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20556
<!-- Hibernate GitHub Bot issue links end -->