### PR TITLE
Rework mirror support to use a less intrusive, more exhaustive approach

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -12,6 +12,7 @@ defaults:
 permissions: { } # none, jobs are defining their own if they need any
 
 env:
+  COMMON_GRADLE_ARGS: "-Igradle/init.gradle"
   MIRROR_MAVEN_CENTRAL_URL: "https://maven-central.storage-download.googleapis.com/maven2/"
   MIRROR_MAVEN_CENTRAL_FALLBACK: "true"
 
@@ -104,6 +105,7 @@ jobs:
         if: ${{ steps.downloadBuildScan.outcome != 'failure'}}
         run: |
           shopt -s nullglob # Don't run the loop below if there are no artifacts
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
           published=0
           failed=0
           mkdir -p ~/.gradle/
@@ -111,7 +113,7 @@ jobs:
           do
             rm -rf ~/.gradle/build-scan-data
             mv "$build_scan_data_directory" ~/.gradle/build-scan-data
-            if ./gradlew --no-build-cache buildScanPublishPrevious; then
+            if ./gradlew "${common_gradle_args[@]}" --no-build-cache buildScanPublishPrevious; then
               published=$((published + 1))
             else
               echo "::warning::Failed to publish build scan from $(basename "$build_scan_data_directory")"

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -11,6 +11,10 @@ defaults:
 
 permissions: { } # none, jobs are defining their own if they need any
 
+env:
+  MIRROR_MAVEN_CENTRAL_URL: "https://maven-central.storage-download.googleapis.com/maven2/"
+  MIRROR_MAVEN_CENTRAL_FALLBACK: "true"
+
 jobs:
   publish-build-scans:
     name: Publish Develocity build scans

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ concurrency:
   # for pull requests or pushes to forks (not the upstream repository).
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'hibernate/hibernate-orm' }}
 
+env:
+  MIRROR_MAVEN_CENTRAL_URL: "https://maven-central.storage-download.googleapis.com/maven2/"
+  MIRROR_MAVEN_CENTRAL_FALLBACK: "true"
+
 jobs:
 
   # Main job for h2/docker DBs.
@@ -124,8 +128,6 @@ jobs:
         shell: bash
         env:
           RDBMS: ${{ matrix.rdbms }}
-          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
-          MAVEN_CENTRAL_FALLBACK: "true"
           JPA_PREVIEW: "true"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
@@ -253,8 +255,6 @@ jobs:
       - name: Run build script
         env:
           RDBMS: ${{ matrix.rdbms }}
-          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
-          MAVEN_CENTRAL_FALLBACK: "true"
           JPA_PREVIEW: "true"
           RUNID: ${{ github.run_number }}
           TESTPILOT_CONNECTION_STRING_SUFFIX: ${{ steps.create_database.outputs.connection_string_suffix }}
@@ -394,8 +394,6 @@ jobs:
         shell: bash
         env:
           RDBMS: ${{ matrix.rdbms }}
-          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
-          MAVEN_CENTRAL_FALLBACK: "true"
           JPA_PREVIEW: "true"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
@@ -508,7 +506,6 @@ jobs:
         shell: bash
         env:
           RDBMS: ${{ matrix.rdbms }}
-          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
           POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
@@ -609,8 +606,6 @@ jobs:
       - name: Run build script
         run: ./gradlew formatChecks
         env:
-          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
-          MAVEN_CENTRAL_FALLBACK: "true"
           JPA_PREVIEW: "true"
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
@@ -704,8 +699,6 @@ jobs:
       - name: Merge Jacoco Reports
         run: ./gradlew mergeCodeCoverageReport copyDependenciesSonar --no-parallel
         env:
-          MAVEN_MIRROR: "https://maven-central.storage-download.googleapis.com/maven2/"
-          MAVEN_CENTRAL_FALLBACK: "true"
           JPA_PREVIEW: "true"
 
       - name: Store build info for Sonar scanning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'hibernate/hibernate-orm' }}
 
 env:
+  COMMON_GRADLE_ARGS: "-Igradle/init.gradle"
   MIRROR_MAVEN_CENTRAL_URL: "https://maven-central.storage-download.googleapis.com/maven2/"
   MIRROR_MAVEN_CENTRAL_FALLBACK: "true"
 
@@ -124,7 +125,9 @@ jobs:
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-
 
       - name: Run build script
-        run: ./ci/build-github.sh
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ./ci/build-github.sh "${common_gradle_args[@]}"
         shell: bash
         env:
           RDBMS: ${{ matrix.rdbms }}
@@ -274,7 +277,9 @@ jobs:
           ORG_GRADLE_PROJECT_toolchain.compiler.jvmargs: "-Dlog4j2.disableJmx=true -Xmx4g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8"
           # Gradle workers (Tests...)
           ORG_GRADLE_PROJECT_toolchain.launcher.jvmargs: "-Dlog4j2.disableJmx=true -Xmx3g -XX:MaxMetaspaceSize=448m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8"
-        run: ./ci/build-github.sh
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ./ci/build-github.sh "${common_gradle_args[@]}"
         shell: bash
 
       - uses: oracle-actions/setup-testpilot@37676e7f43dabdebb120915f2862f6ddd55d28d6 # v1.0.25
@@ -390,7 +395,9 @@ jobs:
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-
 
       - name: Run build script
