### PR TITLE
HHH-20626 +  HHH-20627 HbmXmlTransformer fixes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1375,7 +1375,7 @@ public class HbmXmlTransformer {
 							hbmComponent,
 							componentTypeInfo
 					);
-					final var embedded = componentHandler.transformEmbedded( jaxbEmbeddable, hbmComponent );
+					final var embedded = componentHandler.transformEmbedded( jaxbEmbeddable, hbmComponent, componentTypeInfo );
 					transferAccess(
 							hbmComponent.getAccess(),
 							embedded::setAccess,
@@ -3320,7 +3320,7 @@ public class HbmXmlTransformer {
 							hbmComponent,
 							componentTypeInfo
 					);
-					final var embedded = componentHandler.transformEmbedded( jaxbEmbeddable, hbmComponent );
+					final var embedded = componentHandler.transformEmbedded( jaxbEmbeddable, hbmComponent, componentTypeInfo );
 					transferAccess(
 							hbmComponent.getAccess(),
 							embedded::setAccess,

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
@@ -9,16 +9,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributeOverrideImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributesContainer;
 import jakarta.persistence.AccessType;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbColumnImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCompositeUserTypeRegistrationImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableAttributesContainerImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Property;
 
 import static org.hibernate.internal.util.StringHelper.isNotEmpty;
 
@@ -53,6 +58,7 @@ public class HbmXmlTransformerComponentHandler {
 
 	// todo (7.0) : use transformation-state instead
 	private final Map<String, JaxbEmbeddableImpl> jaxbEmbeddableByClassName = new HashMap<>();
+	private final Map<String, ComponentTypeInfo> referenceComponentByClassName = new HashMap<>();
 	private int counter = 1;
 
 	/**
@@ -123,6 +129,9 @@ public class HbmXmlTransformerComponentHandler {
 
 		if ( isNotEmpty( embeddableClassName ) ) {
 			jaxbEmbeddableByClassName.put( embeddableClassName, jaxbEmbeddable );
+			if ( componentTypeInfo != null ) {
+				referenceComponentByClassName.put( embeddableClassName, componentTypeInfo );
+			}
 		}
 
 		return jaxbEmbeddable;
@@ -130,11 +139,73 @@ public class HbmXmlTransformerComponentHandler {
 
 	public JaxbEmbeddedImpl transformEmbedded(
 			JaxbEmbeddableImpl jaxbEmbeddable,
-			JaxbHbmCompositeAttributeType hbmComponent) {
+			JaxbHbmCompositeAttributeType hbmComponent,
+			ComponentTypeInfo componentTypeInfo) {
 		final var embedded = new JaxbEmbeddedImpl();
 		embedded.setName( hbmComponent.getName() );
 		embedded.setTarget( jaxbEmbeddable.getName() );
+
+		if ( componentTypeInfo != null ) {
+			final String embeddableClassName = jaxbEmbeddable.getClazz();
+			final var referenceInfo = embeddableClassName != null
+					? referenceComponentByClassName.get( embeddableClassName )
+					: null;
+			if ( referenceInfo != null && referenceInfo != componentTypeInfo ) {
+				applyAttributeOverrides( embedded, referenceInfo, componentTypeInfo );
+			}
+		}
+
 		return embedded;
+	}
+
+	private void applyAttributeOverrides(
+			JaxbEmbeddedImpl embedded,
+			ComponentTypeInfo referenceInfo,
+			ComponentTypeInfo currentInfo) {
+		for ( Property currentProp : currentInfo.getComponent().getProperties() ) {
+			final Property referenceProp = findProperty( referenceInfo, currentProp.getName() );
+			if ( referenceProp == null ) {
+				continue;
+			}
+
+			final var currentColumns = currentProp.getValue().getColumns();
+			final var referenceColumns = referenceProp.getValue().getColumns();
+			if ( currentColumns.size() != 1 || referenceColumns.size() != 1 ) {
+				continue;
+			}
+
+			final Column currentCol = currentColumns.get( 0 );
+			final Column referenceCol = referenceColumns.get( 0 );
+			if ( columnsMatch( currentCol, referenceCol ) ) {
+				continue;
+			}
+
+			final var override = new JaxbAttributeOverrideImpl();
+			override.setName( currentProp.getName() );
+			final var column = new JaxbColumnImpl();
+			column.setName( currentCol.getQuotedName() );
+			column.setNullable( currentCol.isNullable() );
+			column.setUnique( currentCol.isUnique() );
+			column.setRead( currentCol.getCustomReadExpression() );
+			column.setWrite( currentCol.getCustomWriteExpression() );
+			override.setColumn( column );
+			embedded.getAttributeOverrides().add( override );
+		}
+	}
+
+	private static Property findProperty(ComponentTypeInfo info, String name) {
+		for ( Property p : info.getComponent().getProperties() ) {
+			if ( name.equals( p.getName() ) ) {
+				return p;
+			}
+		}
+		return null;
+	}
+
+	private static boolean columnsMatch(Column a, Column b) {
+		return Objects.equals( a.getQuotedName(), b.getQuotedName() )
+				&& Objects.equals( a.getCustomReadExpression(), b.getCustomReadExpression() )
+				&& Objects.equals( a.getCustomWriteExpression(), b.getCustomWriteExpression() );
 	}
 
 	private JaxbEmbeddableImpl convertEmbeddable(

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCompositeAttributeType;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributesContainer;
 import jakarta.persistence.AccessType;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbCompositeUserTypeRegistrationImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableAttributesContainerImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedImpl;
@@ -100,6 +101,13 @@ public class HbmXmlTransformerComponentHandler {
 			final var existing = jaxbEmbeddableByClassName.get( embeddableClassName );
 			if ( existing != null ) {
 				return existing;
+			}
+		}
+
+		if ( componentTypeInfo != null ) {
+			final String compositeUserTypeName = componentTypeInfo.getComponent().getTypeName();
+			if ( isNotEmpty( compositeUserTypeName ) && isNotEmpty( embeddableClassName ) ) {
+				applyCompositeUserTypeRegistration( embeddableClassName, compositeUserTypeName );
 			}
 		}
 
@@ -199,6 +207,18 @@ public class HbmXmlTransformerComponentHandler {
 		catch (Exception e) {
 			// if we can't load the class, skip transient generation
 		}
+	}
+
+	private void applyCompositeUserTypeRegistration(String embeddableClassName, String compositeUserTypeName) {
+		for ( JaxbCompositeUserTypeRegistrationImpl existing : mappingRoot.getCompositeUserTypeRegistrations() ) {
+			if ( embeddableClassName.equals( existing.getClazz() ) ) {
+				return;
+			}
+		}
+		final var registration = new JaxbCompositeUserTypeRegistrationImpl();
+		registration.setClazz( embeddableClassName );
+		registration.setDescriptor( compositeUserTypeName );
+		mappingRoot.getCompositeUserTypeRegistrations().add( registration );
 	}
 
 	public String determineEmbeddableName(String componentClassName, String attributeName) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -21,6 +21,7 @@ import org.hibernate.boot.jaxb.hbm.transform.UnsupportedFeatureHandling;
 import org.hibernate.boot.jaxb.internal.stax.HbmEventReader;
 import org.hibernate.boot.jaxb.mapping.GenerationTiming;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbBasicImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbCompositeUserTypeRegistrationImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
@@ -487,6 +488,44 @@ public class HbmTransformationJaxbTests {
 			assertThat( children.getMappedBy() )
 					.as( "mapped-by should resolve to 'id.parent' for key-many-to-one inside composite-id" )
 					.isEqualTo( "id.parent" );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-19424" )
+	public void testCompositeUserTypeComponentTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/composite-user-type/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			assertThat( transformed.getCompositeUserTypeRegistrations() )
+					.as( "CompositeUserType component should generate a <composite-user-type> registration" )
+					.hasSize( 1 );
+
+			final JaxbCompositeUserTypeRegistrationImpl registration =
+					transformed.getCompositeUserTypeRegistrations().get( 0 );
+			assertThat( registration.getClazz() )
+					.isEqualTo( "org.hibernate.orm.test.cut.MonetoryAmount" );
+			assertThat( registration.getDescriptor() )
+					.isEqualTo( "org.hibernate.orm.test.cut.MonetoryAmountUserType" );
+
+			assertThat( transformed.getEmbeddables() ).hasSize( 1 );
+
+			final JaxbEmbeddableImpl embeddable = transformed.getEmbeddables().get( 0 );
+			assertThat( embeddable.getClazz() )
+					.isEqualTo( "org.hibernate.orm.test.cut.MonetoryAmount" );
+
+			final JaxbBasicImpl amountAttr = embeddable.getAttributes().getBasicAttributes().stream()
+					.filter( b -> "amount".equals( b.getName() ) )
+					.findFirst()
+					.orElseThrow();
+
+			final JaxbEntityImpl mutualFundEntity = transformed.getEntities().stream()
+					.filter( e -> "MutualFund".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( mutualFundEntity.getAttributes().getEmbeddedAttributes() ).hasSize( 1 );
+			assertThat( mutualFundEntity.getAttributes().getEmbeddedAttributes().get( 0 ).getName() )
+					.isEqualTo( "holdings" );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -20,9 +20,11 @@ import org.hibernate.boot.jaxb.hbm.transform.HbmXmlTransformer;
 import org.hibernate.boot.jaxb.hbm.transform.UnsupportedFeatureHandling;
 import org.hibernate.boot.jaxb.internal.stax.HbmEventReader;
 import org.hibernate.boot.jaxb.mapping.GenerationTiming;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributeOverrideImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbBasicImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCompositeUserTypeRegistrationImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbIdImpl;
@@ -526,6 +528,41 @@ public class HbmTransformationJaxbTests {
 			assertThat( mutualFundEntity.getAttributes().getEmbeddedAttributes() ).hasSize( 1 );
 			assertThat( mutualFundEntity.getAttributes().getEmbeddedAttributes().get( 0 ).getName() )
 					.isEqualTo( "holdings" );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20627" )
+	public void testSharedEmbeddableAttributeOverrideTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/composite-user-type/hbm.xml", scope, (transformed) -> {
+			final JaxbEntityImpl mutualFundEntity = transformed.getEntities().stream()
+					.filter( e -> "MutualFund".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			final JaxbEmbeddedImpl holdings = mutualFundEntity.getAttributes().getEmbeddedAttributes().get( 0 );
+			assertThat( holdings.getName() ).isEqualTo( "holdings" );
+
+			assertThat( holdings.getAttributeOverrides() )
+					.as( "MutualFund.holdings should have an attribute-override for 'amount'" )
+					.hasSize( 1 );
+
+			final JaxbAttributeOverrideImpl override = holdings.getAttributeOverrides().get( 0 );
+			assertThat( override.getName() ).isEqualTo( "amount" );
+			assertThat( override.getColumn() ).isNotNull();
+			assertThat( override.getColumn().getName() ).isEqualTo( "amount_millions" );
+			assertThat( override.getColumn().getRead() ).isEqualTo( "amount_millions * 1000000.0" );
+			assertThat( override.getColumn().getWrite() ).isEqualTo( "? / 1000000.0" );
+
+			final JaxbEntityImpl transactionEntity = transformed.getEntities().stream()
+					.filter( e -> "Transaction".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			final JaxbEmbeddedImpl value = transactionEntity.getAttributes().getEmbeddedAttributes().get( 0 );
+			assertThat( value.getAttributeOverrides() )
+					.as( "Transaction.value should not have attribute overrides (it matches the embeddable)" )
+					.isEmpty();
 		} );
 	}
 

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-user-type/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-user-type/hbm.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm" package="org.hibernate.orm.test.cut">
+
+    <class name="Transaction" table="Trnsctn">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="description" length="100" not-null="true"/>
+        <component name="value" class="org.hibernate.orm.test.cut.MonetoryAmountUserType">
+            <property name="amount" not-null="true"/>
+            <property name="currency" not-null="true"/>
+        </component>
+    </class>
+
+    <class name="MutualFund" table="MutualFund">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <component name="holdings" class="org.hibernate.orm.test.cut.MonetoryAmountUserType">
+            <property name="amount">
+                <column name="amount_millions"
+                        not-null="true"
+                        read="amount_millions * 1000000.0"
+                        write="? / 1000000.0"/>
+            </property>
+            <property name="currency" not-null="true"/>
+        </component>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HHH-20626 HbmXmlTransformer does not generate <composite-user-type> for CompositeUserType components
- https://hibernate.atlassian.net/browse/HHH-20627 HbmXmlTransformer does not generate <attribute-override> when multiple components share the same embeddable class

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20627 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20626 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->