### PR TITLE
HHH-20638 HHH-20639 HHH-20640 Fixes few issues with HbmXmlTransformer

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -711,7 +711,7 @@ public class HbmXmlTransformer {
 						final var filterParam = new JaxbFilterDefImpl.JaxbFilterParamImpl();
 						filterDef.getFilterParams().add( filterParam );
 						filterParam.setName( hbmFilterParam.getParameterName() );
-						filterParam.setType( hbmFilterParam.getParameterValueTypeName() );
+						filterParam.setType( resolveHbmTypeName( hbmFilterParam.getParameterValueTypeName() ) );
 					}
 				}
 
@@ -720,6 +720,30 @@ public class HbmXmlTransformer {
 				}
 			}
 		}
+	}
+
+	private static String resolveHbmTypeName(String hbmTypeName) {
+		if ( hbmTypeName == null ) {
+			return null;
+		}
+		return switch ( hbmTypeName ) {
+			case "string" -> String.class.getName();
+			case "boolean" -> boolean.class.getName();
+			case "byte" -> byte.class.getName();
+			case "short" -> short.class.getName();
+			case "integer", "int" -> int.class.getName();
+			case "long" -> long.class.getName();
+			case "float" -> float.class.getName();
+			case "double" -> double.class.getName();
+			case "timestamp" -> java.util.Date.class.getName();
+			case "date" -> java.util.Date.class.getName();
+			case "time" -> java.util.Date.class.getName();
+			case "big_decimal" -> java.math.BigDecimal.class.getName();
+			case "big_integer" -> java.math.BigInteger.class.getName();
+			case "locale" -> java.util.Locale.class.getName();
+			case "currency" -> java.util.Currency.class.getName();
+			default -> hbmTypeName;
+		};
 	}
 
 	private void transferImports() {

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -2450,6 +2450,36 @@ public class HbmXmlTransformer {
 		);
 	}
 
