### PR TITLE
HHH-20600 HbmXmlTransformer does not generate <transient/> declarations for unmapped embeddable properties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1318,52 +1318,13 @@ public class HbmXmlTransformer {
 				return;
 			}
 
-			final Set<String> transientNames = new HashSet<>();
-
-			if ( "field".equals( hbmXmlBinding.getRoot().getDefaultAccess().toLowerCase( Locale.ROOT ) ) ) {
-				for ( var field : javaClass.getDeclaredFields() ) {
-					final String fieldName = field.getName();
-					if ( !mappedPropertyNames.contains( fieldName ) ) {
-						transientNames.add( fieldName );
-					}
-				}
-			}
-			else {
-				final var setterNames = new HashSet<>();
-				for ( var method : javaClass.getMethods() ) {
-					if ( method.getParameterCount() == 1
-							&& method.getName().startsWith( "set" ) && method.getName().length() > 3 ) {
-						setterNames.add( org.hibernate.internal.util.StringHelper.decapitalize( method.getName().substring( 3 ) ) );
-					}
-				}
-
-				for ( var method : javaClass.getMethods() ) {
-					final String methodName = method.getName();
-					if ( method.getParameterCount() != 0 ) {
-						continue;
-					}
-					String propertyName = null;
-					if ( methodName.startsWith( "get" ) && methodName.length() > 3 ) {
-						propertyName = org.hibernate.internal.util.StringHelper.decapitalize( methodName.substring( 3 ) );
-					}
-					else if ( methodName.startsWith( "is" ) && methodName.length() > 2
-							&& ( method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class ) ) {
-						propertyName = org.hibernate.internal.util.StringHelper.decapitalize( methodName.substring( 2 ) );
-					}
-					if ( propertyName != null
-							&& setterNames.contains( propertyName )
-							&& !mappedPropertyNames.contains( propertyName )
-							&& !propertyName.equals( "class" ) ) {
-						transientNames.add( propertyName );
-					}
-				}
-			}
-
-			for ( var name : transientNames ) {
-				final var transientMapping = new JaxbTransientImpl();
-				transientMapping.setName( name );
-				mappingEntity.getAttributes().getTransients().add( transientMapping );
-			}
+			final boolean fieldAccess = "field".equals(
+					hbmXmlBinding.getRoot().getDefaultAccess().toLowerCase( Locale.ROOT )
+			);
+			final Set<String> transientNames = TransformationHelper.discoverUnmappedPropertyNames(
+					javaClass, mappedPropertyNames, fieldAccess
+			);
+			TransformationHelper.addTransients( transientNames, mappingEntity.getAttributes().getTransients() );
 		}
 		catch (Exception e) {
 			// if we can't load the class, skip transient generation

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
@@ -5,8 +5,10 @@
 package org.hibernate.boot.jaxb.hbm.transform;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributesContainer;
@@ -149,7 +151,39 @@ public class HbmXmlTransformerComponentHandler {
 				}
 			}
 		}
+
+		transferEmbeddableTransients( embeddableClassName, componentTypeInfo, embeddable );
+
 		return embeddable;
+	}
+
+	private void transferEmbeddableTransients(
+			String embeddableClassName,
+			ComponentTypeInfo componentTypeInfo,
+			JaxbEmbeddableImpl embeddable) {
+		if ( embeddableClassName == null || componentTypeInfo == null ) {
+			return;
+		}
+
+		final var component = componentTypeInfo.getComponent();
+		final Set<String> mappedPropertyNames = new HashSet<>();
+		component.getProperties().forEach( p -> mappedPropertyNames.add( p.getName() ) );
+
+		try {
+			final var javaClass = component.getComponentClass();
+			if ( javaClass == null ) {
+				return;
+			}
+
+			final boolean fieldAccess = component.getParentProperty() == null;
+			final Set<String> transientNames = TransformationHelper.discoverUnmappedPropertyNames(
+					javaClass, mappedPropertyNames, fieldAccess
+			);
+			TransformationHelper.addTransients( transientNames, embeddable.getAttributes().getTransients() );
+		}
+		catch (Exception e) {
+			// if we can't load the class, skip transient generation
+		}
 	}
 
 	public String determineEmbeddableName(String componentClassName, String attributeName) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/TransformationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/TransformationHelper.java
@@ -4,12 +4,16 @@
  */
 package org.hibernate.boot.jaxb.hbm.transform;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.jaxb.hbm.spi.EntityInfo;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbTransientImpl;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.JoinedSubclass;
 import org.hibernate.mapping.PersistentClass;
