### PR TITLE
HHH-20598 + HHH-20599 HbmXmlTranformer fixes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1942,18 +1942,12 @@ public class HbmXmlTransformer {
 		}
 
 		if ( source instanceof JaxbHbmSetType set ) {
-			final String sort = set.getSort();
-			if ( isNotEmpty( sort ) && !"unsorted".equals( sort ) ) {
-				target.setSort( sort );
-			}
+			transferSort( set.getSort(), target );
 			target.setOrderBy( set.getOrderBy() );
 			target.setClassification( LimitedCollectionClassification.SET );
 		}
 		else if ( source instanceof JaxbHbmMapType map ) {
-			final String sort = map.getSort();
-			if ( isNotEmpty( sort ) && !"unsorted".equals( sort ) ) {
-				target.setSort( sort );
-			}
+			transferSort( map.getSort(), target );
 			target.setOrderBy( map.getOrderBy() );
 
 			transferMapKey( map, target );
@@ -1989,6 +1983,17 @@ public class HbmXmlTransformer {
 					target
 			);
 			target.setClassification( LimitedCollectionClassification.LIST );
+		}
+	}
+
+	private void transferSort(String sort, JaxbPluralAttribute target) {
+		if ( isNotEmpty( sort ) && !"unsorted".equals( sort ) ) {
+			if ( "natural".equals( sort ) ) {
+				target.setSortNatural( new JaxbPluralAnyMappingImpl.JaxbSortNaturalImpl() );
+			}
+			else {
+				target.setSort( sort );
+			}
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1097,6 +1097,12 @@ public class HbmXmlTransformer {
 			ColumnAndFormulaTarget target,
 			ColumnDefaults columnDefaults,
 			String table) {
+		if ( table != null
+				&& currentBaseTable != null
+				&& ( currentBaseTable.isPhysicalTable() || currentBaseTable.isSubselect() )
+				&& currentBaseTable.getName().equals( table ) ) {
+			table = null;
+		}
 		for ( int i = 0; i < value.getSelectables().size(); i++ ) {
 			final var selectable = value.getSelectables().get( i );
 			if ( selectable instanceof Formula formula ) {
@@ -2258,12 +2264,20 @@ public class HbmXmlTransformer {
 		embeddable.setClazz( embeddableClassName );
 		embeddable.setName( embeddableName );
 		embeddable.setAttributes( new JaxbEmbeddableAttributesContainerImpl() );
-		transferBaseAttributes(
-				partRole,
-				compositeElement.getAttributes(),
-				componentTypeInfo,
-				embeddable.getAttributes()
-		);
+
+		final var previousBaseTable = currentBaseTable;
+		currentBaseTable = componentTypeInfo.table();
+		try {
+			transferBaseAttributes(
+					partRole,
+					compositeElement.getAttributes(),
+					componentTypeInfo,
+					embeddable.getAttributes()
+			);
+		}
+		finally {
+			currentBaseTable = previousBaseTable;
+		}
 		mappingXmlBinding.getRoot().getEmbeddables().add( embeddable );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -317,6 +317,26 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20598" )
+	public void testSortNaturalTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/sort-natural/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 1 );
+
+			final JaxbEntityImpl personEntity = transformed.getEntities().get( 0 );
+			assertThat( personEntity.getAttributes().getElementCollectionAttributes() ).hasSize( 1 );
+
+			final var nickNames = personEntity.getAttributes().getElementCollectionAttributes().get( 0 );
+			assertThat( nickNames.getName() ).isEqualTo( "nickNames" );
+			assertThat( nickNames.getSortNatural() )
+					.as( "sort='natural' should become <sort-natural/>, not sort='natural'" )
+					.isNotNull();
+			assertThat( nickNames.getSort() )
+					.as( "sort attribute should be null when sort-natural is used" )
+					.isNull();
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20596" )
 	public void testNonAggregatedCompositeIdKeyManyToOneTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/non-aggregate-key-many-to-one/hbm.xml", scope, (transformed) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -317,6 +317,24 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20599" )
+	public void testCompositeElementColumnTableTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/composite-element/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEmbeddables() ).hasSize( 1 );
+
+			final JaxbEmbeddableImpl embeddable = transformed.getEmbeddables().get( 0 );
+			for ( JaxbBasicImpl basic : embeddable.getAttributes().getBasicAttributes() ) {
+				if ( basic.getColumn() != null ) {
+					assertThat( basic.getColumn().getTable() )
+							.as( "Column '%s' should not have a table attribute — it belongs to the collection table, not a secondary table",
+									basic.getName() )
+							.isNull();
+				}
+			}
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20598" )
 	public void testSortNaturalTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/sort-natural/hbm.xml", scope, (transformed) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositeelement/EmbeddedAddress.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositeelement/EmbeddedAddress.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.compositeelement;
+
+public class EmbeddedAddress {
+	private String street;
+	private String city;
+
+	public String getStreet() {
+		return street;
+	}
+
+	public void setStreet(String street) {
+		this.street = street;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public void setCity(String city) {
+		this.city = city;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositeelement/MyEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositeelement/MyEntity.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.compositeelement;
+
+import java.util.Set;
+
+public class MyEntity {
+	private Long id;
+	private String name;
+	private Set addresses;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Set getAddresses() {
+		return addresses;
+	}
+
+	public void setAddresses(Set addresses) {
+		this.addresses = addresses;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/sortnatural/Person.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/sortnatural/Person.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.sortnatural;
+
+import java.util.Set;
+
+public class Person {
+	private Long id;
+	private String name;
+	private Set nickNames;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Set getNickNames() {
+		return nickNames;
+	}
+
+	public void setNickNames(Set nickNames) {
+		this.nickNames = nickNames;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-element/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-element/hbm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.compositeelement">
+	<class name="MyEntity">
+		<id name="id" type="long">
+			<generator class="increment"/>
+		</id>
+		<property name="name"/>
+		<set name="addresses" table="entity_addresses">
+			<key column="entity_id"/>
+			<composite-element class="EmbeddedAddress">
+				<property name="street"/>
+				<property name="city"/>
+			</composite-element>
+		</set>
+	</class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/sort-natural/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/sort-natural/hbm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.sortnatural">
+	<class name="Person">
+		<id name="id" type="long">
+			<generator class="increment"/>
+		</id>
+		<property name="name"/>
+		<set name="nickNames" table="person_nick_names" sort="natural">
+			<key column="person_id"/>
+			<element column="nick_name" type="string"/>
+		</set>
+	</class>
+</hibernate-mapping>


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HHH-20598 HbmXmlTransformer converts sort="natural" as a comparator class name instead of <sort-natural/>
- https://hibernate.atlassian.net/browse/HHH-20598 HbmXmlTransformer converts sort="natural" as a comparator class name instead of <sort-natural/>


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20599 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20598 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20599
<!-- Hibernate GitHub Bot issue links end -->