### PR TITLE
Support org.jetbrains.annotations.Nullable for nullable return type detection

### DIFF
--- a/documentation/src/main/asciidoc/repositories/Repositories.adoc
+++ b/documentation/src/main/asciidoc/repositories/Repositories.adoc
@@ -361,7 +361,7 @@ If there is no `Book` with the given `isbn` in the database, the method throws `
 There are two ways around this if that's not what we want:
 
 - declare the method to return `Optional`, or
-- annotate the method `@jakarta.annotation.Nullable`.
+- annotate the method `@jakarta.annotation.Nullable` or `@org.jetbrains.annotations.Nullable`.
 
 The first option is blessed by the specification:
 

--- a/documentation/src/main/asciidoc/repositories/Repositories.adoc
+++ b/documentation/src/main/asciidoc/repositories/Repositories.adoc
@@ -361,7 +361,7 @@ If there is no `Book` with the given `isbn` in the database, the method throws `
 There are two ways around this if that's not what we want:
 
 - declare the method to return `Optional`, or
-- annotate the method `@jakarta.annotation.Nullable` or `@org.jetbrains.annotations.Nullable`.
+- annotate the method `@jakarta.annotation.Nullable`, `@org.jetbrains.annotations.Nullable`, or `@org.jspecify.annotations.Nullable`.
 
 The first option is blessed by the specification:
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -120,6 +120,7 @@ asciidoctorj = "3.0.0"
 
 # Compilation (static checks)
 jetbrainsAnnotations = "26.1.0"
+jspecify = "1.0.0"
 errorprone = "2.50.0"
 nullaway = "0.13.7"
 ## For custom NullAway LibraryModels
