### PR TITLE
HHH-20635 HbmXmlTransformer does not set the access type on composite-element embeddables

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -2239,8 +2239,15 @@ public class HbmXmlTransformer {
 		}
 
 		final var embeddable = new JaxbEmbeddableImpl();
+		embeddable.setMetadataComplete( true );
 		embeddable.setClazz( embeddableClassName );
 		embeddable.setName( embeddableName );
+
+		final String defaultAccess = hbmXmlBinding.getRoot().getDefaultAccess();
+		if ( defaultAccess == null || "property".equalsIgnoreCase( defaultAccess ) ) {
+			embeddable.setAccess( AccessType.PROPERTY );
+		}
+
 		embeddable.setAttributes( new JaxbEmbeddableAttributesContainerImpl() );
 
 		final var previousBaseTable = currentBaseTable;
@@ -2256,6 +2263,7 @@ public class HbmXmlTransformer {
 		finally {
 			currentBaseTable = previousBaseTable;
 		}
+
 		mappingXmlBinding.getRoot().getEmbeddables().add( embeddable );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -360,6 +360,19 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20628" )
+	public void testCompositeElementAccessTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/composite-element/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEmbeddables() ).hasSize( 1 );
+
+			final JaxbEmbeddableImpl embeddable = transformed.getEmbeddables().get( 0 );
+			assertThat( embeddable.getAccess() )
+					.as( "Composite-element embeddable should have access=PROPERTY (HBM default)" )
+					.isEqualTo( jakarta.persistence.AccessType.PROPERTY );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20599" )
 	public void testCompositeElementColumnTableTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/composite-element/hbm.xml", scope, (transformed) -> {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20635

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20635 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->