-        run: ci/build-tck-github.sh
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ci/build-tck-github.sh "${common_gradle_args[@]}"
         shell: bash
         env:
           RDBMS: ${{ matrix.rdbms }}
@@ -502,7 +509,9 @@ jobs:
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-
 
       - name: Run build script
-        run: ci/build-data-tck-github.sh
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ci/build-data-tck-github.sh "${common_gradle_args[@]}"
         shell: bash
         env:
           RDBMS: ${{ matrix.rdbms }}
@@ -604,7 +613,9 @@ jobs:
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-    
 
       - name: Run build script
-        run: ./gradlew formatChecks
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ./gradlew "${common_gradle_args[@]}" formatChecks
         env:
           JPA_PREVIEW: "true"
           # For jobs running on 'push', publish build scan and cache immediately.
@@ -697,7 +708,9 @@ jobs:
         continue-on-error: true
 
       - name: Merge Jacoco Reports
-        run: ./gradlew mergeCodeCoverageReport copyDependenciesSonar --no-parallel
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ./gradlew "${common_gradle_args[@]}" mergeCodeCoverageReport copyDependenciesSonar --no-parallel
         env:
           JPA_PREVIEW: "true"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,8 @@ import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 this.helper = new JobHelper(this)
 
 helper.runWithNotification {
+env.COMMON_GRADLE_ARGS = '-Igradle/init.gradle'
+
 stage('Configure') {
 	requireApprovalForPullRequest 'hibernate'
 
@@ -270,7 +272,7 @@ void ciBuild(buildEnv, String args) {
 		withCredentials([string(credentialsId: develocityCredentialsId,
 				variable: 'DEVELOCITY_ACCESS_KEY')]) {
 			withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
-				sh "./ci/build.sh $args"
+				sh "./ci/build.sh \$COMMON_GRADLE_ARGS $args"
 			}
 		}
 	}
@@ -278,20 +280,20 @@ void ciBuild(buildEnv, String args) {
 		// Pull request: we can't pass credentials to the build, since we'd be exposing secrets to e.g. tests.
 		// We do the build first, then publish the build scan separately.
 		tryFinally({
-			sh "./ci/build.sh $args"
+			sh "./ci/build.sh \$COMMON_GRADLE_ARGS $args"
 		}, { // Finally
 			withCredentials([string(credentialsId: 'develocity.commonhaus.dev-access-key-pr',
 					variable: 'DEVELOCITY_ACCESS_KEY')]) {
 				withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
 					// Don't fail a build if publishing fails
-					sh './gradlew buildScanPublishPrevious || true'
+					sh "./gradlew \$COMMON_GRADLE_ARGS buildScanPublishPrevious || true"
 				}
 			}
 		})
 	}
 	else {
 		// Don't do build scans
-		sh "./ci/build.sh $args"
+		sh "./ci/build.sh \$COMMON_GRADLE_ARGS $args"
 	}
 }
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,10 +17,29 @@ Continuous integration is split across two platforms:
 
 ### Tips
 
-The Hibernate ORM build can use a mirror instead of Maven central.
-To do so, set the `MAVEN_MIRROR` environment variable to the URL of your mirror,
-e.g. `http://something-on-aws.com/path/to/repo`.
-Alternatively, you can pass `-DMAVEN_MIRROR=...` to the `gradle` command.
+The Hibernate ORM build can use mirrors instead of public repositories.
+The mirror configuration is in `gradle/mirror.gradle`, auto-activated from `settings.gradle`.
+Each mirror is activated independently when its `MIRROR_*_URL` property is set.
+
+Supported mirrors (each with `_URL`, `_USERNAME`, `_PASSWORD`, `_FALLBACK` suffixes):
+
+| Prefix                            | Repository              |
+|-----------------------------------|-------------------------|
+| `MIRROR_MAVEN_CENTRAL`            | Maven Central           |
+| `MIRROR_MAVEN_CENTRAL_SNAPSHOTS`  | Central Portal Snapshots|
+| `MIRROR_GRADLE_PLUGIN_PORTAL`     | Gradle Plugin Portal    |
+
+For example, to mirror Maven Central set `MIRROR_MAVEN_CENTRAL_URL` via any of
+(in order of precedence):
+* System property: `-DMIRROR_MAVEN_CENTRAL_URL=<url>`
+* Environment variable: `MIRROR_MAVEN_CENTRAL_URL=<url>`
+
+Optional properties (same resolution order per mirror):
+* `*_USERNAME` / `*_PASSWORD` — mirror credentials
+* `*_FALLBACK` — set to `true` to also keep the original repo as a fallback
+
+Note: Gradle project properties (`-P`) are not supported because they don't
+propagate to included builds (`local-build-plugins`).
 
 To pick up locally built dependencies (e.g. a local Jakarta Persistence build),
 pass `-DenableMavenLocalRepo=true` to the `gradle` command.

--- a/ci/build-data-tck-github.sh
+++ b/ci/build-data-tck-github.sh
@@ -4,4 +4,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 java -version
 
-exec bash $DIR/build-data-tck.sh
+exec bash $DIR/build-data-tck.sh "$@"

--- a/ci/build-github.sh
+++ b/ci/build-github.sh
@@ -4,4 +4,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 java -version
 
-exec bash $DIR/build.sh
+exec bash $DIR/build.sh "$@"

