### PR TITLE
HHH-20596 HbmXmlTransformer does not support key-many-to-one in non-aggregated composite-id

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/BootModelPreprocessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/BootModelPreprocessor.java
@@ -71,7 +71,7 @@ public class BootModelPreprocessor {
 				final String componentRole = rootClass.getEntityName() + ".id";
 				buildComponentEntries( componentRole, component, transformationState );
 				registerCompositeIdMappableAttributes(
-						rootClass.getEntityName(), "id", component, transformationState
+						rootClass.getEntityName(), null, component, transformationState
 				);
 			}
 		}
@@ -134,9 +134,12 @@ public class BootModelPreprocessor {
 			TransformationState transformationState) {
 		component.getProperties().forEach( property -> {
 			if ( property.getValue() instanceof ToOne toOne ) {
+				final String attributePath = idPropertyName != null
+						? idPropertyName + "." + property.getName()
+						: property.getName();
 				transformationState.registerMappableAttributesByColumns(
 						entityName,
-						idPropertyName + "." + property.getName(),
+						attributePath,
 						toOne.getSelectables()
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1298,6 +1298,10 @@ public class HbmXmlTransformer {
 		if ( persistentClass.getIdentifierProperty() != null ) {
 			mappedPropertyNames.add( persistentClass.getIdentifierProperty().getName() );
 		}
+		else if ( persistentClass instanceof RootClass rootClass
+				&& rootClass.getIdentifier() instanceof Component compositeId ) {
+			compositeId.getProperties().forEach( p -> mappedPropertyNames.add( p.getName() ) );
+		}
 		if ( persistentClass instanceof RootClass rootClass && rootClass.getVersion() != null ) {
 			mappedPropertyNames.add( rootClass.getVersion().getName() );
 		}
@@ -3068,8 +3072,11 @@ public class HbmXmlTransformer {
 						keyPropertyInfo
 				) );
 			}
-			else if ( hbmIdProperty instanceof JaxbHbmCompositeKeyManyToOneType ) {
-				handleUnsupported( "Transformation of <key-many-to-one/> not supported" );
+			else if ( hbmIdProperty instanceof JaxbHbmCompositeKeyManyToOneType hbmKeyManyToOne ) {
+				final PropertyInfo keyManyToOneInfo = componentTypeInfo.propertyInfoMap().get( hbmKeyManyToOne.getName() );
+				final var jaxbManyToOne = transformCompositeKeyManyToOne( hbmKeyManyToOne, keyManyToOneInfo );
+				jaxbManyToOne.setId( true );
+				mappingXmlEntity.getAttributes().getManyToOneAttributes().add( jaxbManyToOne );
 			}
 			else {
 				throw new AssertionFailure( "Unexpected non-aggregated composite id property kind : " + hbmIdProperty );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -317,6 +317,29 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20596" )
+	public void testNonAggregatedCompositeIdKeyManyToOneTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/non-aggregate-key-many-to-one/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl detailEntity = transformed.getEntities().stream()
+					.filter( e -> "Detail".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( detailEntity.getAttributes().getManyToOneAttributes() )
+					.as( "key-many-to-one should be transformed to a many-to-one with id=true" )
+					.hasSize( 1 );
+
+			final JaxbManyToOneImpl manyToOne = detailEntity.getAttributes().getManyToOneAttributes().get( 0 );
+			assertThat( manyToOne.getName() ).isEqualTo( "master" );
+			assertThat( manyToOne.isId() )
+					.as( "many-to-one should have id=true for non-aggregated composite-id key-many-to-one" )
+					.isTrue();
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20593" )
 	public void testCompositePkPropertyRefOneToOneTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/composite-pk-property-ref/hbm.xml", scope, (transformed) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/nonaggregatekeymanytoone/Detail.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/nonaggregatekeymanytoone/Detail.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.nonaggregatekeymanytoone;
+
+public class Detail {
+	private Master master;
+	private int version;
+	private String text;
+
+	public Master getMaster() {
+		return master;
+	}
+
+	public void setMaster(Master master) {
+		this.master = master;
+	}
+
+	public int getVersion() {
+		return version;
+	}
+
+	public void setVersion(int version) {
+		this.version = version;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/nonaggregatekeymanytoone/Master.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/nonaggregatekeymanytoone/Master.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.nonaggregatekeymanytoone;
+
+public class Master {
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/non-aggregate-key-many-to-one/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/non-aggregate-key-many-to-one/hbm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<!--
+    Reproduces non-aggregated composite-id with key-many-to-one.
+    The transformer must produce a many-to-one with id="true".
+-->
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.nonaggregatekeymanytoone">
+	<class name="Master">
+		<id name="id" type="long">
+			<generator class="increment"/>
+		</id>
+		<property name="name"/>
+	</class>
+	<class name="Detail">
+		<composite-id>
+			<key-many-to-one name="master"/>
+			<key-property name="version"/>
+		</composite-id>
+		<property name="text" type="text"/>
+	</class>
+</hibernate-mapping>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/12834 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20596 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20596
<!-- Hibernate GitHub Bot issue links end -->