### PR TITLE
HHH-20602 - Deprecate hibernate.mapping.default_list_semantics (8.0)

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/domain/collections.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/collections.adoc
@@ -88,6 +88,8 @@ To maintain the order, it is necessary to explicitly use the `jakarta.persistenc
 Starting in 6.0, Hibernate allows to configure the default semantics of `List` without `@OrderColumn`
 via the `hibernate.mapping.default_list_semantics` setting.
 To switch to the more natural LIST semantics with an implicit order-column, set the setting to `LIST`.
+The setting is deprecated, and `@Bag` should be used at the attribute, type, or package level
+to indicate unordered `List` mappings.
 Beware that default LIST semantics only affects owned collection mappings.
 Unowned mappings like `@ManyToMany(mappedBy = "...")` and `@OneToMany(mappedBy = "...")` do not retain the element
 order by default, and explicitly annotating `@OrderColumn` for `@ManyToMany(mappedBy = "...")` mappings is illegal.
@@ -263,8 +265,8 @@ include::{example-dir-collection}/classification/bag/EntityWithBagAsCollection.j
 ----
 ====
 
-Some apps map BAG collections using `java.util.List` instead.  Hibernate provides 2 ways to handle
-lists as bags.  First an explicit annotation
+Some apps map BAG collections using `java.util.List` instead. Hibernate provides `@Bag` to handle
+lists as bags:
 
 [[collection-bag-list-ex]]
 .@Bag
@@ -275,11 +277,12 @@ include::{example-dir-collection}/classification/bag/EntityWithBagAsList.java[ta
 ----
 ====
 
-Specifically, the usage of `@Bag` forces the classification as BAG.  Even though the `names` attribute is defined
-as `List`, Hibernate will treat it using the BAG semantics.
+Specifically, the usage of `@Bag` forces the classification as BAG. Even though the `names` attribute is defined
+as `List`, Hibernate will treat it using the BAG semantics. `@Bag` may also be specified at the type or package
+level, where it acts as a default for `List` mappings with no explicit list index details.
 
-Additionally, as discussed in <<collection-list>>, the `hibernate.mapping.default_list_semantics` setting
-is available to have Hibernate interpret a `List` with no `@OrderColumn` and no `@ListIndexBase` as a BAG.
+The deprecated `hibernate.mapping.default_list_semantics` setting may also have Hibernate interpret a `List` with
+no `@OrderColumn` and no `@ListIndexBase` as a BAG.
 
 
 An ID_BAG is similar to a BAG, except that it maps a generated, per-row identifier into the collection
@@ -1103,5 +1106,4 @@ include::{example-dir-collection}/asbasic/CommaDelimitedStringsConverter.java[ta
 include::{example-dir-collection}/asbasic/CommaDelimitedStringsConverterTests.java[tags=ex-csv-converter-model,indent=0]
 ----
 ====
-
 

--- a/hibernate-core/src/main/java/org/hibernate/annotations/Bag.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/Bag.java
@@ -10,23 +10,24 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /// Specifies that an attribute of type [java.util.List] is semantically a
 /// [bag][org.hibernate.metamodel.CollectionClassification#BAG] - that the order of
 /// the list elements is not significant, and should not be persistent.
 ///
-/// This annotation is not necessary, and has no effect, unless the configuration
-/// property {@value org.hibernate.cfg.AvailableSettings#DEFAULT_LIST_SEMANTICS}
-/// is set to {@link org.hibernate.metamodel.CollectionClassification#LIST}.
-/// However, its use is still encouraged, since the explicit annotation serves
-/// as useful documentation.
+/// This annotation may be applied to a field or property, or to a type or
+/// package descriptor. When applied at the type or package level, it acts as a
+/// default for every {@code List}-typed persistent attribute with no explicit
+/// list index details.
 ///
 /// @apiNote This annotation causes an exception if the attribute is also annotated
 /// [jakarta.persistence.OrderColumn] or [ListIndexBase].
 ///
 /// @author Steve Ebersole
-@Target({METHOD, FIELD, ANNOTATION_TYPE})
+@Target({METHOD, FIELD, TYPE, PACKAGE, ANNOTATION_TYPE})
 @Retention(RUNTIME)
 public @interface Bag {
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -522,6 +522,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 			implicitListClassification = configService.getSetting(
 					DEFAULT_LIST_SEMANTICS,
 					value -> {
+						DEPRECATION_LOGGER.deprecatedSetting( DEFAULT_LIST_SEMANTICS );
 						final var classification = CollectionClassification.interpretSetting( value );
 						if ( classification != CollectionClassification.LIST
 							&& classification != CollectionClassification.BAG ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -922,7 +922,7 @@ public abstract class CollectionBinder {
 		}
 
 		final var modelsContext = buildingContext.getBootstrapContext().getModelsContext();
-		if ( !property.hasAnnotationUsage( Bag.class, modelsContext ) ) {
+		if ( property.locateAnnotationUsage( Bag.class, modelsContext ) == null ) {
 			return determineCollectionClassification( determineSemanticJavaType( property ), property, buildingContext );
 		}
 
@@ -1004,7 +1004,9 @@ public abstract class CollectionBinder {
 			}
 
 			// otherwise, return the implicit classification for List attributes
-			return buildingContext.getBuildingOptions().getMappingDefaults().getImplicitListClassification();
+			return hasScopedBagDefault( property, buildingContext )
+					? CollectionClassification.BAG
+					: buildingContext.getBuildingOptions().getMappingDefaults().getImplicitListClassification();
 		}
 
 		if ( java.util.SortedSet.class.isAssignableFrom( semanticJavaType ) ) {
@@ -1030,6 +1032,17 @@ public abstract class CollectionBinder {
 		}
 
 		return null;
+	}
+
+	private static boolean hasScopedBagDefault(
+			MemberDetails property,
+			MetadataBuildingContext buildingContext) {
+		final var modelsContext = buildingContext.getBootstrapContext().getModelsContext();
+		return property.fromContainers(
+				false,
+				modelsContext,
+				container -> container.locateAnnotationUsage( Bag.class, modelsContext )
+		) != null;
 	}
 
 	private static Class<?> determineSemanticJavaType(MemberDetails property) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorAnnotationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorAnnotationHelper.java
@@ -132,21 +132,23 @@ public class GeneratorAnnotationHelper {
 		// lastly, on the package
 		final var packageInfo = locatePackageInfoDetails( idMember.getDeclaringType(), context );
 		if ( packageInfo != null ) {
-			for ( A generatorAnnotation:
-					packageInfo.getRepeatedAnnotationUsages( generatorAnnotationType, modelsContext ) ) {
-				if ( nameExtractor != null ) {
-					final String registrationName = nameExtractor.apply( generatorAnnotation );
-					if ( registrationName.isEmpty() ) {
-						if ( possibleMatch == null ) {
-							possibleMatch = generatorAnnotation;
+			final var generatorAnnotations = packageInfo.getRepeatedAnnotationUsages( generatorAnnotationType, modelsContext );
+			if ( generatorAnnotations != null ) {
+				for ( A generatorAnnotation: generatorAnnotations ) {
+					if ( nameExtractor != null ) {
+						final String registrationName = nameExtractor.apply( generatorAnnotation );
+						if ( registrationName.isEmpty() ) {
+							if ( possibleMatch == null ) {
+								possibleMatch = generatorAnnotation;
+							}
+						}
+						else if ( registrationName.equals( matchName ) ) {
+							return generatorAnnotation;
 						}
 					}
-					else if ( registrationName.equals( matchName ) ) {
+					else {
 						return generatorAnnotation;
 					}
-				}
-				else {
-					return generatorAnnotation;
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/HibernateAnnotations.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/HibernateAnnotations.java
@@ -113,7 +113,7 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<Bag, BagAnnotation> BAG = new OrmAnnotationDescriptor<>(
 			Bag.class,
 			BagAnnotation.class,
-			EnumSet.of( Kind.METHOD, Kind.FIELD, Kind.ANNOTATION ),
+			EnumSet.of( Kind.METHOD, Kind.FIELD, Kind.CLASS, Kind.PACKAGE, Kind.ANNOTATION ),
 			false
 	);
 	OrmAnnotationDescriptor<BatchSize, BatchSizeAnnotation> BATCH_SIZE = new OrmAnnotationDescriptor<>(

--- a/hibernate-core/src/main/java/org/hibernate/cfg/MappingSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/MappingSettings.java
@@ -498,8 +498,12 @@ public interface MappingSettings {
 	 *
 	 * @since 6.0
 	 *
+	 * @deprecated Use {@link org.hibernate.annotations.Bag @Bag} at the
+	 * attribute, type, or package level instead.
+	 *
 	 * @see org.hibernate.annotations.Bag
 	 */
+	@Deprecated(since = "8.0", forRemoval = true)
 	String DEFAULT_LIST_SEMANTICS = "hibernate.mapping.default_list_semantics";
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/bag/packagelevel/PackageLevelBagTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/bag/packagelevel/PackageLevelBagTests.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.collections.bag.packagelevel;
+
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.mapping.Property;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.ImplicitListAsListProvider;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OrderColumn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.cfg.AvailableSettings.DEFAULT_LIST_SEMANTICS;
+
+@ServiceRegistry(
+		settingProviders = @SettingProvider(
+				settingName = DEFAULT_LIST_SEMANTICS,
+				provider = ImplicitListAsListProvider.class
+		)
+)
+@DomainModel( annotatedClasses = PackageLevelBagTests.PackageLevelBagEntity.class )
+class PackageLevelBagTests {
+	@Test
+	void packageLevelBagActsAsDefault(DomainModelScope scope) {
+		scope.withHierarchy( PackageLevelBagEntity.class, (descriptor) -> {
+			final Property implicitBag = descriptor.getProperty( "implicitBag" );
+			assertThat( implicitBag.getValue() ).isInstanceOf( org.hibernate.mapping.Bag.class );
+
+			final Property explicitList = descriptor.getProperty( "explicitList" );
+			assertThat( explicitList.getValue() ).isInstanceOf( org.hibernate.mapping.List.class );
+
+			final Property set = descriptor.getProperty( "set" );
+			assertThat( set.getValue() ).isInstanceOf( org.hibernate.mapping.Set.class );
+		} );
+	}
+
+	@Entity( name = "PackageLevelBagEntity" )
+	static class PackageLevelBagEntity {
+		@Id
+		private Integer id;
+
+		@ElementCollection
+		private List<String> implicitBag;
+
+		@ElementCollection
+		@OrderColumn( name = "explicit_list_position" )
+		private List<String> explicitList;
+
+		@ElementCollection
+		private Set<String> set;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/bag/packagelevel/package-info.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/bag/packagelevel/package-info.java
@@ -1,0 +1,2 @@
+@org.hibernate.annotations.Bag
+package org.hibernate.orm.test.mapping.collections.bag.packagelevel;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/bag/typelevel/TypeLevelBagTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/bag/typelevel/TypeLevelBagTests.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.collections.bag.typelevel;
+
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.annotations.Bag;
+import org.hibernate.mapping.Property;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.ImplicitListAsListProvider;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OrderColumn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.cfg.AvailableSettings.DEFAULT_LIST_SEMANTICS;
+
+@ServiceRegistry(
+		settingProviders = @SettingProvider(
+				settingName = DEFAULT_LIST_SEMANTICS,
+				provider = ImplicitListAsListProvider.class
+		)
+)
+@DomainModel( annotatedClasses = TypeLevelBagTests.TypeLevelBagEntity.class )
+class TypeLevelBagTests {
+	@Test
+	void typeLevelBagActsAsDefault(DomainModelScope scope) {
+		scope.withHierarchy( TypeLevelBagEntity.class, (descriptor) -> {
+			final Property implicitBag = descriptor.getProperty( "implicitBag" );
+			assertThat( implicitBag.getValue() ).isInstanceOf( org.hibernate.mapping.Bag.class );
+
+			final Property explicitList = descriptor.getProperty( "explicitList" );
+			assertThat( explicitList.getValue() ).isInstanceOf( org.hibernate.mapping.List.class );
+
+			final Property set = descriptor.getProperty( "set" );
+			assertThat( set.getValue() ).isInstanceOf( org.hibernate.mapping.Set.class );
+		} );
+	}
+
+	@Bag
+	@Entity( name = "TypeLevelBagEntity" )
+	static class TypeLevelBagEntity {
+		@Id
+		private Integer id;
+
+		@ElementCollection
+		private List<String> implicitBag;
+
+		@ElementCollection
+		@OrderColumn( name = "explicit_list_position" )
+		private List<String> explicitList;
+
+		@ElementCollection
+		private Set<String> set;
+	}
+}


### PR DESCRIPTION
HHH-20602 - Deprecate hibernate.mapping.default_list_semantics
HHH-20603 - Allow @Bag on TYPE and PACKAGE

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20602 (Deprecation):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20602
<!-- Hibernate GitHub Bot issue links end -->