### PR TITLE
HHH-20538 Backport Altibase dialect fixes to 7.4

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/AltibaseDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/AltibaseDialect.java
@@ -5,6 +5,8 @@
 package org.hibernate.community.dialect;
 
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.community.dialect.pagination.AltibaseLimitHandler;
@@ -17,10 +19,15 @@ import org.hibernate.dialect.DmlTargetColumnQualifierSupport;
 import org.hibernate.dialect.NationalizationSupport;
 import org.hibernate.dialect.NullOrdering;
 import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.RowLockStrategy;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.function.OracleTruncFunction;
-import org.hibernate.dialect.lock.internal.LockingSupportSimple;
+import org.hibernate.dialect.function.TrimFunction;
+import org.hibernate.dialect.lock.PessimisticLockStyle;
+import org.hibernate.dialect.lock.internal.LockingSupportParameterized;
+import org.hibernate.dialect.lock.spi.LockTimeoutType;
 import org.hibernate.dialect.lock.spi.LockingSupport;
+import org.hibernate.dialect.lock.spi.OuterJoinLockingType;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.sequence.SequenceSupport;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
@@ -29,6 +36,7 @@ import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
 import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.ConstraintViolationException.ConstraintKind;
 import org.hibernate.exception.LockTimeoutException;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.internal.util.JdbcExceptionHelper;
@@ -36,9 +44,11 @@ import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TrimSpec;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.query.sqm.produce.function.FunctionParameterType;
 import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
 import org.hibernate.service.ServiceRegistry;
+import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SqlAppender;
@@ -46,9 +56,15 @@ import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JsonJdbcType;
+import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.descriptor.sql.internal.CapacityDependentDdlType;
+import org.hibernate.type.descriptor.sql.internal.DdlTypeImpl;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -58,6 +74,8 @@ import java.sql.Types;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.hibernate.type.SqlTypes.BINARY;
 import static org.hibernate.type.SqlTypes.BIT;
@@ -67,6 +85,7 @@ import static org.hibernate.type.SqlTypes.FLOAT;
 import static org.hibernate.type.SqlTypes.LONGVARBINARY;
 import static org.hibernate.type.SqlTypes.LONGVARCHAR;
 import static org.hibernate.type.SqlTypes.NCLOB;
+import static org.hibernate.type.SqlTypes.JSON;
 import static org.hibernate.type.SqlTypes.TIME;
 import static org.hibernate.type.SqlTypes.TIMESTAMP;
 import static org.hibernate.type.SqlTypes.TIMESTAMP_WITH_TIMEZONE;
@@ -85,6 +104,20 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithM
 public class AltibaseDialect extends Dialect {
 
 	private static final DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 7, 1 );
+	// Altibase's IN-list limit is around 1,020 elements; use 1,000 to stay below
+	// that limit and avoid "Calculation stack overflow" during prepare.
+	private static final int IN_LIST_SIZE_LIMIT = 1000;
+	private static final Pattern CHECK_CONSTRAINT_NAME_PATTERN = Pattern.compile( "Check constraint (.+) violated" );
+	private static final Pattern FOR_CONSTRAINT_NAME_PATTERN = Pattern.compile( ".*\\sfor\\s+([^.]+)\\.?" );
+	private static final Pattern COLON_CONSTRAINT_NAME_PATTERN = Pattern.compile( ".*:\\s*(.+)" );
+	private static final LockingSupport LOCKING_SUPPORT = new LockingSupportParameterized(
+			PessimisticLockStyle.CLAUSE,
+			RowLockStrategy.NONE,
+			true,
+			true,
+			false,
+			OuterJoinLockingType.UNSUPPORTED
+	);
 
 	@SuppressWarnings("unused")
 	public AltibaseDialect() {
@@ -131,6 +164,34 @@ public class AltibaseDialect extends Dialect {
 						.withTypeCapacity( 64000, columnType( BIT ) )
 						.build()
 		);
+		if ( supportsNativeJsonType() ) {
+			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "json", this ) );
+		}
+	}
+
+	@Override
+	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+		super.contributeTypes( typeContributions, serviceRegistry );
+		if ( supportsNativeJsonType() ) {
+			typeContributions.contributeJdbcType( JsonJdbcType.INSTANCE );
+		}
+	}
+
+	private boolean supportsNativeJsonType() {
+		return getVersion().isSameOrAfter( 8, 1 );
+	}
+
+	@Override
+	public JdbcType resolveSqlTypeDescriptor(
+			String columnTypeName,
+			int jdbcTypeCode,
+			int precision,
+			int scale,
+			JdbcTypeRegistry jdbcTypeRegistry) {
+		if ( supportsNativeJsonType() && "json".equalsIgnoreCase( columnTypeName ) ) {
+			return jdbcTypeRegistry.getDescriptor( JSON );
+		}
+		return super.resolveSqlTypeDescriptor( columnTypeName, jdbcTypeCode, precision, scale, jdbcTypeRegistry );
 	}
 
 	@Override
