### PR TITLE
HHH-20621 Ensure proxy implementation is set when claiming existing EntityHolder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -396,6 +396,12 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		if ( oldHolder != null ) {
 			if ( entity != null ) {
 				assert oldHolder.entity == null || oldHolder.entity == entity;
+				if ( oldHolder.proxy != null && oldHolder.entity == null ) {
+					// When there was a proxy before, we have to set the implementation of the proxy to the new entity
+					final LazyInitializer lazyInitializer = extractLazyInitializer( oldHolder.proxy );
+					assert lazyInitializer != null;
+					lazyInitializer.setImplementation( entity );
+				}
 				oldHolder.entity = entity;
 			}
 			// Skip setting a new entity initializer if there already is one owner
@@ -499,6 +505,12 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		final EntityHolderImpl holder;
 		if ( oldHolder != null ) {
 //			assert oldHolder.entity == null || oldHolder.entity == entity;
+			if ( oldHolder.proxy != null && oldHolder.entity == null ) {
+				// When there was a proxy before, we have to set the implementation of the proxy to the new entity
+				final LazyInitializer lazyInitializer = extractLazyInitializer( oldHolder.proxy );
+				assert lazyInitializer != null;
+				lazyInitializer.setImplementation( entity );
+			}
 			oldHolder.entity = entity;
 			holder = oldHolder;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -947,9 +947,6 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 				assert data.entityHolder.getProxy() != instance;
 				instance = resolveEntityInstance( data );
 				data.entityKey = data.entityHolder.getEntityKey();
-				if ( data.entityHolder.getProxy() != null ) {
-					castNonNull( extractLazyInitializer( data.entityHolder.getProxy() ) ).setImplementation( instance );
-				}
 			}
 			else if ( data.entityHolder.getEntity() != instance ) {
 				// The instance contained in the parent entity is different from the managed persistent instance
@@ -999,13 +996,9 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 			// Resolve and potentially create the entity instance
 			if ( data.entityHolder.getProxy() == instance ) {
 				data.entityInstanceForNotify = resolveEntityInstance( data );
-				lazyInitializer.setImplementation( data.entityInstanceForNotify );
 			}
 			else if ( data.entityHolder.getEntity() == null ) {
 				data.entityInstanceForNotify = resolveEntityInstance( data );
-				if ( data.entityHolder.getProxy() != null ) {
-					castNonNull( extractLazyInitializer( data.entityHolder.getProxy() ) ).setImplementation( data.entityInstanceForNotify );
-				}
 			}
 			else {
 				data.entityInstanceForNotify = data.entityHolder.getEntity();
@@ -1026,9 +1019,6 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 			else if ( data.entityHolder.getEntity() == null ) {
 				data.entityInstanceForNotify = resolveEntityInstance( data );
 				data.entityKey = data.entityHolder.getEntityKey();
-				if ( data.entityHolder.getProxy() != null ) {
-					castNonNull( extractLazyInitializer( data.entityHolder.getProxy() ) ).setImplementation( data.entityInstanceForNotify );
-				}
 				data.setState( State.RESOLVED );
 			}
 			else {
@@ -1142,7 +1132,6 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 					final LazyInitializer lazyInitializer = extractLazyInitializer( proxy );
 					assert lazyInitializer != null;
 					data.entityInstanceForNotify = resolveEntityInstance2( data );
-					lazyInitializer.setImplementation( data.entityInstanceForNotify );
 				}
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/joined/ProxyEntityCoexistenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/joined/ProxyEntityCoexistenceTest.java
@@ -1,0 +1,164 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.inheritance.joined;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				ProxyEntityCoexistenceTest.Foo.class,
+				ProxyEntityCoexistenceTest.Bar.class,
+				ProxyEntityCoexistenceTest.Baz.class
+		}
+)
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-20621")
+public class ProxyEntityCoexistenceTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Bar bar = new Bar();
+			bar.setId( 1L );
+			bar.setName( "bar1" );
+			session.persist( bar );
+
+			Baz baz = new Baz();
+			baz.setId( 1L );
+			baz.setFoo( bar );
+			session.persist( baz );
+		} );
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createMutationQuery( "delete from Baz" ).executeUpdate();
+			session.createMutationQuery( "delete from Bar" ).executeUpdate();
+			session.createMutationQuery( "delete from Foo" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testProxyEntityCoexistence(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			// Step 1: Load Baz#1, creates a lazy proxy for Foo#1 typed as Foo (not Bar)
+			Baz baz = session.find( Baz.class, 1L );
+			assertThat( baz ).isNotNull();
+
+			// Step 2: Access the reference, does NOT initialize the proxy
+			Foo foo = baz.getFoo();
+			assertThat( foo ).isNotNull();
+
+			// Step 3: Load Bar#1 with its bazList using join fetch
+			Bar bar = session.createQuery( "from Bar bar join fetch bar.bazList where bar.id = :id", Bar.class )
+					.setParameter( "id", foo.getId() )
+					.getSingleResult();
+			assertThat( bar ).isNotNull();
+			assertThat( bar.getBazList() ).hasSize( 1 );
+
+			// Step 4: Load Baz#1 again with join fetch on foo
+			Baz baz2 = session.createQuery( "from Baz baz join fetch baz.foo where baz.id = :id", Baz.class )
+					.setParameter( "id", baz.getId() )
+					.getSingleResult();
+			assertThat( baz2 ).isNotNull();
+			assertThat( baz2.getFoo() ).isNotNull();
+			assertThat( Hibernate.unproxy( foo ) ).isSameAs( bar );
+
+			// Step 5: This should not throw NPE
+			Bar bar2 = session.find( Bar.class, 1L );
+			assertThat( bar2 ).isNotNull();
+			assertThat( bar2.getId() ).isEqualTo( 1L );
+		} );
+	}
+
+	@Entity(name = "Foo")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	public static class Foo {
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany(mappedBy = "foo")
+		private List<Baz> bazList = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public List<Baz> getBazList() {
+			return bazList;
+		}
+
+		public void setBazList(List<Baz> bazList) {
+			this.bazList = bazList;
+		}
+	}
+
+	@Entity(name = "Bar")
+	public static class Bar extends Foo {
+	}
+
+	@Entity(name = "Baz")
+	public static class Baz {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Foo foo;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Foo getFoo() {
+			return foo;
+		}
+
+		public void setFoo(Foo foo) {
+			this.foo = foo;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20621 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20621
<!-- Hibernate GitHub Bot issue links end -->