### PR TITLE
HHH-20632 Reproduce UnknownTableReferenceException when an eager @Any resolves to an entity holding another @Any

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyDiscriminatorPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyDiscriminatorPart.java
@@ -330,7 +330,10 @@ public class AnyDiscriminatorPart implements DiscriminatorMapping, FetchOptions 
 		final var fromClauseAccess = sqlAstCreationState.getFromClauseAccess();
 		final var sqlExpressionResolver = sqlAstCreationState.getSqlExpressionResolver();
 
-		final var tableGroup = fromClauseAccess.getTableGroup( fetchablePath.getParent().getParent() );
+		final var tableGroup = DiscriminatedAssociationMapping.getTableGroup(
+				fetchablePath.getParent(),
+				fromClauseAccess
+		);
 		final var tableReference = tableGroup.resolveTableReference( fetchablePath, table );
 		final var columnReference = sqlExpressionResolver.resolveSqlExpression(
 				tableReference,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyKeyPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyKeyPart.java
@@ -263,9 +263,10 @@ public class AnyKeyPart implements BasicValuedModelPart, FetchOptions {
 		final var sqlExpressionResolver = sqlAstCreationState.getSqlExpressionResolver();
 
 		final var tableReference =
-				sqlAstCreationState.getFromClauseAccess()
-						.getTableGroup( fetchParent.getNavigablePath().getParent() )
-						.resolveTableReference( fetchablePath, table );
+				DiscriminatedAssociationMapping.getTableGroup(
+						fetchParent.getNavigablePath(),
+						sqlAstCreationState.getFromClauseAccess()
+				).resolveTableReference( fetchablePath, table );
 
 		final var sqlSelection =
 				sqlExpressionResolver.resolveSqlSelection(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/DiscriminatedAssociationMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/DiscriminatedAssociationMapping.java
@@ -29,6 +29,7 @@ import org.hibernate.metamodel.mapping.SelectablePath;
 import org.hibernate.metamodel.mapping.SingleAttributeIdentifierMapping;
 import org.hibernate.metamodel.model.domain.NavigableRole;
 import org.hibernate.spi.NavigablePath;
+import org.hibernate.spi.TreatedNavigablePath;
 import org.hibernate.sql.ast.spi.query.from.SqlAstJoinType;
 import org.hibernate.sql.ast.spi.creation.FromClauseAccess;
 import org.hibernate.sql.ast.spi.query.from.TableGroup;
@@ -404,6 +405,34 @@ public class DiscriminatedAssociationMapping implements MappingType, FetchOption
 
 	public static NavigablePath concreteEntityPath(NavigablePath associationPath, EntityMappingType entityMappingType) {
 		return associationPath.treatAs( entityMappingType.getEntityName() );
+	}
+
+	/**
+	 * Get the already-registered {@link TableGroup} exposing the table which holds the discriminator
+	 * and key columns of the any-valued mapping reached through the given path, that is, the table
+	 * group of the entity declaring it.
+	 * <p>
+	 * When the association is reached through an implicit {@code treat()} - as happens when join
+	 * fetching an {@code @Any} whose target entity declares another {@code @Any} - the declaring
+	 * table is only exposed by the table group registered under the treated path, while
+	 * {@link NavigablePath#getParent()} deliberately skips over the {@code treat()}.
+	 *
+	 * @param anyPath the path of the any-valued mapping itself
+	 *
+	 * @return the table group declaring the any-valued mapping, never {@code null}
+	 *
+	 * @throws org.hibernate.sql.ast.spi.creation.SqlTreeCreationException if no table group is registered for
+	 * the declaring path
+	 */
+	static TableGroup getTableGroup(NavigablePath anyPath, FromClauseAccess fromClauseAccess) {
+		final var realParent = anyPath.getRealParent();
+		if ( realParent instanceof TreatedNavigablePath ) {
+			final var treatedTableGroup = fromClauseAccess.findTableGroup( realParent );
+			if ( treatedTableGroup != null ) {
+				return treatedTableGroup;
+			}
+		}
+		return fromClauseAccess.getTableGroup( anyPath.getParent() );
 	}
 
 	TableGroup createRootTableGroupJoin(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/TreatedAnyToAnyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/TreatedAnyToAnyTest.java
@@ -1,0 +1,191 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.any;
+
+import org.hibernate.annotations.Any;
+import org.hibernate.annotations.AnyDiscriminatorValue;
+import org.hibernate.annotations.AnyKeyJavaClass;
+import org.hibernate.cfg.JdbcSettings;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Expected behavior:
+ * <p>
+ * Loading an entity whose eager fetch graph walks through an {@link org.hibernate.annotations.Any}
+ * association into a <em>second</em> {@code @Any} association must succeed. No HQL is involved: the
+ * {@code treat()} is generated implicitly by the entity loader while building the select.
+ * </p>
+ *
+ * <p>
+ * Here {@link Container#reference} is an eager {@code @Any} (declared type {@link Reference}). A plain
+ * {@code entityManager.find(Container.class, id)} eagerly join-fetches {@code reference}, resolves it to
+ * {@link Publication}, and must read {@link Publication#destinataire} — itself an {@code @Any} (declared
+ * type {@link Recipient}) whose discriminator/key columns live on {@code Publication}'s own table
+ * ({@code TPUBLICATION}). The inner {@code @Any} discriminator is always fetched {@code IMMEDIATE}.
+ * </p>
+ *
+ * <p>
+ * This worked up to 7.3.5.Final and regressed in 7.4.x (still failing on 7.4.3.Final and on
+ * {@code main} / 8.1-SNAPSHOT), apparently because of HHH-16730 ("joining @Any and @ManyToAny
+ * mappings", 7.4.0.CR1): {@code DiscriminatedAssociationAttributeMapping} switched from a
+ * {@code StandardVirtualTableGroup} (which resolved the discriminator/key columns against the owner
+ * table) + {@code FetchStyle.SELECT} to a real {@code createRootTableGroupJoin(...)} +
+ * {@code FetchStyle.JOIN} for {@code IMMEDIATE} fetching. Under the implicit {@code treat()} over an
+ * {@code @Any}, the resulting table group no longer exposes the owner table, so fetching the inner
+ * {@code @Any} discriminator fails with:
+ * </p>
+ *
+ * <pre>
+ * org.hibernate.sql.ast.tree.from.UnknownTableReferenceException:
+ *     Unable to determine TableReference (`TPUBLICATION`) for
+ *     `treat(container.reference as Publication).destinataire.{discriminator}`
+ *         at AnyDiscriminatorPart.generateFetch(AnyDiscriminatorPart.java:375)
+ *         at FetchParent.generateFetchableFetch(FetchParent.java:120)
+ *         at LoaderSelectBuilder.lambda$createFetchableConsumer$0(...)
+ * </pre>
+ *
+ * @author Vincent Bouthinon
+ */
+@Jpa(
+		annotatedClasses = {
+				TreatedAnyToAnyTest.Container.class,
+				TreatedAnyToAnyTest.Publication.class,
+				TreatedAnyToAnyTest.Person.class
+		},
+		integrationSettings = @Setting(name = JdbcSettings.SHOW_SQL, value = "true")
+)
+@JiraKey("HHH-20632")
+class TreatedAnyToAnyTest {
+
+	@Test
+	void testLoadEntityWithEagerAnyToAnotherAny(EntityManagerFactoryScope scope) {
+
+		final Long[] containerId = new Long[1];
+
+		scope.inTransaction(
+				entityManager -> {
+					Person person = new Person();
+					entityManager.persist( person );
+
+					Publication publication = new Publication();
+					publication.setDestinataire( person );
+					entityManager.persist( publication );
+
+					Container container = new Container();
+					container.setReference( publication );
+					entityManager.persist( container );
+
+					containerId[0] = container.getId();
+				}
+		);
+
+		scope.inTransaction(
+				entityManager -> {
+					// No HQL: the eager @Any 'reference' makes the loader walk into Publication and read
+					// its inner @Any 'destinataire' discriminator (implicit treat over the @Any).
+					Container container = entityManager.find( Container.class, containerId[0] );
+
+					assertNotNull( container );
+					assertNotNull( container.getReference() );
+				}
+		);
+	}
+
+	@Entity(name = "Container")
+	@Table(name = "TCONTAINER")
+	public static class Container {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Any(fetch = FetchType.EAGER)
+		@AnyKeyJavaClass(Long.class)
+		@AnyDiscriminatorValue(entity = Publication.class, discriminator = "P")
+		@Column(name = "REFERENCE_ROLE")
+		@JoinColumn(name = "REFERENCE_ID")
+		private Reference reference;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Reference getReference() {
+			return reference;
+		}
+
+		public void setReference(final Reference reference) {
+			this.reference = reference;
+		}
+	}
+
+	@Entity(name = "Publication")
+	@Table(name = "TPUBLICATION")
+	public static class Publication implements Reference {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Any(fetch = FetchType.LAZY)
+		@AnyKeyJavaClass(Long.class)
+		@AnyDiscriminatorValue(entity = Person.class, discriminator = "U")
+		@Column(name = "DESTINATAIRE_ROLE")
+		@JoinColumn(name = "DESTINATAIRE_ID")
+		private Recipient destinataire;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Recipient getDestinataire() {
+			return destinataire;
+		}
+
+		public void setDestinataire(final Recipient destinataire) {
+			this.destinataire = destinataire;
+		}
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "TPERSON")
+	public static class Person implements Recipient {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+	}
+
+	/**
+	 * Declared type of the outer {@code @Any} ({@link Container#reference}).
+	 */
+	public interface Reference {
+	}
+
+	/**
+	 * Declared type of the inner {@code @Any} ({@link Publication#destinataire}).
+	 */
+	public interface Recipient {
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/TreatedAnyToAnyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/TreatedAnyToAnyTest.java
@@ -1,0 +1,193 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.any;
+
+import org.hibernate.annotations.Any;
+import org.hibernate.annotations.AnyDiscriminatorValue;
+import org.hibernate.annotations.AnyKeyJavaClass;
+import org.hibernate.cfg.JdbcSettings;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Expected behavior:
+ * <p>
+ * Loading an entity whose eager fetch graph walks through an {@link org.hibernate.annotations.Any}
+ * association into a <em>second</em> {@code @Any} association must succeed. No HQL is involved: the
+ * {@code treat()} is generated implicitly by the entity loader while building the select.
+ * </p>
+ *
+ * <p>
+ * Here {@link Container#reference} is an eager {@code @Any} (declared type {@link Reference}). A plain
+ * {@code entityManager.find(Container.class, id)} eagerly join-fetches {@code reference}, resolves it to
+ * {@link Publication}, and must read {@link Publication#destinataire} — itself an {@code @Any} (declared
+ * type {@link Recipient}) whose discriminator/key columns live on {@code Publication}'s own table
+ * ({@code TPUBLICATION}). The inner {@code @Any} discriminator is always fetched {@code IMMEDIATE}.
+ * </p>
+ *
+ * <p>
+ * This worked up to 7.3.5.Final and regressed in 7.4.x because of HHH-16730 ("joining @Any and
+ * @ManyToAny mappings", 7.4.0.CR1): {@code DiscriminatedAssociationAttributeMapping} switched from a
+ * {@code StandardVirtualTableGroup} (which resolved the discriminator/key columns against the owner
+ * table) + {@code FetchStyle.SELECT} to a real {@code createRootTableGroupJoin(...)} +
+ * {@code FetchStyle.JOIN} for {@code IMMEDIATE} fetching. Under the implicit {@code treat()} over an
+ * {@code @Any}, the discriminator and key columns of the inner {@code @Any} then had to be resolved
+ * against the table group registered under the treated path, while
+ * {@code AnyDiscriminatorPart}/{@code AnyKeyPart} located the owner table group through
+ * {@code NavigablePath#getParent()}, which skips over a {@code TreatedNavigablePath}. Fetching the
+ * inner {@code @Any} discriminator therefore failed with:
+ * </p>
+ *
+ * <pre>
+ * org.hibernate.sql.ast.tree.from.UnknownTableReferenceException:
+ *     Unable to determine TableReference (`TPUBLICATION`) for
+ *     `treat(container.reference as Publication).destinataire.{discriminator}`
+ *         at AnyDiscriminatorPart.generateFetch(AnyDiscriminatorPart.java:334)
+ *         at FetchParent.generateFetchableFetch(FetchParent.java:120)
+ *         at LoaderSelectBuilder.lambda$createFetchableConsumer$0(...)
+ * </pre>
+ *
+ * @author Vincent Bouthinon
+ */
+@Jpa(
+		annotatedClasses = {
+				TreatedAnyToAnyTest.Container.class,
+				TreatedAnyToAnyTest.Publication.class,
+				TreatedAnyToAnyTest.Person.class
+		},
+		integrationSettings = @Setting(name = JdbcSettings.SHOW_SQL, value = "true")
+)
+@JiraKey("HHH-20632")
+class TreatedAnyToAnyTest {
+
+	@Test
+	void testLoadEntityWithEagerAnyToAnotherAny(EntityManagerFactoryScope scope) {
+
+		final Long[] containerId = new Long[1];
+
+		scope.inTransaction(
+				entityManager -> {
+					Person person = new Person();
+					entityManager.persist( person );
+
+					Publication publication = new Publication();
+					publication.setDestinataire( person );
+					entityManager.persist( publication );
+
+					Container container = new Container();
+					container.setReference( publication );
+					entityManager.persist( container );
+
+					containerId[0] = container.getId();
+				}
+		);
+
+		scope.inTransaction(
+				entityManager -> {
+					// No HQL: the eager @Any 'reference' makes the loader walk into Publication and read
+					// its inner @Any 'destinataire' discriminator (implicit treat over the @Any).
+					Container container = entityManager.find( Container.class, containerId[0] );
+
+					assertNotNull( container );
+					assertNotNull( container.getReference() );
+				}
+		);
+	}
+
+	@Entity(name = "Container")
+	@Table(name = "TCONTAINER")
+	public static class Container {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Any(fetch = FetchType.EAGER)
+		@AnyKeyJavaClass(Long.class)
+		@AnyDiscriminatorValue(entity = Publication.class, discriminator = "P")
+		@Column(name = "REFERENCE_ROLE")
+		@JoinColumn(name = "REFERENCE_ID")
+		private Reference reference;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Reference getReference() {
+			return reference;
+		}
+
+		public void setReference(final Reference reference) {
+			this.reference = reference;
+		}
+	}
+
+	@Entity(name = "Publication")
+	@Table(name = "TPUBLICATION")
+	public static class Publication implements Reference {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Any(fetch = FetchType.LAZY)
+		@AnyKeyJavaClass(Long.class)
+		@AnyDiscriminatorValue(entity = Person.class, discriminator = "U")
+		@Column(name = "DESTINATAIRE_ROLE")
+		@JoinColumn(name = "DESTINATAIRE_ID")
+		private Recipient destinataire;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Recipient getDestinataire() {
+			return destinataire;
+		}
+
+		public void setDestinataire(final Recipient destinataire) {
+			this.destinataire = destinataire;
+		}
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "TPERSON")
+	public static class Person implements Recipient {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+	}
+
+	/**
+	 * Declared type of the outer {@code @Any} ({@link Container#reference}).
+	 */
+	public interface Reference {
+	}
+
+	/**
+	 * Declared type of the inner {@code @Any} ({@link Publication#destinataire}).
+	 */
+	public interface Recipient {
+	}
+}


### PR DESCRIPTION
HHH-20632 : Reproduce UnknownTableReferenceException when an eager @Any resolves to an entity holding another @Any

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20632 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20632
<!-- Hibernate GitHub Bot issue links end -->