### PR TITLE
HHH-20637 HbmXmlTransformer does not transform <parent> declarations in component and composite-element mappings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -2264,6 +2264,10 @@ public class HbmXmlTransformer {
 			currentBaseTable = previousBaseTable;
 		}
 
+		if ( compositeElement.getParent() != null ) {
+			embeddable.getAttributes().setParent( compositeElement.getParent().getName() );
+		}
+
 		mappingXmlBinding.getRoot().getEmbeddables().add( embeddable );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformerComponentHandler.java
@@ -245,6 +245,10 @@ public class HbmXmlTransformerComponentHandler {
 
 		transferEmbeddableTransients( embeddableClassName, componentTypeInfo, hbmComponent, embeddable );
 
+		if ( hbmComponent.getParent() != null ) {
+			embeddable.getAttributes().setParent( hbmComponent.getParent().getName() );
+		}
+
 		return embeddable;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -360,6 +360,30 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	public void testCompositeElementParentTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/parent/composite-element-parent.hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEmbeddables() ).hasSize( 1 );
+
+			final JaxbEmbeddableImpl embeddable = transformed.getEmbeddables().get( 0 );
+			assertThat( embeddable.getAttributes().getParent() )
+					.as( "<parent> in <composite-element> should produce <parent> in the embeddable" )
+					.isEqualTo( "parent" );
+		} );
+	}
+
+	@Test
+	public void testComponentParentTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/parent/component-parent.hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEmbeddables() ).hasSize( 1 );
+
+			final JaxbEmbeddableImpl embeddable = transformed.getEmbeddables().get( 0 );
+			assertThat( embeddable.getAttributes().getParent() )
+					.as( "<parent> in <component> should produce <parent> in the embeddable" )
+					.isEqualTo( "owner" );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20628" )
 	public void testCompositeElementAccessTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/composite-element/hbm.xml", scope, (transformed) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/parent/ComponentChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/parent/ComponentChild.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.parent;
+
+public class ComponentChild {
+	private ParentEntity owner;
+	private String description;
+
+	public ParentEntity getOwner() {
+		return owner;
+	}
+
+	public void setOwner(ParentEntity owner) {
+		this.owner = owner;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/parent/CompositeChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/parent/CompositeChild.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.parent;
+
+public class CompositeChild {
+	private ParentEntity parent;
+	private String name;
+	private NestedAddress address;
+
+	public ParentEntity getParent() {
+		return parent;
+	}
+
+	public void setParent(ParentEntity parent) {
+		this.parent = parent;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public NestedAddress getAddress() {
+		return address;
+	}
+
+	public void setAddress(NestedAddress address) {
+		this.address = address;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/parent/NestedAddress.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/parent/NestedAddress.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.parent;
+
+public class NestedAddress {
+	private CompositeChild owner;
+	private String street;
+	private String city;
+
+	public CompositeChild getOwner() {
+		return owner;
+	}
+
+	public void setOwner(CompositeChild owner) {
+		this.owner = owner;
+	}
+
+	public String getStreet() {
+		return street;
+	}
+
+	public void setStreet(String street) {
+		this.street = street;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public void setCity(String city) {
+		this.city = city;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/parent/ParentEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/parent/ParentEntity.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.parent;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ParentEntity {
+	private Long id;
+	private String name;
+	private Set<CompositeChild> children = new HashSet<>();
+	private ComponentChild component;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Set<CompositeChild> getChildren() {
+		return children;
+	}
+
+	public void setChildren(Set<CompositeChild> children) {
+		this.children = children;
+	}
+
+	public ComponentChild getComponent() {
+		return component;
+	}
+
+	public void setComponent(ComponentChild component) {
+		this.component = component;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/parent/component-parent.hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/parent/component-parent.hbm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.parent">
+    <class name="ParentEntity">
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name"/>
+        <component name="component" class="ComponentChild">
+            <parent name="owner"/>
+            <property name="description"/>
+        </component>
+    </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/parent/composite-element-parent.hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/parent/composite-element-parent.hbm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.parent">
+    <class name="ParentEntity">
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name"/>
+        <set name="children" table="ParentChild">
+            <key column="parent_id"/>
+            <composite-element class="CompositeChild">
+                <parent name="parent"/>
+                <property name="name" not-null="true"/>
+            </composite-element>
+        </set>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/12952 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20637 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20637
<!-- Hibernate GitHub Bot issue links end -->