### PR TITLE
HHH-20585 Include soft-delete marker in set keys

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
@@ -19,6 +19,8 @@ import org.hibernate.type.OrderedSetType;
 import org.hibernate.type.SetType;
 import org.hibernate.type.SortedSetType;
 import org.hibernate.type.MappingContext;
+import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
+import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
 import org.hibernate.usertype.UserCollectionType;
 
 /**
@@ -88,10 +90,9 @@ public non-sealed class Set extends Collection {
 			if ( !collectionTable.hasPrimaryKey()
 					&& collectionTable.getUniqueKeys().isEmpty() ) {
 				final var softDeleteColumn = getSoftDeleteColumn();
-				if ( softDeleteColumn != null && getSoftDeleteStrategy() != SoftDeleteType.TIMESTAMP ) {
-					return;
-				}
-				boolean useUniqueKey = false;
+				final boolean useLiveRowUniqueIndex =
+						softDeleteColumn != null && getSoftDeleteStrategy() != SoftDeleteType.TIMESTAMP;
+				boolean useUniqueKey = useLiveRowUniqueIndex;
 				for ( var selectable : getElement().getSelectables() ) {
 					if ( selectable instanceof Column column ) {
 						try {
@@ -110,57 +111,36 @@ public non-sealed class Set extends Collection {
 				if ( softDeleteColumn != null && softDeleteColumn.isNullable() ) {
 					useUniqueKey = true;
 				}
-				final Constraint key;
-				if ( useUniqueKey ) {
-					final var uniqueKey = new UniqueKey( collectionTable );
-					uniqueKey.setNullsNotDistinct( true );
-					key = uniqueKey;
+				if ( useLiveRowUniqueIndex ) {
+					createLiveRowUniqueIndex( collectionTable, softDeleteColumn );
 				}
 				else {
-					key = new PrimaryKey( collectionTable );
-				}
-				key.addColumns( getKey() );
-				for ( var selectable : getElement().getSelectables() ) {
-					if ( selectable instanceof Column column ) {
-						key.addColumn( column );
-					}
-				}
-				if ( softDeleteColumn != null ) {
-					key.addColumn( softDeleteColumn );
-				}
-				key.setName( getBuildingContext().getBuildingOptions().getImplicitNamingStrategy()
-						.determineUniqueKeyName( new ImplicitUniqueKeyNameSource() {
-							@Override
-							public Identifier getTableName() {
-								return getTable().getNameIdentifier();
-							}
-
-							@Override
-							public List<Identifier> getColumnNames() {
-								final List<Identifier> list = new ArrayList<>();
-								for ( var c : key.getColumns() ) {
-									list.add( c.getNameIdentifier( getBuildingContext() ) );
-								}
-								return list;
-							}
-
-							@Override
-							public Identifier getUserProvidedIdentifier() {
-								return null;
-							}
-
-							@Override
-							public MetadataBuildingContext getBuildingContext() {
-								return Set.this.getBuildingContext();
-							}
-						} )
-						.render( getMetadata().getDatabase().getDialect() ) );
-				if ( key.getColumnSpan() > getKey().getColumnSpan() ) {
+					final Constraint key;
 					if ( useUniqueKey ) {
-						collectionTable.addUniqueKey( (UniqueKey) key );
+						final var uniqueKey = new UniqueKey( collectionTable );
+						uniqueKey.setNullsNotDistinct( true );
+						key = uniqueKey;
 					}
 					else {
-						collectionTable.setPrimaryKey( (PrimaryKey) key );
+						key = new PrimaryKey( collectionTable );
+					}
+					key.addColumns( getKey() );
+					for ( var selectable : getElement().getSelectables() ) {
+						if ( selectable instanceof Column column ) {
+							key.addColumn( column );
+						}
+					}
+					if ( softDeleteColumn != null ) {
+						key.addColumn( softDeleteColumn );
+					}
+					key.setName( determineUniqueKeyName( key.getColumns() ) );
+					if ( key.getColumnSpan() > getKey().getColumnSpan() ) {
+						if ( useUniqueKey ) {
+							collectionTable.addUniqueKey( (UniqueKey) key );
+						}
+						else {
+							collectionTable.setPrimaryKey( (PrimaryKey) key );
+						}
 					}
 				}
 //				else {
@@ -173,6 +153,81 @@ public non-sealed class Set extends Collection {
 //		else {
 			//create an index on the key columns??
 //		}
+	}
+
+	private void createLiveRowUniqueIndex(Table collectionTable, Column softDeleteColumn) {
+		final List<Column> keyColumns = new ArrayList<>();
+		for ( var selectable : getKey().getSelectables() ) {
+			if ( selectable instanceof Column column ) {
+				keyColumns.add( column );
+			}
+		}
+		for ( var selectable : getElement().getSelectables() ) {
+			if ( selectable instanceof Column column ) {
+				keyColumns.add( column );
+			}
+		}
+		keyColumns.add( softDeleteColumn );
+
+		final var index = collectionTable.getOrCreateIndex( determineUniqueKeyName( keyColumns ) );
+		index.setUnique( true );
+		for ( int i = 0; i < keyColumns.size() - 1; i++ ) {
+			index.addColumn( keyColumns.get( i ) );
+		}
+		index.addColumn( new Formula( liveRowSoftDeleteFormula( softDeleteColumn ) ) );
+	}
+
+	private String liveRowSoftDeleteFormula(Column softDeleteColumn) {
+		final String nonDeletedLiteral = softDeleteColumn.getValue() instanceof BasicValue basicValue
+				? softDeleteNonDeletedLiteral( basicValue )
+				: getSoftDeleteStrategy() == SoftDeleteType.ACTIVE ? "true" : "false";
+		return "(case when " + softDeleteColumn.getQuotedName( getMetadata().getDatabase().getDialect() )
+				+ " = " + nonDeletedLiteral + " then " + nonDeletedLiteral + " end)";
+	}
+
+	private String softDeleteNonDeletedLiteral(BasicValue softDeleteValue) {
+		final var resolution = softDeleteValue.resolve();
+		@SuppressWarnings("unchecked")
+		final var converter = (BasicValueConverter<Boolean, ?>) resolution.getValueConverter();
+		final Object nonDeletedValue = converter == null
+				? getSoftDeleteStrategy() == SoftDeleteType.ACTIVE
+						? true
+						: false
+				: converter.toRelationalValue( false );
+		@SuppressWarnings("unchecked")
+		final var literalFormatter =
+				(JdbcLiteralFormatter<Object>) resolution.getJdbcMapping().getJdbcLiteralFormatter();
+		return literalFormatter.toJdbcLiteral( nonDeletedValue, getMetadata().getDatabase().getDialect(), null );
+	}
+
+	private String determineUniqueKeyName(List<Column> columns) {
+		return getBuildingContext().getBuildingOptions().getImplicitNamingStrategy()
+				.determineUniqueKeyName( new ImplicitUniqueKeyNameSource() {
+					@Override
+					public Identifier getTableName() {
+						return getTable().getNameIdentifier();
+					}
+
+					@Override
+					public List<Identifier> getColumnNames() {
+						final List<Identifier> list = new ArrayList<>();
+						for ( var column : columns ) {
+							list.add( column.getNameIdentifier( getBuildingContext() ) );
+						}
+						return list;
+					}
+
+					@Override
+					public Identifier getUserProvidedIdentifier() {
+						return null;
+					}
+
+					@Override
+					public MetadataBuildingContext getBuildingContext() {
+						return Set.this.getBuildingContext();
+					}
+				} )
+				.render( getMetadata().getDatabase().getDialect() );
 	}
 
 	public Object accept(ValueVisitor visitor) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import org.hibernate.MappingException;
+import org.hibernate.annotations.SoftDeleteType;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.ImplicitUniqueKeyNameSource;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -86,6 +87,10 @@ public non-sealed class Set extends Collection {
 			final var collectionTable = getCollectionTable();
 			if ( !collectionTable.hasPrimaryKey()
 					&& collectionTable.getUniqueKeys().isEmpty() ) {
+				final var softDeleteColumn = getSoftDeleteColumn();
+				if ( softDeleteColumn != null && getSoftDeleteStrategy() != SoftDeleteType.TIMESTAMP ) {
+					return;
+				}
 				boolean useUniqueKey = false;
 				for ( var selectable : getElement().getSelectables() ) {
 					if ( selectable instanceof Column column ) {
@@ -102,7 +107,6 @@ public non-sealed class Set extends Collection {
 						}
 					}
 				}
-				final var softDeleteColumn = getSoftDeleteColumn();
 				if ( softDeleteColumn != null && softDeleteColumn.isNullable() ) {
 					useUniqueKey = true;
 				}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
@@ -102,6 +102,10 @@ public non-sealed class Set extends Collection {
 						}
 					}
 				}
+				final var softDeleteColumn = getSoftDeleteColumn();
+				if ( softDeleteColumn != null && softDeleteColumn.isNullable() ) {
+					useUniqueKey = true;
+				}
 				final Constraint key;
 				if ( useUniqueKey ) {
 					final var uniqueKey = new UniqueKey( collectionTable );
@@ -116,6 +120,9 @@ public non-sealed class Set extends Collection {
 					if ( selectable instanceof Column column ) {
 						key.addColumn( column );
 					}
+				}
+				if ( softDeleteColumn != null ) {
+					key.addColumn( softDeleteColumn );
 				}
 				key.setName( getBuildingContext().getBuildingOptions().getImplicitNamingStrategy()
 						.determineUniqueKeyName( new ImplicitUniqueKeyNameSource() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
@@ -92,7 +92,6 @@ public non-sealed class Set extends Collection {
 				final var softDeleteColumn = getSoftDeleteColumn();
 				final boolean useLiveRowUniqueIndex =
 						softDeleteColumn != null && getSoftDeleteStrategy() != SoftDeleteType.TIMESTAMP;
-				boolean useUniqueKey = useLiveRowUniqueIndex;
 				for ( var selectable : getElement().getSelectables() ) {
 					if ( selectable instanceof Column column ) {
 						try {
@@ -103,18 +102,14 @@ public non-sealed class Set extends Collection {
 						catch (MappingException me) {
 							// ignore
 						}
-						if ( column.isNullable() ) {
-							useUniqueKey = true;
-						}
 					}
-				}
-				if ( softDeleteColumn != null && softDeleteColumn.isNullable() ) {
-					useUniqueKey = true;
 				}
 				if ( useLiveRowUniqueIndex ) {
 					createLiveRowUniqueIndex( collectionTable, softDeleteColumn );
 				}
 				else {
+					final boolean useUniqueKey = getElement().isNullable()
+							|| softDeleteColumn != null && softDeleteColumn.isNullable();
 					final Constraint key;
 					if ( useUniqueKey ) {
 						final var uniqueKey = new UniqueKey( collectionTable );
@@ -178,11 +173,9 @@ public non-sealed class Set extends Collection {
 	}
 
 	private String liveRowSoftDeleteFormula(Column softDeleteColumn) {
-		final String nonDeletedLiteral = softDeleteColumn.getValue() instanceof BasicValue basicValue
-				? softDeleteNonDeletedLiteral( basicValue )
-				: getSoftDeleteStrategy() == SoftDeleteType.ACTIVE ? "true" : "false";
+		final String nonDeletedLiteral = softDeleteNonDeletedLiteral( (BasicValue) softDeleteColumn.getValue() );
 		return "(case when " + softDeleteColumn.getQuotedName( getMetadata().getDatabase().getDialect() )
-				+ " = " + nonDeletedLiteral + " then " + nonDeletedLiteral + " end)";
+				+ " = " + nonDeletedLiteral + " then 1 end)";
 	}
 
 	private String softDeleteNonDeletedLiteral(BasicValue softDeleteValue) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/softdelete/collections/SoftDeleteElementCollectionReaddTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/softdelete/collections/SoftDeleteElementCollectionReaddTest.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.softdelete.collections;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.hibernate.annotations.SoftDelete;
+import org.hibernate.annotations.SoftDeleteType;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel( annotatedClasses = SoftDeleteElementCollectionReaddTest.SoftDeleteCollectionOwner.class )
+@SessionFactory
+@Jira( "https://hibernate.atlassian.net/browse/HHH-20585" )
+public class SoftDeleteElementCollectionReaddTest {
+	@Test
+	void readdingPreviouslySoftDeletedElementCollectionEntry(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final SoftDeleteCollectionOwner owner = new SoftDeleteCollectionOwner( 1L );
+			owner.getMobiles().addAll( Set.of( "1", "2" ) );
+			session.persist( owner );
+		} );
+
+		scope.inTransaction( session -> {
+			final SoftDeleteCollectionOwner owner = session.get( SoftDeleteCollectionOwner.class, 1L );
+			owner.getMobiles().clear();
+			owner.getMobiles().addAll( Set.of( "2", "3" ) );
+		} );
+
+		scope.inTransaction( session -> {
+			final SoftDeleteCollectionOwner owner = session.get( SoftDeleteCollectionOwner.class, 1L );
+			owner.getMobiles().clear();
+			owner.getMobiles().addAll( Set.of( "1", "3" ) );
+		} );
+
+		scope.inTransaction( session -> {
+			final SoftDeleteCollectionOwner owner = session.get( SoftDeleteCollectionOwner.class, 1L );
+			assertThat( owner.getMobiles() ).containsExactlyInAnyOrder( "1", "3" );
+		} );
+	}
+
+	@Entity( name = "SoftDeleteCollectionOwner" )
+	@Table( name = "soft_delete_collection_owner" )
+	static class SoftDeleteCollectionOwner {
+		@Id
+		private Long id;
+
+		@ElementCollection
+		@CollectionTable( name = "soft_delete_collection_owner_mobile", joinColumns = @JoinColumn( name = "owner_id" ) )
+		@SoftDelete( columnName = "deleted_at", strategy = SoftDeleteType.TIMESTAMP )
+		private Set<String> mobiles = new LinkedHashSet<>();
+
+		SoftDeleteCollectionOwner() {
+		}
+
+		SoftDeleteCollectionOwner(Long id) {
+			this.id = id;
+		}
+
+		Set<String> getMobiles() {
+			return mobiles;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/softdelete/collections/SoftDeleteElementCollectionReaddTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/softdelete/collections/SoftDeleteElementCollectionReaddTest.java
@@ -24,39 +24,107 @@ import jakarta.persistence.Table;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DomainModel( annotatedClasses = SoftDeleteElementCollectionReaddTest.SoftDeleteCollectionOwner.class )
+@DomainModel( annotatedClasses = {
+		SoftDeleteElementCollectionReaddTest.TimestampSoftDeleteCollectionOwner.class,
+		SoftDeleteElementCollectionReaddTest.ActiveSoftDeleteCollectionOwner.class,
+		SoftDeleteElementCollectionReaddTest.DeletedSoftDeleteCollectionOwner.class
+} )
 @SessionFactory
 @Jira( "https://hibernate.atlassian.net/browse/HHH-20585" )
 public class SoftDeleteElementCollectionReaddTest {
 	@Test
-	void readdingPreviouslySoftDeletedElementCollectionEntry(SessionFactoryScope scope) {
+	void readdingPreviouslyTimestampSoftDeletedElementCollectionEntry(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
-			final SoftDeleteCollectionOwner owner = new SoftDeleteCollectionOwner( 1L );
+			final TimestampSoftDeleteCollectionOwner owner = new TimestampSoftDeleteCollectionOwner( 1L );
 			owner.getMobiles().addAll( Set.of( "1", "2" ) );
 			session.persist( owner );
 		} );
 
 		scope.inTransaction( session -> {
-			final SoftDeleteCollectionOwner owner = session.get( SoftDeleteCollectionOwner.class, 1L );
+			final TimestampSoftDeleteCollectionOwner owner = session.get( TimestampSoftDeleteCollectionOwner.class, 1L );
 			owner.getMobiles().clear();
 			owner.getMobiles().addAll( Set.of( "2", "3" ) );
 		} );
 
 		scope.inTransaction( session -> {
-			final SoftDeleteCollectionOwner owner = session.get( SoftDeleteCollectionOwner.class, 1L );
+			final TimestampSoftDeleteCollectionOwner owner = session.get( TimestampSoftDeleteCollectionOwner.class, 1L );
 			owner.getMobiles().clear();
 			owner.getMobiles().addAll( Set.of( "1", "3" ) );
 		} );
 
 		scope.inTransaction( session -> {
-			final SoftDeleteCollectionOwner owner = session.get( SoftDeleteCollectionOwner.class, 1L );
+			final TimestampSoftDeleteCollectionOwner owner = session.get( TimestampSoftDeleteCollectionOwner.class, 1L );
 			assertThat( owner.getMobiles() ).containsExactlyInAnyOrder( "1", "3" );
+		} );
+	}
+
+	@Test
+	void reremovingPreviouslyActiveSoftDeletedElementCollectionEntry(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final ActiveSoftDeleteCollectionOwner owner = new ActiveSoftDeleteCollectionOwner( 1L );
+			owner.getMobiles().addAll( Set.of( "1", "2" ) );
+			session.persist( owner );
+		} );
+
+		scope.inTransaction( session -> {
+			final ActiveSoftDeleteCollectionOwner owner = session.get( ActiveSoftDeleteCollectionOwner.class, 1L );
+			owner.getMobiles().clear();
+			owner.getMobiles().addAll( Set.of( "2", "3" ) );
+		} );
+
+		scope.inTransaction( session -> {
+			final ActiveSoftDeleteCollectionOwner owner = session.get( ActiveSoftDeleteCollectionOwner.class, 1L );
+			owner.getMobiles().clear();
+			owner.getMobiles().addAll( Set.of( "1", "3" ) );
+		} );
+
+		scope.inTransaction( session -> {
+			final ActiveSoftDeleteCollectionOwner owner = session.get( ActiveSoftDeleteCollectionOwner.class, 1L );
+			owner.getMobiles().clear();
+			owner.getMobiles().add( "3" );
+		} );
+
+		scope.inTransaction( session -> {
+			final ActiveSoftDeleteCollectionOwner owner = session.get( ActiveSoftDeleteCollectionOwner.class, 1L );
+			assertThat( owner.getMobiles() ).containsExactly( "3" );
+		} );
+	}
+
+	@Test
+	void reremovingPreviouslyDeletedSoftDeletedElementCollectionEntry(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final DeletedSoftDeleteCollectionOwner owner = new DeletedSoftDeleteCollectionOwner( 1L );
+			owner.getMobiles().addAll( Set.of( "1", "2" ) );
+			session.persist( owner );
+		} );
+
+		scope.inTransaction( session -> {
+			final DeletedSoftDeleteCollectionOwner owner = session.get( DeletedSoftDeleteCollectionOwner.class, 1L );
+			owner.getMobiles().clear();
+			owner.getMobiles().addAll( Set.of( "2", "3" ) );
+		} );
+
+		scope.inTransaction( session -> {
+			final DeletedSoftDeleteCollectionOwner owner = session.get( DeletedSoftDeleteCollectionOwner.class, 1L );
+			owner.getMobiles().clear();
+			owner.getMobiles().addAll( Set.of( "1", "3" ) );
+		} );
+
+		scope.inTransaction( session -> {
+			final DeletedSoftDeleteCollectionOwner owner = session.get( DeletedSoftDeleteCollectionOwner.class, 1L );
+			owner.getMobiles().clear();
+			owner.getMobiles().add( "3" );
+		} );
+
+		scope.inTransaction( session -> {
+			final DeletedSoftDeleteCollectionOwner owner = session.get( DeletedSoftDeleteCollectionOwner.class, 1L );
+			assertThat( owner.getMobiles() ).containsExactly( "3" );
 		} );
 	}
 
 	@Entity( name = "SoftDeleteCollectionOwner" )
 	@Table( name = "soft_delete_collection_owner" )
-	static class SoftDeleteCollectionOwner {
+	static class TimestampSoftDeleteCollectionOwner {
 		@Id
 		private Long id;
 
@@ -65,10 +133,56 @@ public class SoftDeleteElementCollectionReaddTest {
 		@SoftDelete( columnName = "deleted_at", strategy = SoftDeleteType.TIMESTAMP )
 		private Set<String> mobiles = new LinkedHashSet<>();
 
-		SoftDeleteCollectionOwner() {
+		TimestampSoftDeleteCollectionOwner() {
 		}
 
-		SoftDeleteCollectionOwner(Long id) {
+		TimestampSoftDeleteCollectionOwner(Long id) {
+			this.id = id;
+		}
+
+		Set<String> getMobiles() {
+			return mobiles;
+		}
+	}
+
+	@Entity( name = "ActiveSoftDeleteCollectionOwner" )
+	@Table( name = "active_soft_delete_collection_owner" )
+	static class ActiveSoftDeleteCollectionOwner {
+		@Id
+		private Long id;
+
+		@ElementCollection
+		@CollectionTable( name = "active_soft_delete_collection_owner_mobile", joinColumns = @JoinColumn( name = "owner_id" ) )
+		@SoftDelete( strategy = SoftDeleteType.ACTIVE )
+		private Set<String> mobiles = new LinkedHashSet<>();
+
+		ActiveSoftDeleteCollectionOwner() {
+		}
+
+		ActiveSoftDeleteCollectionOwner(Long id) {
+			this.id = id;
+		}
+
+		Set<String> getMobiles() {
+			return mobiles;
+		}
+	}
+
+	@Entity( name = "DeletedSoftDeleteCollectionOwner" )
+	@Table( name = "deleted_soft_delete_collection_owner" )
+	static class DeletedSoftDeleteCollectionOwner {
+		@Id
+		private Long id;
+
+		@ElementCollection
+		@CollectionTable( name = "deleted_soft_delete_collection_owner_mobile", joinColumns = @JoinColumn( name = "owner_id" ) )
+		@SoftDelete( strategy = SoftDeleteType.DELETED )
+		private Set<String> mobiles = new LinkedHashSet<>();
+
+		DeletedSoftDeleteCollectionOwner() {
+		}
+
+		DeletedSoftDeleteCollectionOwner(Long id) {
 			this.id = id;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/softdelete/collections/SoftDeleteElementCollectionReaddTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/softdelete/collections/SoftDeleteElementCollectionReaddTest.java
@@ -9,7 +9,9 @@ import java.util.Set;
 
 import org.hibernate.annotations.SoftDelete;
 import org.hibernate.annotations.SoftDeleteType;
+import org.hibernate.mapping.Index;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
 import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -56,6 +58,12 @@ public class SoftDeleteElementCollectionReaddTest {
 			final TimestampSoftDeleteCollectionOwner owner = session.get( TimestampSoftDeleteCollectionOwner.class, 1L );
 			assertThat( owner.getMobiles() ).containsExactlyInAnyOrder( "1", "3" );
 		} );
+	}
+
+	@Test
+	void booleanSoftDeleteCollectionTablesUseUniqueIndexWithLiveRowExpression(DomainModelScope scope) {
+		assertLiveRowIndex( scope, ActiveSoftDeleteCollectionOwner.class, "active", "true" );
+		assertLiveRowIndex( scope, DeletedSoftDeleteCollectionOwner.class, "deleted", "false" );
 	}
 
 	@Test
@@ -120,6 +128,28 @@ public class SoftDeleteElementCollectionReaddTest {
 			final DeletedSoftDeleteCollectionOwner owner = session.get( DeletedSoftDeleteCollectionOwner.class, 1L );
 			assertThat( owner.getMobiles() ).containsExactly( "3" );
 		} );
+	}
+
+	private static void assertLiveRowIndex(
+			DomainModelScope scope,
+			Class<?> collectionOwner,
+			String softDeleteColumnName,
+			String liveRowLiteral) {
+		final org.hibernate.mapping.Table table = scope.getDomainModel()
+				.getCollectionBinding( collectionOwner.getName() + ".mobiles" )
+				.getCollectionTable();
+
+		assertThat( table.getUniqueKeys() ).isEmpty();
+		assertThat( table.getIndexes().values() )
+				.singleElement()
+				.satisfies( index -> assertLiveRowIndex( index, softDeleteColumnName, liveRowLiteral ) );
+	}
+
+	private static void assertLiveRowIndex(Index index, String softDeleteColumnName, String liveRowLiteral) {
+		assertThat( index.isUnique() ).isTrue();
+		assertThat( index.getSelectables() ).hasSize( 3 );
+		assertThat( index.getSelectables().get( 2 ).getText() )
+				.contains( "case when", softDeleteColumnName, liveRowLiteral );
 	}
 
 	@Entity( name = "SoftDeleteCollectionOwner" )


### PR DESCRIPTION
HHH-20585

For timestamp soft-delete element collection sets, the generated timestamp column remains part of the implicit set key. That frees the active `(owner, element, null)` slot after a row is marked deleted, so the same element can be added again without colliding with the historical timestamped row.

For boolean `ACTIVE` and `DELETED` soft-delete strategies, Hibernate now skips the implicit set primary/unique key for the collection table. A boolean indicator cannot distinguish multiple historical delete cycles for the same element, so a database key over `(owner, element, indicator)` can still collide when an element is added, removed, re-added, and removed again.

The regression test now covers:
- `TIMESTAMP`: re-adding a previously soft-deleted set entry
- `ACTIVE`: add/remove/re-add/remove of the same set entry
- `DELETED`: add/remove/re-add/remove of the same set entry

Checks:
- `./gradlew --no-daemon :hibernate-core:test --tests org.hibernate.orm.test.softdelete.collections.SoftDeleteElementCollectionReaddTest`
- `./gradlew --no-daemon :hibernate-core:test --tests 'org.hibernate.orm.test.softdelete.collections.*'`
- `git diff --check HEAD^ HEAD`

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20585 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20585
<!-- Hibernate GitHub Bot issue links end -->