@@ -176,6 +177,7 @@ oracleucp = { group = "com.oracle.database.jdbc", name = "ucp17", version.ref = 
 
 # Compilation (static checks)
 compilation-jetbrainsAnnotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrainsAnnotations" }
+compilation-jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
 compilation-errorprone = { group = "com.google.errorprone", name = "error_prone_core", version.ref = "errorprone" }
 compilation-nullaway = { group = "com.uber.nullaway", name = "nullaway", version.ref = "nullaway" }
 ## For custom NullAway LibraryModels

--- a/tooling/metamodel-generator/hibernate-processor.gradle
+++ b/tooling/metamodel-generator/hibernate-processor.gradle
@@ -87,8 +87,10 @@ dependencies {
 	jakartaDataImplementation "org.hibernate.reactive:hibernate-reactive-core:3.0.1.Final"
 	jakartaDataImplementation "io.quarkus:quarkus-hibernate-orm-panache:3.24.1"
 
+	testImplementation libs.compilation.jetbrainsAnnotations
+	testImplementation libs.compilation.jspecify
+
 	integrationTestImplementation project( ':hibernate-testing' )
-	integrationTestCompileOnly libs.compilation.jetbrainsAnnotations
 
 	dataIntegrationTestImplementation project( ':hibernate-testing' )
 	dataIntegrationTestImplementation "jakarta.data:jakarta.data-api:1.1.0-M3"

--- a/tooling/metamodel-generator/hibernate-processor.gradle
+++ b/tooling/metamodel-generator/hibernate-processor.gradle
@@ -88,6 +88,7 @@ dependencies {
 	jakartaDataImplementation "io.quarkus:quarkus-hibernate-orm-panache:3.24.1"
 
 	integrationTestImplementation project( ':hibernate-testing' )
+	integrationTestCompileOnly libs.compilation.jetbrainsAnnotations
 
 	dataIntegrationTestImplementation project( ':hibernate-testing' )
 	dataIntegrationTestImplementation "jakarta.data:jakarta.data-api:1.1.0-M3"

--- a/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/dao/BookDao.java
+++ b/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/dao/BookDao.java
@@ -37,6 +37,10 @@ public interface BookDao {
 	@HQL("from Book where isbn = :isbn")
 	Book findByIsbn(String isbn);
 
+	@org.jetbrains.annotations.Nullable
+	@HQL("from Book where isbn = :isbn")
+	Book findByIsbnNullable(String isbn);
+
 	@HQL("delete from Book where isbn = :isbn")
 	int deleteByIsbn(String isbn);
 

--- a/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/dao/BookDao.java
+++ b/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/dao/BookDao.java
@@ -41,6 +41,9 @@ public interface BookDao {
 	@HQL("from Book where isbn = :isbn")
 	Book findByIsbnNullable(String isbn);
 
+	@HQL("from Book where isbn = :isbn")
+	@org.jspecify.annotations.Nullable Book findByIsbnNullableJspecify(String isbn);
+
 	@HQL("delete from Book where isbn = :isbn")
 	int deleteByIsbn(String isbn);
 

--- a/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/test/BookDaoTest.java
+++ b/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/test/BookDaoTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DomainModel(annotatedClasses = { Book.class })
@@ -145,6 +146,21 @@ class BookDaoTest {
 			int deleted = dao.deleteByIsbn( "isbn-del" );
 			assertEquals( 1, deleted );
 			assertEquals( 0, dao.countBooks() );
+		} );
+	}
+
+	@Test
+	void testHqlFindByIsbnNullable(SessionFactoryScope scope) {
+		scope.inStatelessTransaction( session -> {
+			session.insert( new Book( "isbn-kotlin", "Kotlin Programming", "Author K", 100 ) );
+		} );
+		scope.inStatelessTransaction( session -> {
+			var dao = new _BookDao( session );
+			Book found = dao.findByIsbnNullable( "isbn-kotlin" );
+			assertNotNull( found );
+			assertEquals( "Kotlin Programming", found.getTitle() );
+			Book notFound = dao.findByIsbnNullable( "nonexistent" );
+			assertNull( notFound );
 		} );
 	}
 

--- a/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/test/BookDaoTest.java
+++ b/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/test/BookDaoTest.java
@@ -165,6 +165,21 @@ class BookDaoTest {
 	}
 
 	@Test
+	void testHqlFindByIsbnNullableJspecify(SessionFactoryScope scope) {
+		scope.inStatelessTransaction( session -> {
+			session.insert( new Book( "isbn-jspecify", "JSpecify Programming", "Author J", 100 ) );
+		} );
+		scope.inStatelessTransaction( session -> {
+			var dao = new _BookDao( session );
+			Book found = dao.findByIsbnNullableJspecify( "isbn-jspecify" );
+			assertNotNull( found );
+			assertEquals( "JSpecify Programming", found.getTitle() );
+			Book notFound = dao.findByIsbnNullableJspecify( "nonexistent" );
+			assertNull( notFound );
+		} );
+	}
+
+	@Test
 	void testSqlFindByIsbn(SessionFactoryScope scope) {
 		scope.inStatelessTransaction( session -> {
 			session.insert( new Book( "isbn-native", "Native Title", "Author", 100 ) );

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -102,6 +102,7 @@ import static org.hibernate.processor.util.TypeUtils.getAnnotationValue;
 import static org.hibernate.processor.util.TypeUtils.getInheritedAnnotationMirror;
 import static org.hibernate.processor.util.TypeUtils.hasAnnotation;
 import static org.hibernate.processor.util.TypeUtils.implementsInterface;
+import static org.hibernate.processor.util.TypeUtils.isAnnotationMirrorOfType;
 import static org.hibernate.processor.util.TypeUtils.isPluralAttribute;
 import static org.hibernate.processor.util.TypeUtils.primitiveClassMatchesKind;
 import static org.hibernate.processor.util.TypeUtils.propertyName;
@@ -5544,7 +5545,20 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	}
 
 	private static boolean hasNullableAnnotation(ExecutableElement method) {
-		return hasAnnotation( method, NULLABLE ) || hasAnnotation( method, JETBRAINS_NULLABLE );
+		return hasAnnotation( method, NULLABLE )
+			|| hasAnnotation( method, JETBRAINS_NULLABLE )
+			|| hasJspecifyNullableAnnotation( method );
+	}
+
+	// org.jspecify.annotations.Nullable is @Target(TYPE_USE), so on a method
+	// it's attached to the return type, not to the method element itself.
+	private static boolean hasJspecifyNullableAnnotation(ExecutableElement method) {
+		for ( var mirror : method.getReturnType().getAnnotationMirrors() ) {
+			if ( isAnnotationMirrorOfType( mirror, JSPECIFY_NULLABLE ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private void checkParameters(

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -3324,7 +3324,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						context.addNonnullAnnotation(),
 						jakartaDataRepository,
 						fullReturnType( method ),
-						hasAnnotation( method, NULLABLE )
+						hasNullableAnnotation( method )
 				)
 		);
 	}
@@ -3721,7 +3721,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 							context.addNonnullAnnotation(),
 							jakartaDataRepository,
 							fullReturnType( method ),
-							hasAnnotation( method, NULLABLE )
+							hasNullableAnnotation( method )
 					)
 			);
 		}
@@ -3745,7 +3745,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 							context.addNonnullAnnotation(),
 							jakartaDataRepository,
 							fullReturnType( method ),
-							hasAnnotation( method, NULLABLE )
+							hasNullableAnnotation( method )
 					)
 			);
 		}
@@ -3804,7 +3804,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									context.addNonnullAnnotation(),
 									jakartaDataRepository,
 									fullReturnType( method ),
-									hasAnnotation( method, NULLABLE )
+									hasNullableAnnotation( method )
 							)
 					);
 					break;
