### PR TITLE
HHH-20615 The HbmXml transformer should set the correct access value for <embeddable>.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributesContainer;
+import jakarta.persistence.AccessType;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableAttributesContainerImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedImpl;
@@ -139,6 +140,12 @@ public class HbmXmlTransformerComponentHandler {
 		embeddable.setMetadataComplete( true );
 		embeddable.setName( embeddableName );
 		embeddable.setClazz( embeddableClassName );
+
+		final String componentAccess = hbmComponent.getAccess();
+		final String effectiveAccess = componentAccess != null ? componentAccess : defaultAccess;
+		if ( effectiveAccess == null || "property".equalsIgnoreCase( effectiveAccess ) ) {
+			embeddable.setAccess( AccessType.PROPERTY );
+		}
 
 		embeddable.setAttributes( new JaxbEmbeddableAttributesContainerImpl() );
 		if ( nestedAttributeProcessor != null ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/hbm/transform/HbmXmlComponentVisitorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/hbm/transform/HbmXmlComponentVisitorTest.java
@@ -22,6 +22,8 @@ import org.hibernate.boot.jaxb.spi.Binding;
 
 import org.junit.jupiter.api.Test;
 
+import jakarta.persistence.AccessType;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -190,6 +192,71 @@ public class HbmXmlComponentVisitorTest {
 		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
 
 		assertThat( result.getEmbeddables() ).isEmpty();
+	}
+
+	@Test
+	void embeddableDefaultAccessIsProperty() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType entity = new JaxbHbmRootEntityType();
+		entity.setName( "MyEntity" );
+
+		JaxbHbmCompositeAttributeType component = new JaxbHbmCompositeAttributeType();
+		component.setName( "address" );
+		component.setClazz( "com.example.Address" );
+		entity.getAttributes().add( component );
+
+		hbmMapping.getClazz().add( entity );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() )
+				.hasSize( 1 )
+				.allSatisfy( e -> assertThat( e.getAccess() ).isEqualTo( AccessType.PROPERTY ) );
+	}
+
+	@Test
+	void embeddableExplicitFieldAccess() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType entity = new JaxbHbmRootEntityType();
+		entity.setName( "MyEntity" );
+
+		JaxbHbmCompositeAttributeType component = new JaxbHbmCompositeAttributeType();
+		component.setName( "address" );
+		component.setClazz( "com.example.Address" );
+		component.setAccess( "field" );
+		entity.getAttributes().add( component );
+
+		hbmMapping.getClazz().add( entity );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() )
+				.hasSize( 1 )
+				.allSatisfy( e -> assertThat( e.getAccess() ).isNull() );
+	}
+
+	@Test
+	void embeddableExplicitPropertyAccess() {
+		JaxbHbmHibernateMapping hbmMapping = new JaxbHbmHibernateMapping();
+
+		JaxbHbmRootEntityType entity = new JaxbHbmRootEntityType();
+		entity.setName( "MyEntity" );
+
+		JaxbHbmCompositeAttributeType component = new JaxbHbmCompositeAttributeType();
+		component.setName( "address" );
+		component.setClazz( "com.example.Address" );
+		component.setAccess( "property" );
+		entity.getAttributes().add( component );
+
+		hbmMapping.getClazz().add( entity );
+
+		JaxbEntityMappingsImpl result = processWithHandler( hbmMapping );
+
+		assertThat( result.getEmbeddables() )
+				.hasSize( 1 )
+				.allSatisfy( e -> assertThat( e.getAccess() ).isEqualTo( AccessType.PROPERTY ) );
 	}
 
 	/**


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20615]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20615 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->