### PR TITLE
HHH-19569 Use DiscriminatorType instead of underlying JDBC mapping for SqlSelection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractDiscriminatorMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractDiscriminatorMapping.java
@@ -153,7 +153,7 @@ public abstract class AbstractDiscriminatorMapping implements EntityDiscriminato
 		// create a SqlSelection based on the underlying JdbcMapping
 		final var sqlSelection = resolveSqlSelection(
 				fetchablePath,
-				underlyingJdbcMapping,
+				getJdbcMapping(),
 				tableGroup,
 				fetchParent,
 				creationState.getSqlAstCreationState()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CaseStatementDiscriminatorMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CaseStatementDiscriminatorMappingImpl.java
@@ -329,7 +329,7 @@ public class CaseStatementDiscriminatorMappingImpl extends AbstractDiscriminator
 										),
 										new QueryLiteral<>(
 												tableDiscriminatorDetails.getDiscriminatorValue(),
-												getUnderlyingJdbcMapping()
+												(BasicType<?>) getJdbcMapping()
 										)
 								);
 							}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1997,12 +1997,9 @@ public abstract class AbstractEntityPersister
 		);
 
 		final var entityPath = new NavigablePath( getRootPathName() );
-		final var rootTableGroup = createRootTableGroup(
-				true,
+		final var rootTableGroup = createSelectFragmentRootTableGroup(
+				alias,
 				entityPath,
-				null,
-				new SqlAliasBaseConstant( alias ),
-				() -> p -> {},
 				sqlAstCreationState
 		);
 
@@ -2028,7 +2025,7 @@ public abstract class AbstractEntityPersister
 			assert discriminatorMapping.getJdbcTypeCount() == 1;
 			final var selectableMapping = discriminatorMapping.getSelectable( 0 );
 			if ( processedExpressions.add( selectableMapping.getSelectionExpression() ) ) {
-				aliasSelection( sqlSelections, i, getDiscriminatorAlias() + suffix );
+				aliasSelection( sqlSelections, i, getDiscriminatorAlias( suffix ) );
 				i++;
 			}
 		}
@@ -2084,6 +2081,54 @@ public abstract class AbstractEntityPersister
 		final var expression = sqlSelections.get( selectionIndex ).getExpression();
 		sqlSelections.set( selectionIndex,
 				new SqlSelectionImpl( selectionIndex, new AliasedExpression( expression, alias ) ) );