+	private String resolveManyToManyMappedBy(
+			Property bootModelProperty,
+			Collection bootModelValue) {
+		if ( isNotEmpty( bootModelValue.getMappedByProperty() ) ) {
+			return bootModelValue.getMappedByProperty();
+		}
+
+		final var toOneElement = (ToOne) bootModelValue.getElement();
+		final var targetEntityName = toOneElement.getReferencedEntityName();
+		final var targetEntity = transformationState.getEntityInfoByName().get( targetEntityName );
+		if ( targetEntity != null ) {
+			for ( Property targetProp : targetEntity.getPersistentClass().getProperties() ) {
+				if ( targetProp.getValue() instanceof Collection targetCollection
+						&& !targetCollection.isInverse()
+						&& matches( bootModelValue.getKey(), targetCollection.getElement().getSelectables() ) ) {
+					return targetProp.getName();
+				}
+			}
+		}
+
+		throw new AssertionFailure(
+				String.format(
+						Locale.ROOT,
+						"Unable to determine mapped-by name for inverse many-to-many : %s.%s",
+						bootModelProperty.getPersistentClass().getEntityName(),
+						bootModelProperty.getName()
+				)
+		);
+	}
+
 	private boolean matches(KeyValue collectionKey, List<Selectable> candidate) {
 		final var collectionKeySelectables = collectionKey.getSelectables();
 		if ( collectionKeySelectables.size() != candidate.size() ) {
@@ -2483,6 +2513,11 @@ public class HbmXmlTransformer {
 
 	private JaxbManyToManyImpl transformManyToMany(PluralAttributeInfo hbmCollection, PropertyInfo propertyInfo) {
 		final var target = new JaxbManyToManyImpl();
+		final var bootModelProperty = propertyInfo.bootModelProperty();
+		final var bootValue = (Collection) bootModelProperty.getValue();
+		if ( bootValue.isInverse() ) {
+			target.setMappedBy( resolveManyToManyMappedBy( bootModelProperty, bootValue ) );
+		}
 		transferManyToManyInfo(
 				hbmCollection,
 				hbmCollection.getManyToMany(),
@@ -2532,11 +2567,19 @@ public class HbmXmlTransformer {
 		if ( isNotEmpty( tableName ) ) {
 			joinTable.setName( tableName );
 		}
-		target.setJoinTable( joinTable );
 
 		final var key = hbmCollection.getKey();
+		if ( bootValue.isInverse() ) {
+			// skip join table setup — mapped-by is set by the caller
+		}
+		else {
+			target.setJoinTable( joinTable );
+			if ( key != null ) {
+				joinTable.setForeignKey( transformForeignKey( key.getForeignKey() ) );
+			}
+		}
+
 		if ( key != null ) {
-			joinTable.setForeignKey( transformForeignKey( key.getForeignKey() ) );
 			transferColumnsAndFormulas(
 					new ColumnAndFormulaSource() {
 						@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -2639,6 +2639,9 @@ public class HbmXmlTransformer {
 		for ( var hbmFilter : hbmCollection.getFilter() ) {
 			target.getFilters().add( convert( hbmFilter ) );
 		}
+		for ( var hbmFilter : manyToMany.getFilter() ) {
+			target.getFilters().add( convert( hbmFilter ) );
+		}
 
 		if ( isNotEmpty( manyToMany.getWhere() ) ) {
 			target.setSqlRestriction( manyToMany.getWhere() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -778,4 +778,43 @@ public class HbmTransformationJaxbTests {
 					.contains( "effectiveDate", "cat" );
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20640" )
+	public void testInverseManyToManyMappedByTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/many-to-many-inverse/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl productEntity = transformed.getEntities().stream()
+					.filter( e -> "Product".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( productEntity.getAttributes().getManyToManyAttributes() ).hasSize( 1 );
+			final JaxbManyToManyImpl categories = productEntity.getAttributes().getManyToManyAttributes().get( 0 );
+			assertThat( categories.getName() ).isEqualTo( "categories" );
+			assertThat( categories.getMappedBy() )
+					.as( "Owning side should not have mapped-by" )
+					.isNull();
+			assertThat( categories.getJoinTable() )
+					.as( "Owning side should have a join-table" )
+					.isNotNull();
+			assertThat( categories.getJoinTable().getName() ).isEqualTo( "PROD_CAT" );
+
+			final JaxbEntityImpl categoryEntity = transformed.getEntities().stream()
+					.filter( e -> "Category".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( categoryEntity.getAttributes().getManyToManyAttributes() ).hasSize( 1 );
+			final JaxbManyToManyImpl products = categoryEntity.getAttributes().getManyToManyAttributes().get( 0 );
+			assertThat( products.getName() ).isEqualTo( "products" );
+			assertThat( products.getMappedBy() )
+					.as( "Inverse side should have mapped-by pointing to the owning side" )
+					.isEqualTo( "categories" );
+			assertThat( products.getJoinTable() )
+					.as( "Inverse side should not have a join-table" )
+					.isNull();
+		} );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -698,4 +698,60 @@ public class HbmTransformationJaxbTests {
 			}
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20638" )
+	public void testFilterDefParameterTypeResolution(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/filter-def-types/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getFilterDefinitions() ).hasSize( 3 );
+
+			final var stringFilter = transformed.getFilterDefinitions().stream()
+					.filter( f -> "stringFilter".equals( f.getName() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( stringFilter.getFilterParams() ).hasSize( 1 );
+			assertThat( stringFilter.getFilterParams().get( 0 ).getType() )
+					.as( "HBM type 'string' should resolve to java.lang.String" )
+					.isEqualTo( "java.lang.String" );
+
+			final var timestampFilter = transformed.getFilterDefinitions().stream()
+					.filter( f -> "timestampFilter".equals( f.getName() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( timestampFilter.getFilterParams() ).hasSize( 1 );
+			assertThat( timestampFilter.getFilterParams().get( 0 ).getType() )
+					.as( "HBM type 'timestamp' should resolve to java.util.Date" )
+					.isEqualTo( "java.util.Date" );
+
+			final var numericFilter = transformed.getFilterDefinitions().stream()
+					.filter( f -> "numericFilter".equals( f.getName() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( numericFilter.getFilterParams() ).hasSize( 3 );
+
+			final var doubleParam = numericFilter.getFilterParams().stream()
+					.filter( p -> "amount".equals( p.getName() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( doubleParam.getType() )
+					.as( "HBM type 'double' should resolve to double" )
+					.isEqualTo( "double" );
+
+			final var longParam = numericFilter.getFilterParams().stream()
+					.filter( p -> "count".equals( p.getName() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( longParam.getType() )
+					.as( "HBM type 'long' should resolve to long" )
+					.isEqualTo( "long" );
+
+			final var intParam = numericFilter.getFilterParams().stream()
+					.filter( p -> "code".equals( p.getName() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( intParam.getType() )
+					.as( "HBM type 'integer' should resolve to int" )
+					.isEqualTo( "int" );
+		} );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -754,4 +754,28 @@ public class HbmTransformationJaxbTests {
 					.isEqualTo( "int" );
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20639" )
+	public void testManyToManyElementFilterTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/many-to-many-element-filter/hbm.xml", scope, (transformed) -> {
+			final JaxbEntityImpl productEntity = transformed.getEntities().stream()
+					.filter( e -> "Product".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( productEntity.getAttributes().getManyToManyAttributes() ).hasSize( 1 );
+
+			final JaxbManyToManyImpl categories = productEntity.getAttributes().getManyToManyAttributes().get( 0 );
+			assertThat( categories.getName() ).isEqualTo( "categories" );
+
+			assertThat( categories.getFilters() )
+					.as( "Filters from <many-to-many> element should be transferred" )
+					.hasSizeGreaterThanOrEqualTo( 2 );
+
+			assertThat( categories.getFilters() )
+					.extracting( f -> f.getName() )
+					.contains( "effectiveDate", "cat" );
+		} );
+	}
 }

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/filter-def-types/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/filter-def-types/hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping">
+
+    <filter-def name="stringFilter">
+        <filter-param name="name" type="string"/>
+    </filter-def>
+
+    <filter-def name="timestampFilter">
+        <filter-param name="asOfDate" type="timestamp"/>
+    </filter-def>
+
+    <filter-def name="numericFilter">
+        <filter-param name="amount" type="double"/>
+        <filter-param name="count" type="long"/>
+        <filter-param name="code" type="integer"/>
+    </filter-def>
+
+    </hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/many-to-many-element-filter/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/many-to-many-element-filter/hbm.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.filter">
+
+    <filter-def name="effectiveDate">
+        <filter-param name="asOfDate" type="timestamp"/>
+    </filter-def>
+
+    <filter-def name="cat">
+        <filter-param name="catId" type="long"/>
+    </filter-def>
+
+    <class name="Product" table="PRODUCT">
+        <id name="id" column="PROD_ID">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+        <set name="categories" table="PROD_CAT" fetch="join" lazy="false" cascade="all">
+            <key column="PROD_ID"/>
+            <many-to-many class="Category" column="CAT_ID" fetch="join">
+                <filter name="effectiveDate" condition=":asOfDate BETWEEN eff_start_dt and eff_end_dt"/>
+                <filter name="cat" condition="CAT_ID = :catId"/>
+            </many-to-many>
+        </set>
+        <filter name="effectiveDate" condition=":asOfDate BETWEEN eff_start_dt and eff_end_dt"/>
+    </class>
+
+    <class name="Category" table="CATEGORY">
+        <id name="id" column="CAT_ID">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/many-to-many-inverse/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/many-to-many-inverse/hbm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.filter">
+
+    <class name="Product" table="PRODUCT">
+        <id name="id" column="PROD_ID">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+        <set name="categories" table="PROD_CAT" cascade="all" inverse="false">
+            <key column="PROD_ID"/>
+            <many-to-many class="Category" column="CAT_ID"/>
+        </set>
+    </class>
+
+    <class name="Category" table="CATEGORY">
+        <id name="id" column="CAT_ID">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+        <set name="products" table="PROD_CAT" cascade="none" inverse="true">
+            <key column="CAT_ID"/>
+            <many-to-many class="Product" column="PROD_ID"/>
+        </set>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HHH-20638 HbmXmlTransformer does not resolve HBM type names in filter-def parameters
- https://hibernate.atlassian.net/browse/HHH-20639 HbmXmlTransformer drops filters defined on the <many-to-many> element
- https://hibernate.atlassian.net/browse/HHH-20640 HbmXmlTransformer does not generate mapped-by for inverse many-to-many collections
- 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20640 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20639 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20638 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->