### PR TITLE
Fix Panache 2 inherited entity metamodel accessors

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/io/quarkus/hibernate/panache/PanacheEntityMarker.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/io/quarkus/hibernate/panache/PanacheEntityMarker.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package io.quarkus.hibernate.panache;
+
+// Minimal test fixture for Quarkus Panache 2 detection.
+public interface PanacheEntityMarker {
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingRepositoryBase.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/io/quarkus/hibernate/panache/managed/blocking/PanacheManagedBlockingRepositoryBase.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package io.quarkus.hibernate.panache.managed.blocking;
+
+// Minimal test fixture for generated Quarkus Panache 2 repository types.
+public interface PanacheManagedBlockingRepositoryBase<Entity, Identifier> {
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryBase.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/io/quarkus/hibernate/panache/stateless/blocking/PanacheStatelessBlockingRepositoryBase.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package io.quarkus.hibernate.panache.stateless.blocking;
+
+// Minimal test fixture for generated Quarkus Panache 2 repository types.
+public interface PanacheStatelessBlockingRepositoryBase<Entity, Identifier> {
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/quarkus/Panache2Child.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/quarkus/Panache2Child.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.quarkus;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Panache2Child extends Panache2Parent {
+	public String childName;
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/quarkus/Panache2Parent.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/quarkus/Panache2Parent.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.quarkus;
+
+import io.quarkus.hibernate.panache.PanacheEntityMarker;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+
+@Entity
+@Inheritance
+public class Panache2Parent implements PanacheEntityMarker {
+	@Id
+	public Long id;
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/quarkus/QuarkusOrmPanacheTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/quarkus/QuarkusOrmPanacheTest.java
@@ -57,4 +57,19 @@ class QuarkusOrmPanacheTest {
 		Assertions.assertNotNull( constructor );
 		Assertions.assertTrue( constructor.isAnnotationPresent( Inject.class ) );
 	}
+
+	@Test
+	@WithClasses({ Panache2Parent.class, Panache2Child.class })
+	void testPanache2InheritedEntityMetamodel() throws Exception {
+		Class<?> parentMetamodel = getMetamodelClassFor( Panache2Parent.class );
+		Class<?> childMetamodel = getMetamodelClassFor( Panache2Child.class );
+
+		Assertions.assertEquals( parentMetamodel.getName(), childMetamodel.getSuperclass().getName() );
+		Assertions.assertNotNull( parentMetamodel.getDeclaredMethod( "managedBlocking" ) );
+		Assertions.assertNotNull( parentMetamodel.getDeclaredMethod( "statelessBlocking" ) );
+		Assertions.assertThrows( NoSuchMethodException.class,
+				() -> childMetamodel.getDeclaredMethod( "managedBlocking" ) );
+		Assertions.assertThrows( NoSuchMethodException.class,
+				() -> childMetamodel.getDeclaredMethod( "statelessBlocking" ) );
+	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -683,7 +683,11 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 				}
 			}
 		}
-		if ( quarkusInjection ) {
+		// Entity metamodels in an inheritance hierarchy extend the parent metamodel.
+		// Panache 2 default repository accessors have fixed names, but their generated
+		// repository return types are entity-specific, so emitting them on subclasses
+		// would produce invalid static method hiding.
+		if ( quarkusInjection && !hasPanache2EntitySuperType() ) {
 			// FIXME: perhaps import id type?
 			final var idType = findIdType();
 			addAccessors( managedBlockingRepository, idType, "managedBlocking",
@@ -698,6 +702,13 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						PANACHE2_STATELESS_REACTIVE_REPOSITORY_BASE, nestedRepositories );
 			}
 		}
+	}
+
+	private boolean hasPanache2EntitySuperType() {
+		final var superTypeElement = getSuperTypeElement();
+		return superTypeElement instanceof TypeElement superType
+			&& hasAnnotation( superType, ENTITY )
+			&& isPanache2Type( superType );
 	}
 
 	private boolean addRepositoryAccessor(


### PR DESCRIPTION
Fixes the generated Panache 2 static metamodel for entity inheritance hierarchies.

When a Panache 2 entity extends another Panache 2 entity, the generated subclass metamodel extends the parent metamodel. Emitting default `managedBlocking()` and `statelessBlocking()` accessors on both classes creates illegal static method hiding because the per-entity generated repository return types are not covariant.

This skips default Panache 2 repository accessors on inherited entity metamodels, leaving the inherited parent accessors in place and still allowing user-named nested repository accessors.

Added a regression test that reproduces the compilation failure reported in quarkusio/quarkus#54961.

Testing:
- `./gradlew :hibernate-processor:jakartaDataTest --tests org.hibernate.processor.test.data.quarkus.QuarkusOrmPanacheTest`
- `./gradlew :hibernate-processor:jakartaDataTest`
