### PR TITLE
HHH-20318 + HHH-20647 Fix Clob/NClob unwrap and wrap conversions

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobJavaType.java
@@ -15,6 +15,7 @@ import org.hibernate.SharedSessionContract;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.engine.jdbc.ClobImplementer;
+import org.hibernate.engine.jdbc.internal.CharacterStreamImpl;
 import org.hibernate.engine.jdbc.proxy.ClobProxy;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -122,7 +123,7 @@ public class ClobJavaType extends AbstractClassJavaType<Clob> {
 				}
 				else {
 					// otherwise we need to build a CharacterStream...
-					return type.cast( value.getCharacterStream() );
+					return type.cast( new CharacterStreamImpl( value.getCharacterStream(), value.length() ) );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/NClobJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/NClobJavaType.java
@@ -14,6 +14,7 @@ import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.NClobImplementer;
+import org.hibernate.engine.jdbc.internal.CharacterStreamImpl;
 import org.hibernate.engine.jdbc.proxy.NClobProxy;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -131,7 +132,7 @@ public class NClobJavaType extends AbstractClassJavaType<NClob> {
 				}
 				else {
 					// otherwise we need to build a CharacterStream...
-					return type.cast( value.getCharacterStream() );
+					return type.cast( new CharacterStreamImpl( value.getCharacterStream(), value.length() ) );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/NClobJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/NClobJavaType.java
@@ -6,6 +6,7 @@ package org.hibernate.type.descriptor.java;
 
 import java.io.Reader;
 import java.io.Serializable;
+import java.sql.Clob;
 import java.sql.NClob;
 import java.sql.SQLException;
 
@@ -105,6 +106,15 @@ public class NClobJavaType extends AbstractClassJavaType<NClob> {
 			if ( NClob.class.isAssignableFrom( type ) ) {
 				return type.cast( options.getLobCreator().toJdbcNClob( value ) );
 			}
+			else if ( Clob.class.isAssignableFrom( type ) ){
+				try {
+					return type.cast( options.getLobCreator().createClob( value.getCharacterStream(), value.length() ) );
+				}
+				catch ( SQLException ex ) {
+					// This basically shouldn't happen unless you've lost connection to the database.
+					throw new HibernateException( ex );
+				}
+			}
 			else if ( String.class.isAssignableFrom( type ) ) {
 				if (value instanceof NClobImplementer clobImplementer) {
 					// if the incoming Clob is a wrapper, just get the underlying String.
@@ -151,6 +161,15 @@ public class NClobJavaType extends AbstractClassJavaType<NClob> {
 			final LobCreator lobCreator = options.getLobCreator();
 			if ( value instanceof NClob clob ) {
 				return lobCreator.wrap( clob );
+			}
+			else if ( value instanceof Clob clob ) {
+				try {
+					return lobCreator.createNClob( clob.getCharacterStream(), clob.length() );
+				}
+				catch ( SQLException ex ) {
+					// This basically shouldn't happen unless you've lost connection to the database.
+					throw new HibernateException( ex );
+				}
 			}
 			else if ( value instanceof String string ) {
 				return lobCreator.createNClob( string );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/ClobAttributeQueryUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/ClobAttributeQueryUpdateTest.java
@@ -1,0 +1,198 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.basic;
+
+import java.io.BufferedReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.sql.Clob;
+import java.sql.SQLException;
+
+import jakarta.persistence.Query;
+import org.hibernate.engine.jdbc.proxy.ClobProxy;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.hibernate.Hibernate.getLobHelper;
+
+@DomainModel(
+		annotatedClasses = {
+				ClobAttributeQueryUpdateTest.TestEntity.class
+		}
+)
+@SessionFactory
+@JiraKey("HHH-20318")
+public class ClobAttributeQueryUpdateTest {
+
+	private static final String INITIAL_TEXT = "initial";
+	private static final String UPDATED_TEXT_1 = "update1";
+	private static final String UPDATED_TEXT_2 = "update2";
+
+	@BeforeEach
+	public void setup(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					TestEntity testEntity = new TestEntity(
+							1,
+							"test",
+							getLobHelper().createClob( INITIAL_TEXT )
+					);
+					session.persist( testEntity );
+				}
+		);
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testUpdateUsingClobProxy(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			TestEntity testEntity = session.find( TestEntity.class, 1 );
+			Clob clobValue1 = ClobProxy.generateProxy( UPDATED_TEXT_1 );
+			testEntity.setClobValue( clobValue1 );
+		} );
+
+		scope.inTransaction( session -> {
+			TestEntity testEntity = session.find( TestEntity.class, 1 );
+			checkClobValue( testEntity, UPDATED_TEXT_1 );
+		} );
+
+		scope.inTransaction(
+				session -> {
+					Query query = session.createQuery(
+							"UPDATE TestEntity c SET c.clobValue = :clobValue WHERE c.id = :id"
+					);
+					query.setParameter( "id", 1 );
+					Clob value = ClobProxy.generateProxy( UPDATED_TEXT_2 );
+					query.setParameter( "clobValue", value );
+					query.executeUpdate();
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					TestEntity testEntity = session.find( TestEntity.class, 1 );
+					checkClobValue( testEntity, UPDATED_TEXT_2 );
+				}
+		);
+	}
+
+	@Test
+	public void testUpdateUsingLobHelper(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			TestEntity testEntity = session.find( TestEntity.class, 1 );
+			Clob clobValue1 = getLobHelper().createClob( UPDATED_TEXT_1 );
+			testEntity.setClobValue( clobValue1 );
+		} );
+
+		scope.inTransaction( session -> {
+			TestEntity testEntity = session.find( TestEntity.class, 1 );
+			checkClobValue( testEntity, UPDATED_TEXT_1 );
+		} );
+
+
+		scope.inTransaction(
+				session -> {
+					Query query = session.createQuery(
+							"UPDATE TestEntity c SET c.clobValue = :clobValue WHERE c.id = :id"
+					);
+					query.setParameter( "id", 1 );
+					Clob value = getLobHelper().createClob( UPDATED_TEXT_2 );
+					query.setParameter( "clobValue", value );
+					query.executeUpdate();
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					TestEntity testEntity = session.find( TestEntity.class, 1 );
+					checkClobValue( testEntity, UPDATED_TEXT_2 );
+				}
+		);
+	}
+
+	@Test
+	public void testUpdateUsingLobHelperFromReader(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Query query = session.createQuery(
+							"UPDATE TestEntity c SET c.clobValue = :clobValue WHERE c.id = :id"
+					);
+					query.setParameter( "id", 1 );
+					try ( Reader reader = new StringReader( UPDATED_TEXT_2 ) ) {
+						Clob value = getLobHelper().createClob( reader, UPDATED_TEXT_2.length() );
+						query.setParameter( "clobValue", value );
+						query.executeUpdate();
+					}
+					catch ( Exception e ) {
+						throw new RuntimeException( e );
+					}
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					TestEntity testEntity = session.find( TestEntity.class, 1 );
+					checkClobValue( testEntity, UPDATED_TEXT_2 );
+				}
+		);
+	}
+
+	private static void checkClobValue(TestEntity testEntity, String expectedValue) {
+		try ( Reader reader = testEntity.getClobValue().getCharacterStream();
+				BufferedReader bufferedReader = new BufferedReader( reader ) ) {
+			assertThat( bufferedReader.readLine() ).isEqualTo( expectedValue );
+		}
+		catch ( SQLException | java.io.IOException e ) {
+			throw new RuntimeException( e );
+		}
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		@Lob
+		private Clob clobValue;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Integer id, String name, Clob clobValue) {
+			this.id = id;
+			this.name = name;
+			this.clobValue = clobValue;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public Clob getClobValue() {
+			return clobValue;
+		}
+
+		public void setClobValue(Clob clobValue) {
+			this.clobValue = clobValue;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/NClobAttributeQueryUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/NClobAttributeQueryUpdateTest.java
@@ -1,0 +1,198 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.basic;
+
+import java.io.BufferedReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.sql.NClob;
+import java.sql.SQLException;
+
+import jakarta.persistence.Query;
+import org.hibernate.engine.jdbc.proxy.NClobProxy;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.hibernate.Hibernate.getLobHelper;
+
+@DomainModel(
+		annotatedClasses = {
+				NClobAttributeQueryUpdateTest.TestEntity.class
+		}
+)
+@SessionFactory
+@JiraKey("HHH-20318")
+public class NClobAttributeQueryUpdateTest {
+
+	private static final String INITIAL_TEXT = "initial";
+	private static final String UPDATED_TEXT_1 = "update1";
+	private static final String UPDATED_TEXT_2 = "update2";
+
+	@BeforeEach
+	public void setup(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					TestEntity testEntity = new TestEntity(
+							1,
+							"test",
+							getLobHelper().createNClob( INITIAL_TEXT )
+					);
+					session.persist( testEntity );
+				}
+		);
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testUpdateUsingNClobProxy(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			TestEntity testEntity = session.find( TestEntity.class, 1 );
+			NClob nClobValue1 = NClobProxy.generateProxy( UPDATED_TEXT_1 );
+			testEntity.setNClobValue( nClobValue1 );
+		} );
+
+		scope.inTransaction( session -> {
+			TestEntity testEntity = session.find( TestEntity.class, 1 );
+			checkNClobValue( testEntity, UPDATED_TEXT_1 );
+		} );
+
+		scope.inTransaction(
+				session -> {
+					Query query = session.createQuery(
+							"UPDATE TestEntity n SET n.nClobValue = :nClobValue WHERE n.id = :id"
+					);
+					query.setParameter( "id", 1 );
+					NClob value = NClobProxy.generateProxy( UPDATED_TEXT_2 );
+					query.setParameter( "nClobValue", value );
+					query.executeUpdate();
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					TestEntity testEntity = session.find( TestEntity.class, 1 );
+					checkNClobValue( testEntity, UPDATED_TEXT_2 );
+				}
+		);
+	}
+
+	@Test
+	public void testUpdateUsingLobHelper(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			TestEntity testEntity = session.find( TestEntity.class, 1 );
+			NClob nClobValue1 = getLobHelper().createNClob( UPDATED_TEXT_1 );
+			testEntity.setNClobValue( nClobValue1 );
+		} );
+
+		scope.inTransaction( session -> {
+			TestEntity testEntity = session.find( TestEntity.class, 1 );
+			checkNClobValue( testEntity, UPDATED_TEXT_1 );
+		} );
+
+
+		scope.inTransaction(
+				session -> {
+					Query query = session.createQuery(
+							"UPDATE TestEntity n SET n.nClobValue = :nClobValue WHERE n.id = :id"
+					);
+					query.setParameter( "id", 1 );
+					NClob value = getLobHelper().createNClob( UPDATED_TEXT_2 );
+					query.setParameter( "nClobValue", value );
+					query.executeUpdate();
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					TestEntity testEntity = session.find( TestEntity.class, 1 );
+					checkNClobValue( testEntity, UPDATED_TEXT_2 );
+				}
+		);
+	}
+
+	@Test
+	public void testUpdateUsingLobHelperFromReader(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Query query = session.createQuery(
+							"UPDATE TestEntity n SET n.nClobValue = :nClobValue WHERE n.id = :id"
+					);
+					query.setParameter( "id", 1 );
+					try ( Reader reader = new StringReader( UPDATED_TEXT_2 ) ) {
+						NClob value = getLobHelper().createNClob( reader, UPDATED_TEXT_2.length() );
+						query.setParameter( "nClobValue", value );
+						query.executeUpdate();
+					}
+					catch ( Exception e ) {
+						throw new RuntimeException( e );
+					}
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					TestEntity testEntity = session.find( TestEntity.class, 1 );
+					checkNClobValue( testEntity, UPDATED_TEXT_2 );
+				}
+		);
+	}
+
+	private static void checkNClobValue(TestEntity testEntity, String expectedValue) {
+		try ( Reader reader = testEntity.getNClobValue().getCharacterStream();
+			BufferedReader bufferedReader = new BufferedReader( reader ) ) {
+			assertThat( bufferedReader.readLine() ).isEqualTo( expectedValue );
+		}
+		catch ( SQLException | java.io.IOException e ) {
+			throw new RuntimeException( e );
+		}
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		@Lob
+		private NClob nClobValue;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Integer id, String name, NClob nClobValue) {
+			this.id = id;
+			this.name = name;
+			this.nClobValue = nClobValue;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public NClob getNClobValue() {
+			return nClobValue;
+		}
+
+		public void setNClobValue(NClob nClobValue) {
+			this.nClobValue = nClobValue;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

## HHH-20318

### issue

`SerializableClobProxy` (wrapped when a `Clob` instance is passed during parameter wrap)
  and `java.sql.Clob` do not implement `ClobImplementer`.

The class passed to the `unwrap` function then differs depending on the Dialect.

**Dialects where `useStreamForLobBinding() == false` (PostgreSQL, etc.)**
- `CLOB_BINDING` → calls `unwrap(clob, Clob.class, _)`
- The `SerializableClobProxy` is successfully unwrapped via the `toJdbcClob` helper

**Dialects inheriting the default (H2, MySQL, etc.)**
- `STREAM_BINDING` → calls `unwrap(clob, CharacterStream.class, _)`
- `instanceof ClobImplementer` is `false`, so the `else` branch is entered
- Attempting to cast a `java.io.Reader` to Hibernate's `CharacterStream` interface throws a `ClassCastException`

### fix
Applied the same logic as `BlobJavaType.unwrap`'s `return type.cast( new StreamBackedBinaryStream( value.getBinaryStream(), value.length() ) );`.

In the `else` branch, explicitly construct a `CharacterStreamImpl(Reader, long)` to wrap the `Reader` in a `CharacterStream` implementation.

`NClobJavaType.unwrap` has the same issue and is fixed as well.

## HHH-20647

### issue

PostgreSQL declares `NationalizationSupport.IMPLICIT`, so `Dialect#contributeTypes(TypeContributions, ServiceRegistry)` does not register the NClob descriptor. As a result, descriptor lookup falls back to the family descriptor — `ClobJdbcType`.

At bind time, the following call is then made, and because none of the branches in `NClobJavaType#unwrap` match `Clob.class`, execution falls through to `throw unknownUnwrap(type);` at `NClobJavaType.java:143`:

```java
st.setClob( index, javaType.unwrap( nclob, Clob.class, options ) );
```

### fix

Added conversion logic 
— `NClob` → `Clob` in `unwrap`
and `Clob` → `NClob` in `wrap`.

---

https://hibernate.atlassian.net/browse/HHH-20318
https://hibernate.atlassian.net/browse/HHH-20647

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20647 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20318 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->