### PR TITLE
Backport mirror rework to 7.2

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -10,6 +10,7 @@ defaults:
     shell: bash
 
 env:
+  COMMON_GRADLE_ARGS: "-Igradle/init.gradle"
   MIRROR_MAVEN_CENTRAL_URL: "https://maven-central.storage-download.googleapis.com/maven2/"
   MIRROR_MAVEN_CENTRAL_FALLBACK: "true"
 
@@ -69,13 +70,14 @@ jobs:
         if: ${{ steps.downloadBuildScan.outcome != 'failure'}}
         run: |
           shopt -s nullglob # Don't run the loop below if there are no artifacts
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
           status=0
           mkdir -p ~/.gradle/
           for build_scan_data_directory in /tmp/downloaded-build-scan-data/*
           do
             rm -rf ~/.gradle/build-scan-data
             mv "$build_scan_data_directory" ~/.gradle/build-scan-data \
-            && ./gradlew --no-build-cache buildScanPublishPrevious || status=1
+            && ./gradlew "${common_gradle_args[@]}" --no-build-cache buildScanPublishPrevious || status=1
           done
           exit $status
         env:

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -9,6 +9,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  MIRROR_MAVEN_CENTRAL_URL: "https://maven-central.storage-download.googleapis.com/maven2/"
+  MIRROR_MAVEN_CENTRAL_FALLBACK: "true"
+
 jobs:
   publish-build-scans:
     name: Publish Develocity build scans

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 permissions: { } # none
 
 env:
+  COMMON_GRADLE_ARGS: "-Igradle/init.gradle"
   MIRROR_MAVEN_CENTRAL_URL: "https://maven-central.storage-download.googleapis.com/maven2/"
   MIRROR_MAVEN_CENTRAL_FALLBACK: "true"
 
@@ -113,7 +114,9 @@ jobs:
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-
 
       - name: Run build script
-        run: ./ci/build-github.sh
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ./ci/build-github.sh "${common_gradle_args[@]}"
         shell: bash
         env:
           RDBMS: ${{ matrix.rdbms }}
@@ -258,7 +261,9 @@ jobs:
           ORG_GRADLE_PROJECT_toolchain.compiler.jvmargs: "-Dlog4j2.disableJmx=true -Xmx4g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8"
           # Gradle workers (Tests...)
           ORG_GRADLE_PROJECT_toolchain.launcher.jvmargs: "-Dlog4j2.disableJmx=true -Xmx3g -XX:MaxMetaspaceSize=448m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8"
-        run: ./ci/build-github.sh
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ./ci/build-github.sh "${common_gradle_args[@]}"
         shell: bash
 
       - uses: oracle-actions/setup-testpilot@f620f11f9f26dacfe80ba1823342e3e92604c55f # v1.0.23
@@ -359,7 +364,9 @@ jobs:
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-    
 
       - name: Run build script
-        run: ./gradlew formatChecks
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ./gradlew "${common_gradle_args[@]}" formatChecks
         env:
           # For jobs running on 'push', publish build scan and cache immediately.
           # This won't work for pull requests, since they don't have access to secrets.
@@ -448,7 +455,9 @@ jobs:
         continue-on-error: true
 
       - name: Merge Jacoco Reports
-        run: ./gradlew mergeCodeCoverageReport copyDependenciesSonar --no-parallel
+        run: |
+          read -ra common_gradle_args <<< "$COMMON_GRADLE_ARGS"
+          ./gradlew "${common_gradle_args[@]}" mergeCodeCoverageReport copyDependenciesSonar --no-parallel
 
       - name: Store build info for Sonar scanning
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 
 permissions: { } # none
 
+env:
+  MIRROR_MAVEN_CENTRAL_URL: "https://maven-central.storage-download.googleapis.com/maven2/"
+  MIRROR_MAVEN_CENTRAL_FALLBACK: "true"
+
 # See https://github.com/hibernate/hibernate-orm/pull/4615 for a description of the behavior we're getting.
 concurrency:
   # Consider that two builds are in the same concurrency group (cannot run concurrently)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,8 @@ import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 this.helper = new JobHelper(this)
 
 helper.runWithNotification {
+env.COMMON_GRADLE_ARGS = '-Igradle/init.gradle'
+
 stage('Configure') {
 	requireApprovalForPullRequest 'hibernate'
 
@@ -261,7 +263,7 @@ void ciBuild(buildEnv, String args) {
 		withCredentials([string(credentialsId: develocityCredentialsId,
 				variable: 'DEVELOCITY_ACCESS_KEY')]) {
 			withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
-				sh "./ci/build.sh $args"
+				sh "./ci/build.sh \$COMMON_GRADLE_ARGS $args"
 			}
 		}
 	}
@@ -269,20 +271,20 @@ void ciBuild(buildEnv, String args) {
 		// Pull request: we can't pass credentials to the build, since we'd be exposing secrets to e.g. tests.
 		// We do the build first, then publish the build scan separately.
 		tryFinally({
-			sh "./ci/build.sh $args"
+			sh "./ci/build.sh \$COMMON_GRADLE_ARGS $args"
 		}, { // Finally
 			withCredentials([string(credentialsId: 'develocity.commonhaus.dev-access-key-pr',
 					variable: 'DEVELOCITY_ACCESS_KEY')]) {
 				withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
 					// Don't fail a build if publishing fails
-					sh './gradlew buildScanPublishPrevious || true'
+					sh "./gradlew \$COMMON_GRADLE_ARGS buildScanPublishPrevious || true"
 				}
 			}
 		})
 	}
 	else {
 		// Don't do build scans
-		sh "./ci/build.sh $args"
+		sh "./ci/build.sh \$COMMON_GRADLE_ARGS $args"
 	}
 }
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,10 +17,29 @@ Continuous integration is split across two platforms:
 
 ### Tips
 
-The Hibernate ORM build can use a mirror instead of Maven central.
-To do so, set the `MAVEN_MIRROR` environment variable to the URL of your mirror,
-e.g. `http://something-on-aws.com/path/to/repo`.
-The mirror can use unsecure HTTP, but obviously that exposes you to MITM attacks unless the build runs in a completely isolated network.
+The Hibernate ORM build can use mirrors instead of public repositories.
+The mirror configuration is in `gradle/mirror.gradle`, auto-activated from `settings.gradle`.
+Each mirror is activated independently when its `MIRROR_*_URL` property is set.
+
+Supported mirrors (each with `_URL`, `_USERNAME`, `_PASSWORD`, `_FALLBACK` suffixes):
+
+| Prefix                            | Repository              |
+|-----------------------------------|-------------------------|
+| `MIRROR_MAVEN_CENTRAL`            | Maven Central           |
+| `MIRROR_MAVEN_CENTRAL_SNAPSHOTS`  | Central Portal Snapshots|
+| `MIRROR_GRADLE_PLUGIN_PORTAL`     | Gradle Plugin Portal    |
+
+For example, to mirror Maven Central set `MIRROR_MAVEN_CENTRAL_URL` via any of
+(in order of precedence):
+* System property: `-DMIRROR_MAVEN_CENTRAL_URL=<url>`
+* Environment variable: `MIRROR_MAVEN_CENTRAL_URL=<url>`
+
+Optional properties (same resolution order per mirror):
+* `*_USERNAME` / `*_PASSWORD` — mirror credentials
+* `*_FALLBACK` — set to `true` to also keep the original repo as a fallback
+
+Note: Gradle project properties (`-P`) are not supported because they don't
+propagate to included builds (`local-build-plugins`).
 
 ### GitHub Actions workflows
 

--- a/ci/build-github.sh
+++ b/ci/build-github.sh
@@ -4,4 +4,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 java -version
 
-exec bash $DIR/build.sh
+exec bash $DIR/build.sh "$@"

--- a/ci/jpa-3.2-tck.Jenkinsfile
+++ b/ci/jpa-3.2-tck.Jenkinsfile
@@ -18,6 +18,9 @@ pipeline {
     tools {
         jdk 'OpenJDK 25 Latest'
     }
+    environment {
+        COMMON_GRADLE_ARGS = '-Igradle/init.gradle'
+    }
     options {
         buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
         disableConcurrentBuilds(abortPrevious: true)
@@ -47,11 +50,11 @@ pipeline {
                             withEnv([
                                     "DISABLE_REMOTE_GRADLE_CACHE=true"
                             ]) {
-                                sh './gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace'
+                                sh './gradlew $COMMON_GRADLE_ARGS clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace'
                                 // For some reason, Gradle does not publish hibernate-platform and hibernate-testing
                                 // to the local maven repository with the previous command,
                                 // but requires an extra run instead
-                                sh './gradlew :hibernate-testing:publishToMavenLocal :hibernate-platform:publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace'
+                                sh './gradlew $COMMON_GRADLE_ARGS :hibernate-testing:publishToMavenLocal :hibernate-platform:publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace'
                             }
                             script {
                                 env.HIBERNATE_VERSION = sh (

--- a/ci/quarkus.Jenkinsfile
+++ b/ci/quarkus.Jenkinsfile
@@ -91,6 +91,9 @@ def configurations = [
 
 pipeline {
     agent none
+    environment {
+        COMMON_GRADLE_ARGS = '-Igradle/init.gradle'
+    }
     options {
         buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
         disableConcurrentBuilds(abortPrevious: true)
@@ -113,7 +116,7 @@ pipeline {
                 script {
                     dir('hibernate') {
                         checkout scm
-                        sh "./gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -Dmaven.repo.local=${env.WORKSPACE_TMP}/.m2repository"
+                        sh "./gradlew \$COMMON_GRADLE_ARGS clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -Dmaven.repo.local=${env.WORKSPACE_TMP}/.m2repository"
                         script {
                             env.HIBERNATE_VERSION = sh (
                                     script: "grep hibernateVersion gradle/version.properties|cut -d'=' -f2",

--- a/gradle/init.gradle
+++ b/gradle/init.gradle
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-// Repository mirror configuration, applied from settings.gradle.
+// Repository mirror configuration, applied as an init script via -Igradle/init.gradle.
 //
 // Mirrors are configured per repository via MIRROR_<REPO>_(URL|USERNAME|PASSWORD|FALLBACK)
 // properties. Resolution order: system property (-D) > environment variable.
@@ -64,6 +64,7 @@ def __mirrors = []
 if (centralMirror) __mirrors << "Maven Central -> ${centralMirror.url}"
 if (snapshotsMirror) __mirrors << "Central Portal Snapshots -> ${snapshotsMirror.url}"
 if (pluginPortalMirror) __mirrors << "Gradle Plugin Portal -> ${pluginPortalMirror.url}"
+println "Repository mirrors active: ${__mirrors.join(', ')}"
 
 def __rewriteRepo(repositories, String repoName, __MirrorConfig mirror) {
     if (!mirror) return
@@ -110,31 +111,16 @@ def __addAllFallbacks(repositories, centralMirror, snapshotsMirror, pluginPortal
     __addFallback(repositories, 'Gradle Central Plugin Repository', 'https://plugins.gradle.org/m2', pluginPortalMirror)
 }
 
-// When applied from an applied script's buildscript block, the caller passes its
-// ScriptHandler via gradle.ext.__mirrorBuildScript so we can rewrite that script's
-// repositories. Lifecycle callbacks only reach project.buildscript, not applied
-// scripts' separate ScriptHandlers.
-def __buildScript = gradle.ext.has('__mirrorBuildScript') ? gradle.ext.__mirrorBuildScript : null
-if (__buildScript != null) {
-    gradle.ext.__mirrorBuildScript = null
-    def __source = __buildScript.sourceFile?.name
-    def __logPrefix = __source ? "${rootProject.getName()}:${__source}" : rootProject.getName()
-    println "${__logPrefix}: Repository mirrors active: ${__mirrors.join(', ')}"
-    __rewriteAll(__buildScript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-    __addAllFallbacks(__buildScript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-    return
+gradle.beforeSettings { settings ->
+    __rewriteAll(settings.pluginManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __rewriteAll(settings.buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
 }
 
-println "${rootProject.getName()}: Repository mirrors active: ${__mirrors.join(', ')}"
-
-__rewriteAll(buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-__addAllFallbacks(buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-
-__rewriteAll(pluginManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-
-gradle.settingsEvaluated { s ->
-    __rewriteAll(s.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
-    __addAllFallbacks(s.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+gradle.settingsEvaluated { settings ->
+    __addAllFallbacks(settings.pluginManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(settings.buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __rewriteAll(settings.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(settings.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
 }
 
 gradle.beforeProject { p ->

--- a/gradle/mirror.gradle
+++ b/gradle/mirror.gradle
@@ -1,0 +1,148 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+
+// Repository mirror configuration, applied from settings.gradle.
+//
+// Mirrors are configured per repository via MIRROR_<REPO>_(URL|USERNAME|PASSWORD|FALLBACK)
+// properties. Resolution order: system property (-D) > environment variable.
+//
+// Supported repositories:
+//   MIRROR_MAVEN_CENTRAL_*          - Maven Central (repo name: MavenRepo)
+//   MIRROR_MAVEN_CENTRAL_SNAPSHOTS_*- Central Portal Snapshots
+//   MIRROR_GRADLE_PLUGIN_PORTAL_*   - Gradle Plugin Portal (repo name: Gradle Central Plugin Repository)
+//
+// For each, the properties are:
+//   *_URL       - URL of the mirror (required to activate mirroring for that repo)
+//   *_USERNAME  - Optional mirror credentials
+//   *_PASSWORD  - Optional mirror credentials
+//   *_FALLBACK  - Set to 'true' to keep the original repo as a fallback
+//
+// See also: MAINTAINERS.md
+//
+// Adapted from https://blog.gradle.org/maven-central-mirror to not require a init.gradle,
+// because that solution cannot work in some environments where we don't control the filesystem
+// but only environment variables.
+
+// NOTE: using methods instead of closures-in-variables — Gradle's script classloading
+// breaks across build boundaries when inner closure classes are cached and reused.
+
+def __resolve(String key) {
+    def value = System.getProperty(key)
+    if (value) return value
+    value = System.getenv(key)
+    if (value) return value
+    return null
+}
+
+class __MirrorConfig {
+    String url
+    String username
+    String password
+    boolean fallback
+}
+
+def __loadMirror(String prefix, resolveFunc) {
+    def url = resolveFunc("${prefix}_URL")
+    if (!url) return null
+    def cfg = new __MirrorConfig()
+    cfg.url = url
+    cfg.username = resolveFunc("${prefix}_USERNAME")
+    cfg.password = resolveFunc("${prefix}_PASSWORD")
+    cfg.fallback = 'true'.equalsIgnoreCase(resolveFunc("${prefix}_FALLBACK"))
+    return cfg
+}
+
+def centralMirror = __loadMirror('MIRROR_MAVEN_CENTRAL', this.&__resolve)
+def snapshotsMirror = __loadMirror('MIRROR_MAVEN_CENTRAL_SNAPSHOTS', this.&__resolve)
+def pluginPortalMirror = __loadMirror('MIRROR_GRADLE_PLUGIN_PORTAL', this.&__resolve)
+
+if (!centralMirror && !snapshotsMirror && !pluginPortalMirror) return
+
+def __mirrors = []
+if (centralMirror) __mirrors << "Maven Central -> ${centralMirror.url}"
+if (snapshotsMirror) __mirrors << "Central Portal Snapshots -> ${snapshotsMirror.url}"
+if (pluginPortalMirror) __mirrors << "Gradle Plugin Portal -> ${pluginPortalMirror.url}"
+
+def __rewriteRepo(repositories, String repoName, __MirrorConfig mirror) {
+    if (!mirror) return
+    repositories.withType(MavenArtifactRepository).configureEach { repo ->
+        if (repo.name == repoName) {
+            repo.url = URI.create(mirror.url)
+            if (mirror.username || mirror.password) {
+                repo.credentials {
+                    if (mirror.username) {
+                        username = mirror.username
+                    }
+                    if (mirror.password) {
+                        password = mirror.password
+                    }
+                }
+            }
+        }
+    }
+}
+
+def __addFallback(repositories, String repoName, String originalUrl, __MirrorConfig mirror) {
+    if (!mirror || !mirror.fallback) return
+    def original = repositories.findByName(repoName)
+    if (!original) return
+    def fallbackName = "${repoName} (fallback)"
+    if (repositories.findByName(fallbackName)) return
+    def fallback = repositories.maven {
+        name = fallbackName
+        url = URI.create(originalUrl)
+    }
+    repositories.remove(fallback)
+    repositories.add(repositories.indexOf(original) + 1, fallback)
+}
+
+def __rewriteAll(repositories, centralMirror, snapshotsMirror, pluginPortalMirror) {
+    __rewriteRepo(repositories, 'MavenRepo', centralMirror)
+    __rewriteRepo(repositories, 'Central Portal Snapshots', snapshotsMirror)
+    __rewriteRepo(repositories, 'Gradle Central Plugin Repository', pluginPortalMirror)
+}
+
+def __addAllFallbacks(repositories, centralMirror, snapshotsMirror, pluginPortalMirror) {
+    __addFallback(repositories, 'MavenRepo', 'https://repo.maven.apache.org/maven2/', centralMirror)
+    __addFallback(repositories, 'Central Portal Snapshots', 'https://central.sonatype.com/repository/maven-snapshots/', snapshotsMirror)
+    __addFallback(repositories, 'Gradle Central Plugin Repository', 'https://plugins.gradle.org/m2', pluginPortalMirror)
+}
+
+// When applied from an applied script's buildscript block, the caller passes its
+// ScriptHandler via gradle.ext.__mirrorBuildScript so we can rewrite that script's
+// repositories. Lifecycle callbacks only reach project.buildscript, not applied
+// scripts' separate ScriptHandlers.
+def __buildScript = gradle.ext.has('__mirrorBuildScript') ? gradle.ext.__mirrorBuildScript : null
+if (__buildScript != null) {
+    gradle.ext.__mirrorBuildScript = null
+    def __source = __buildScript.sourceFile?.name
+    def __logPrefix = __source ? "${rootProject.getName()}:${__source}" : rootProject.getName()
+    println "${__logPrefix}: Repository mirrors active: ${__mirrors.join(', ')}"
+    __rewriteAll(__buildScript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(__buildScript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    return
+}
+
+println "${rootProject.getName()}: Repository mirrors active: ${__mirrors.join(', ')}"
+
+__rewriteAll(buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+__addAllFallbacks(buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+
+__rewriteAll(pluginManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+
+gradle.settingsEvaluated { s ->
+    __rewriteAll(s.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(s.dependencyResolutionManagement.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+}
+
+gradle.beforeProject { p ->
+    __rewriteAll(p.buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __rewriteAll(p.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+}
+
+gradle.afterProject { p ->
+    __addAllFallbacks(p.buildscript.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+    __addAllFallbacks(p.repositories, centralMirror, snapshotsMirror, pluginPortalMirror)
+}

--- a/local-build-plugins/settings.gradle
+++ b/local-build-plugins/settings.gradle
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+pluginManagement {
+    repositories {
+        // mavenCentral before gradlePluginPortal: the plugin portal redirects transitive
+        // deps to Maven Central via HTTP 303 — with a mirror, those redirects would fail.
+        // Listing mavenCentral first lets Gradle resolve transitive deps directly
+        // (or from the mirror when MIRROR_MAVEN_CENTRAL_URL is set; see gradle/mirror.gradle).
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    // Repository mirrors: rewrites repository URLs when MIRROR_*_URL is set (see MAINTAINERS.md).
+    apply from: '../gradle/mirror.gradle'
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/local-build-plugins/settings.gradle
+++ b/local-build-plugins/settings.gradle
@@ -4,16 +4,10 @@
  */
 pluginManagement {
     repositories {
-        // mavenCentral before gradlePluginPortal: the plugin portal redirects transitive
-        // deps to Maven Central via HTTP 303 — with a mirror, those redirects would fail.
-        // Listing mavenCentral first lets Gradle resolve transitive deps directly
-        // (or from the mirror when MIRROR_MAVEN_CENTRAL_URL is set; see gradle/mirror.gradle).
         mavenCentral()
         gradlePluginPortal()
     }
 
-    // Repository mirrors: rewrites repository URLs when MIRROR_*_URL is set (see MAINTAINERS.md).
-    apply from: '../gradle/mirror.gradle'
 }
 
 dependencyResolutionManagement {

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,11 @@
 
 pluginManagement {
     repositories {
+        // mavenCentral before gradlePluginPortal: the plugin portal redirects transitive
+        // deps to Maven Central via HTTP 303 — with a mirror, those redirects would fail.
+        // Listing mavenCentral first lets Gradle resolve transitive deps directly
+        // (or from the mirror when MIRROR_MAVEN_CENTRAL_URL is set; see gradle/mirror.gradle).
+        mavenCentral()
         gradlePluginPortal()
         maven {
             name = 'localPluginRepository'
@@ -13,6 +18,11 @@ pluginManagement {
     }
 
     includeBuild 'local-build-plugins'
+
+    // Repository mirrors: rewrites repository URLs when MIRROR_*_URL is set (see MAINTAINERS.md).
+    // Applied inside pluginManagement so that repos are rewritten before settings plugins
+    // are resolved at the plugins {} block; lifecycle callbacks handle per-project repos.
+    apply from: 'gradle/mirror.gradle'
 }
 
 plugins {
@@ -24,18 +34,7 @@ plugins {
 
 dependencyResolutionManagement {
     repositories {
-        // See MAINTAINERS.md for documentation.
-        // TODO Move to infra overrides instead;
-        //  see https://blog.gradle.org/maven-central-mirror#overriding-the-urls-for-maven-central-and-the-plugin-portal-repositories
-        if ( System.env['MAVEN_MIRROR'] ) {
-            maven {
-                url System.env['MAVEN_MIRROR']
-                allowInsecureProtocol = true
-            }
-        }
-        else {
-            mavenCentral()
-        }
+        mavenCentral()
 
         if (System.getProperty('JPA_PREVIEW') != null) {
 			maven {
@@ -373,5 +372,4 @@ rootProject.children.each { project ->
     assert project.buildFile.isFile()
 }
 include 'hibernate-platform'
-
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,10 +5,6 @@
 
 pluginManagement {
     repositories {
-        // mavenCentral before gradlePluginPortal: the plugin portal redirects transitive
-        // deps to Maven Central via HTTP 303 — with a mirror, those redirects would fail.
-        // Listing mavenCentral first lets Gradle resolve transitive deps directly
-        // (or from the mirror when MIRROR_MAVEN_CENTRAL_URL is set; see gradle/mirror.gradle).
         mavenCentral()
         gradlePluginPortal()
         maven {
@@ -19,10 +15,6 @@ pluginManagement {
 
     includeBuild 'local-build-plugins'
 
-    // Repository mirrors: rewrites repository URLs when MIRROR_*_URL is set (see MAINTAINERS.md).
-    // Applied inside pluginManagement so that repos are rewritten before settings plugins
-    // are resolved at the plugins {} block; lifecycle callbacks handle per-project repos.
-    apply from: 'gradle/mirror.gradle'
 }
 
 plugins {

--- a/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/AbstractMavenTestIT.java
+++ b/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/AbstractMavenTestIT.java
@@ -29,20 +29,114 @@ public abstract class AbstractMavenTestIT {
 	public static void initMavenCli() throws Exception {
 		classWorld = new ClassWorld( "plexus.core", Thread.currentThread().getContextClassLoader() );
 		mavenCli = new MavenCli( classWorld );
-		String mavenMirror = System.getenv( "MAVEN_MIRROR" );
-		if ( mavenMirror != null && !mavenMirror.isEmpty() ) {
-			mavenSettingsFile = Files.createTempFile( "maven-settings", ".xml" );
-			Files.writeString( mavenSettingsFile,
-					"<settings>\n" +
-					"  <mirrors>\n" +
-					"    <mirror>\n" +
-					"      <id>ci-mirror</id>\n" +
-					"      <mirrorOf>central</mirrorOf>\n" +
-					"      <url>${env.MAVEN_MIRROR}</url>\n" +
-					"    </mirror>\n" +
-					"  </mirrors>\n" +
-					"</settings>\n" );
+		String centralMirror = System.getenv( "MIRROR_MAVEN_CENTRAL_URL" );
+		String centralMirrorUsername = System.getenv( "MIRROR_MAVEN_CENTRAL_USERNAME" );
+		String centralFallback = System.getenv( "MIRROR_MAVEN_CENTRAL_FALLBACK" );
+		String snapshotsMirror = System.getenv( "MIRROR_MAVEN_CENTRAL_SNAPSHOTS_URL" );
+		String snapshotsMirrorUsername = System.getenv( "MIRROR_MAVEN_CENTRAL_SNAPSHOTS_USERNAME" );
+		String snapshotsFallback = System.getenv( "MIRROR_MAVEN_CENTRAL_SNAPSHOTS_FALLBACK" );
+		mavenSettingsFile = Files.createTempFile( "maven-settings", ".xml" );
+		StringBuilder settings = new StringBuilder( "<settings>\n" );
+		boolean hasCentralMirror = centralMirror != null && !centralMirror.isEmpty();
+		boolean hasSnapshotsMirror = snapshotsMirror != null && !snapshotsMirror.isEmpty();
+		if ( hasCentralMirror || hasSnapshotsMirror ) {
+			settings.append( "<mirrors>\n" );
+			if ( hasCentralMirror ) {
+				settings.append( """
+							<mirror>
+							<id>ci-mirror-central</id>
+							<mirrorOf>central</mirrorOf>
+							<url>${env.MIRROR_MAVEN_CENTRAL_URL}</url>
+							</mirror>
+						""" );
+			}
+			if ( hasSnapshotsMirror ) {
+				settings.append( """
+							<mirror>
+							<id>ci-mirror-snapshots</id>
+							<mirrorOf>jakarta-snapshots</mirrorOf>
+							<url>${env.MIRROR_MAVEN_CENTRAL_SNAPSHOTS_URL}</url>
+							</mirror>
+						""" );
+			}
+			settings.append( "</mirrors>\n" );
 		}
+		boolean hasServers = centralMirrorUsername != null || snapshotsMirrorUsername != null;
+		if ( hasServers ) {
+			settings.append( "<servers>\n" );
+			if ( centralMirrorUsername != null ) {
+				settings.append( """
+							<server>
+							<id>ci-mirror-central</id>
+							<username>${env.MIRROR_MAVEN_CENTRAL_USERNAME}</username>
+							<password>${env.MIRROR_MAVEN_CENTRAL_PASSWORD}</password>
+							</server>
+						""" );
+			}
+			if ( snapshotsMirrorUsername != null ) {
+				settings.append( """
+							<server>
+							<id>ci-mirror-snapshots</id>
+							<username>${env.MIRROR_MAVEN_CENTRAL_SNAPSHOTS_USERNAME}</username>
+							<password>${env.MIRROR_MAVEN_CENTRAL_SNAPSHOTS_PASSWORD}</password>
+							</server>
+						""" );
+			}
+			settings.append( "</servers>\n" );
+		}
+		boolean hasCentralFallback = hasCentralMirror && "true".equalsIgnoreCase( centralFallback );
+		boolean hasSnapshotsFallback = hasSnapshotsMirror && "true".equalsIgnoreCase( snapshotsFallback );
+		settings.append( "<profiles>\n" );
+		settings.append( """
+					<profile>
+					<id>jakarta-snapshots</id>
+					<repositories>
+						<repository>
+						<id>jakarta-snapshots</id>
+						<url>https://jakarta.oss.sonatype.org/content/repositories/snapshots/</url>
+						<snapshots>
+							<enabled>true</enabled>
+						</snapshots>
+						<releases>
+							<enabled>false</enabled>
+						</releases>
+						</repository>
+					</repositories>
+					</profile>
+				""" );
+		if ( hasCentralFallback || hasSnapshotsFallback ) {
+			settings.append( "<profile>\n<id>mirror-fallbacks</id>\n<repositories>\n" );
+			if ( hasCentralFallback ) {
+				settings.append( """
+							<repository>
+							<id>central-fallback</id>
+							<url>https://repo.maven.apache.org/maven2/</url>
+							<releases><enabled>true</enabled></releases>
+							<snapshots><enabled>false</enabled></snapshots>
+							</repository>
+						""" );
+			}
+			if ( hasSnapshotsFallback ) {
+				settings.append( """
+							<repository>
+							<id>jakarta-snapshots-fallback</id>
+							<url>https://jakarta.oss.sonatype.org/content/repositories/snapshots/</url>
+							<releases><enabled>false</enabled></releases>
+							<snapshots><enabled>true</enabled></snapshots>
+							</repository>
+						""" );
+			}
+			settings.append( "</repositories>\n</profile>\n" );
+		}
+		settings.append( "</profiles>\n" );
+		settings.append( "<activeProfiles>\n" );
+		settings.append( "<activeProfile>jakarta-snapshots</activeProfile>\n" );
+		if ( hasCentralFallback || hasSnapshotsFallback ) {
+			settings.append( "<activeProfile>mirror-fallbacks</activeProfile>\n" );
+		}
+		settings.append( "</activeProfiles>\n" );
+		settings.append( "</settings>\n" );
+		Files.writeString( mavenSettingsFile, settings.toString() );
 	}
 
 	@AfterAll


### PR DESCRIPTION
## Summary

Backport of #12967 from `main` to `7.2`.

- Replaces the old inline `MAVEN_MIRROR` env var logic with a dedicated Gradle settings script (`gradle/mirror.gradle`) supporting per-repository `MIRROR_*_URL/USERNAME/PASSWORD/FALLBACK` properties
- Adds workflow-level CI mirror env vars
- Updates `AbstractMavenTestIT` to use the new env var names

## Test plan

- [ ] CI passes
- [ ] Mirror works when `MIRROR_MAVEN_CENTRAL_URL` is set
- [ ] Build works without any mirror vars set (no-op path)

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------