--- a/ci/build-tck-github.sh
+++ b/ci/build-tck-github.sh
@@ -4,4 +4,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 java -version
 
-exec bash $DIR/build-tck.sh
+exec bash $DIR/build-tck.sh "$@"

--- a/ci/quarkus.Jenkinsfile
+++ b/ci/quarkus.Jenkinsfile
@@ -95,6 +95,9 @@ def configurations = [
 
 pipeline {
     agent none
+    environment {
+        COMMON_GRADLE_ARGS = '-Igradle/init.gradle'
+    }
     options {
         buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
         disableConcurrentBuilds(abortPrevious: true)
@@ -117,7 +120,7 @@ pipeline {
                 script {
                     dir('hibernate') {
                         checkout scm
-                        sh "./gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -Dmaven.repo.local=${env.WORKSPACE_TMP}/.m2repository"
+                        sh "./gradlew \$COMMON_GRADLE_ARGS clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -Dmaven.repo.local=${env.WORKSPACE_TMP}/.m2repository"
                         script {
                             env.HIBERNATE_VERSION = sh (
                                     script: "grep hibernateVersion gradle/version.properties|cut -d'=' -f2",

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -30,9 +30,9 @@ plugins {
 }
 
 repositories {
-	org.hibernate.orm.env.MavenMirror.maybeAddMavenLocal(it)
-	org.hibernate.orm.env.MavenMirror.maybeAddMavenCentral(it)
-	org.hibernate.orm.env.MavenMirror.maybeAddMavenCentralSnapshots(it) { content ->
+	org.hibernate.orm.env.Repositories.maybeAddMavenLocal(it)
+	mavenCentral()
+	org.hibernate.orm.env.Repositories.maybeAddMavenCentralSnapshots(it) { content ->
 		content.includeGroup "jakarta.persistence"
 	}
 }

--- a/gradle/init.gradle
+++ b/gradle/init.gradle
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-// Repository mirror configuration, applied from settings.gradle.
+// Repository mirror configuration, applied as an init script via -Igradle/init.gradle.
 //
 // Mirrors are configured per repository via MIRROR_<REPO>_(URL|USERNAME|PASSWORD|FALLBACK)
 // properties. Resolution order: system property (-D) > environment variable.
@@ -64,6 +64,7 @@ def __mirrors = []
 if (centralMirror) __mirrors << "Maven Central -> ${centralMirror.url}"
 if (snapshotsMirror) __mirrors << "Central Portal Snapshots -> ${snapshotsMirror.url}"
 if (pluginPortalMirror) __mirrors << "Gradle Plugin Portal -> ${pluginPortalMirror.url}"
+println "Repository mirrors active: ${__mirrors.join(', ')}"
 
 def __rewriteRepo(repositories, String repoName, __MirrorConfig mirror) {
     if (!mirror) return
@@ -110,31 +111,16 @@ def __addAllFallbacks(repositories, centralMirror, snapshotsMirror, pluginPortal
     __addFallback(repositories, 'Gradle Central Plugin Repository', 'https://plugins.gradle.org/m2', pluginPortalMirror)
 }
 
-// When applied from an applied script's buildscript block, the caller passes its
-// ScriptHandler via gradle.ext.__mirrorBuildScript so we can rewrite that script's
-// repositories. Lifecycle callbacks only reach project.buildscript, not applied
-// scripts' separate ScriptHandlers.
-def __buildScript = gradle.ext.has('__mirrorBuildScript') ? gradle.ext.__mirrorBuildScript : null
-if (__buildScript != null) {
-    gradle.ext.__mirrorBuildScript = null
-    def __source = __buildScript.sourceFile?.name
-    def __logPrefix = __source ? "${rootProject.getName()}:${__source}" : rootProject.getName()
-    println "${__logPrefix}: Repository mirrors active: ${__mirrors.join(', ')}"
-    __rewriteAll(__buildScript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-    __addAllFallbacks(__buildScript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-    return
+gradle.beforeSettings { settings ->
+    __rewriteAll(settings.pluginManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __rewriteAll(settings.buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
 }
 
-println "${rootProject.getName()}: Repository mirrors active: ${__mirrors.join(', ')}"
-
-__rewriteAll(buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-__addAllFallbacks(buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-
-__rewriteAll(pluginManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-
-gradle.settingsEvaluated { s ->
-    __rewriteAll(s.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-    __addAllFallbacks(s.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+gradle.settingsEvaluated { settings ->
+    __addAllFallbacks(settings.pluginManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(settings.buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __rewriteAll(settings.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(settings.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
 }
 
 gradle.beforeProject { p ->

--- a/gradle/mirror.gradle
+++ b/gradle/mirror.gradle
@@ -1,0 +1,148 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+
+// Repository mirror configuration, applied from settings.gradle.
+//
+// Mirrors are configured per repository via MIRROR_<REPO>_(URL|USERNAME|PASSWORD|FALLBACK)
+// properties. Resolution order: system property (-D) > environment variable.
+//
+// Supported repositories:
+//   MIRROR_MAVEN_CENTRAL_*          - Maven Central (repo name: MavenRepo)
+//   MIRROR_MAVEN_CENTRAL_SNAPSHOTS_*- Central Portal Snapshots
+//   MIRROR_GRADLE_PLUGIN_PORTAL_*   - Gradle Plugin Portal (repo name: Gradle Central Plugin Repository)
+//
+// For each, the properties are:
+//   *_URL       - URL of the mirror (required to activate mirroring for that repo)
+//   *_USERNAME  - Optional mirror credentials
+//   *_PASSWORD  - Optional mirror credentials
+//   *_FALLBACK  - Set to 'true' to keep the original repo as a fallback
+//
+// See also: MAINTAINERS.md
+//
+// Adapted from https://blog.gradle.org/maven-central-mirror to not require a init.gradle,
+// because that solution cannot work in some environments where we don't control the filesystem
+// but only environment variables.
+
+// NOTE: using methods instead of closures-in-variables — Gradle's script classloading
+// breaks across build boundaries when inner closure classes are cached and reused.
+
+def __resolve(String key) {
+    def value = System.getProperty(key)
+    if (value) return value
+    value = System.getenv(key)
+    if (value) return value
+    return null
+}
+
+class __MirrorConfig {
+    String url
+    String username
+    String password
+    boolean fallback
+}
+
+def __loadMirror(String prefix, resolveFunc) {
+    def url = resolveFunc("${prefix}_URL")
+    if (!url) return null
+    def cfg = new __MirrorConfig()
+    cfg.url = url
+    cfg.username = resolveFunc("${prefix}_USERNAME")
+    cfg.password = resolveFunc("${prefix}_PASSWORD")
+    cfg.fallback = 'true'.equalsIgnoreCase(resolveFunc("${prefix}_FALLBACK"))
+    return cfg
+}
+
+def centralMirror = __loadMirror('MIRROR_MAVEN_CENTRAL', this.&__resolve)
+def snapshotsMirror = __loadMirror('MIRROR_MAVEN_CENTRAL_SNAPSHOTS', this.&__resolve)
+def pluginPortalMirror = __loadMirror('MIRROR_GRADLE_PLUGIN_PORTAL', this.&__resolve)
+
+if (!centralMirror && !snapshotsMirror && !pluginPortalMirror) return
+
+def __mirrors = []
+if (centralMirror) __mirrors << "Maven Central -> ${centralMirror.url}"
+if (snapshotsMirror) __mirrors << "Central Portal Snapshots -> ${snapshotsMirror.url}"
+if (pluginPortalMirror) __mirrors << "Gradle Plugin Portal -> ${pluginPortalMirror.url}"
+
+def __rewriteRepo(repositories, String repoName, __MirrorConfig mirror) {
+    if (!mirror) return
+    repositories.withType(MavenArtifactRepository).configureEach { repo ->
+        if (repo.name == repoName) {
+            repo.url = URI.create(mirror.url)
+            if (mirror.username || mirror.password) {
+                repo.credentials {
+                    if (mirror.username) {
+                        username = mirror.username
+                    }
+                    if (mirror.password) {
+                        password = mirror.password
+                    }
+                }
+            }
+        }
+    }
+}
+
+def __addFallback(repositories, String repoName, String originalUrl, __MirrorConfig mirror) {
+    if (!mirror || !mirror.fallback) return
+    def original = repositories.findByName(repoName)
+    if (!original) return
+    def fallbackName = "${repoName} (fallback)"
+    if (repositories.findByName(fallbackName)) return
+    def fallback = repositories.maven {
+        name = fallbackName
+        url = URI.create(originalUrl)
+    }
+    repositories.remove(fallback)
+    repositories.add(repositories.indexOf(original) + 1, fallback)
+}
+
+def __rewriteAll(repositories, centralMirror, snapshotsMirror, pluginPortalMirror) {
+    __rewriteRepo(repositories, 'MavenRepo', centralMirror)
+    __rewriteRepo(repositories, 'Central Portal Snapshots', snapshotsMirror)
+    __rewriteRepo(repositories, 'Gradle Central Plugin Repository', pluginPortalMirror)
+}
+
+def __addAllFallbacks(repositories, centralMirror, snapshotsMirror, pluginPortalMirror) {
+    __addFallback(repositories, 'MavenRepo', 'https://repo.maven.apache.org/maven2/', centralMirror)
+    __addFallback(repositories, 'Central Portal Snapshots', 'https://central.sonatype.com/repository/maven-snapshots/', snapshotsMirror)
+    __addFallback(repositories, 'Gradle Central Plugin Repository', 'https://plugins.gradle.org/m2', pluginPortalMirror)
+}
+
+// When applied from an applied script's buildscript block, the caller passes its
+// ScriptHandler via gradle.ext.__mirrorBuildScript so we can rewrite that script's
+// repositories. Lifecycle callbacks only reach project.buildscript, not applied
+// scripts' separate ScriptHandlers.
+def __buildScript = gradle.ext.has('__mirrorBuildScript') ? gradle.ext.__mirrorBuildScript : null
+if (__buildScript != null) {
+    gradle.ext.__mirrorBuildScript = null
+    def __source = __buildScript.sourceFile?.name
+    def __logPrefix = __source ? "${rootProject.getName()}:${__source}" : rootProject.getName()
+    println "${__logPrefix}: Repository mirrors active: ${__mirrors.join(', ')}"
+    __rewriteAll(__buildScript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(__buildScript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    return
+}
+
+println "${rootProject.getName()}: Repository mirrors active: ${__mirrors.join(', ')}"
+
+__rewriteAll(buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+__addAllFallbacks(buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+
+__rewriteAll(pluginManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+
+gradle.settingsEvaluated { s ->
+    __rewriteAll(s.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(s.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+}
+
+gradle.beforeProject { p ->
+    __rewriteAll(p.buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __rewriteAll(p.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+}
+
+gradle.afterProject { p ->
+    __addAllFallbacks(p.buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(p.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+}

--- a/hibernate-tck-data-runner/hibernate-tck-data-runner.gradle
+++ b/hibernate-tck-data-runner/hibernate-tck-data-runner.gradle
@@ -11,12 +11,12 @@ plugins {
 description = 'Hibernate ORM\'s Jakarta Data TCK runner'
 
 repositories {
-    org.hibernate.orm.env.MavenMirror.maybeAddMavenLocal(it)
-    org.hibernate.orm.env.MavenMirror.maybeAddMavenCentralSnapshots(it) { content ->
+    org.hibernate.orm.env.Repositories.maybeAddMavenLocal(it)
+    org.hibernate.orm.env.Repositories.maybeAddMavenCentralSnapshots(it) { content ->
         content.includeGroup "jakarta.persistence"
         content.includeGroup "jakarta.data"
     }
-    org.hibernate.orm.env.MavenMirror.maybeAddMavenCentral(it)
+    mavenCentral()
 }
 
 // Configuration to resolve the TCK sources jar

--- a/hibernate-tck-runner/hibernate-tck-runner.gradle
+++ b/hibernate-tck-runner/hibernate-tck-runner.gradle
@@ -11,7 +11,7 @@ plugins {
 description = 'Hibernate ORM\'s Jakarta Persistence TCK runner'
 
 repositories {
-    org.hibernate.orm.env.MavenMirror.maybeAddMavenLocal(it) { content ->
+    org.hibernate.orm.env.Repositories.maybeAddMavenLocal(it) { content ->
         content.includeGroup "jakarta.persistence"
     }
     maven {
@@ -21,8 +21,8 @@ repositories {
             includeGroup "jakarta.persistence"
         }
     }
-    // See MavenMirror and settings.gradle for more info on the mirror configuration
-    org.hibernate.orm.env.MavenMirror.maybeAddMavenCentral(it)
+    // See settings.gradle for more info on the mirror configuration
+    mavenCentral()
 }
 
 dependencies {

--- a/local-build-plugins/settings.gradle
+++ b/local-build-plugins/settings.gradle
@@ -1,4 +1,21 @@
+pluginManagement {
+    repositories {
+        // mavenCentral before gradlePluginPortal: the plugin portal redirects transitive
+        // deps to Maven Central via HTTP 303 — with a mirror, those redirects would fail.
+        // Listing mavenCentral first lets Gradle resolve transitive deps directly
+        // (or from the mirror when MIRROR_MAVEN_CENTRAL_URL is set; see gradle/mirror.gradle).
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    // Repository mirrors: rewrites repository URLs when MIRROR_*_URL is set (see MAINTAINERS.md).
+    apply from: '../gradle/mirror.gradle'
+}
+
 dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
     versionCatalogs {
         libs {
             from(files("../gradle/libs.versions.toml"))

--- a/local-build-plugins/settings.gradle
+++ b/local-build-plugins/settings.gradle
@@ -1,15 +1,8 @@
 pluginManagement {
     repositories {
-        // mavenCentral before gradlePluginPortal: the plugin portal redirects transitive
-        // deps to Maven Central via HTTP 303 — with a mirror, those redirects would fail.
-        // Listing mavenCentral first lets Gradle resolve transitive deps directly
-        // (or from the mirror when MIRROR_MAVEN_CENTRAL_URL is set; see gradle/mirror.gradle).
         mavenCentral()
         gradlePluginPortal()
     }
-
-    // Repository mirrors: rewrites repository URLs when MIRROR_*_URL is set (see MAINTAINERS.md).
-    apply from: '../gradle/mirror.gradle'
 }
 
 dependencyResolutionManagement {

--- a/local-build-plugins/src/main/java/org/hibernate/orm/env/Repositories.java
+++ b/local-build-plugins/src/main/java/org/hibernate/orm/env/Repositories.java
@@ -11,21 +11,12 @@ import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 import java.net.URI;
 
 /**
- * Configures Maven Central or a mirror of it, based on the {@code MAVEN_MIRROR} environment
- * variable or system property. Optionally supports authentication via
- * {@code MAVEN_MIRROR_USERNAME} and {@code MAVEN_MIRROR_PASSWORD}.
- * <p>
- * When using a mirror, set {@code MAVEN_CENTRAL_FALLBACK} to {@code true} to also add
- * {@code mavenCentral()} after the mirror — useful when mirrors lag behind on freshly
- * published artifacts.
- *
- * @see <a href="https://blog.gradle.org/maven-central-mirror">Gradle Maven Central Mirror</a>
+ * Adds optional Maven repositories (mavenLocal, Maven Central Snapshots).
  */
-public class MavenMirror {
+public class Repositories {
 
 	/**
 	 * Adds a {@code mavenLocal()} repository if the {@code enableMavenLocalRepo} system property is set.
-	 * Useful for local development to pick up locally built artifacts.
 	 *
 	 * @param contentFilter optional content filter, e.g. {@code c -> c.includeGroup("jakarta.persistence")}
 	 */
@@ -61,36 +52,6 @@ public class MavenMirror {
 
 	public static void maybeAddMavenCentralSnapshots(RepositoryHandler repositories) {
 		maybeAddMavenCentralSnapshots( repositories, null );
-	}
-
-	/**
-	 * @return {@code true} if a mirror was configured, {@code false} if plain Maven Central was added
-	 */
-	public static boolean maybeAddMavenCentral(RepositoryHandler repositories) {
-		String mirror = resolve( "MAVEN_MIRROR" );
-		if ( mirror != null ) {
-			repositories.maven( repo -> {
-				repo.setUrl( mirror );
-				String username = resolve( "MAVEN_MIRROR_USERNAME" );
-				if ( username != null ) {
-					repo.credentials( creds -> {
-						creds.setUsername( username );
-						String password = resolve( "MAVEN_MIRROR_PASSWORD" );
-						if ( password != null ) {
-							creds.setPassword( password );
-						}
-					} );
-				}
-			} );
-			if ( "true".equalsIgnoreCase( resolve( "MAVEN_CENTRAL_FALLBACK" ) ) ) {
-				repositories.mavenCentral();
-			}
-			return true;
-		}
-		else {
-			repositories.mavenCentral();
-			return false;
-		}
 	}
 
 	private static String resolve(String key) {

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -22,6 +22,8 @@ import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 this.helper = new JobHelper(this)
 
 helper.runWithNotification {
+env.COMMON_GRADLE_ARGS = '-Igradle/init.gradle'
+
 stage('Configure') {
 	this.environments = [
 		// Minimum supported versions
@@ -210,8 +212,8 @@ stage('Build') {
 							def repo2 = tempDir + '/repo2'
 							// build Hibernate ORM two times without any cache and "publish" the resulting artifacts to different maven repositories
 							// so that we can compare them afterwards:
-							sh "./gradlew --no-daemon clean publishToMavenLocal --no-build-cache -Dmaven.repo.local=${repo1}"
-							sh "./gradlew --no-daemon clean publishToMavenLocal --no-build-cache -Dmaven.repo.local=${repo2}"
+							sh "./gradlew \$COMMON_GRADLE_ARGS --no-daemon clean publishToMavenLocal --no-build-cache -Dmaven.repo.local=${repo1}"
+							sh "./gradlew \$COMMON_GRADLE_ARGS --no-daemon clean publishToMavenLocal --no-build-cache -Dmaven.repo.local=${repo2}"
 
 							sh "sh ci/compare-build-results.sh ${repo1} ${repo2}"
 							sh "cat .buildcompare"
@@ -305,7 +307,7 @@ void ciBuild(String develocityCredentialsId, String args) {
   withCredentials([string(credentialsId: develocityCredentialsId,
       variable: 'DEVELOCITY_ACCESS_KEY')]) {
     withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
-      sh "./ci/build.sh $args"
+      sh "./ci/build.sh \$COMMON_GRADLE_ARGS $args"
     }
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,11 @@
 
 pluginManagement {
     repositories {
+        // mavenCentral before gradlePluginPortal: the plugin portal redirects transitive
+        // deps to Maven Central via HTTP 303 — with a mirror, those redirects would fail.
+        // Listing mavenCentral first lets Gradle resolve transitive deps directly
+        // (or from the mirror when MIRROR_MAVEN_CENTRAL_URL is set; see gradle/mirror.gradle).
+        mavenCentral()
         gradlePluginPortal()
         maven {
             name = 'localPluginRepository'
@@ -13,6 +18,11 @@ pluginManagement {
     }
 
     includeBuild 'local-build-plugins'
+
+    // Repository mirrors: rewrites repository URLs when MIRROR_*_URL is set (see MAINTAINERS.md).
+    // Applied inside pluginManagement so that repos are rewritten before settings plugins
+    // are resolved at the plugins {} block; lifecycle callbacks handle per-project repos.
+    apply from: 'gradle/mirror.gradle'
 }
 
 plugins {
@@ -25,11 +35,9 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         // See MAINTAINERS.md for documentation.
-        // TODO Move to infra overrides instead;
-        //  see https://blog.gradle.org/maven-central-mirror#overriding-the-urls-for-maven-central-and-the-plugin-portal-repositories
-        org.hibernate.orm.env.MavenMirror.maybeAddMavenLocal(it)
-        org.hibernate.orm.env.MavenMirror.maybeAddMavenCentral(it)
-        org.hibernate.orm.env.MavenMirror.maybeAddMavenCentralSnapshots(it) { content ->
+        org.hibernate.orm.env.Repositories.maybeAddMavenLocal(it)
+        mavenCentral()
+        org.hibernate.orm.env.Repositories.maybeAddMavenCentralSnapshots(it) { content ->
             content.includeGroup "jakarta.persistence"
         }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,10 +5,6 @@
 
 pluginManagement {
     repositories {
-        // mavenCentral before gradlePluginPortal: the plugin portal redirects transitive
-        // deps to Maven Central via HTTP 303 — with a mirror, those redirects would fail.
-        // Listing mavenCentral first lets Gradle resolve transitive deps directly
-        // (or from the mirror when MIRROR_MAVEN_CENTRAL_URL is set; see gradle/mirror.gradle).
         mavenCentral()
         gradlePluginPortal()
         maven {
@@ -19,10 +15,6 @@ pluginManagement {
 
     includeBuild 'local-build-plugins'
 
-    // Repository mirrors: rewrites repository URLs when MIRROR_*_URL is set (see MAINTAINERS.md).
-    // Applied inside pluginManagement so that repos are rewritten before settings plugins
-    // are resolved at the plugins {} block; lifecycle callbacks handle per-project repos.
-    apply from: 'gradle/mirror.gradle'
 }
 
 plugins {

--- a/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
+++ b/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
@@ -87,14 +87,13 @@ publishingExtension.publications.named("publishedArtifacts") {
 integrationTest {
     environment "hibernateVersion", project.version
     environment "h2Version", libs.versions.h2.get()
-    providers.environmentVariable('MAVEN_MIRROR').orElse(providers.gradleProperty('MAVEN_MIRROR')).orElse('').get().with {
-        if (!empty) environment 'MAVEN_MIRROR', it
-    }
-    providers.environmentVariable('MAVEN_MIRROR_USERNAME').orElse(providers.gradleProperty('MAVEN_MIRROR_USERNAME')).orElse('').get().with {
-        if (!empty) environment 'MAVEN_MIRROR_USERNAME', it
-    }
-    providers.environmentVariable('MAVEN_MIRROR_PASSWORD').orElse(providers.gradleProperty('MAVEN_MIRROR_PASSWORD')).orElse('').get().with {
-        if (!empty) environment 'MAVEN_MIRROR_PASSWORD', it
+    ['MIRROR_MAVEN_CENTRAL_URL', 'MIRROR_MAVEN_CENTRAL_USERNAME', 'MIRROR_MAVEN_CENTRAL_PASSWORD',
+     'MIRROR_MAVEN_CENTRAL_FALLBACK',
+     'MIRROR_MAVEN_CENTRAL_SNAPSHOTS_URL', 'MIRROR_MAVEN_CENTRAL_SNAPSHOTS_USERNAME', 'MIRROR_MAVEN_CENTRAL_SNAPSHOTS_PASSWORD',
+     'MIRROR_MAVEN_CENTRAL_SNAPSHOTS_FALLBACK'].each { key ->
+        providers.environmentVariable(key).orElse(providers.gradleProperty(key)).orElse('').get().with {
+            if (!empty) environment key, it
+        }
     }
     testLogging {
         exceptionFormat = 'full'

--- a/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/AbstractMavenTestIT.java
+++ b/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/AbstractMavenTestIT.java
@@ -29,34 +29,65 @@ public abstract class AbstractMavenTestIT {
 	public static void initMavenCli() throws Exception {
 		classWorld = new ClassWorld( "plexus.core", Thread.currentThread().getContextClassLoader() );
 		mavenCli = new MavenCli( classWorld );
-		String mavenMirror = System.getenv( "MAVEN_MIRROR" );
-		String mavenMirrorUsername = System.getenv( "MAVEN_MIRROR_USERNAME" );
+		String centralMirror = System.getenv( "MIRROR_MAVEN_CENTRAL_URL" );
+		String centralMirrorUsername = System.getenv( "MIRROR_MAVEN_CENTRAL_USERNAME" );
+		String centralFallback = System.getenv( "MIRROR_MAVEN_CENTRAL_FALLBACK" );
+		String snapshotsMirror = System.getenv( "MIRROR_MAVEN_CENTRAL_SNAPSHOTS_URL" );
+		String snapshotsMirrorUsername = System.getenv( "MIRROR_MAVEN_CENTRAL_SNAPSHOTS_USERNAME" );
+		String snapshotsFallback = System.getenv( "MIRROR_MAVEN_CENTRAL_SNAPSHOTS_FALLBACK" );
 		mavenSettingsFile = Files.createTempFile( "maven-settings", ".xml" );
 		StringBuilder settings = new StringBuilder( "<settings>\n" );
-		if ( mavenMirror != null && !mavenMirror.isEmpty() ) {
-			settings.append( """
-					<mirrors>
-						<mirror>
-						<id>ci-mirror</id>
-						<mirrorOf>central</mirrorOf>
-						<url>${env.MAVEN_MIRROR}</url>
-						</mirror>
-					</mirrors>
-					""" );
-			if ( mavenMirrorUsername != null ) {
+		boolean hasCentralMirror = centralMirror != null && !centralMirror.isEmpty();
+		boolean hasSnapshotsMirror = snapshotsMirror != null && !snapshotsMirror.isEmpty();
+		if ( hasCentralMirror || hasSnapshotsMirror ) {
+			settings.append( "<mirrors>\n" );
+			if ( hasCentralMirror ) {
 				settings.append( """
-						<servers>
-							<server>
-							<id>ci-mirror</id>
-							<username>${env.MAVEN_MIRROR_USERNAME}</username>
-							<password>${env.MAVEN_MIRROR_PASSWORD}</password>
-							</server>
-						</servers>
+							<mirror>
+							<id>ci-mirror-central</id>
+							<mirrorOf>central</mirrorOf>
+							<url>${env.MIRROR_MAVEN_CENTRAL_URL}</url>
+							</mirror>
 						""" );
 			}
+			if ( hasSnapshotsMirror ) {
+				settings.append( """
+							<mirror>
+							<id>ci-mirror-snapshots</id>
+							<mirrorOf>central-portal-snapshots</mirrorOf>
+							<url>${env.MIRROR_MAVEN_CENTRAL_SNAPSHOTS_URL}</url>
+							</mirror>
+						""" );
+			}
+			settings.append( "</mirrors>\n" );
 		}
+		boolean hasServers = centralMirrorUsername != null || snapshotsMirrorUsername != null;
+		if ( hasServers ) {
+			settings.append( "<servers>\n" );
+			if ( centralMirrorUsername != null ) {
+				settings.append( """
+							<server>
+							<id>ci-mirror-central</id>
+							<username>${env.MIRROR_MAVEN_CENTRAL_USERNAME}</username>
+							<password>${env.MIRROR_MAVEN_CENTRAL_PASSWORD}</password>
+							</server>
+						""" );
+			}
+			if ( snapshotsMirrorUsername != null ) {
+				settings.append( """
+							<server>
+							<id>ci-mirror-snapshots</id>
+							<username>${env.MIRROR_MAVEN_CENTRAL_SNAPSHOTS_USERNAME}</username>
+							<password>${env.MIRROR_MAVEN_CENTRAL_SNAPSHOTS_PASSWORD}</password>
+							</server>
+						""" );
+			}
+			settings.append( "</servers>\n" );
+		}
+		boolean hasCentralFallback = hasCentralMirror && "true".equalsIgnoreCase( centralFallback );
+		boolean hasSnapshotsFallback = hasSnapshotsMirror && "true".equalsIgnoreCase( snapshotsFallback );
+		settings.append( "<profiles>\n" );
 		settings.append( """
-				<profiles>
 					<profile>
 					<id>central-snapshots</id>
 					<repositories>
@@ -72,11 +103,38 @@ public abstract class AbstractMavenTestIT {
 						</repository>
 					</repositories>
 					</profile>
-				</profiles>
-				<activeProfiles>
-					<activeProfile>central-snapshots</activeProfile>
-				</activeProfiles>
 				""" );
+		if ( hasCentralFallback || hasSnapshotsFallback ) {
+			settings.append( "<profile>\n<id>mirror-fallbacks</id>\n<repositories>\n" );
+			if ( hasCentralFallback ) {
+				settings.append( """
+							<repository>
+							<id>central-fallback</id>
+							<url>https://repo.maven.apache.org/maven2/</url>
+							<releases><enabled>true</enabled></releases>
+							<snapshots><enabled>false</enabled></snapshots>
+							</repository>
+						""" );
+			}
+			if ( hasSnapshotsFallback ) {
+				settings.append( """
+							<repository>
+							<id>central-portal-snapshots-fallback</id>
+							<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+							<releases><enabled>false</enabled></releases>
+							<snapshots><enabled>true</enabled></snapshots>
+							</repository>
+						""" );
+			}
+			settings.append( "</repositories>\n</profile>\n" );
+		}
+		settings.append( "</profiles>\n" );
+		settings.append( "<activeProfiles>\n" );
+		settings.append( "<activeProfile>central-snapshots</activeProfile>\n" );
+		if ( hasCentralFallback || hasSnapshotsFallback ) {
+			settings.append( "<activeProfile>mirror-fallbacks</activeProfile>\n" );
+		}
+		settings.append( "</activeProfiles>\n" );
 		settings.append( "</settings>\n" );
 		Files.writeString( mavenSettingsFile, settings.toString() );
 	}


### PR DESCRIPTION
~~Use a Gradle script imported into `settings.gradle` that rewrites repository URLs via lifecycle callbacks. That way it doesn't need to be explicit (every use of `mavenCentral()` gets replaced) and there can't be a un-mirrored `mavenCentral()` that slips through the cracks.~~ => Switched to init.gradle instead, because that's much less fragile (see second commit).

In particular, we previously used a `MavenMirror` class in local plugins, and since local plugins themselves have dependencies... their build didn't have access to `MavenMirror`, and thus were not using a mirror.

This also adds support for mirroring other repositories, using a consistent naming scheme (`<PREFIX>_URL`, `<PREFIX>_USERNAME`, `<PREFIX>_PASSWORD`, `<PREFIX>_FALLBACK`):

  | Prefix | Repository |
  |---|---|
  | `MIRROR_MAVEN_CENTRAL` | Maven Central |
  | `MIRROR_MAVEN_CENTRAL_SNAPSHOTS` | Central Portal Snapshots |
  | `MIRROR_GRADLE_PLUGIN_PORTAL` | Gradle Plugin Portal |

Some choices:

  - ~~**Settings script, not `init.gradle`**: An init script requires filesystem access and `-I` flags. The settings-applied script works with just env vars, which suits CI environments where we don't control the Gradle home.~~ => Switched to init.gradle instead, because that's much less fragile (see second commit).
  - **No `-P` support**: Project properties don't propagate to included builds — they'd silently fail for `local-build-plugins`.
  - **Added `mavenCentral()` before `gradlePluginPortal()`**: The plugin portal redirects transitive deps to Maven Central via HTTP 303, which used to, and still would, bypass mirroring.

Tested locally by playing with `/etc/hosts` to block Maven Central, and it seemed to pass. So... fingers crossed, this might actually work.

If everyone agrees with this approach, I'll start backporting... It'll be a lot of fun.