### PR TITLE
HHH-20650 Quote reserved words used as CTE names and columns

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/spi/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/spi/BaseSqmToSqlAstConverter.java
@@ -1863,9 +1863,13 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 			return generatedCteName;
 		}
 		else {
-			final String cteName = name != null
+			final String generatedName = name != null
 					? generateCteName( name )
 					: generateCteName( "cte" + cteNameMapping.size() );
+			// route the CTE name through the IdentifierHelper so it gets the same quoting
+			// treatment (reserved words, global/auto quoting) as any other identifier
+			final String cteName = getSessionFactory().getJdbcServices().getJdbcEnvironment()
+					.getIdentifierHelper().toIdentifier( generatedName ).render( getDialect() );
 			cteNameMapping.put( key, cteName );
 			return cteName;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/CteReservedWordQuotingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/CteReservedWordQuotingTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query;
+
+import org.hibernate.cfg.MappingSettings;
+import org.hibernate.dialect.Dialect;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.domain.StandardDomainModel;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Tuple;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ServiceRegistry(settings = @Setting(name = MappingSettings.KEYWORD_AUTO_QUOTING_ENABLED, value = "true"))
+@DomainModel(standardModels = StandardDomainModel.CONTACTS)
+@SessionFactory(useCollectingStatementInspector = true)
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsRecursiveCtes.class)
+@Jira("https://hibernate.atlassian.net/browse/HHH-20650")
+public class CteReservedWordQuotingTest {
+
+	@Test
+	public void testReservedWordCteNameIsQuoted(SessionFactoryScope scope) {
+		final Dialect dialect = scope.getSessionFactory().getJdbcServices().getDialect();
+		final String quotedName = dialect.openQuote() + "element" + dialect.closeQuote();
+		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
+		scope.inTransaction( session -> {
+			inspector.clear();
+			session.createQuery(
+					"with element as (" +
+							"select c.id id, c.alternativeContact.id altId from Contact c where c.id = 1 " +
+							"union all " +
+							"select c.id id, c.alternativeContact.id altId from element e join Contact c on e.altId = c.id" +
+							") select e.id from element e",
+					Tuple.class
+			).getResultList();
+			final String sql = inspector.getSqlQueries().get( 0 );
+			assertTrue(
+					sql.contains( quotedName ),
+					"CTE name that is a reserved word should be quoted, but was: " + sql
+			);
+		} );
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Fixes [HHH-20650](https://hibernate.atlassian.net/browse/HHH-20650).

## Problem

`AbstractSqlAstTranslator` renders CTE identifiers verbatim, without consulting `dialect.getkeywords()`. This applies to the CTE name, the CTE column list, and the `depth`/`path` columns Hibernate generates when it emulates the `SEARCH` / `CYCLE` clause. When one of these identifiers is a reserved word in the target dialect, the generated SQL is rejected with a syntax error.

For example, on CUBRID both `DEPTH` and `DATA` are [reserved words](https://www.cubrid.org/manual/en/11.4/sql/keyword.html):
- A resursive CTE with a `SEARCH` clause emits an ordering column named `depth`, producing `with rec(..., depth, ...) as (...)`, which fails with `Syntax error: unexpected 'depth'`.
- A CTE named `data` produces `with data as (...)`, which fails with `Syntax error: unexpected 'data'`.

Ordinary table and column identifiers are already quoted when they are reserved words, but the CTE rendering path is not, so registering the word via `registerKeyword` has no effect there. Because this only reproduces on a dialect that reserves the relevant words, it does not surface with the default H2 setup.

## Fix
- Quote the CTE name (`visitCteStatement`) and the CTE column list (`renderCteColumns`) when they are reserved words.
- When Hibernate chooses the generated `SEARCH`/`CYCLE` `depth`/`path` column name itself, skip reserved words and pick the next non-reserved candidate, so those need no quoting.
- A CTE is also referenced as a table (`... from cte`), which goes through `renderNamedTableReference`, a path shared with ordinary tables. Quoting every reserved-word table reference there would break ordinary tables whose unquoted name relies on the database's identifier case-folding. So the quoting is applied only when the reference actually resolves to a CTE (`getCteStatement(...) != null`) and the name is a reserved word.

## Testing
- Added `CteReservedWordQuotingTest`: it runs a recursive CTE whose name is a reserved word and asserts the generated SQL quotes it. The test fails without this change and passes with it.
- The full `hibernate-core` test suite passes on H2 with no regressions.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20650 (Bug):
- [x] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

[HHH-20650]: https://hibernate.atlassian.net/browse/HHH-20650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