### PR TITLE
Exclude hibernate-tck-data-runner project on JDK < 21

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -181,7 +181,11 @@ include 'hibernate-reveng'
 project(':hibernate-reveng').projectDir = new File(rootProject.projectDir, "tooling/hibernate-reveng")
 
 include 'hibernate-tck-runner'
-include 'hibernate-tck-data-runner'
+
+// Jakarta Data TCK dependencies require JDK 21+
+if ( jdkVersions.test.launcher.asInt() >= 21 ) {
+    include 'hibernate-tck-data-runner'
+}
 
 rootProject.children.each { project ->
     project.buildFileName = "${project.name}.gradle"


### PR DESCRIPTION
since it depends on libs that require JDK 21+

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
