### PR TITLE
HHH-20629 Add Dialect.supportsWindowFrames() capability

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
@@ -383,6 +383,12 @@ public class CUBRIDDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsWindowFrames() {
+		// CUBRID has window functions but no 'over' frame clause (rows/range)
+		return false;
+	}
+
+	@Override
 	public boolean supportsWithClauseInSubquery() {
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -4901,6 +4901,20 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	}
 
 	/**
+	 * Does this dialect support the {@code frame} clause of a window specification,
+	 * that is, {@code rows}/{@code range}/{@code groups} bounds such as
+	 * {@code rows between 2 preceding and current row}?
+	 *
+	 * @return {@code true} if the underlying database supports window frames,
+	 *         {@code false} otherwise. By default this matches
+	 *         {@link #supportsWindowFunctions()}, since most databases that
+	 *         support window functions also support frames.
+	 */
+	public boolean supportsWindowFrames() {
+		return supportsWindowFunctions();
+	}
+
+	/**
 	 * Does this dialect support the SQL {@code lateral} keyword or a
 	 * proprietary alternative?
 	 *

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaWindowFunctionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaWindowFunctionTest.java
@@ -198,6 +198,7 @@ public class CriteriaWindowFunctionTest {
 	}
 
 	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsWindowFrames.class)
 	@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "No support for nth_value function")
 	@SkipForDialect(dialectClass = DB2Dialect.class, majorVersion = 10, reason = "No support for nth_value function")
 	@SkipForDialect(dialectClass = InformixDialect.class, reason = "No support for nth_value function")
@@ -360,6 +361,7 @@ public class CriteriaWindowFunctionTest {
 	}
 
 	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsWindowFrames.class)
 	public void testFrame(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/WindowFunctionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/WindowFunctionTest.java
@@ -153,6 +153,7 @@ public class WindowFunctionTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsWindowFunctions.class)
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsWindowFrames.class)
 	public void testFrame(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -739,6 +739,12 @@ abstract public class DialectFeatureChecks {
 		}
 	}
 
+	public static class SupportsWindowFrames implements DialectFeatureCheck {
+		public boolean apply(Dialect dialect) {
+			return dialect.supportsWindowFrames();
+		}
+	}
+
 	public static class SupportsFilterClause implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
 			return dialect instanceof PostgreSQLDialect;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Adds a `Dialect.supportsWindowFrames()` capability so a dialect that supports window functions but not the `OVER` frame clause (`ROWS`/`RANGE`...`PRECEDING`/`FOLLOWING`) can be distinguished. It defaults to `supportsWindowFunctions()`, so it is additive with no change for existing dialects. `CUBRIDDialect` overrides it to `false`, and the frame-using tests are gated with a new `DialectFeatureChecks.SupportsWindowFrames`.

If you would prefer a different approach (for example @SkipForDialect instead of a new capability), please let me know.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20629 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20629
<!-- Hibernate GitHub Bot issue links end -->