### PR TITLE
[7.4] HHH-20633 Unnecessary cast to SessionFactoryImplementor in AuditLogFactory

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/audit/AuditLogFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/audit/AuditLogFactory.java
@@ -12,7 +12,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.StatelessSession;
 import org.hibernate.audit.internal.AuditLogImpl;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -49,9 +48,8 @@ public final class AuditLogFactory {
 	 * @return a new audit log (must be closed by the caller)
 	 */
 	public static AuditLog create(SessionFactory sessionFactory) {
-		final var sf = (SessionFactoryImplementor) sessionFactory;
 		final var session = (SharedSessionContractImplementor)
-				sf.withOptions()
+				sessionFactory.withOptions()
 						.atChangeset( AuditLog.ALL_CHANGESETS )
 						.openSession();
 		return new AuditLogImpl( session );


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/12929

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20633 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20633
<!-- Hibernate GitHub Bot issue links end -->