### PR TITLE
HHH-20524 Fix dynamic update dirty attribute resolution

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2469,6 +2469,16 @@ public abstract class AbstractEntityPersister
 			&& ( currentAttributeName.length() == nameLength || currentAttributeName.charAt(nameLength) == '.' );
 	}
 
+	private static int nextAttributeNameIndex(
+			final AttributeMapping attributeMapping,
+			final String[] attributeNames,
+			int index) {
+		while ( index < attributeNames.length && isPrefix( attributeMapping, attributeNames[index] ) ) {
+			index++;
+		}
+		return index;
+	}
+
 	@Override
 	public int[] resolveAttributeIndexes(String[] attributeNames) {
 		if ( attributeNames == null || attributeNames.length == 0 ) {
@@ -2484,19 +2494,8 @@ public abstract class AbstractEntityPersister
 			final var attributeMapping = attributeMappings.get( i );
 			if ( isPrefix( attributeMapping, attributeNames[index] ) ) {
 				fields.add( attributeMapping.getStateArrayPosition() );
-				index++;
-				if ( index < attributeNames.length ) {
-					// Skip duplicates
-					do {
-						if ( attributeNames[index].equals( attributeMapping.getAttributeName() ) ) {
-							index++;
-						}
-						else {
-							break;
-						}
-					} while ( index < attributeNames.length );
-				}
-				else {
+				index = nextAttributeNameIndex( attributeMapping, attributeNames, index + 1 );
+				if ( index >= attributeNames.length ) {
 					break;
 				}
 			}
@@ -2566,19 +2565,8 @@ public abstract class AbstractEntityPersister
 						if ( propertyUpdateability[position] && !fields.contains( position ) ) {
 							fields.add( position );
 						}
-						index++;
-						if ( index < attributeNames.length ) {
-							// Skip duplicates
-							do {
-								if ( attributeNames[index].equals( attributeName ) ) {
-									index++;
-								}
-								else {
-									break;
-								}
-							} while ( index < attributeNames.length );
-						}
-						else {
+						index = nextAttributeNameIndex( attributeMapping, attributeNames, index + 1 );
+						if ( index >= attributeNames.length ) {
 							break;
 						}
 					}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/NestedEmbeddableDynamicUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/NestedEmbeddableDynamicUpdateTest.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.bytecode.internal.BytecodeProviderInitiator;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Environment;
+
+import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+@DomainModel(
+		annotatedClasses = NestedEmbeddableDynamicUpdateTest.Account.class
+)
+@SessionFactory
+@BytecodeEnhanced
+@CustomEnhancementContext({ NoDirtyCheckEnhancementContext.class, DirtyCheckEnhancementContext.class })
+public class NestedEmbeddableDynamicUpdateTest {
+	@BeforeAll
+	static void beforeAll() {
+		String byteCodeProvider = Environment.getProperties().getProperty( AvailableSettings.BYTECODE_PROVIDER );
+		assumeFalse( byteCodeProvider != null && !BytecodeProviderInitiator.BYTECODE_PROVIDER_NAME_BYTEBUDDY.equals(
+				byteCodeProvider ) );
+	}
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Account account = new Account();
+			account.setId( 1L );
+			account.setAaa( "aaa" );
+			account.setZzz( "zzz" );
+			account.setCoords( new Coords( "label", new Inner( "note" ) ) );
+			session.persist( account );
+		} );
+	}
+
+	@Test
+	public void nestedEmbeddableDirtyNameDoesNotHideLaterDirtyScalar(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Account account = session.find( Account.class, 1L );
+			account.setAaa( "aaa updated" );
+			account.getCoords().setLabel( "label updated" );
+			account.getCoords().getInner().setNote( "note updated" );
+			account.setZzz( "zzz updated" );
+		} );
+
+		scope.inTransaction( session -> {
+			final Account account = session.find( Account.class, 1L );
+			assertThat( account.getAaa(), is( "aaa updated" ) );
+			assertThat( account.getCoords().getLabel(), is( "label updated" ) );
+			assertThat( account.getCoords().getInner().getNote(), is( "note updated" ) );
+			assertThat( account.getZzz(), is( "zzz updated" ) );
+		} );
+	}
+
+	@Entity(name = "Account")
+	@Table(name = "account")
+	@DynamicUpdate
+	public static class Account {
+		@Id
+		private Long id;
+
+		private String aaa;
+
+		@Embedded
+		private Coords coords;
+
+		private String zzz;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getAaa() {
+			return aaa;
+		}
+
+		public void setAaa(String aaa) {
+			this.aaa = aaa;
+		}
+
+		public Coords getCoords() {
+			return coords;
+		}
+
+		public void setCoords(Coords coords) {
+			this.coords = coords;
+		}
+
+		public String getZzz() {
+			return zzz;
+		}
+
+		public void setZzz(String zzz) {
+			this.zzz = zzz;
+		}
+	}
+
+	@Embeddable
+	public static class Coords {
+		private String label;
+
+		@Embedded
+		private Inner inner;
+
+		public Coords() {
+		}
+
+		public Coords(String label, Inner inner) {
+			this.label = label;
+			this.inner = inner;
+		}
+
+		public String getLabel() {
+			return label;
+		}
+
+		public void setLabel(String label) {
+			this.label = label;
+		}
+
+		public Inner getInner() {
+			return inner;
+		}
+
+		public void setInner(Inner inner) {
+			this.inner = inner;
+		}
+	}
+
+	@Embeddable
+	public static class Inner {
+		private String note;
+
+		public Inner() {
+		}
+
+		public Inner(String note) {
+			this.note = note;
+		}
+
+		public String getNote() {
+			return note;
+		}
+
+		public void setNote(String note) {
+			this.note = note;
+		}
+	}
+}


### PR DESCRIPTION
HHH-20524

`AbstractEntityPersister#resolveDirtyAttributeIndexes` sorted dirty names and attribute mappings together, but after matching an embeddable it only skipped an exact duplicate of the embeddable name. With inline dirty tracking, a nested embeddable change can report both the embeddable name and a dotted nested path such as `coords` and `coords.inner`. That left the dirty-name pointer on the nested path after the `coords` mapping was consumed, so updateable attributes that sort after the nested path could be missed and omitted from an `@DynamicUpdate` statement.

This updates the sorted traversal to consume every dirty name represented by the matched attribute mapping before continuing. The same helper is used by `resolveAttributeIndexes` so nested names do not hide later attributes there either.

Added bytecode-enhanced regression coverage for inline dirty tracking + `@DynamicUpdate` + a nested embeddable + a dirty scalar that sorts after the nested path.

Checks:
- `./gradlew --no-daemon :hibernate-core:test --tests org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.NestedEmbeddableDynamicUpdateTest` (failed before the fix; passes after)
- `./gradlew --no-daemon :hibernate-core:test --tests org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.NestedEmbeddableDynamicUpdateTest --tests org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.SimpleDynamicUpdateTest`
- `git diff --check HEAD^ HEAD`

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20524 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20524
<!-- Hibernate GitHub Bot issue links end -->