@@ -36,6 +40,58 @@ public class TransformationHelper {
 		final T value = source.get();
 		if ( value != null ) {
 			target.accept( value );
+		}
+	}
+
+	static Set<String> discoverUnmappedPropertyNames(
+			Class<?> javaClass,
+			Set<String> mappedPropertyNames,
+			boolean fieldAccess) {
+		final Set<String> transientNames = new HashSet<>();
+		if ( fieldAccess ) {
+			for ( var field : javaClass.getDeclaredFields() ) {
+				if ( !mappedPropertyNames.contains( field.getName() ) ) {
+					transientNames.add( field.getName() );
+				}
+			}
+		}
+		else {
+			final var setterNames = new HashSet<String>();
+			for ( var method : javaClass.getMethods() ) {
+				if ( method.getParameterCount() == 1
+						&& method.getName().startsWith( "set" ) && method.getName().length() > 3 ) {
+					setterNames.add( StringHelper.decapitalize( method.getName().substring( 3 ) ) );
+				}
+			}
+			for ( var method : javaClass.getMethods() ) {
+				if ( method.getParameterCount() != 0 ) {
+					continue;
+				}
+				String propertyName = null;
+				final String methodName = method.getName();
+				if ( methodName.startsWith( "get" ) && methodName.length() > 3 ) {
+					propertyName = StringHelper.decapitalize( methodName.substring( 3 ) );
+				}
+				else if ( methodName.startsWith( "is" ) && methodName.length() > 2
+						&& ( method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class ) ) {
+					propertyName = StringHelper.decapitalize( methodName.substring( 2 ) );
+				}
+				if ( propertyName != null
+						&& setterNames.contains( propertyName )
+						&& !mappedPropertyNames.contains( propertyName )
+						&& !propertyName.equals( "class" ) ) {
+					transientNames.add( propertyName );
+				}
+			}
+		}
+		return transientNames;
+	}
+
+	static void addTransients(Set<String> transientNames, List<JaxbTransientImpl> target) {
+		for ( var name : transientNames ) {
+			final var transientMapping = new JaxbTransientImpl();
+			transientMapping.setName( name );
+			target.add( transientMapping );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.boot.jaxb.mapping;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.xml.stream.XMLEventFactory;
@@ -317,6 +318,22 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20600" )
+	public void testRecursiveComponentTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/recursive-component/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 1 );
+			assertThat( transformed.getEmbeddables() ).hasSize( 1 );
+
+			final JaxbEmbeddableImpl embeddable = transformed.getEmbeddables().get( 0 );
+			assertThat( embeddable.getAttributes().getBasicAttributes() )
+					.as( "Only the mapped 'name' property should be present" )
+					.hasSize( 1 );
+			assertThat( embeddable.getAttributes().getBasicAttributes().get( 0 ).getName() )
+					.isEqualTo( "name" );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20599" )
 	public void testCompositeElementColumnTableTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/composite-element/hbm.xml", scope, (transformed) -> {
@@ -493,6 +510,55 @@ public class HbmTransformationJaxbTests {
 			}
 			catch (IOException e) {
 				throw new RuntimeException( "Error accessing mapping file", e );
+			}
+		} );
+	}
+
+	private void transformAndVerifyMultiple(
+			String[] resourceNames,
+			ServiceRegistryScope scope,
+			Consumer<List<JaxbEntityMappingsImpl>> assertions) {
+		scope.withService( ClassLoaderService.class, (cls) -> {
+			try {
+				final JAXBContext jaxbCtx = JAXBContext.newInstance( JaxbHbmHibernateMapping.class );
+				final List<Binding<JaxbHbmHibernateMapping>> hbmBindings = new ArrayList<>();
+
+				for ( String resourceName : resourceNames ) {
+					try (final InputStream inputStream = cls.locateResourceStream( resourceName )) {
+						withStaxEventReader( inputStream, cls, (staxEventReader) -> {
+							final XMLEventReader reader = new HbmEventReader( staxEventReader, XMLEventFactory.newInstance() );
+							try {
+								final JaxbHbmHibernateMapping hbmMapping = JaxbHelper.VALIDATING.jaxb(
+										reader,
+										MappingXsdSupport.hbmXml.getSchema(),
+										jaxbCtx
+								);
+								hbmBindings.add( new Binding<>( hbmMapping, new Origin( SourceType.RESOURCE, resourceName ) ) );
+							}
+							catch (JAXBException e) {
+								throw new RuntimeException( "Error during JAXB processing of " + resourceName, e );
+							}
+						} );
+					}
+				}
+
+				final MetadataSources metadataSources = new MetadataSources( scope.getRegistry() );
+				hbmBindings.forEach( metadataSources::addHbmXmlBinding );
+				final MetadataImplementor metadata = (MetadataImplementor) metadataSources.buildMetadata();
+
+				final List<Binding<JaxbEntityMappingsImpl>> transformedBindings = HbmXmlTransformer.transform(
+						hbmBindings,
+						metadata,
+						UnsupportedFeatureHandling.ERROR
+				);
+
+				final List<JaxbEntityMappingsImpl> transformedRoots = transformedBindings.stream()
+						.map( Binding::getRoot )
+						.toList();
+				assertions.accept( transformedRoots );
+			}
+			catch (JAXBException | IOException e) {
+				throw new RuntimeException( "Error during transformation", e );
 			}
 		} );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/recursivecomponent/MyComponent.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/recursivecomponent/MyComponent.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.recursivecomponent;
+
+public class MyComponent {
+	private String name;
+	private int count;
+	private MyComponent subcomponent;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public int getCount() {
+		return count;
+	}
+
+	public void setCount(int count) {
+		this.count = count;
+	}
+
+	public MyComponent getSubcomponent() {
+		return subcomponent;
+	}
+
+	public void setSubcomponent(MyComponent subcomponent) {
+		this.subcomponent = subcomponent;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/recursivecomponent/MyEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/recursivecomponent/MyEntity.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.recursivecomponent;
+
+public class MyEntity {
+	private Long id;
+	private MyComponent component;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public MyComponent getComponent() {
+		return component;
+	}
+
+	public void setComponent(MyComponent component) {
+		this.component = component;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/recursive-component/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/recursive-component/hbm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<!--
+    Reproduces a component with a self-referencing subcomponent of
+    the same type. The hbm.xml only maps "name", so "subcomponent"
+    should be treated as unmapped.
+-->
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.recursivecomponent">
+	<class name="MyEntity">
+		<id name="id" type="long">
+			<generator class="increment"/>
+		</id>
+		<component name="component" class="MyComponent">
+			<property name="name" column="comp_name"/>
+		</component>
+	</class>
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20600

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20600 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->