### PR TITLE
HHH-6686 JPQL operator "is empty" fails for @ElementCollection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlParser.java
@@ -348,9 +348,8 @@ public final class HqlParser extends HqlBaseParser {
 		AST ast = ASTUtil.createParent( astFactory, RANGE, "RANGE", node );
 		ast = ASTUtil.createParent( astFactory, FROM, "from", ast );
 
-		AST alias = ASTUtil.createSibling( astFactory, ALIAS, "_", node );
-		ASTUtil.insertChild( ASTUtil.createSibling( astFactory, SELECT, "select", ast ), astFactory.create(IDENT, alias.getText() ) );
-		
+		ASTUtil.insertChild( ASTUtil.createSibling( astFactory, SELECT, "select", ast ), astFactory.create( NUM_INT, "1" ) );
+
 		ast = ASTUtil.createParent( astFactory, SELECT_FROM, "SELECT_FROM", ast );
 		ast = ASTUtil.createParent( astFactory, QUERY, "QUERY", ast );
 		return ast;

--- a/hibernate-core/src/test/java/org/hibernate/query/IsEmptyWithManyToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/IsEmptyWithManyToManyTest.java
@@ -1,0 +1,172 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.query;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+
+public class IsEmptyWithManyToManyTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+			Project.class,
+			Developer.class
+		};
+	}
+
+	@Before
+	public void setUp() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Developer dev1 = new Developer();
+			dev1.companyId = "CMP1";
+			dev1.developerId = 1001L;
+			dev1.name = "John Doe";
+			entityManager.persist( dev1 );
+
+			Project emptyProject = new Project();
+			emptyProject.orgId = "ORG1";
+			emptyProject.projectId = 2001L;
+			emptyProject.title = "Empty Project";
+			entityManager.persist( emptyProject );
+
+			Project projectWithDev = new Project();
+			projectWithDev.orgId = "ORG1";
+			projectWithDev.projectId = 2002L;
+			projectWithDev.title = "Project With Developer";
+			projectWithDev.developers.add( dev1 );
+			entityManager.persist( projectWithDev );
+		});
+	}
+
+	@Test
+	public void testIsEmptyWithManyToMany() {
+		List<Project> projectsWithDevelopers = doInJPA( this::entityManagerFactory, entityManager -> {
+			return entityManager.createQuery(
+					"select p from Project p where p.developers is not empty", Project.class )
+					.getResultList();
+		});
+
+		assertEquals( 1, projectsWithDevelopers.size() );
+
+		List<Project> projectsWithoutDevelopers = doInJPA( this::entityManagerFactory, entityManager -> {
+			return entityManager.createQuery(
+					"select p from Project p where p.developers is empty", Project.class )
+					.getResultList();
+		});
+
+		assertEquals( 1, projectsWithoutDevelopers.size() );
+	}
+
+	@Entity(name = "Project")
+	@IdClass(ProjectId.class)
+	public static class Project {
+
+		@Id
+		private String orgId;
+
+		@Id
+		private Long projectId;
+
+		private String title;
+
+		@ManyToMany
+		private final List<Developer> developers = new ArrayList<>();
+	}
+
+	public static class ProjectId implements Serializable {
+		private String orgId;
+		private Long projectId;
+
+		public ProjectId() {
+		}
+
+		public ProjectId(String orgId, Long projectId) {
+			this.orgId = orgId;
+			this.projectId = projectId;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			ProjectId that = (ProjectId) o;
+
+			return Objects.equals(orgId, that.orgId) && Objects.equals(projectId, that.projectId);
+		}
+
+		@Override
+		public int hashCode() {
+            return Objects.hash( orgId, projectId );
+		}
+	}
+
+	@Entity(name = "Developer")
+	@IdClass(DeveloperId.class)
+	public static class Developer {
+
+		@Id
+		private String companyId;
+
+		@Id
+		private Long developerId;
+
+		private String name;
+	}
+
+	public static class DeveloperId implements Serializable {
+		private String companyId;
+		private Long developerId;
+
+		public DeveloperId() {
+		}
+
+		public DeveloperId(String companyId, Long developerId) {
+			this.companyId = companyId;
+			this.developerId = developerId;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			DeveloperId that = (DeveloperId) o;
+
+			return Objects.equals(companyId, that.companyId) && Objects.equals(developerId, that.developerId);
+		}
+
+		@Override
+		public int hashCode() {
+            return Objects.hash( companyId, developerId );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/EJBQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/EJBQLTest.java
@@ -99,14 +99,11 @@ public class EJBQLTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	public void testIsEmpty() throws Exception {
-		//String hql = "from Animal a where not exists (from a.offspring)";
-		String hql = "from Animal a where not exists elements(a.offspring)";
+		String hql = "from Animal a where not exists (select 1 from a.offspring)";
 		String ejbql = "select object(a) from Animal a where a.offspring is empty";
-		//parse(hql);
-		//parse(ejbql);
 		assertEjbqlEqualsHql(ejbql, hql);
 
-		hql = "from Animal a where exists (from a.mother.father.offspring)";
+		hql = "from Animal a where exists (select 1 from a.mother.father.offspring)";
 		ejbql = "select object(a) from Animal a where a.mother.father.offspring is not empty";
 		assertEjbqlEqualsHql( ejbql, hql );
 	}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Alternative fix for https://hibernate.atlassian.net/browse/HHH-6686 which should work regardless of composite keys.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-6686 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->