### PR TITLE
Do not copy fonts into Javadoc jars

### DIFF
--- a/local-build-plugins/src/main/groovy/local.javadoc.gradle
+++ b/local-build-plugins/src/main/groovy/local.javadoc.gradle
@@ -67,6 +67,7 @@ tasks.withType(Javadoc).configureEach {
         quiet()
 
         addBooleanOption('Xdoclint:all,-missing', true)
+        addBooleanOption('-no-fonts', true)
         // uncomment the `Werror` to get a bit more failures ;)
         // addBooleanOption('Werror', true)
 


### PR DESCRIPTION
we are using a custom theme that links to specific fonts we need so built-in fonts just take space for no good reason

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