@@ -179,16 +240,14 @@ public class AltibaseDialect extends Dialect {
 		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.ceiling_ceil();
 		functionFactory.trim2();
+		functionContributions.getFunctionRegistry().register(
+				"trim",
+				new TrimFunction( this, typeConfiguration, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+		);
 		functionFactory.stddev();
 		functionFactory.variance();
 		functionFactory.char_chr();
-		functionFactory.concat_pipeOperator();
-		functionFactory.coalesce();
 		functionFactory.initcap();
-		functionFactory.repeat_rpad();
-
-		functionFactory.radians_acos();
-		functionFactory.degrees_acos();
 
 		functionFactory.ascii();
 		functionFactory.toCharNumberDateTimestamp();
@@ -200,10 +259,7 @@ public class AltibaseDialect extends Dialect {
 		functionFactory.cosh();
 		functionFactory.sinh();
 		functionFactory.tanh();
-		functionFactory.log();
 		functionFactory.log10_log();
-		functionFactory.substring_substr();
-		functionFactory.leftRight_substr();
 		functionFactory.translate();
 		functionFactory.addMonths();
 		functionFactory.listagg( null );
@@ -229,6 +285,176 @@ public class AltibaseDialect extends Dialect {
 							.setArgumentTypeResolver( StandardFunctionArgumentTypeResolvers.ARGUMENT_OR_IMPLIED_RESULT_TYPE )
 							.register();
 		functionFactory.regexpLike_predicateFunction();
+		registerNoPlainParameterFunctions( functionContributions, typeConfiguration );
+	}
+
+	private static void registerNoPlainParameterFunctions(
+			FunctionContributions functionContributions,
+			TypeConfiguration typeConfiguration) {
+		// Keep Altibase's host-variable workaround local to the dialect for the 7.4 backport.
+		final SqmFunctionRegistry functionRegistry = functionContributions.getFunctionRegistry();
+		final BasicTypeRegistry basicTypeRegistry = typeConfiguration.getBasicTypeRegistry();
+		final BasicType<String> stringType = basicTypeRegistry.resolve( StandardBasicTypes.STRING );
+		final BasicType<Integer> integerType = basicTypeRegistry.resolve( StandardBasicTypes.INTEGER );
+		final BasicType<Double> doubleType = basicTypeRegistry.resolve( StandardBasicTypes.DOUBLE );
+
+		functionRegistry.patternDescriptorBuilder( "concat", "(?1||?2...)" )
+				.setInvariantType( stringType )
+				.setMinArgumentCount( 1 )
+				.setArgumentTypeResolver(
+						StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+								typeConfiguration,
+								FunctionParameterType.STRING
+						)
+				)
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.setArgumentListSignature( "(STRING string0[, STRING string1[, ...]])" )
+				.register();
+
+		functionRegistry.namedDescriptorBuilder( "coalesce" )
+				.setMinArgumentCount( 1 )
+				.setArgumentTypeResolver( StandardFunctionArgumentTypeResolvers.ARGUMENT_OR_IMPLIED_RESULT_TYPE )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
+		functionRegistry.namedDescriptorBuilder( "nullif" )
+				.setExactArgumentCount( 2 )
+				.setArgumentTypeResolver( StandardFunctionArgumentTypeResolvers.ARGUMENT_OR_IMPLIED_RESULT_TYPE )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
+		functionRegistry.namedDescriptorBuilder( "character_length" )
+				.setInvariantType( integerType )
+				.setExactArgumentCount( 1 )
+				.setParameterTypes( FunctionParameterType.STRING_OR_CLOB )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
+		functionRegistry.registerAlternateKey( "length", "character_length" );
+
+		functionRegistry.namedDescriptorBuilder( "substring", "substr" )
+				.setArgumentListSignature( "(STRING string{ from|,} INTEGER start[{ for|,} INTEGER length])" )
+				.setInvariantType( stringType )
+				.setArgumentCountBetween( 2, 3 )
+				.setParameterTypes(
+						FunctionParameterType.STRING,
+						FunctionParameterType.INTEGER,
+						FunctionParameterType.INTEGER
+				)
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
+		functionRegistry.patternDescriptorBuilder( "repeat", "rpad(?1,?2*length(?1),?1)" )
+				.setInvariantType( stringType )
+				.setExactArgumentCount( 2 )
+				.setParameterTypes( FunctionParameterType.STRING, FunctionParameterType.INTEGER )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.setArgumentListSignature( "(STRING string, INTEGER times)" )
+				.register();
+
+		functionRegistry.namedDescriptorBuilder( "lpad" )
+				.setInvariantType( stringType )
+				.setArgumentCountBetween( 2, 3 )
+				.setParameterTypes(
+						FunctionParameterType.STRING,
+						FunctionParameterType.INTEGER,
+						FunctionParameterType.STRING
+				)
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.setArgumentListSignature( "(STRING string, INTEGER length[, STRING padding])" )
+				.register();
+
+		functionRegistry.namedDescriptorBuilder( "rpad" )
+				.setInvariantType( stringType )
+				.setArgumentCountBetween( 2, 3 )
+				.setParameterTypes(
+						FunctionParameterType.STRING,
+						FunctionParameterType.INTEGER,
+						FunctionParameterType.STRING
+				)
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.setArgumentListSignature( "(STRING string, INTEGER length[, STRING padding])" )
+				.register();
+
+		functionRegistry.patternDescriptorBuilder( "left", "substr(?1,1,?2)" )
+				.setInvariantType( stringType )
+				.setExactArgumentCount( 2 )
+				.setParameterTypes( FunctionParameterType.STRING, FunctionParameterType.INTEGER )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.setArgumentListSignature( "(STRING string, INTEGER length)" )
+				.register();
+
+		functionRegistry.patternDescriptorBuilder( "right", "substr(?1,-?2)" )
+				.setInvariantType( stringType )
+				.setExactArgumentCount( 2 )
+				.setParameterTypes( FunctionParameterType.STRING, FunctionParameterType.INTEGER )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.setArgumentListSignature( "(STRING string, INTEGER length)" )
+				.register();
+
+		functionRegistry.namedDescriptorBuilder( "replace" )
+				.setInvariantType( stringType )
+				.setExactArgumentCount( 3 )
+				.setParameterTypes(
+						FunctionParameterType.STRING,
+						FunctionParameterType.STRING,
+						FunctionParameterType.STRING
+				)
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.setArgumentListSignature( "(STRING string, STRING pattern, STRING replacement)" )
+				.register();
+
+		functionRegistry.namedDescriptorBuilder( "log" )
+				.setArgumentCountBetween( 1, 2 )
+				.setParameterTypes( FunctionParameterType.NUMERIC, FunctionParameterType.NUMERIC )
+				.setInvariantType( doubleType )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
+		functionRegistry.namedDescriptorBuilder( "power" )
+				.setExactArgumentCount( 2 )
+				.setParameterTypes( FunctionParameterType.NUMERIC, FunctionParameterType.NUMERIC )
+				.setInvariantType( doubleType )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
+		functionRegistry.patternDescriptorBuilder( "hex", "to_char(?1)" )
+				.setExactArgumentCount( 1 )
+				.setParameterTypes( FunctionParameterType.BINARY )
+				.setInvariantType( stringType )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
+		functionRegistry.patternDescriptorBuilder( "radians", "(?1*acos(-1)/180)" )
+				.setInvariantType( doubleType )
+				.setExactArgumentCount( 1 )
+				.setParameterTypes( FunctionParameterType.NUMERIC )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
+		functionRegistry.patternDescriptorBuilder( "degrees", "(?1/acos(-1)*180)" )
+				.setInvariantType( doubleType )
+				.setExactArgumentCount( 1 )
+				.setParameterTypes( FunctionParameterType.NUMERIC )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
+		for ( String functionName : new String[] { "sin", "cos", "tan", "asin", "acos", "atan" } ) {
+			functionRegistry.namedDescriptorBuilder( functionName )
+					.setInvariantType( doubleType )
+					.setExactArgumentCount( 1 )
+					.setParameterTypes( FunctionParameterType.NUMERIC )
+					.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+					.register();
+		}
+
+		functionRegistry.namedDescriptorBuilder( "atan2" )
+				.setInvariantType( doubleType )
+				.setExactArgumentCount( 2 )
+				.setParameterTypes( FunctionParameterType.NUMERIC, FunctionParameterType.NUMERIC )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
+				.register();
+
 	}
 
 	@Override
@@ -328,7 +554,6 @@ public class AltibaseDialect extends Dialect {
 
 	@Override
 	public void appendBinaryLiteral(SqlAppender appender, byte[] bytes) {
-
 		appender.appendSql( "VARBYTE'" );
 		PrimitiveByteArrayJavaType.INSTANCE.appendString( appender, bytes );
 		appender.appendSql( '\'' );
@@ -544,7 +769,52 @@ public class AltibaseDialect extends Dialect {
 
 	@Override
 	public LockingSupport getLockingSupport() {
-		return LockingSupportSimple.NO_OUTER_JOIN;
+		return LOCKING_SUPPORT;
+	}
+
+	@Override
+	public String getForUpdateNowaitString() {
+		return getForUpdateString() + " nowait";
+	}
+
+	@Override
+	public String getForUpdateNowaitString(String aliases) {
+		return getForUpdateString( aliases ) + " nowait";
+	}
+
+	@Override
+	public String getForUpdateString(Timeout timeout) {
+		return withLockTimeout( getForUpdateString(), timeout );
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return withLockTimeout( getForUpdateString(), timeout );
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		return withLockTimeout( getForUpdateString( aliases ), timeout );
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return getWriteLockString( timeout );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
+		return getWriteLockString( aliases, timeout );
+	}
+
+	private String withLockTimeout(String lockString, Timeout timeout) {
+		return switch ( timeout.milliseconds() ) {
+			case Timeouts.NO_WAIT_MILLI -> LOCKING_SUPPORT.getMetadata().getLockTimeoutType( timeout ) == LockTimeoutType.QUERY
+					? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI, Timeouts.WAIT_FOREVER_MILLI -> lockString;
+			default -> LOCKING_SUPPORT.getMetadata().getLockTimeoutType( timeout ) == LockTimeoutType.QUERY
+					? lockString + " wait " + Timeouts.getTimeoutInSeconds( timeout ) : lockString;
+		};
 	}
 
 	@Override
@@ -608,6 +878,11 @@ public class AltibaseDialect extends Dialect {
 	}
 
 	@Override
+	public int getInExpressionCountLimit() {
+		return IN_LIST_SIZE_LIMIT;
+	}
+
+	@Override
 	public boolean supportsWindowFunctions() {
 		return true;
 	}
@@ -649,25 +924,75 @@ public class AltibaseDialect extends Dialect {
 			switch ( JdbcExceptionHelper.extractErrorCode( sqlException ) ) {
 				case 334393:       // response timeout
 				case 4164:         // query timeout
+				case 69749:        // lock timeout
 					return new LockTimeoutException(message, sqlException, sql );
+				case 334421:       // row already exists in a unique index
 				case 69720:        // unique constraint violated
-					constraintName = getViolatedConstraintNameExtractor().extractConstraintName( sqlException );
+					constraintName = extractConstraintName( sqlException );
 					return new ConstraintViolationException(
 							message,
 							sqlException,
 							sql,
-							ConstraintViolationException.ConstraintKind.UNIQUE,
+							ConstraintKind.UNIQUE,
 							constraintName
 					);
 				case 200820:        // Cannot insert NULL or update to NULL
+					constraintName = extractConstraintName( sqlException );
+					return new ConstraintViolationException(
+							message,
+							sqlException,
+							sql,
+							ConstraintKind.NOT_NULL,
+							constraintName
+					);
 				case 200823:        // foreign key constraint violation
 				case 200822: 	    // failed on update or delete by foreign key constraint violation
-					constraintName = getViolatedConstraintNameExtractor().extractConstraintName( sqlException );
-					return new ConstraintViolationException( message, sqlException, sql, constraintName );
+					constraintName = extractConstraintName( sqlException );
+					return new ConstraintViolationException(
+							message,
+							sqlException,
+							sql,
+							ConstraintKind.FOREIGN_KEY,
+							constraintName
+					);
+				case 201618:        // check constraint violation
+					constraintName = extractConstraintName( sqlException );
+					return new ConstraintViolationException(
+							message,
+							sqlException,
+							sql,
+							ConstraintKind.CHECK,
+							constraintName
+					);
 				default:
 					return null;
 			}
 		};
+	}
+
+	private static String extractConstraintName(SQLException sqlException) {
+		final String sqlExceptionMessage = sqlException.getMessage();
+		if ( sqlExceptionMessage == null ) {
+			return null;
+		}
+		final String checkConstraintName = extractConstraintName( sqlExceptionMessage, CHECK_CONSTRAINT_NAME_PATTERN );
+		if ( checkConstraintName != null ) {
+			return checkConstraintName;
+		}
+		final String forConstraintName = extractConstraintName( sqlExceptionMessage, FOR_CONSTRAINT_NAME_PATTERN );
+		if ( forConstraintName != null ) {
+			return forConstraintName;
+		}
+		return extractConstraintName( sqlExceptionMessage, COLON_CONSTRAINT_NAME_PATTERN );
+	}
+
+	private static String extractConstraintName(String sqlExceptionMessage, Pattern pattern) {
+		final Matcher matcher = pattern.matcher( sqlExceptionMessage );
+		if ( !matcher.matches() ) {
+			return null;
+		}
+		final String constraintName = matcher.group( 1 ).trim();
+		return constraintName.isEmpty() ? null : constraintName;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/AltibaseSqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/AltibaseSqlAstTranslator.java
@@ -4,22 +4,44 @@
  */
 package org.hibernate.community.dialect;
 
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.hibernate.Locking;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.generator.internal.CurrentTimestampGeneration;
 import org.hibernate.internal.util.collections.Stack;
+import org.hibernate.metamodel.mapping.EntityVersionMapping;
+import org.hibernate.query.IllegalQueryOperationException;
 import org.hibernate.query.sqm.ComparisonOperator;
 import org.hibernate.query.common.FrameExclusion;
 import org.hibernate.query.common.FrameKind;
 import org.hibernate.sql.ast.Clause;
+import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.LockingClauseStrategy;
 import org.hibernate.sql.ast.tree.Statement;
+import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
 import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
+import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
+import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
+import org.hibernate.sql.ast.tree.expression.CastTarget;
+import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.FunctionExpression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.Over;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.SqlTupleContainer;
 import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
@@ -28,9 +50,13 @@ import org.hibernate.sql.ast.tree.insert.InsertSelectStatement;
 import org.hibernate.sql.ast.tree.predicate.Predicate;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
+import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.ast.tree.update.Assignment;
 import org.hibernate.sql.ast.tree.update.UpdateStatement;
+import org.hibernate.sql.exec.internal.VersionTypeSeedParameterSpecification;
 import org.hibernate.sql.exec.spi.JdbcOperation;
+import org.hibernate.type.descriptor.java.ClockHelper;
+import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
 
 /**
  * A SQL AST translator for Altibase.
@@ -38,6 +64,11 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
  * @author Geoffrey Park
  */
 public class AltibaseSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAstTranslator<T> {
+
+	// Tracks INSERT SELECT/VALUES source rendering so values like SELECT ?/version seed can be inlined.
+	private boolean renderingInsertSelectSource;
+	// Tracks SELECT-list expression rendering so CASE result parameters can be rendered Altibase-compatibly.
+	private boolean renderingSelectExpression;
 
 	public AltibaseSqlAstTranslator(SessionFactoryImplementor sessionFactory, Statement statement) {
 		super( sessionFactory, statement );
@@ -53,8 +84,129 @@ public class AltibaseSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 
 	@Override
 	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
-		// Altibase does not support is distinct from clause. So override renderComparion() and use not exists
-		renderComparisonEmulateIntersect( lhs, operator, rhs );
+		if ( operator == ComparisonOperator.DISTINCT_FROM || operator == ComparisonOperator.NOT_DISTINCT_FROM ) {
+			// Emulate null-safe comparisons directly; DISTINCT FROM needs explicit null-mismatch predicates.
+			final SqlTuple lhsTuple = SqlTupleContainer.getSqlTuple( lhs );
+			final SqlTuple rhsTuple = SqlTupleContainer.getSqlTuple( rhs );
+			if ( lhsTuple != null && rhsTuple != null ) {
+				renderDistinctFromPredicate( lhsTuple.getExpressions(), operator, rhsTuple.getExpressions() );
+			}
+			else {
+				renderDistinctFromPredicate( List.of( lhs ), operator, List.of( rhs ) );
+			}
+			return;
+		}
+		if ( renderCastedScalarSubqueryComparison( lhs, operator, rhs ) ) {
+			return;
+		}
+		lhs.accept( this );
+		appendSql( operator.sqlText() );
+		rhs.accept( this );
+	}
+
+	private boolean renderCastedScalarSubqueryComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		if ( operator != ComparisonOperator.EQUAL ) {
+			return false;
+		}
+		if ( rhs instanceof SelectStatement selectStatement && hasSingleJdbcType( lhs ) ) {
+			lhs.accept( this );
+			appendSql( operator.sqlText() );
+			renderCastedScalarSubquery( selectStatement, lhs );
+			return true;
+		}
+		if ( lhs instanceof SelectStatement selectStatement && hasSingleJdbcType( rhs ) ) {
+			renderCastedScalarSubquery( selectStatement, rhs );
+			appendSql( operator.sqlText() );
+			rhs.accept( this );
+			return true;
+		}
+		return false;
+	}
+
+	private boolean hasSingleJdbcType(Expression expression) {
+		return expression.getExpressionType() != null && expression.getExpressionType().getJdbcTypeCount() == 1;
+	}
+
+	private void renderCastedScalarSubquery(SelectStatement selectStatement, Expression targetTypeExpression) {
+		appendSql( "cast(" );
+		selectStatement.accept( this );
+		appendSql( " as " );
+		new CastTarget( targetTypeExpression.getExpressionType().getSingleJdbcMapping() ).accept( this );
+		appendSql( ')' );
+	}
+
+	@Override
+	protected void emulateTupleComparison(
+			List<? extends SqlAstNode> lhsExpressions,
+			List<? extends SqlAstNode> rhsExpressions,
+			ComparisonOperator operator,
+			boolean indexOptimized) {
+		// Handle DISTINCT_FROM/NOT_DISTINCT_FROM tuple comparisons with Altibase's
+		// null-safe equality emulation; delegate other tuple comparisons to Hibernate.
+		if ( operator == ComparisonOperator.DISTINCT_FROM || operator == ComparisonOperator.NOT_DISTINCT_FROM ) {
+			renderDistinctFromPredicate( lhsExpressions, operator, rhsExpressions );
+		}
+		else {
+			super.emulateTupleComparison( lhsExpressions, rhsExpressions, operator, indexOptimized );
+		}
+	}
+
+	/*
+	 * a is not distinct from b
+	 *   -> (a = b or a is null and b is null)
+	 * a is distinct from b
+	 *   -> (a <> b or a is null and b is not null or a is not null and b is null)
+	 * (a, b) is not distinct from (x, y)
+	 *   -> (a is not distinct from x) and (b is not distinct from y)
+	 * (a, b) is distinct from (x, y)
+	 *   -> (a is distinct from x) or (b is distinct from y)
+	 */
+	private void renderDistinctFromPredicate(
+			List<? extends SqlAstNode> lhsExpressions,
+			ComparisonOperator operator,
+			List<? extends SqlAstNode> rhsExpressions) {
+		appendSql( '(' );
+		String separator = "";
+		for ( int i = 0; i < lhsExpressions.size(); i++ ) {
+			appendSql( separator );
+			if ( operator == ComparisonOperator.DISTINCT_FROM ) {
+				renderDistinctComparison( lhsExpressions.get( i ), rhsExpressions.get( i ) );
+				separator = " or ";
+			}
+			else {
+				renderNotDistinctComparison( lhsExpressions.get( i ), rhsExpressions.get( i ) );
+				separator = " and ";
+			}
+		}
+		appendSql( ')' );
+	}
+
+	private void renderNotDistinctComparison(SqlAstNode lhs, SqlAstNode rhs) {
+		appendSql( '(' );
+		lhs.accept( this );
+		appendSql( '=' );
+		rhs.accept( this );
+		appendSql( " or " );
+		lhs.accept( this );
+		appendSql( " is null and " );
+		rhs.accept( this );
+		appendSql( " is null)" );
+	}
+
+	private void renderDistinctComparison(SqlAstNode lhs, SqlAstNode rhs) {
+		appendSql( '(' );
+		lhs.accept( this );
+		appendSql( "<>" );
+		rhs.accept( this );
+		appendSql( " or " );
+		lhs.accept( this );
+		appendSql( " is null and " );
+		rhs.accept( this );
+		appendSql( " is not null or " );
+		lhs.accept( this );
+		appendSql( " is not null and " );
+		rhs.accept( this );
+		appendSql( " is null)" );
 	}
 
 	@Override
@@ -92,6 +244,23 @@ public class AltibaseSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 	}
 
 	@Override
+	protected LockStrategy determineLockingStrategy(QuerySpec querySpec, Locking.FollowOn followOnStrategy) {
+		final LockStrategy lockStrategy = super.determineLockingStrategy( querySpec, followOnStrategy );
+		final LockingClauseStrategy lockingClauseStrategy = getLockingClauseStrategy();
+		if ( lockingClauseStrategy != null && lockingClauseStrategy.containsJoins() ) {
+			// Altibase does not allow FOR UPDATE when the query also contains joins.
+			if ( followOnStrategy == Locking.FollowOn.DISALLOW ) {
+				throw new IllegalQueryOperationException( "Locking with joins is not supported" );
+			}
+			else if ( followOnStrategy == Locking.FollowOn.IGNORE ) {
+				return LockStrategy.NONE;
+			}
+			return LockStrategy.FOLLOW_ON;
+		}
+		return lockStrategy;
+	}
+
+	@Override
 	protected void renderPartitionItem(Expression expression) {
 		if ( expression instanceof Literal ) {
 			appendSql( "'0' || '0'" );
@@ -116,18 +285,216 @@ public class AltibaseSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 
 	@Override
 	public void visitValuesTableReference(ValuesTableReference tableReference) {
-		emulateValuesTableReferenceColumnAliasing( tableReference );
+		// Emulated VALUES sources render through a SELECT-list, where Altibase does not reliably
+		// handle plain parameter markers. Mark this context so supported values can be inlined.
+		final boolean previousRenderingInsertSelectSource = renderingInsertSelectSource;
+		renderingInsertSelectSource = true;
+		try {
+			emulateValuesTableReferenceColumnAliasing( tableReference );
+		}
+		finally {
+			renderingInsertSelectSource = previousRenderingInsertSelectSource;
+		}
 	}
 
 	@Override
 	protected void visitInsertStatementOnly(InsertSelectStatement statement) {
-		if ( statement.getConflictClause() == null || statement.getConflictClause().isDoNothing() ) {
-			// Render plain insert statement and possibly run into unique constraint violation
-			super.visitInsertStatementOnly( statement );
+		// INSERT SELECT uses the same SELECT-list workaround as emulated VALUES sources.
+		final boolean previousRenderingInsertSelectSource = renderingInsertSelectSource;
+		renderingInsertSelectSource = statement.getSourceSelectStatement() != null;
+		try {
+			if ( statement.getConflictClause() == null || statement.getConflictClause().isDoNothing() ) {
+				// Render plain insert statement and possibly run into unique constraint violation
+				super.visitInsertStatementOnly( statement );
+			}
+			else {
+				visitInsertStatementEmulateMerge( statement );
+			}
 		}
-		else {
-			visitInsertStatementEmulateMerge( statement );
+		finally {
+			renderingInsertSelectSource = previousRenderingInsertSelectSource;
 		}
+	}
+
+	@Override
+	protected void renderSelectExpression(Expression expression) {
+		// In INSERT SELECT/VALUES sources, inline simple values, version seeds and bound
+		// parameters that Hibernate would otherwise render as SELECT-list parameter markers.
+		final boolean previousRenderingSelectExpression = renderingSelectExpression;
+		final boolean previousRenderingInsertSelectSource = renderingInsertSelectSource;
+		renderingSelectExpression = true;
+		try {
+			// Apply INSERT SELECT/VALUES-specific inlining only while rendering their source SELECT-list.
+			if ( renderingInsertSelectSource ) {
+				renderingInsertSelectSource = false;
+				// Render literals directly instead of turning them into parameter markers.
+				if ( expression instanceof Literal literal ) {
+					renderLiteral( literal, true );
+					return;
+				}
+				// Render generated version seed values as SQL expressions such as 0 or current timestamp.
+				if ( expression instanceof VersionTypeSeedParameterSpecification versionSeedParameter
+						&& renderVersionSeedParameter( versionSeedParameter ) ) {
+					return;
+				}
+				// Render remaining parameters in the source SELECT-list as SQL literals.
+				withParameterRenderingMode(
+						SqlAstNodeRenderingMode.INLINE_PARAMETERS,
+						() -> super.renderSelectExpression( expression )
+				);
+				return;
+			}
+			// SELECT-list CASE expressions need the same Altibase-compatible parameter rendering,
+			// including nested CASE result expressions reached during recursive SQL AST rendering.
+			if ( expression instanceof CaseSearchedExpression caseSearchedExpression ) {
+				visitCaseSearchedExpression( caseSearchedExpression, true );
+				return;
+			}
+			if ( expression instanceof CaseSimpleExpression caseSimpleExpression ) {
+				visitCaseSimpleExpression( caseSimpleExpression, true );
+				return;
+			}
+			super.renderSelectExpression( expression );
+		}
+		finally {
+			renderingSelectExpression = previousRenderingSelectExpression;
+			renderingInsertSelectSource = previousRenderingInsertSelectSource;
+		}
+	}
+
+	// Handles searched CASE: "case when <predicate> then <result> end".
+	// It inlines parameter markers in predicates and result expressions for Altibase.
+	@Override
+	protected void visitCaseSearchedExpression(CaseSearchedExpression caseSearchedExpression, boolean inSelect) {
+		if ( !inSelect && !renderingSelectExpression ) {
+			super.visitCaseSearchedExpression( caseSearchedExpression, false );
+			return;
+		}
+
+		appendSql( "case" );
+		for ( CaseSearchedExpression.WhenFragment whenFragment : caseSearchedExpression.getWhenFragments() ) {
+			appendSql( " when " );
+			withParameterRenderingMode(
+					SqlAstNodeRenderingMode.INLINE_PARAMETERS,
+					() -> whenFragment.getPredicate().accept( this )
+			);
+			appendSql( " then " );
+			withParameterRenderingMode(
+					SqlAstNodeRenderingMode.INLINE_PARAMETERS,
+					() -> whenFragment.getResult().accept( this )
+			);
+		}
+
+		final Expression otherwise = caseSearchedExpression.getOtherwise();
+		if ( otherwise != null ) {
+			appendSql( " else " );
+			withParameterRenderingMode(
+					SqlAstNodeRenderingMode.INLINE_PARAMETERS,
+					() -> otherwise.accept( this )
+			);
+		}
+
+		appendSql( " end" );
+	}
+
+	// Handles simple CASE: "case <fixture> when <value> then <result> end".
+	// It inlines parameter markers in the fixture, check values and result expressions for Altibase.
+	@Override
+	protected void visitCaseSimpleExpression(CaseSimpleExpression caseSimpleExpression, boolean inSelect) {
+		if ( !inSelect && !renderingSelectExpression ) {
+			super.visitCaseSimpleExpression( caseSimpleExpression, false );
+			return;
+		}
+
+		appendSql( "case " );
+		withParameterRenderingMode(
+				SqlAstNodeRenderingMode.INLINE_PARAMETERS,
+				() -> caseSimpleExpression.getFixture().accept( this )
+		);
+		for ( CaseSimpleExpression.WhenFragment whenFragment : caseSimpleExpression.getWhenFragments() ) {
+			appendSql( " when " );
+			withParameterRenderingMode(
+					SqlAstNodeRenderingMode.INLINE_PARAMETERS,
+					() -> whenFragment.getCheckValue().accept( this )
+			);
+			appendSql( " then " );
+			withParameterRenderingMode(
+					SqlAstNodeRenderingMode.INLINE_PARAMETERS,
+					() -> whenFragment.getResult().accept( this )
+			);
+		}
+
+		final Expression otherwise = caseSimpleExpression.getOtherwise();
+		if ( otherwise != null ) {
+			appendSql( " else " );
+			withParameterRenderingMode(
+					SqlAstNodeRenderingMode.INLINE_PARAMETERS,
+					() -> otherwise.accept( this )
+			);
+		}
+
+		appendSql( " end" );
+	}
+
+	// Renders optimistic-lock version seeds through the JDBC literal formatter when possible.
+	@SuppressWarnings("unchecked")
+	private boolean renderVersionSeedParameter(VersionTypeSeedParameterSpecification versionSeedParameter) {
+		final EntityVersionMapping versionMapping = versionSeedParameter.getVersionMapping();
+		final JdbcLiteralFormatter<Object> literalFormatter = (JdbcLiteralFormatter<Object>) versionMapping.getJdbcMapping()
+				.getJdbcType()
+				.getJdbcLiteralFormatter( versionMapping.getJavaType() );
+		if ( literalFormatter == null ) {
+			return false;
+		}
+		final Object seedValue = getVersionSeedValue( versionMapping );
+		literalFormatter.appendJdbcLiteral( this, seedValue, getDialect(), getWrapperOptions() );
+		return true;
+	}
+
+	private Object getVersionSeedValue(EntityVersionMapping versionMapping) {
+		final int precision = getVersionSeedPrecision( versionMapping );
+		final Class<?> javaTypeClass = versionMapping.getJavaType().getJavaTypeClass();
+
+		// Temporal @Version seeds are normally created while binding with a Hibernate Session.
+		// Here we need a SQL literal instead, so build the timestamp value from the configured clock.
+		if ( Date.class.isAssignableFrom( javaTypeClass ) ) {
+			return Timestamp.from( getVersionSeedClock( precision, 9 ).instant() );
+		}
+		if ( Calendar.class.isAssignableFrom( javaTypeClass ) ) {
+			return GregorianCalendar.from( ZonedDateTime.now( getVersionSeedClock( precision, 3 ) ) );
+		}
+		if ( javaTypeClass == Instant.class ) {
+			return Instant.now( getVersionSeedClock( precision, 9 ) );
+		}
+		if ( javaTypeClass == LocalDateTime.class ) {
+			return LocalDateTime.now( getVersionSeedClock( precision, 9 ) );
+		}
+		if ( javaTypeClass == OffsetDateTime.class ) {
+			return OffsetDateTime.now( getVersionSeedClock( precision, 9 ) );
+		}
+		if ( javaTypeClass == ZonedDateTime.class ) {
+			return ZonedDateTime.now( getVersionSeedClock( precision, 9 ) );
+		}
+
+		return versionMapping.getJavaType().seed(
+				versionMapping.getLength(),
+				precision,
+				versionMapping.getScale(),
+				null
+		);
+	}
+
+	private int getVersionSeedPrecision(EntityVersionMapping versionMapping) {
+		final Integer precision = versionMapping.getTemporalPrecision() != null
+				? versionMapping.getTemporalPrecision()
+				: versionMapping.getPrecision();
+		return precision != null ? precision : getDialect().getDefaultTimestampPrecision();
+	}
+
+	private Clock getVersionSeedClock(int precision, int maxPrecision) {
+		final Clock baseClock = (Clock) getSessionFactory().getProperties()
+				.get( CurrentTimestampGeneration.CLOCK_SETTING_NAME );
+		return ClockHelper.forPrecision( baseClock, precision, maxPrecision );
 	}
 
 	@Override
@@ -164,6 +531,18 @@ public class AltibaseSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 		if ( getClauseStack().getCurrent() != Clause.INSERT ) {
 			renderTableReferenceIdentificationVariable( tableReference );
 		}
+	}
+
+	// Qualify assignment columns for multi-table updates to avoid ambiguity, but keep
+	// INSERT SELECT merge emulation assignments unqualified for Altibase MERGE syntax.
+	@Override
+	protected void appendAssignmentColumn(ColumnReference column) {
+		column.appendColumnForWrite(
+				this,
+				getAffectedTableNames().size() > 1 && !( getStatement() instanceof InsertSelectStatement )
+						? determineColumnReferenceQualifier( column )
+						: null
+		);
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/AltibaseDialectTestCase.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/AltibaseDialectTestCase.java
@@ -9,10 +9,14 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.orm.test.dialect.LimitQueryOptions;
 import org.hibernate.query.spi.Limit;
 import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.spi.TypeConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Types;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,8 +66,45 @@ public class AltibaseDialectTestCase {
 				.isEqualTo( "select c1, c2 from t1 order by c1, c2 desc" );
 	}
 
+	@Test
+	public void testJsonTypeNotRegisteredForAltibase71() {
+		final Dialect dialect = new AltibaseDialect( DatabaseVersion.make( 7, 1 ) );
+		final TypeConfiguration typeConfiguration = typeConfigurationFor( dialect );
+
+		assertThat( typeConfiguration.getDdlTypeRegistry().getDescriptor( SqlTypes.JSON ) ).isNull();
+		assertThat( typeConfiguration.getJdbcTypeRegistry().findDescriptor( SqlTypes.JSON ) ).isNull();
+	}
+
+	@Test
+	public void testJsonTypeRegisteredForAltibase81() {
+		final Dialect dialect = new AltibaseDialect( DatabaseVersion.make( 8, 1 ) );
+		final TypeConfiguration typeConfiguration = typeConfigurationFor( dialect );
+
+		assertThat( typeConfiguration.getDdlTypeRegistry().getTypeName( SqlTypes.JSON, dialect ) )
+				.isEqualTo( "json" );
+		assertThat( typeConfiguration.getDdlTypeRegistry().getSqlTypeCode( "json" ) )
+				.isEqualTo( SqlTypes.JSON );
+
+		final JdbcType jsonJdbcType = typeConfiguration.getJdbcTypeRegistry().findDescriptor( SqlTypes.JSON );
+		assertThat( jsonJdbcType ).isNotNull();
+		assertThat( jsonJdbcType.getDdlTypeCode() ).isEqualTo( SqlTypes.JSON );
+		assertThat( dialect.resolveSqlTypeDescriptor(
+				"json",
+				Types.CLOB,
+				0,
+				0,
+				typeConfiguration.getJdbcTypeRegistry()
+		).getDdlTypeCode() ).isEqualTo( SqlTypes.JSON );
+	}
+
 	private String withLimit(String sql, Limit limit) {
 		return dialect.getLimitHandler().processSql( sql, -1, null, new LimitQueryOptions( limit ) );
+	}
+
+	private TypeConfiguration typeConfigurationFor(Dialect dialect) {
+		final TypeConfiguration typeConfiguration = new TypeConfiguration();
+		dialect.contributeTypes( () -> typeConfiguration, null );
+		return typeConfiguration;
 	}
 
 	private Limit toRowSelection(Integer firstRow, Integer maxRows) {

--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/AltibaseFunctionsTest.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/AltibaseFunctionsTest.java
@@ -5,7 +5,7 @@
 package org.hibernate.community.dialect;
 
 import jakarta.persistence.Tuple;
-import org.hibernate.query.Query;
+import jakarta.persistence.TypedQuery;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -22,6 +22,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hibernate.Hibernate.getLobHelper;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @DomainModel(annotatedClasses = Person.class)
@@ -34,7 +35,6 @@ public class AltibaseFunctionsTest {
 		scope.inTransaction(
 				session -> {
 					final Person person = new Person();
-					person.setId( 1 );
 					person.setName( "test.1" );
 					ZonedDateTime zonedDateTime = ZonedDateTime.of(
 							1990, Month.APRIL.getValue(), 15,
@@ -122,7 +122,7 @@ public class AltibaseFunctionsTest {
 	public void testBitLengthFunction(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					final Query<Tuple> query = session.createQuery(
+					final TypedQuery<Tuple> query = session.createQuery(
 							"select bit_length(p.comments) from Person p",
 							Tuple.class
 					);
@@ -130,6 +130,72 @@ public class AltibaseFunctionsTest {
 					assertThat( results.size(), is( 1 ) );
 					final Tuple testEntity = results.get( 0 );
 					assertThat( testEntity.get( 0, Integer.class ), is( 64 ) );
+				}
+		);
+	}
+
+	@Test
+	public void testTrigonometricFunctionParameters(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final double angle = 1.0d;
+					final double ratio = 0.5d;
+					final TypedQuery<Tuple> query = session.createQuery(
+							"select sin(:angle), cos(:angle), tan(:angle), asin(:ratio), acos(:ratio), atan(:angle), " +
+									"atan2(:angle, :ratio), radians(:degreesValue), degrees(:radiansValue) " +
+									"from Person p where p.id = 1",
+							Tuple.class
+					);
+					query.setParameter( "angle", angle );
+					query.setParameter( "ratio", ratio );
+					query.setParameter( "degreesValue", 180.0d );
+					query.setParameter( "radiansValue", Math.PI );
+
+					final Tuple result = query.getSingleResult();
+					assertEquals( Math.sin( angle ), result.get( 0, Double.class ), 1e-9 );
+					assertEquals( Math.cos( angle ), result.get( 1, Double.class ), 1e-9 );
+					assertEquals( Math.tan( angle ), result.get( 2, Double.class ), 1e-9 );
+					assertEquals( Math.asin( ratio ), result.get( 3, Double.class ), 1e-9 );
+					assertEquals( Math.acos( ratio ), result.get( 4, Double.class ), 1e-9 );
+					assertEquals( Math.atan( angle ), result.get( 5, Double.class ), 1e-9 );
+					assertEquals( Math.atan2( angle, ratio ), result.get( 6, Double.class ), 1e-9 );
+					assertEquals( Math.PI, result.get( 7, Double.class ), 1e-9 );
+					assertEquals( 180.0d, result.get( 8, Double.class ), 1e-9 );
+				}
+		);
+	}
+
+	@Test
+	public void testCoalesceFunctionParameters(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final TypedQuery<Tuple> query = session.createQuery(
+							"select coalesce(:value, p.name), coalesce(nullif(p.name, p.name), :value) " +
+									"from Person p where p.id = 1",
+							Tuple.class
+					);
+					query.setParameter( "value", "param" );
+
+					final Tuple result = query.getSingleResult();
+					assertThat( result.get( 0, String.class ), is( "param" ) );
+					assertThat( result.get( 1, String.class ), is( "param" ) );
+				}
+		);
+	}
+
+	@Test
+	public void testConcatFunctionParameters(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final String result = session.createQuery(
+									"select concat(:prefix, p.name, :suffix) from Person p where p.id = 1",
+									String.class
+							)
+							.setParameter( "prefix", "pre-" )
+							.setParameter( "suffix", "-post" )
+							.getSingleResult();
+
+					assertThat( result, is( "pre-test.1-post" ) );
 				}
 		);
 	}

--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/AltibaseVersionSeedTest.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/AltibaseVersionSeedTest.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import java.sql.Timestamp;
+import java.util.Locale;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DomainModel( annotatedClasses = {
+		AltibaseVersionSeedTest.VersionedEntry.class,
+		AltibaseVersionSeedTest.SourceEntry.class
+} )
+@RequiresDialect( AltibaseDialect.class )
+@SessionFactory( useCollectingStatementInspector = true )
+public class AltibaseVersionSeedTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.persist( new SourceEntry( 1, "source" ) ) );
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testInsertSelectTimestampVersionSeedUsesJdbcLiteralFormatter(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		scope.inTransaction(
+				session -> {
+					final SourceEntry source = session.find( SourceEntry.class, 1 );
+					assertThat( source.getId() ).isEqualTo( 1 );
+					assertThat( source.getName() ).isEqualTo( "source" );
+					statementInspector.clear();
+					final int rows = session.createMutationQuery(
+							"insert into VersionedEntry (id, name) " +
+									"select 1, s.name from SourceEntry s"
+					).executeUpdate();
+					assertEquals( 1, rows );
+
+					assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+					final String insertSql = statementInspector.getSqlQueries().get( 0 ).toLowerCase( Locale.ROOT );
+					assertThat( insertSql ).contains( "{ts '" );
+					assertThat( insertSql ).doesNotContain( "sysdate" );
+					final VersionedEntry inserted = session.find( VersionedEntry.class, 1 );
+					assertThat( inserted.getId() ).isEqualTo( 1 );
+					assertThat( inserted.getName() ).isEqualTo( "source" );
+					assertThat( inserted.getVersion() ).isNotNull();
+				}
+		);
+	}
+
+	@Test
+	public void testInsertSelectDoesNotInlineNestedSubqueryParameters(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		scope.inTransaction(
+				session -> {
+					statementInspector.clear();
+					final int rows = session.createMutationQuery(
+									"insert into VersionedEntry (id, name) " +
+											"select 2, (select :nestedName from SourceEntry s2 where s2.id = s.id) " +
+											"from SourceEntry s"
+							)
+							.setParameter( "nestedName", "nested-name" )
+							.executeUpdate();
+					assertEquals( 1, rows );
+
+					assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+					final String insertSql = statementInspector.getSqlQueries().get( 0 ).toLowerCase( Locale.ROOT );
+					assertThat( insertSql ).contains( "cast(?" );
+					assertThat( insertSql ).doesNotContain( "nested-name" );
+					final VersionedEntry inserted = session.find( VersionedEntry.class, 2 );
+					assertThat( inserted.getName() ).isEqualTo( "nested-name" );
+				}
+		);
+	}
+
+	@Entity( name = "VersionedEntry" )
+	@Table( name = "ALTIBASE_VERSIONED_ENTRY" )
+	public static class VersionedEntry {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		@Version
+		private Timestamp version;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Timestamp getVersion() {
+			return version;
+		}
+	}
+
+	@Entity( name = "SourceEntry" )
+	@Table( name = "ALTIBASE_VERSION_SOURCE" )
+	public static class SourceEntry {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		public SourceEntry() {
+		}
+
+		public SourceEntry(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -566,7 +566,10 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			appliedParameterBindings.put( parameter, null );
 		}
 		else {
-			final JdbcMapping bindType = binding.getBindType();
+			// If the binding has no explicit type, fall back to the SQL AST parameter's expression type.
+			final JdbcMapping bindType = binding.getBindType() == null
+					? parameter.getExpressionType().getSingleJdbcMapping()
+					: binding.getBindType();
 			//noinspection unchecked
 			final Object value = ( (JavaType<Object>) bindType.getJdbcJavaType() )
 					.getMutabilityPlan()

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/VersionTypeSeedParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/VersionTypeSeedParameterSpecification.java
@@ -29,6 +29,10 @@ public class VersionTypeSeedParameterSpecification extends AbstractJdbcParameter
 		this.versionMapping = versionMapping;
 	}
 
+	public EntityVersionMapping getVersionMapping() {
+		return versionMapping;
+	}
+
 	@Override
 	public void bindParameterValue(
 			PreparedStatement statement,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeUnsavedEntitiesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeUnsavedEntitiesTest.java
@@ -10,9 +10,11 @@ import java.util.List;
 import java.util.Set;
 
 import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
@@ -35,8 +37,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 		annotatedClasses = {
 				MergeUnsavedEntitiesTest.Parent.class,
 				MergeUnsavedEntitiesTest.Child.class,
-				MergeUnsavedEntitiesTest.Book.class,
-				MergeUnsavedEntitiesTest.BookNote.class,
 		}
 )
 @SessionFactory
@@ -106,6 +106,14 @@ public class MergeUnsavedEntitiesTest {
 
 	@Test
 	@Jira("HHH-18177")
+	@DomainModel(
+			annotatedClasses = {
+					MergeUnsavedEntitiesTest.Book.class,
+					MergeUnsavedEntitiesTest.BookNote.class,
+			}
+	)
+	@SessionFactory
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
 	public void testMergeTransientInstanceWithGeneratedId(SessionFactoryScope scope) {
 		Book merged = scope.fromTransaction(
 				session -> {
@@ -121,7 +129,6 @@ public class MergeUnsavedEntitiesTest {
 					assertThat( book.getBookNotes() ).isEmpty();
 				}
 		);
-
 	}
 
 	@Entity(name = "Parent")
@@ -275,7 +282,6 @@ public class MergeUnsavedEntitiesTest {
 		public String getNote() {
 			return note;
 		}
-
 	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cid/CompositeIdAndMergeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cid/CompositeIdAndMergeTest.java
@@ -8,7 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 )
 @SessionFactory
 @JiraKey("HHH-18131")
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
 public class CompositeIdAndMergeTest {
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ConstraintInterpretationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ConstraintInterpretationTest.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import org.hibernate.community.dialect.InformixDialect;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.dialect.SpannerPostgreSQLDialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.DB2Dialect;
@@ -82,8 +83,8 @@ public class ConstraintInterpretationTest {
 			}
 			catch (ConstraintViolationException cve) {
 				assertEquals( ConstraintViolationException.ConstraintKind.UNIQUE, cve.getKind() );
-				// DB2 error message doesn't contain unique constraint name
-				if ( !(scope.getDialect() instanceof DB2Dialect) && !(scope.getDialect() instanceof SpannerPostgreSQLDialect) ) {
+				// DB2 and Altibase error messages don't contain unique constraint name
+				if ( !(scope.getDialect() instanceof DB2Dialect) && !(scope.getDialect() instanceof SpannerPostgreSQLDialect) && !(scope.getDialect() instanceof AltibaseDialect) ) {
 					assertTrue( cve.getConstraintName().toLowerCase().contains( "ssnuk" ) );
 				}
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ConstraintInterpretationTest2.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ConstraintInterpretationTest2.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.SpannerPostgreSQLDialect;
 import org.hibernate.dialect.CockroachDialect;
@@ -81,8 +82,8 @@ public class ConstraintInterpretationTest2 {
 			}
 			catch (ConstraintViolationException cve) {
 				assertEquals( ConstraintViolationException.ConstraintKind.UNIQUE, cve.getKind() );
-				// DB2 error message doesn't contain unique constraint name
-				if ( !(scope.getDialect() instanceof DB2Dialect) && !(scope.getDialect() instanceof SpannerPostgreSQLDialect) ) {
+				// DB2 and Altibase error messages don't contain unique constraint name
+				if ( !(scope.getDialect() instanceof DB2Dialect) && !(scope.getDialect() instanceof SpannerPostgreSQLDialect) && !(scope.getDialect() instanceof AltibaseDialect) ) {
 					assertTrue( cve.getConstraintName().toLowerCase().contains( "ssnuk" ) );
 				}
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/datasource/DataSourceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/datasource/DataSourceTest.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.JdbcSettings;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
@@ -40,6 +41,7 @@ public class DataSourceTest {
 		assertTrue( dialect instanceof OracleDialect
 					|| dialect instanceof DB2Dialect
 					|| dialect instanceof InformixDialect // Informix metadata does not include the URL
+					|| dialect instanceof AltibaseDialect // Altibase DataSource metadata rewrites the JDBC protocol with a driver version
 					|| listener.seen );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/engine/spi/LoadQueryInfluencersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/engine/spi/LoadQueryInfluencersTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -101,7 +100,9 @@ public class LoadQueryInfluencersTest {
 	@BatchSize(size = 1)
 	public class EntityWithBatchSize1 {
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		// Identifier generation is not under test; use the default strategy so this
+		// metadata test remains portable to dialects without identity columns.
+		@GeneratedValue
 		private Long id;
 
 		private String name;
@@ -139,7 +140,9 @@ public class LoadQueryInfluencersTest {
 	@Table(name = "ChildEntity")
 	public class ChildEntity {
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		// Identifier generation is not under test; use the default strategy so this
+		// metadata test remains portable to dialects without identity columns.
+		@GeneratedValue
 		private Long id;
 
 		private String name;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/PreInsertEventListenerVetoBidirectionalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/PreInsertEventListenerVetoBidirectionalTest.java
@@ -14,10 +14,10 @@ import jakarta.persistence.OneToOne;
 import org.hibernate.action.internal.EntityActionVetoException;
 import org.hibernate.event.spi.EventType;
 
-import org.hibernate.testing.DialectChecks;
-import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * @author Chris Cranford
  */
-@RequiresDialectFeature(DialectChecks.SupportsIdentityColumns.class)
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
 @JiraKey(value = "HHH-11721")
 @DomainModel(
 		annotatedClasses = {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/PreInsertEventListenerVetoUnidirectionalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/PreInsertEventListenerVetoUnidirectionalTest.java
@@ -14,10 +14,10 @@ import jakarta.persistence.OneToOne;
 import org.hibernate.action.internal.EntityActionVetoException;
 import org.hibernate.event.spi.EventType;
 
-import org.hibernate.testing.DialectChecks;
-import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * @author Chris Cranford
  */
-@RequiresDialectFeature(DialectChecks.SupportsIdentityColumns.class)
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
 @JiraKey(value = "HHH-11721")
 @DomainModel(
 		annotatedClasses = {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/SingleTableConstraintsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/SingleTableConstraintsTest.java
@@ -82,7 +82,7 @@ class SingleTableConstraintsTest {
 			try {
 				em.createNativeQuery(
 							"""
-							insert into Publication (text, title, edition,\spublisher_id, type, id)
+							insert into Publication (text, title, edition, publisher_id, publication_type, id)
 							values ('Lorem ipsum', 'Lorem Ipsum', 1, 1, 'Monograph', 5)
 							""" )
 						.executeUpdate();
@@ -96,7 +96,7 @@ class SingleTableConstraintsTest {
 			try {
 				em.createNativeQuery(
 							"""
-							insert into Publication (pages, text, edition, publisher_id, type, id)
+							insert into Publication (pages, text, edition, publisher_id, publication_type, id)
 							values (20, 'Lorem ipsum', 1, 1, 'Monograph', 5)
 							""" )
 						.executeUpdate();
@@ -110,7 +110,7 @@ class SingleTableConstraintsTest {
 			try {
 				em.createNativeQuery(
 							"""
-							insert into Publication (pages, text, title, publisher_id, type, id)
+							insert into Publication (pages, text, title, publisher_id, publication_type, id)
 							values (100, 'Lorem ipsum', 'Lorem Ipsum', 1, 'Monograph', 5)
 							""" )
 					.executeUpdate();
@@ -124,7 +124,7 @@ class SingleTableConstraintsTest {
 			try {
 				em.createNativeQuery(
 							"""
-							insert into Publication (pages, text, title, edition, type, id)
+							insert into Publication (pages, text, title, edition, publication_type, id)
 							values (100, 'Lorem ipsum', 'Lorem Ipsum', 1, 'Monograph', 5)
 							""" )
 						.executeUpdate();
@@ -138,7 +138,7 @@ class SingleTableConstraintsTest {
 			try {
 				em.createNativeQuery(
 							"""
-							insert into Publication (pages, text, title, edition, publisher_id, type, id)
+							insert into Publication (pages, text, title, edition, publisher_id, publication_type, id)
 							values (100, 'Lorem ipsum', 'Lorem Ipsum', 1, 1, 'Shrubbery', 5)
 							""" )
 						.executeUpdate();
@@ -151,7 +151,7 @@ class SingleTableConstraintsTest {
 		scope.inTransaction( em -> {
 			em.createNativeQuery(
 							"""
-							insert into Publication (pages, text, title, edition, publisher_id, type, id)
+							insert into Publication (pages, text, title, edition, publisher_id, publication_type, id)
 							values (100, 'Lorem ipsum', 'Lorem Ipsum', 1, 1, 'Monograph', 5)
 							""" )
 					.executeUpdate();
@@ -159,7 +159,8 @@ class SingleTableConstraintsTest {
 	}
 
 	@Entity(name = "Publication")
-	@DiscriminatorColumn(name = "type")
+	// This test targets single-table constraints, not reserved-word handling.
+	@DiscriminatorColumn(name = "publication_type")
 	static abstract class Publication {
 		@Id
 		long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/insertordering/InsertOrderingSelfReferenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/insertordering/InsertOrderingSelfReferenceTest.java
@@ -13,10 +13,8 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.SortNatural;
-import org.hibernate.community.dialect.AltibaseDialect;
 
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
@@ -37,7 +35,6 @@ import jakarta.persistence.OneToMany;
  * @author Nathan Xu
  */
 @JiraKey(value = "HHH-14227")
-@SkipForDialect( dialectClass = AltibaseDialect.class, reason = "'TYPE' is not escaped even though autoQuoteKeywords is enabled")
 public class InsertOrderingSelfReferenceTest extends BaseInsertOrderingTest {
 
 	@Override
@@ -79,13 +76,13 @@ public class InsertOrderingSelfReferenceTest extends BaseInsertOrderingTest {
 		verifyContainsBatches(
 				new Batch( "insert into Placeholder (name,id) values (?,?)", 2 ),
 				new Batch( List.of(
-						"insert into Parameter (name,parent_id,TYPE,id) values (?,?," + literal( "INPUT" ) + ",?)",
-						"insert into \"Parameter\" (name,\"parent_id\",TYPE,id) values (?,?," + literal( "INPUT" ) + ",?)",
-						"insert into `Parameter` (name,`parent_id`,TYPE,id) values (?,?," + literal( "INPUT" ) + ",?)" ) ),
+						"insert into Parameter (name,parent_id,PARAMETER_TYPE,id) values (?,?," + literal( "INPUT" ) + ",?)",
+						"insert into \"Parameter\" (name,\"parent_id\",PARAMETER_TYPE,id) values (?,?," + literal( "INPUT" ) + ",?)",
+						"insert into `Parameter` (name,`parent_id`,PARAMETER_TYPE,id) values (?,?," + literal( "INPUT" ) + ",?)" ) ),
 				new Batch( List.of(
-						"insert into Parameter (name,parent_id,TYPE,id) values (?,?," + literal( "OUTPUT" ) + ",?)",
-						"insert into \"Parameter\" (name,\"parent_id\",TYPE,id) values (?,?," + literal( "OUTPUT" ) + ",?)",
-						"insert into `Parameter` (name,`parent_id`,TYPE,id) values (?,?," + literal( "OUTPUT" ) + ",?)" ),
+						"insert into Parameter (name,parent_id,PARAMETER_TYPE,id) values (?,?," + literal( "OUTPUT" ) + ",?)",
+						"insert into \"Parameter\" (name,\"parent_id\",PARAMETER_TYPE,id) values (?,?," + literal( "OUTPUT" ) + ",?)",
+						"insert into `Parameter` (name,`parent_id`,PARAMETER_TYPE,id) values (?,?," + literal( "OUTPUT" ) + ",?)" ),
 						3 )
 		);
 	}
@@ -104,7 +101,9 @@ public class InsertOrderingSelfReferenceTest extends BaseInsertOrderingTest {
 	}
 
 	@Entity(name = "Parameter")
-	@DiscriminatorColumn(name = "TYPE")
+	// This test is about insert ordering, not identifier quoting. Keep the discriminator
+	// column non-reserved because @SQLRestriction repeats it as raw SQL.
+	@DiscriminatorColumn(name = "PARAMETER_TYPE")
 	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 	static abstract class Parameter extends AbstractEntity {
 		String name;
@@ -119,7 +118,7 @@ public class InsertOrderingSelfReferenceTest extends BaseInsertOrderingTest {
 
 		@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "parent")
 		@SortNatural
-		@SQLRestriction("TYPE = 'INPUT'")
+		@SQLRestriction("PARAMETER_TYPE = 'INPUT'")
 		@Fetch(FetchMode.SUBSELECT)
 		List<InputParameter> children = new ArrayList<>();
 	}
@@ -133,7 +132,7 @@ public class InsertOrderingSelfReferenceTest extends BaseInsertOrderingTest {
 
 		@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "parent")
 		@SortNatural
-		@SQLRestriction("TYPE = 'OUTPUT'")
+		@SQLRestriction("PARAMETER_TYPE = 'OUTPUT'")
 		@Fetch(FetchMode.SUBSELECT)
 		@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 		List<OutputParameter> children = new ArrayList<>();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/joinedsubclass/JoinedSubclassWithExplicitDiscriminatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/joinedsubclass/JoinedSubclassWithExplicitDiscriminatorTest.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 
-import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.metamodel.mapping.DiscriminatorValue.Literal;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.JoinedSubclassEntityPersister;
@@ -22,7 +21,6 @@ import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,20 +43,19 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class JoinedSubclassWithExplicitDiscriminatorTest {
 
 	@Test
-	@SkipForDialect( dialectClass = AltibaseDialect.class, reason = "'TYPE' is a keyword in Altibase and escaped here")
 	public void metadataAssertions(SessionFactoryScope scope) {
 		EntityPersister p = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor(Dog.class.getName());
 		assertNotNull( p );
 		final JoinedSubclassEntityPersister dogPersister = assertTyping( JoinedSubclassEntityPersister.class, p );
 		assertEquals( "string", dogPersister.getDiscriminatorType().getName() );
-		assertEquals( "type", dogPersister.getDiscriminatorColumnName() );
+		assertEquals( "animal_type", dogPersister.getDiscriminatorColumnName() );
 		assertEquals( new Literal("dog"), dogPersister.getDiscriminatorValue() );
 
 		p = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor(Cat.class.getName());
 		assertNotNull( p );
 		final JoinedSubclassEntityPersister catPersister = assertTyping( JoinedSubclassEntityPersister.class, p );
 		assertEquals( "string", catPersister.getDiscriminatorType().getName() );
-		assertEquals( "type", catPersister.getDiscriminatorColumnName() );
+		assertEquals( "animal_type", catPersister.getDiscriminatorColumnName() );
 		assertEquals( new Literal("cat"), catPersister.getDiscriminatorValue() );
 	}
 
@@ -100,7 +97,8 @@ public class JoinedSubclassWithExplicitDiscriminatorTest {
 	@Entity(name = "Animal")
 	@Table(name = "animal")
 	@Inheritance(strategy = InheritanceType.JOINED)
-	@DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
+	// Use a non-keyword name so the discriminator mapping is portable across dialects.
+	@DiscriminatorColumn(name = "animal_type", discriminatorType = DiscriminatorType.STRING)
 	@DiscriminatorValue(value = "???animal???")
 	public static abstract class Animal {
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/convert/Log.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/convert/Log.java
@@ -9,14 +9,13 @@ import jakarta.persistence.Convert;
 import jakarta.persistence.Converter;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 import java.util.Date;
 @Entity
 public class Log {
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@GeneratedValue
 	private Long id;
 	@Convert(converter = DateConverter.class)
 	private Date lastUpdate;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryWithDatetimesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryWithDatetimesTest.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.PostgresPlusDialect;
@@ -29,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 public class NativeQueryWithDatetimesTest {
 	@SkipForDialect(dialectClass = PostgresPlusDialect.class)
 	@SkipForDialect(dialectClass = OracleDialect.class)
+	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase maps DATE and TIME to TIMESTAMP in native query result metadata")
 	@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "type:resolved.gauss will map localdate to timestamp")
 	@Test void test(EntityManagerFactoryScope scope) {
 		scope.inTransaction(s -> s.persist(new Datetimes()));

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/ScopeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/ScopeTests.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.locking.options;
 
 import org.hibernate.EnabledFetchProfile;
 import org.hibernate.Hibernate;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.HSQLDialect;
@@ -44,6 +45,8 @@ import static org.hibernate.orm.test.locking.options.Helper.Table.REPORT_LABELS;
 @Jira( "https://hibernate.atlassian.net/browse/HHH-19336" )
 @Jira( "https://hibernate.atlassian.net/browse/HHH-19459" )
 @RequiresDialectFeature( feature = DialectFeatureChecks.SupportsSelectLocking.class )
+@SkipForDialect(dialectClass = AltibaseDialect.class,
+		reason = "Altibase lock-wait probes can leave interrupted async DML in a state that interferes with schema truncation cleanup")
 @SkipForDialect(dialectClass = SybaseASEDialect.class, majorVersion = 16, minorVersion = 0, microVersion = 2,
 		versionMatchMode = VersionMatchMode.SAME_OR_OLDER, reason = "holdlock isn't the same as updating a row. Bug in our Sybase ASE version?")
 @RequiresDialectFeature( feature = DialectFeatureChecks.SupportsConcurrentTransactions.class )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/NClobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/NClobStringTest.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 
 import org.hibernate.annotations.Nationalized;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.dialect.SybaseASEDialect;
 
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Vlad Mihalcea
  */
 @SkipForDialect(dialectClass = SybaseASEDialect.class)
+@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase CLOB does not preserve supplementary Unicode characters")
 @Jpa( annotatedClasses = {NClobStringTest.Product.class} )
 public class NClobStringTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/NationalizedJsonMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/NationalizedJsonMappingTests.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Nationalized;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.NationalizationSupport;
 import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
@@ -24,6 +25,7 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.junit.jupiter.api.Test;
@@ -33,6 +35,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @RequiresDialectFeature(feature = DialectFeatureChecks.SupportsNationalizedData.class)
+@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase JSON/CLOB storage does not preserve supplementary Unicode characters")
 public class NationalizedJsonMappingTests {
 
 	private static final String UNICODE_JSON = "{\"name\": \"🦑 Unicode Test 🦑\"}";

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/NationalizedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/NationalizedTest.java
@@ -8,11 +8,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
 import org.hibernate.annotations.Nationalized;
+import org.hibernate.community.dialect.AltibaseDialect;
 
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @Jpa(annotatedClasses = NationalizedTest.Product.class)
 @RequiresDialectFeature(feature = DialectFeatureChecks.SupportsUnicodeNClob.class)
+@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase character types do not preserve supplementary Unicode characters")
 public class NationalizedTest {
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/StringNationalizedMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/StringNationalizedMappingTests.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 
 import org.hibernate.annotations.Nationalized;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.NationalizationSupport;
 import org.hibernate.dialect.SybaseASEDialect;
@@ -39,6 +40,8 @@ import static org.hamcrest.Matchers.is;
 @SessionFactory
 @SkipForDialect(dialectClass = SybaseASEDialect.class,
 		reason = "Error converting characters into server's character set")
+@SkipForDialect(dialectClass = AltibaseDialect.class,
+		reason = "Altibase character types do not preserve supplementary Unicode characters")
 public class StringNationalizedMappingTests {
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/where/DiscriminatorWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/where/DiscriminatorWhereTest.java
@@ -7,13 +7,11 @@ package org.hibernate.orm.test.mapping.where;
 import java.util.Set;
 
 import org.hibernate.annotations.SQLRestriction;
-import org.hibernate.community.dialect.AltibaseDialect;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.DiscriminatorColumn;
@@ -33,7 +31,6 @@ import jakarta.persistence.Table;
 })
 @SessionFactory
 @JiraKey( "https://hibernate.atlassian.net/browse/HHH-14977" )
-@SkipForDialect( dialectClass = AltibaseDialect.class, reason = "'TYPE' is not escaped even though autoQuoteKeywords is enabled")
 public class DiscriminatorWhereTest {
 	@Test
 	public void testAddDiscriminatedEntityToCollectionWithWhere(SessionFactoryScope scope) {
@@ -46,7 +43,7 @@ public class DiscriminatorWhereTest {
 		} );
 
 		// Fetch EntityA and add a new EntityC to its collection.
-		// The collection is annotated with @Where("TYPE = 'C'")
+		// The collection uses a SQL restriction on the discriminator column.
 		scope.inTransaction( (session) -> {
 			final EntityA entityA = session.find( EntityA.class, id );
 			final EntityC entityC = new EntityC();
@@ -72,7 +69,7 @@ public class DiscriminatorWhereTest {
 
 		@OneToMany
 		@JoinColumn(name = "allC")
-		@SQLRestriction("type = 'C'")
+		@SQLRestriction("entity_type = 'C'")
 		private Set<EntityC> allMyC;
 
 		public Integer getId() {
@@ -102,7 +99,8 @@ public class DiscriminatorWhereTest {
 
 	@Entity(name = "EntityB")
 	@Table(name = "b_tab")
-	@DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
+	// The SQL restriction above references this name directly, so keep it non-keyword.
+	@DiscriminatorColumn(name = "entity_type", discriminatorType = DiscriminatorType.STRING)
 	@DiscriminatorValue( value = "B")
 	public static class EntityB {
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/merge/BidirectionalOneToManyMergeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/merge/BidirectionalOneToManyMergeTest.java
@@ -7,8 +7,6 @@ package org.hibernate.orm.test.merge;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -48,7 +46,7 @@ public class BidirectionalOneToManyMergeTest {
 	public void testMerge(EntityManagerFactoryScope scope) {
 		scope.inTransaction( entityManager -> {
 			Post post = entityManager.find( Post.class, 1L );
-			post.addComment( new PostComment( "This post rocks!", post ) );
+			post.addComment( new PostComment( "This post rocks!", post ).setId( 1L ) );
 			post.getComments().isEmpty();
 			entityManager.merge( post );
 		} );
@@ -118,7 +116,6 @@ public class BidirectionalOneToManyMergeTest {
 	public static class PostComment {
 
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
 		private Long id;
 
 		private String review;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/MappedSuperclassAttributeInMultipleSubtypesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/MappedSuperclassAttributeInMultipleSubtypesTest.java
@@ -6,6 +6,8 @@ package org.hibernate.orm.test.query;
 
 import java.util.List;
 
+import org.hibernate.community.dialect.AltibaseDialect;
+import org.hibernate.dialect.SpannerDialect;
 import org.hibernate.query.PathException;
 
 import org.hibernate.testing.orm.domain.gambit.BasicEntity;
@@ -14,7 +16,6 @@ import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
-import org.hibernate.dialect.SpannerDialect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,11 @@ public class MappedSuperclassAttributeInMultipleSubtypesTest {
 			final BasicEntity basicEntity = new BasicEntity( 1, "basic" );
 			session.persist( basicEntity );
 			session.persist( new ChildOne( 1L, "test", 1, basicEntity ) );
+			if ( session.getDialect() instanceof AltibaseDialect ) {
+				// Split the setup insert batch because Altibase JDBC rejects changing
+				// the bind type for the same parameter index between ChildOne and ChildTwo.
+				session.flush();
+			}
 			session.persist( new ChildTwo( 2L, "test", 1D, basicEntity ) );
 		} );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/QuerySqlExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/QuerySqlExceptionTest.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 
@@ -86,6 +87,10 @@ public class QuerySqlExceptionTest {
 	private Query createQueryTriggeringStatementExecutionFailure(EntityManager entityManager) {
 		var dialect = entityManager.getEntityManagerFactory().unwrap( SessionFactoryImplementor.class )
 				.getJdbcServices().getDialect();
+		if ( dialect instanceof AltibaseDialect ) {
+			return entityManager.createNativeQuery( "select cast( :param as integer ) from contacts" )
+					.setParameter( "param", "foo" );
+		}
 		Object badParamValue;
 		if ( dialect instanceof MySQLDialect ) {
 			// These databases are perfectly fine with the operation `"foo" / 2`

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/ExtractTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/ExtractTest.java
@@ -7,8 +7,10 @@ package org.hibernate.orm.test.query.criteria;
 import jakarta.persistence.criteria.LocalDateField;
 import jakarta.persistence.criteria.LocalDateTimeField;
 import jakarta.persistence.criteria.LocalTimeField;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -20,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 @Jpa
 class ExtractTest {
-	@Test void testLocalDate(EntityManagerFactoryScope scope) {
+	@Test
+	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "local date is evaluated in the database local time zone")
+	void testLocalDate(EntityManagerFactoryScope scope) {
 		scope.inEntityManager( entityManager -> {
 			var builder = entityManager.getCriteriaBuilder();
 			var query = builder.createQuery( Object[].class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/plan/CriteriaPlanTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/plan/CriteriaPlanTest.java
@@ -49,11 +49,13 @@ class CriteriaPlanTest {
 
 	public Author populateData(SessionImplementor entityManager) {
 		final Author author = new Author();
+		author.authorId = 1L;
 		author.name = "David Gourley";
 		entityManager.persist(author);
 
 		for (int i = 0; i < 5; i++) {
 			final Book book = new Book();
+			book.bookId = i + 1L;
 			book.name = "HTTP Definitive guide " + i;
 			book.author = author;
 			entityManager.persist(book);
@@ -67,7 +69,6 @@ class CriteriaPlanTest {
 	@Table(name = "Author")
 	public static class Author {
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
 		public Long authorId;
 
 		@Column
@@ -100,7 +101,6 @@ class CriteriaPlanTest {
 	@Table(name = "Book")
 	public static class Book {
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
 		public Long bookId;
 
 		@Column

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -642,6 +642,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "datetime truncation is not supported")
 	@SkipForDialect(dialectClass = SpannerDialect.class, reason = "date and timestamp are not compatible")
 	@SkipForDialect(dialectClass = InformixDialect.class, reason = "Datetime truncation is not supported")
 	@SkipForDialect(dialectClass = CockroachDialect.class, reason = "unsupported binary operator: <timestamptz> - <date>")
@@ -2269,6 +2270,8 @@ public class FunctionTests {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "local datetime is evaluated in the database local time zone")
+	@SkipForDialect(dialectClass = InformixDialect.class, reason = "The clock in the container likes to get skewed, so to avoid false negatives, skip the test")
 	public void testExtractFunctionEpoch(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/RegexTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/RegexTest.java
@@ -4,11 +4,13 @@
  */
 package org.hibernate.orm.test.query.hql;
 
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,6 +41,7 @@ class RegexTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "regexp_like does not support flags")
 	void testInSelectCaseInsensitive(EntityManagerFactoryScope scope) {
 		scope.inEntityManager( em -> {
 			assertTrue( em.createQuery( "select regexp_like('ABCDEF', 'ab.*', 'i')", Boolean.class ).getSingleResult() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/set/UnionOfPartitionResultsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/set/UnionOfPartitionResultsTest.java
@@ -17,8 +17,6 @@ import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 
@@ -158,7 +156,6 @@ public class UnionOfPartitionResultsTest {
 	@Entity(name = "Apple")
 	public static class Apple {
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
 		private Integer id;
 		private LocalDate bakedOn;
 		@ManyToOne
@@ -195,7 +192,6 @@ public class UnionOfPartitionResultsTest {
 	@Entity(name = "Pie")
 	public static class Pie {
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
 		private Integer id;
 		private String taste;
 

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/collection/StringMapLobTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/collection/StringMapLobTest.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.HANADialect;
 import org.hibernate.dialect.DB2Dialect;
@@ -46,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SkipForDialect(dialectClass = DB2Dialect.class, matchSubTypes = true, reason = "DB2 jdbc driver doesn't support setNString")
 @SkipForDialect(dialectClass = DerbyDialect.class, matchSubTypes = true, reason = "Derby jdbc driver doesn't support setNString")
 @SkipForDialect(dialectClass = InformixDialect.class, reason = "It's not possible to compare blobs with simple equality operators")
+@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase doesn't support comparing LOBs with the = operator")
 public class StringMapLobTest {
 	@BeforeClassTemplate
 	public void initData(EntityManagerFactoryScope scope) {

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/collection/StringMapNationalizedLobTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/collection/StringMapNationalizedLobTest.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 
 import org.hibernate.annotations.Nationalized;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.HANADialect;
 import org.hibernate.dialect.DB2Dialect;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SkipForDialect(dialectClass = DB2Dialect.class, matchSubTypes = true, reason = "DB2 jdbc driver doesn't support setNString")
 @SkipForDialect(dialectClass = DerbyDialect.class, matchSubTypes = true, reason = "Derby jdbc driver doesn't support setNString")
 @SkipForDialect(dialectClass = InformixDialect.class, reason = "It's not possible to compare blobs with simple equality operators")
+@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase doesn't support comparing LOBs with the = operator")
 public class StringMapNationalizedLobTest {
 	@BeforeClassTemplate
 	public void initData(EntityManagerFactoryScope scope) {

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/discriminatorformula/ClassTypeEntity.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/discriminatorformula/ClassTypeEntity.java
@@ -7,6 +7,7 @@ package org.hibernate.orm.test.envers.integration.inheritance.single.discriminat
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Column;
 
 /**
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
@@ -20,6 +21,7 @@ public class ClassTypeEntity {
 	@GeneratedValue
 	private Long id;
 
+	@Column(name = "entity_type")
 	private String type;
 
 	public boolean equals(Object o) {

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/discriminatorformula/DiscriminatorFormulaTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/discriminatorformula/DiscriminatorFormulaTest.java
@@ -7,7 +7,6 @@ package org.hibernate.orm.test.envers.integration.inheritance.single.discriminat
 import java.util.Arrays;
 import java.util.List;
 
-import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.envers.AuditReaderFactory;
 import org.hibernate.mapping.Formula;
 
@@ -17,7 +16,6 @@ import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.DomainModelScope;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SessionFactory;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -103,7 +101,6 @@ public class DiscriminatorFormulaTest {
 	}
 
 	@Test
-	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "'TYPE' is not escaped even though autoQuoteKeywords is enabled")
 	public void testRevisionsCounts(SessionFactoryScope scope) {
 		scope.inSession( em -> {
 			final var auditReader = AuditReaderFactory.get( em );
@@ -119,7 +116,6 @@ public class DiscriminatorFormulaTest {
 	}
 
 	@Test
-	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "'TYPE' is not escaped even though autoQuoteKeywords is enabled")
 	public void testHistoryOfParent(SessionFactoryScope scope) {
 		scope.inSession( em -> {
 			final var auditReader = AuditReaderFactory.get( em );
@@ -129,7 +125,6 @@ public class DiscriminatorFormulaTest {
 	}
 
 	@Test
-	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "'TYPE' is not escaped even though autoQuoteKeywords is enabled")
 	public void testHistoryOfChild(SessionFactoryScope scope) {
 		scope.inSession( em -> {
 			final var auditReader = AuditReaderFactory.get( em );
@@ -139,7 +134,6 @@ public class DiscriminatorFormulaTest {
 	}
 
 	@Test
-	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "'TYPE' is not escaped even though autoQuoteKeywords is enabled")
 	public void testPolymorphicQuery(SessionFactoryScope scope) {
 		scope.inSession( em -> {
 			final var auditReader = AuditReaderFactory.get( em );

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/discriminatorformula/ParentEntity.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/discriminatorformula/ParentEntity.java
@@ -20,7 +20,7 @@ import org.hibernate.envers.Audited;
 @DiscriminatorValue(ClassTypeEntity.PARENT_TYPE)
 @Audited
 public class ParentEntity {
-	public static final String DISCRIMINATOR_QUERY = "(SELECT c.type FROM ClassTypeEntity c WHERE c.id = typeId)";
+	public static final String DISCRIMINATOR_QUERY = "(SELECT c.entity_type FROM ClassTypeEntity c WHERE c.id = typeId)";
 
 	@Id
 	@GeneratedValue

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -45,6 +45,7 @@ import org.hibernate.boot.spi.NaturalIdUniqueKeyBinder;
 import org.hibernate.boot.spi.PropertyData;
 import org.hibernate.boot.spi.SecondPass;
 import org.hibernate.cfg.MappingSettings;
+import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.DerbyDialect;
 import org.hibernate.community.dialect.FirebirdDialect;
 import org.hibernate.community.dialect.GaussDBDialect;
@@ -650,7 +651,8 @@ abstract public class DialectFeatureChecks {
 
 	public static class SupportsDateTimeTruncation implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
-			if (dialect instanceof DerbyDialect
+			if (dialect instanceof AltibaseDialect
+				|| dialect instanceof DerbyDialect
 				|| dialect instanceof FirebirdDialect
 				|| dialect instanceof InformixDialect) {
 				return false;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of PR #12765 to the 7.4 branch.

Summary
- Backport the Altibase dialect compatibility fixes for [HHH-20538](https://hibernate.atlassian.net/browse/HHH-20538).
- Keep the 7.4 changes local to the Altibase dialect where possible.
- Avoid depending on PR #12828 , following the review feedback from PR #12765.
- Add focused Altibase coverage for function rendering and version seed literal handling.

Testing
- ./gradlew clean test -Pdb=altibase -x spotlessJava -x spotlessJavaApply
- Result: BUILD SUCCESSFUL

Notes
- The version seed handling differs slightly from main because 7.4 keeps the existing VersionJavaType seed API unchanged.
- Temporal @Version seeds are rendered as SQL literals in Altibase INSERT SELECT/VALUES contexts using the configured clock.
- Spotless tasks were excluded from the Altibase verification run because the current 7.4 branch fails in the Spotless path before the database tests start.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20538 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

[HHH-20538]: https://hibernate.atlassian.net/browse/HHH-20538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