+	}
+
+	private TableGroup createSelectFragmentRootTableGroup(
+			String alias,
+			NavigablePath entityPath,
+			SqlAstCreationState sqlAstCreationState) {
+
+		final TableReference rootTableReference = new NamedTableReference(
+				getTableName(),
+				alias
+		);
+		return new StandardTableGroup(
+				true,
+				entityPath,
+				this,
+				null,
+				rootTableReference,
+				true,
+				new SqlAliasBaseConstant( alias ),
+				getRootEntityDescriptor()::containsTableReference,
+				(tableExpression, tg) -> {
+					final String[] subclassTableNames = getSubclassTableNames();
+					for ( int i = 0; i < subclassTableNames.length; i++ ) {
+						if ( tableExpression.equals( subclassTableNames[i] ) ) {
+							final NamedTableReference joinedTableReference = new NamedTableReference(
+									tableExpression,
+									generateTableAlias( alias, i ),
+									isNullableSubclassTable( i )
+							);
+							return new TableReferenceJoin(
+									shouldInnerJoinSubclassTable( i, emptySet() ),
+									joinedTableReference,
+									generateJoinPredicate(
+											rootTableReference,
+											joinedTableReference,
+											needsDiscriminator()
+													? getRootTableKeyColumnNames()
+													: getIdentifierColumnNames(),
+											getSubclassTableKeyColumns( i ),
+											sqlAstCreationState
+									)
+							);
+						}
+					}
+					return null;
+				},
+				getFactory()
+		);
 	}
 
 	private ImmutableFetchList fetchProcessor(FetchParent fetchParent, LoaderSqlAstCreationState creationState) {

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/ResultsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/ResultsHelper.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.query.results.internal;
 
-import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.internal.SingleAttributeIdentifierMapping;
@@ -14,7 +13,6 @@ import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 import static org.hibernate.sql.ast.spi.SqlExpressionResolver.createColumnReferenceKey;
-import static org.hibernate.sql.ast.spi.SqlExpressionResolver.createDiscriminatorColumnReferenceKey;
 
 /**
  * @author Steve Ebersole
@@ -58,25 +56,6 @@ public class ResultsHelper {
 					final int jdbcPosition = jdbcValuesMetadata.resolveColumnPosition( columnAlias );
 					final int valuesArrayPosition = jdbcPositionToValuesArrayPosition( jdbcPosition );
 					return new ResultSetMappingSqlSelection( valuesArrayPosition, selectableMapping.getJdbcMapping() );
-				}
-		);
-	}
-
-	public static Expression resolveSqlExpression(
-			DomainResultCreationStateImpl resolver,
-			JdbcValuesMetadata jdbcValuesMetadata,
-			TableReference tableReference,
-			EntityDiscriminatorMapping discriminatorMapping,
-			String columnAlias) {
-		return resolver.resolveSqlExpression(
-				createDiscriminatorColumnReferenceKey(
-						tableReference,
-						discriminatorMapping
-				),
-				processingState -> {
-					final int jdbcPosition = jdbcValuesMetadata.resolveColumnPosition( columnAlias );
-					final int valuesArrayPosition = jdbcPositionToValuesArrayPosition( jdbcPosition );
-					return new ResultSetMappingSqlSelection( valuesArrayPosition, discriminatorMapping.getJdbcMapping() );
 				}
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/complete/CompleteFetchBuilderBasicPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/complete/CompleteFetchBuilderBasicPart.java
@@ -7,7 +7,6 @@ package org.hibernate.query.results.internal.complete;
 import org.hibernate.AssertionFailure;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.BasicValuedModelPart;
-import org.hibernate.metamodel.mapping.DiscriminatorMapping;
 import org.hibernate.query.results.spi.FetchBuilder;
 import org.hibernate.query.results.spi.FetchBuilderBasicValued;
 import org.hibernate.query.results.MissingSqlSelectionException;
@@ -84,15 +83,11 @@ public class CompleteFetchBuilderBasicPart implements CompleteFetchBuilder, Fetc
 						? jdbcResultsMetadata.resolveColumnName( jdbcPosition )
 						: selectionAlias;
 
-		final var jdbcMapping =
-				referencedModelPart instanceof DiscriminatorMapping discriminatorMapping
-						? discriminatorMapping.getUnderlyingJdbcMapping()
-						: referencedModelPart.getJdbcMapping();
-
 		final int valuesArrayPosition = jdbcPositionToValuesArrayPosition( jdbcPosition );
+
 		// we just care about the registration here.  The ModelPart will find it later
 		creationStateImpl.resolveSqlExpression(
-				createColumnReferenceKey( tableReference, referencedModelPart.getSelectablePath(), jdbcMapping ),
+				createColumnReferenceKey( tableReference, referencedModelPart ),
 				processingState -> new ResultSetMappingSqlSelection( valuesArrayPosition, referencedModelPart )
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderEntityStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderEntityStandard.java
@@ -9,7 +9,6 @@ import org.hibernate.AssertionFailure;
 import org.hibernate.LockMode;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.CollectionPart;
-import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -248,7 +247,7 @@ public class DynamicResultBuilderEntityStandard
 		}
 
 		if ( discriminatorColumnName != null ) {
-			resolveDiscriminatorSqlSelection(
+			resolveSqlSelection(
 					discriminatorColumnName,
 					tableReference,
 					entityMapping.getDiscriminatorMapping(),
@@ -289,23 +288,6 @@ public class DynamicResultBuilderEntityStandard
 		else {
 			return null;
 		}
-	}
-
-	private static void resolveDiscriminatorSqlSelection(String columnAlias, TableReference tableReference, EntityDiscriminatorMapping discriminatorMapping, JdbcValuesMetadata jdbcResultsMetadata, DomainResultCreationState domainResultCreationState) {
-		final var creationStateImpl = impl( domainResultCreationState );
-		creationStateImpl.resolveSqlSelection(
-				resolveSqlExpression(
-						creationStateImpl,
-						jdbcResultsMetadata,
-						tableReference,
-						discriminatorMapping,
-						columnAlias
-				),
-				discriminatorMapping.getJdbcMapping().getJdbcJavaType(),
-				null,
-				domainResultCreationState.getSqlAstCreationState().getCreationContext()
-						.getTypeConfiguration()
-		);
 	}
 
 	private FetchBuilder findIdFetchBuilder() {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EntityValuedPathInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EntityValuedPathInterpretation.java
@@ -316,7 +316,7 @@ public class EntityValuedPathInterpretation<T> extends AbstractSqmPathInterpreta
 				if ( discriminatorMapping != null ) {
 					expressions.add( discriminatorMapping.resolveSqlExpression(
 							navigablePath,
-							discriminatorMapping.getUnderlyingJdbcMapping(),
+							discriminatorMapping.getJdbcMapping(),
 							tableGroup,
 							sqlAstCreationState
 					) );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
@@ -94,11 +94,14 @@ public interface SqlExpressionResolver {
 
 	/**
 	 * Convenience form for creating a key from TableReference and EntityDiscriminatorMapping
+	 *
+	 * @deprecated Use {@link #createColumnReferenceKey(TableReference, SelectableMapping)} instead
 	 */
+	@Deprecated(forRemoval = true)
 	static ColumnReferenceKey createDiscriminatorColumnReferenceKey(TableReference tableReference, EntityDiscriminatorMapping discriminatorMapping) {
 		assert tableReference.containsAffectedTableName( discriminatorMapping.getContainingTableExpression() )
 				: String.format( ROOT, "Expecting tables to match between TableReference (%s) and SelectableMapping (%s)", tableReference.getTableId(), discriminatorMapping.getContainingTableExpression() );
-		return createColumnReferenceKey( tableReference, discriminatorMapping.getSelectablePath(), discriminatorMapping.getUnderlyingJdbcMapping() );
+		return createColumnReferenceKey( tableReference, discriminatorMapping.getSelectablePath(), discriminatorMapping.getJdbcMapping() );
 	}
 
 	default Expression resolveSqlExpression(TableReference tableReference, SelectableMapping selectableMapping) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/joinedSubclass/JoinedSubclassNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/joinedSubclass/JoinedSubclassNativeQueryTest.java
@@ -7,15 +7,15 @@ package org.hibernate.orm.test.hql.joinedSubclass;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.internal.SqlTypedMappingImpl;
+
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Jan Schatteman
@@ -39,7 +41,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JoinedSubclassNativeQueryTest {
 
 	@Test
-	@JiraKey( value = "HHH-16180")
+	@Jira("https://hibernate.atlassian.net/browse/HHH-19569")
+	public void testJoinedInheritanceAliasInjection(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Person p = session.createNativeQuery( "select {p.*} from Person p left join Employee p_1_ on p.id=p_1_.id where p.id = 2", Person.class )
+							.addEntity( "p", Person.class )
+							.getSingleResult();
+					assertNotNull( p );
+					assertInstanceOf( Employee.class, p );
+					assertEquals( "Christian", p.getFirstName() );
+					assertEquals( "CommonHaus", ((Employee) p).getCompanyName() );
+				}
+		);
+	}
+
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-16180")
 	public void testJoinedInheritanceNativeQuery(SessionFactoryScope scope) {
 		final SessionFactoryImplementor sessionFactory = scope.getSessionFactory();
 		final TypeConfiguration typeConfiguration = sessionFactory.getTypeConfiguration();
@@ -53,7 +71,7 @@ public class JoinedSubclassNativeQueryTest {
 
 		final String qry = String.format(
 				Locale.ROOT,
-				"select p.*, %s as company_name, 0 as clazz_  from Person p",
+				"select p.*, %s as company_name, 0 as clazz_ from Person p where p.id = 1",
 				nullColumnString
 		);
 
@@ -63,18 +81,26 @@ public class JoinedSubclassNativeQueryTest {
 			session.setProperty( AvailableSettings.NATIVE_IGNORE_JDBC_PARAMETERS, true );
 
 			Person p = session.createNativeQuery( qry, Person.class ).getSingleResult();
-			assertThat( p ).isNotNull();
-			assertThat( p.getFirstName() ).isEqualTo( "Jan" );
+					assertThat( p ).isNotNull();
+					assertThat( p.getFirstName() ).isEqualTo( "Jan" );
 		} );
 	}
 
 	@BeforeEach
 	public void setup(SessionFactoryScope scope) {
-		scope.inTransaction( (session) -> {
-			Person p = new Person();
-			p.setFirstName( "Jan" );
-			session.persist( p );
-		} );
+		scope.inTransaction(
+				session -> {
+					Person p = new Person();
+					p.setId( 1L );
+					p.setFirstName( "Jan" );
+					session.persist( p );
+					Employee p2 = new Employee();
+					p2.setId( 2L );
+					p2.setFirstName( "Christian" );
+					p2.setCompanyName( "CommonHaus" );
+					session.persist( p2 );
+				}
+		);
 	}
 
 	@AfterEach
@@ -86,12 +112,19 @@ public class JoinedSubclassNativeQueryTest {
 	@Inheritance(strategy = InheritanceType.JOINED)
 	public static class Person {
 		@Id
-		@GeneratedValue
 		private Long id;
 
 		@Basic(optional = false)
 		@Column(name = "first_name")
 		private String firstName;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
 
 		public String getFirstName() {
 			return firstName;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19569 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19569
<!-- Hibernate GitHub Bot issue links end -->