@@ -3825,7 +3825,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									context.addNonnullAnnotation(),
 									jakartaDataRepository,
 									fullReturnType( method ),
-									hasAnnotation( method, NULLABLE )
+									hasNullableAnnotation( method )
 							)
 					);
 					break;
@@ -3850,7 +3850,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									context.addNonnullAnnotation(),
 									jakartaDataRepository,
 									fullReturnType( method ),
-									hasAnnotation( method, NULLABLE )
+									hasNullableAnnotation( method )
 							)
 					);
 					break;
@@ -4485,7 +4485,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						context.addNonnullAnnotation(),
 						jakartaDataRepository,
 						fullReturnType( method ),
-						hasAnnotation( method, NULLABLE )
+						hasNullableAnnotation( method )
 					);
 		putMember( attribute.getPropertyName() + paramTypes, attribute );
 	}
@@ -5541,6 +5541,10 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			}
 		}
 		return true;
+	}
+
+	private static boolean hasNullableAnnotation(ExecutableElement method) {
+		return hasAnnotation( method, NULLABLE ) || hasAnnotation( method, JETBRAINS_NULLABLE );
 	}
 
 	private void checkParameters(

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
@@ -226,6 +226,7 @@ public final class Constants {
 	public static final String NONNULL = "jakarta.annotation.Nonnull";
 	public static final String NOT_NULL = "jakarta.validation.constraints.NotNull";
 	public static final String JETBRAINS_NULLABLE = "org.jetbrains.annotations.Nullable";
+	public static final String JSPECIFY_NULLABLE = "org.jspecify.annotations.Nullable";
 
 	public static final String PANACHE_ORM_REPOSITORY_BASE = "io.quarkus.hibernate.orm.panache.PanacheRepositoryBase";
 	public static final String PANACHE_ORM_ENTITY_BASE = "io.quarkus.hibernate.orm.panache.PanacheEntityBase";

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
@@ -225,6 +225,7 @@ public final class Constants {
 	public static final String NULLABLE = "jakarta.annotation.Nullable";
 	public static final String NONNULL = "jakarta.annotation.Nonnull";
 	public static final String NOT_NULL = "jakarta.validation.constraints.NotNull";
+	public static final String JETBRAINS_NULLABLE = "org.jetbrains.annotations.Nullable";
 
 	public static final String PANACHE_ORM_REPOSITORY_BASE = "io.quarkus.hibernate.orm.panache.PanacheRepositoryBase";
 	public static final String PANACHE_ORM_ENTITY_BASE = "io.quarkus.hibernate.orm.panache.PanacheEntityBase";

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/nullable/Book.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/nullable/Book.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.nullable;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.NaturalId;
+
+@Entity
+public class Book {
+	@Id
+	String isbn;
+	@NaturalId
+	String title;
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/nullable/BookRepository.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/nullable/BookRepository.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.nullable;
+
+import org.hibernate.StatelessSession;
+import org.hibernate.annotations.processing.Find;
+import org.hibernate.annotations.processing.HQL;
+
+/**
+ * A finder method may be marked nullable using {@code jakarta.annotation.Nullable},
+ * {@code org.jetbrains.annotations.Nullable}, or {@code org.jspecify.annotations.Nullable}.
+ * All three forms must produce a generated method that returns {@code null}
+ * instead of throwing when no result is found.
+ */
+public interface BookRepository {
+
+	StatelessSession session();
+
+	@jakarta.annotation.Nullable
+	@HQL("from Book where isbn = :isbn")
+	Book findByIsbnNullableJakarta(String isbn);
+
+	@org.jetbrains.annotations.Nullable
+	@HQL("from Book where isbn = :isbn")
+	Book findByIsbnNullableJetbrains(String isbn);
+
+	@HQL("from Book where isbn = :isbn")
+	@org.jspecify.annotations.Nullable Book findByIsbnNullableJspecify(String isbn);
+
+	// a type-use annotation on the return type that is not org.jspecify.annotations.Nullable,
+	// so hasJspecifyNullableAnnotation() must iterate past a non-matching annotation mirror
+	@HQL("from Book where isbn = :isbn")
+	@org.jspecify.annotations.NonNull Book findByIsbnNotNullable(String isbn);
+
+	// a @Find finder on a @NaturalId attribute, exercising the NATURAL_ID
+	// finder strategy's call to hasNullableAnnotation()
+	@Find
+	Book findByTitle(String title);
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/nullable/NullableAnnotationTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/nullable/NullableAnnotationTest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.nullable;
+
+import org.hibernate.internal.util.StringHelper;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a finder method annotated {@code @jakarta.annotation.Nullable},
+ * {@code @org.jetbrains.annotations.Nullable}, or {@code @org.jspecify.annotations.Nullable}
+ * is recognized as nullable, so the generated method uses {@code getSingleResultOrNull()}
+ * rather than {@code getSingleResult()}.
+ *
+ * @see BookRepository
+ */
+@CompilationTest
+class NullableAnnotationTest {
+
+	@Test
+	@WithClasses({ Book.class, BookRepository.class })
+	void testNullableAnnotationsAreRecognized() {
+		final String repository = getMetaModelSourceAsString( BookRepository.class, true );
+		System.out.println( repository );
+		assertMetamodelClassGeneratedFor( Book.class );
+		assertMetamodelClassGeneratedFor( BookRepository.class, true );
+
+		// all three nullable annotations must be recognized, so every finder
+		// method uses 'getSingleResultOrNull()' instead of 'getSingleResult()'
+		assertEquals( 3, StringHelper.count( repository, ".getSingleResultOrNull()" ),
+				"expected the jakarta, JetBrains, and jspecify @Nullable variants to all be recognized" );
+		// findByIsbnNotNullable's return type is annotated @NonNull, not @Nullable,
+		// so it must not be treated as nullable
+		assertEquals( 1, StringHelper.count( repository, ".getSingleResult()" ) );
+		// findByTitle is a @Find finder on a @NaturalId attribute (no nullable
+		// annotation at all), exercising the NATURAL_ID finder strategy
+		assertTrue( repository.contains( "public Book findByTitle(String title)" ) );
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]
As a developer using Hibernate Data with Quarkus and Kotlin, I've encountered an issue with how Kotlin nullable types are handled by the annotation processor (KAPT).

When using a repository method to find a book by title (returning `Book?`), I expect to receive `null` if no result is found. Instead, the application throws a `NoResultsException`.

Upon inspecting the generated code, I discovered that KAPT currently generates the `@org.jetbrains.annotations.Nullable `annotation for Kotlin nullable types. However, Hibernate expects the `@jakarta.annotation.Nullable` annotation to correctly identify nullable return types and handle empty results gracefully.

This PR updates the annotation processor to recognize and support both `@org.jetbrains.annotations.Nullable` and `@jakarta.annotation.Nullable`, ensuring that null is returned instead of throwing an exception when no record is found.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20654 (Proposal):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20654
<!-- Hibernate GitHub Bot issue links end -->