### PR TITLE
HHH-20600 HbmXmlTransformer does not generate <transient/> declarations for unmapped embeddable properties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -271,7 +271,8 @@ public class HbmXmlTransformer {
 		this.componentHandler = new HbmXmlTransformerComponentHandler(
 				transformationState.getEmbeddableInfoByRole(),
 				mappingXmlBinding.getRoot(),
-				this::transferBaseAttributes
+				this::transferBaseAttributes,
+				hbmXmlBinding.getRoot().getDefaultAccess()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
@@ -7,6 +7,7 @@ package org.hibernate.boot.jaxb.hbm.transform;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -46,6 +47,7 @@ public class HbmXmlTransformerComponentHandler {
 	private final Map<String, ComponentTypeInfo> embeddableInfoByRole;
 	private final JaxbEntityMappingsImpl mappingRoot;
 	private final NestedAttributeProcessor nestedAttributeProcessor;
+	private final String defaultAccess;
 
 	// todo (7.0) : use transformation-state instead
 	private final Map<String, JaxbEmbeddableImpl> jaxbEmbeddableByClassName = new HashMap<>();
@@ -57,14 +59,17 @@ public class HbmXmlTransformerComponentHandler {
 	 * @param embeddableInfoByRole component type info populated from the boot model
 	 * @param mappingRoot the target mapping root to add embeddables to
 	 * @param nestedAttributeProcessor callback to process nested attributes inside a component
+	 * @param defaultAccess the HBM mapping's default-access value
 	 */
 	public HbmXmlTransformerComponentHandler(
 			Map<String, ComponentTypeInfo> embeddableInfoByRole,
 			JaxbEntityMappingsImpl mappingRoot,
-			NestedAttributeProcessor nestedAttributeProcessor) {
+			NestedAttributeProcessor nestedAttributeProcessor,
+			String defaultAccess) {
 		this.embeddableInfoByRole = embeddableInfoByRole;
 		this.mappingRoot = mappingRoot;
 		this.nestedAttributeProcessor = nestedAttributeProcessor;
+		this.defaultAccess = defaultAccess;
 	}
 
 	/**
@@ -75,7 +80,7 @@ public class HbmXmlTransformerComponentHandler {
 	 * @param mappingRoot the target mapping root to add embeddables to
 	 */
 	public HbmXmlTransformerComponentHandler(JaxbEntityMappingsImpl mappingRoot) {
-		this( Map.of(), mappingRoot, null );
+		this( Map.of(), mappingRoot, null, "property" );
 	}
 
 	/**
@@ -152,7 +157,7 @@ public class HbmXmlTransformerComponentHandler {
 			}
 		}
 
-		transferEmbeddableTransients( embeddableClassName, componentTypeInfo, embeddable );
+		transferEmbeddableTransients( embeddableClassName, componentTypeInfo, hbmComponent, embeddable );
 
 		return embeddable;
 	}
@@ -160,6 +165,7 @@ public class HbmXmlTransformerComponentHandler {
 	private void transferEmbeddableTransients(
 			String embeddableClassName,
 			ComponentTypeInfo componentTypeInfo,
+			JaxbHbmCompositeAttributeType hbmComponent,
 			JaxbEmbeddableImpl embeddable) {
 		if ( embeddableClassName == null || componentTypeInfo == null ) {
 			return;
@@ -175,7 +181,9 @@ public class HbmXmlTransformerComponentHandler {
 				return;
 			}
 
-			final boolean fieldAccess = component.getParentProperty() == null;
+			final String componentAccess = hbmComponent.getAccess();
+			final String effectiveAccess = componentAccess != null ? componentAccess : defaultAccess;
+			final boolean fieldAccess = "field".equals( effectiveAccess.toLowerCase( Locale.ROOT ) );
 			final Set<String> transientNames = TransformationHelper.discoverUnmappedPropertyNames(
 					javaClass, mappedPropertyNames, fieldAccess
 			);

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/TransformationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/TransformationHelper.java
@@ -56,13 +56,6 @@ public class TransformationHelper {
 			}
 		}
 		else {
-			final var setterNames = new HashSet<String>();
-			for ( var method : javaClass.getMethods() ) {
-				if ( method.getParameterCount() == 1
-						&& method.getName().startsWith( "set" ) && method.getName().length() > 3 ) {
-					setterNames.add( StringHelper.decapitalize( method.getName().substring( 3 ) ) );
-				}
-			}
 			for ( var method : javaClass.getMethods() ) {
 				if ( method.getParameterCount() != 0 ) {
 					continue;
@@ -77,7 +70,6 @@ public class TransformationHelper {
 					propertyName = StringHelper.decapitalize( methodName.substring( 2 ) );
 				}
 				if ( propertyName != null
-						&& setterNames.contains( propertyName )
 						&& !mappedPropertyNames.contains( propertyName )
 						&& !propertyName.equals( "class" ) ) {
 					transientNames.add( propertyName );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -334,6 +334,27 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20600" )
+	public void testComponentPropertyAccessTransientDetection(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/component-access-transient/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEmbeddables() ).hasSize( 1 );
+
+			final JaxbEmbeddableImpl embeddable = transformed.getEmbeddables().get( 0 );
+
+			assertThat( embeddable.getAttributes().getBasicAttributes() )
+					.extracting( JaxbBasicImpl::getName )
+					.containsExactlyInAnyOrder( "street", "city" );
+
+			assertThat( embeddable.getAttributes().getTransients() )
+					.extracting( JaxbTransientImpl::getName )
+					.as( "getFullAddress() is an unmapped getter — with property access it must be marked transient" )
+					.contains( "fullAddress" )
+					.as( "Mapped properties should not be marked transient" )
+					.doesNotContain( "street", "city" );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20599" )
 	public void testCompositeElementColumnTableTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/composite-element/hbm.xml", scope, (transformed) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/componentaccesstransient/Address.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/componentaccesstransient/Address.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.componentaccesstransient;
+
+public class Address {
+	private String street;
+	private String city;
+
+	public String getStreet() {
+		return street;
+	}
+
+	public void setStreet(String street) {
+		this.street = street;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public void setCity(String city) {
+		this.city = city;
+	}
+
+	public String getFullAddress() {
+		return street + ", " + city;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/componentaccesstransient/Person.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/componentaccesstransient/Person.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.componentaccesstransient;
+
+public class Person {
+	private Long id;
+	private String name;
+	private Address address;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(Address address) {
+		this.address = address;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/component-access-transient/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/component-access-transient/hbm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<!--
+    The component maps only "street" and "city" out of the Address class.
+    Address also has a getFullAddress() getter with no backing field.
+    With the default property access, "fullAddress" must be detected
+    as a transient property.  If the transformer incorrectly used
+    field access, it would look at fields instead and miss it.
+-->
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.componentaccesstransient">
+	<class name="Person">
+		<id name="id" type="long">
+			<generator class="increment"/>
+		</id>
+		<property name="name" column="person_name"/>
+		<component name="address" class="Address">
+			<property name="street" column="addr_street"/>
+			<property name="city" column="addr_city"/>
+		</component>
+	</class>
+</hibernate-mapping>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/12894 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20600 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20600
<!-- Hibernate GitHub Bot issue links end -->