### PR TITLE
HHH-20634 Fix method based properties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
@@ -583,7 +583,7 @@ public class EmbeddableBinder {
 			MetadataBuildingContext context) {
 		final var memberDetails = propertyAnnotatedElement.getAttributeMember();
 		if ( isIdClass || subholder.isOrWithinEmbeddedId() ) {
-			final var property = findProperty( embeddable, memberDetails.getName() );
+			final var property = findProperty( embeddable, propertyAnnotatedElement.getPropertyName() );
 			if ( property != null ) {
 				// Identifier properties are always simple values
 				final var value = (SimpleValue) property.getValue();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/EmbeddedIdGeneratedValueMethodTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/EmbeddedIdGeneratedValueMethodTest.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.identifier;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Access;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+
+import static jakarta.persistence.AccessType.PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Philippe Marschall
+ */
+@DomainModel( annotatedClasses = EmbeddedIdGeneratedValueMethodTest.SystemUser.class )
+@SessionFactory
+@Jira( "https://hibernate.atlassian.net/browse/HHH-20634" )
+public class EmbeddedIdGeneratedValueMethodTest {
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.createMutationQuery( "delete from SystemUser" ).execute() );
+	}
+
+	@Test
+	public void test(SessionFactoryScope scope) {
+		String userName = "Philippe Marschall";
+		String userId = "pmarschall";
+		final SystemUser _systemUser = scope.fromTransaction( session -> {
+			final SystemUser systemUser = new SystemUser();
+			systemUser.setId( new PK( userId ) );
+			systemUser.setName( userName );
+			session.persist( systemUser );
+			return systemUser;
+		} );
+
+		scope.inSession( session -> {
+			final SystemUser systemUser = session.find( SystemUser.class, _systemUser.getId() );
+			assertThat( systemUser.getName() ).isEqualTo( userName );
+			assertThat( systemUser.getId().getUsername() ).isEqualTo( userId );
+			assertThat( systemUser.getId().getRegistrationId() ).isNotNull();
+		} );
+	}
+
+	@Entity( name = "SystemUser" )
+	public static class SystemUser {
+		@EmbeddedId
+		private PK id;
+
+		private String name;
+
+		public PK getId() {
+			return id;
+		}
+
+		public void setId(PK id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Embeddable
+	@Access(PROPERTY)
+	public static class PK implements Serializable {
+		private String username;
+
+		private Integer registrationId;
+
+		public PK() {
+		}
+
+		public PK(String username) {
+			this.username = username;
+		}
+
+		public String getUsername() {
+			return username;
+		}
+
+		public void setUsername(String username) {
+			this.username = username;
+		}
+
+		@GeneratedValue
+		public Integer getRegistrationId() {
+			return registrationId;
+		}
+
+		public void setRegistrationId(Integer registrationId) {
+			this.registrationId = registrationId;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/EmbeddedIdGeneratedValueMethodTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/EmbeddedIdGeneratedValueMethodTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class EmbeddedIdGeneratedValueMethodTest {
 	@AfterAll
 	public void tearDown(SessionFactoryScope scope) {
-		scope.inTransaction( session -> session.createMutationQuery( "delete from SystemUser" ).execute() );
+		scope.dropData();
 	}
 
 	@Test


### PR DESCRIPTION
Fix the lookup of properties when method based access is used. This makes `@GeneratedValue` on methods of embedded ids work again.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20634 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20634
<!-- Hibernate GitHub Bot issue links end -->