### PR TITLE
Backport HHH-20509 to branch 8.0 - Hibernate Data Repositories generates a BasicRepository impl that can't 'saveAll' entities with null ids

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/StatelessSessionMultipleOpsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/StatelessSessionMultipleOpsTest.java
@@ -5,6 +5,7 @@
 package org.hibernate.orm.test.stateless;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
@@ -17,9 +18,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DomainModel(annotatedClasses = {
-		StatelessSessionMultipleOpsTest.Person.class
+		StatelessSessionMultipleOpsTest.Person.class,
+		StatelessSessionMultipleOpsTest.PersonGenId.class
 })
 @SessionFactory(useCollectingStatementInspector = true)
 @Jira("https://hibernate.atlassian.net/browse/HHH-20065")
@@ -143,6 +146,27 @@ public class StatelessSessionMultipleOpsTest {
 		return people;
 	}
 
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-20509")
+	public void testUpsertMultipleRejectsNullGeneratedIds(SessionFactoryScope scope) {
+		final var people = new ArrayList<PersonGenId>();
+		for ( int i = 0; i < 3; i++ ) {
+			people.add( new PersonGenId( "person_" + i ) );
+		}
+
+		scope.inStatelessTransaction( session -> {
+			assertThrows( Exception.class, () -> session.upsertMultiple( people ) );
+		} );
+	}
+
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-20509")
+	public void testUpsertRejectsNullGeneratedId(SessionFactoryScope scope) {
+		scope.inStatelessTransaction( session -> {
+			assertThrows( Exception.class, () -> session.upsert( new PersonGenId( "person" ) ) );
+		} );
+	}
+
 	@Entity(name = "Person")
 	public static class Person {
 		@Id
@@ -154,6 +178,21 @@ public class StatelessSessionMultipleOpsTest {
 
 		public Person(Integer id, String name) {
 			this.id = id;
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "PersonGenId")
+	public static class PersonGenId {
+		@Id
+		@GeneratedValue
+		public Long id;
+		public String name;
+
+		public PersonGenId() {
+		}
+
+		public PersonGenId(String name) {
 			this.name = name;
 		}
 	}

--- a/tooling/metamodel-generator/src/dataIntegrationTest/java/org/hibernate/processor/test/integ/repository/AuthorRepository.java
+++ b/tooling/metamodel-generator/src/dataIntegrationTest/java/org/hibernate/processor/test/integ/repository/AuthorRepository.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.integ.repository;
+
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
+import org.hibernate.StatelessSession;
+import org.hibernate.processor.test.integ.model.Author;
+
+import java.util.List;
+
+@Repository
+public interface AuthorRepository {
+
+	StatelessSession session();
+
+	@Insert
+	void insert(Author author);
+
+	@Save
+	void save(Author author);
+
+	@Save
+	void saveAll(List<Author> authors);
+
+	@Find
+	Author byId(Long id);
+}

--- a/tooling/metamodel-generator/src/dataIntegrationTest/java/org/hibernate/processor/test/integ/test/AuthorRepositoryTest.java
+++ b/tooling/metamodel-generator/src/dataIntegrationTest/java/org/hibernate/processor/test/integ/test/AuthorRepositoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.integ.test;
+
+import org.hibernate.processor.test.integ.model.Author;
+import org.hibernate.processor.test.integ.repository.AuthorRepository;
+import org.hibernate.processor.test.integ.repository._AuthorRepository;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DomainModel(annotatedClasses = { Author.class, AuthorRepository.class })
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-20509")
+class AuthorRepositoryTest {
+
+	@AfterEach
+	void cleanup(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	void testSaveNewAuthor(SessionFactoryScope scope) {
+		scope.inStatelessTransaction( session -> {
+			var repo = new _AuthorRepository( session );
+			Author author = new Author( "Alice" );
+			repo.save( author );
+			assertNotNull( author.getId(), "ID should be generated after save" );
+			Author found = repo.byId( author.getId() );
+			assertNotNull( found );
+			assertEquals( "Alice", found.getName() );
+		} );
+	}
+
+	@Test
+	void testSaveAllNewAuthors(SessionFactoryScope scope) {
+		scope.inStatelessTransaction( session -> {
+			var repo = new _AuthorRepository( session );
+			List<Author> authors = List.of(
+					new Author( "Bob" ),
+					new Author( "Carol" )
+			);
+			repo.saveAll( authors );
+			for ( Author author : authors ) {
+				assertNotNull( author.getId(), "ID should be generated after saveAll" );
+				Author found = repo.byId( author.getId() );
+				assertNotNull( found );
+			}
+		} );
+	}
+
+	@Test
+	void testSaveExistingAuthor(SessionFactoryScope scope) {
+		scope.inStatelessTransaction( session -> {
+			var repo = new _AuthorRepository( session );
+			Author author = new Author( "Dave" );
+			repo.insert( author );
+			assertNotNull( author.getId() );
+			author.setName( "David" );
+			repo.save( author );
+			Author found = repo.byId( author.getId() );
+			assertEquals( "David", found.getName() );
+		} );
+	}
+}

--- a/tooling/metamodel-generator/src/dataIntegrationTest/java/org/hibernate/processor/test/integ/test/AuthorRepositoryTest.java
+++ b/tooling/metamodel-generator/src/dataIntegrationTest/java/org/hibernate/processor/test/integ/test/AuthorRepositoryTest.java
@@ -14,6 +14,7 @@ import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,6 +57,40 @@ class AuthorRepositoryTest {
 				Author found = repo.byId( author.getId() );
 				assertNotNull( found );
 			}
+		} );
+	}
+
+	@Test
+	void testSaveAllExistingAuthors(SessionFactoryScope scope) {
+		scope.inStatelessTransaction( session -> {
+			var repo = new _AuthorRepository( session );
+			Author bob = new Author( "Bob" );
+			Author carol = new Author( "Carol" );
+			repo.insert( bob );
+			repo.insert( carol );
+			assertNotNull( bob.getId() );
+			assertNotNull( carol.getId() );
+			bob.setName( "Robert" );
+			carol.setName( "Caroline" );
+			repo.saveAll( new ArrayList<>( List.of( bob, carol ) ) );
+			assertEquals( "Robert", repo.byId( bob.getId() ).getName() );
+			assertEquals( "Caroline", repo.byId( carol.getId() ).getName() );
+		} );
+	}
+
+	@Test
+	void testSaveAllMixedNewAndExistingAuthors(SessionFactoryScope scope) {
+		scope.inStatelessTransaction( session -> {
+			var repo = new _AuthorRepository( session );
+			Author existing = new Author( "Eve" );
+			repo.insert( existing );
+			assertNotNull( existing.getId() );
+			existing.setName( "Evelyn" );
+			Author newAuthor = new Author( "Frank" );
+			repo.saveAll( new ArrayList<>( List.of( existing, newAuthor ) ) );
+			assertEquals( "Evelyn", repo.byId( existing.getId() ).getName() );
+			assertNotNull( newAuthor.getId(), "New author should get an ID from saveAll" );
+			assertEquals( "Frank", repo.byId( newAuthor.getId() ).getName() );
 		} );
 	}
 

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/hhh20509/Item.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/hhh20509/Item.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.hhh20509;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Item {
+	@Id
+	@GeneratedValue
+	Long id;
+
+	String name;
+
+	protected Item() {
+	}
+
+	public Item(String name) {
+		this.name = name;
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/hhh20509/ItemRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/hhh20509/ItemRepository.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.hhh20509;
+
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
+import org.hibernate.StatelessSession;
+
+import java.util.List;
+
+@Repository
+public interface ItemRepository {
+
+	StatelessSession session();
+
+	@Save
+	void save(Item item);
+
+	@Save
+	List<Item> saveAll(List<Item> items);
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/hhh20509/ReactiveItemRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/hhh20509/ReactiveItemRepository.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.hhh20509;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import java.util.List;
+
+@Repository
+public interface ReactiveItemRepository {
+
+	Mutiny.StatelessSession session();
+
+	@Save
+	Uni<Void> save(Item item);
+
+	@Save
+	Uni<List<Item>> saveAll(List<Item> items);
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/hhh20509/SaveAllGeneratedIdTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/hhh20509/SaveAllGeneratedIdTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.hhh20509;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@CompilationTest
+class SaveAllGeneratedIdTest {
+	@Test
+	@WithClasses({ Item.class, ItemRepository.class })
+	void testGeneratedCodeForSaveAllWithGeneratedId() {
+		assertMetamodelClassGeneratedFor( Item.class, true );
+		assertMetamodelClassGeneratedFor( ItemRepository.class, true );
+		final String repository = getMetaModelSourceAsString( ItemRepository.class, true );
+		System.out.println( repository );
+
+		// Single save should check the identifier and route to insert for null ids
+		assertTrue( repository.contains( "getIdentifier(item)" ),
+				"Single save should check the entity identifier" );
+		assertTrue( repository.contains( ".insert(item)" ),
+				"Single save should route to insert() when id is null" );
+
+		// saveAll must NOT call getIdentifier on the list itself
+		assertFalse( repository.contains( "getIdentifier(items)" ),
+				"saveAll must not call getIdentifier on the list parameter" );
+
+		// saveAll should not call upsertMultiple without a null-id guard
+		// It should either iterate and check each entity, or use an appropriate bulk operation
+		assertFalse( repository.contains( "upsertMultiple(items)" ),
+				"saveAll must not blindly call upsertMultiple without handling null ids" );
+	}
+
+	@Test
+	@WithClasses({ Item.class, ReactiveItemRepository.class })
+	void testGeneratedCodeForReactiveSaveAllWithGeneratedId() {
+		assertMetamodelClassGeneratedFor( ReactiveItemRepository.class, true );
+		final String repository = getMetaModelSourceAsString( ReactiveItemRepository.class, true );
+		System.out.println( repository );
+
+		// Single save should check the identifier and route to insert for null ids
+		assertTrue( repository.contains( "getIdentifier(item)" ),
+				"Reactive single save should check the entity identifier" );
+		assertTrue( repository.contains( ".insert(item)" ),
+				"Reactive single save should route to insert() when id is null" );
+
+		// saveAll must NOT call getIdentifier on the list itself
+		assertFalse( repository.contains( "getIdentifier(items)" ),
+				"Reactive saveAll must not call getIdentifier on the list parameter" );
+
+		// saveAll should check each entity individually
+		assertTrue( repository.contains( "getIdentifier(_entity)" ),
+				"Reactive saveAll should check each entity's identifier individually" );
+		assertTrue( repository.contains( ".insert(_entity)" ),
+				"Reactive saveAll should route to insert() for null ids" );
+		assertTrue( repository.contains( ".upsert(_entity)" ),
+				"Reactive saveAll should route to upsert() for non-null ids" );
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/LifecycleMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/LifecycleMethod.java
@@ -189,24 +189,18 @@ public class LifecycleMethod extends AbstractAnnotatedMethod {
 		else if ( isStatefulOperation() && parameterKind != ParameterKind.NORMAL ) {
 			delegateStatefulManyBlockingly( declaration );
 		}
+		else if ( isGeneratedIdUpsert() && parameterKind != ParameterKind.NORMAL ) {
+			declaration
+					.append("\t\tfor (var _entity : ")
+					.append(parameterName)
+					.append(") {\n");
+			upsertOrInsertByGeneratedId( declaration, "_entity", "\t\t\t" );
+			declaration.append("\t\t}\n");
+		}
+		else if ( isGeneratedIdUpsert() ) {
+			upsertOrInsertByGeneratedId( declaration, parameterName, "\t\t" );
+		}
 		else {
-			if ( isGeneratedIdUpsert() ) {
-				declaration
-						.append("\t\tif (")
-						.append(sessionWithGetIdentifier())
-						.append(".getIdentifier(")
-						.append(parameterName)
-						.append(") == null)\n")
-						.append("\t\t\t")
-						.append(sessionName)
-						.append(getObjectCall())
-						.append('.')
-						.append("insert");
-				argument( declaration );
-				declaration
-						.append(";\n")
-						.append("\t\telse\n\t");
-			}
 			declaration
 					.append("\t\t")
 					.append(sessionName)
@@ -238,6 +232,32 @@ public class LifecycleMethod extends AbstractAnnotatedMethod {
 				.append(operationName)
 				.append("(_entity);\n")
 				.append("\t\t}\n");
+	}
+
+	private void upsertOrInsertByGeneratedId(StringBuilder declaration, String entityVar, String indent) {
+		declaration
+				.append(indent)
+				.append("if (")
+				.append(sessionWithGetIdentifier())
+				.append(".getIdentifier(")
+				.append(entityVar)
+				.append(") == null)\n")
+				.append(indent)
+				.append('\t')
+				.append(sessionName)
+				.append(getObjectCall())
+				.append(".insert(")
+				.append(entityVar)
+				.append(");\n")
+				.append(indent)
+				.append("else\n")
+				.append(indent)
+				.append('\t')
+				.append(sessionName)
+				.append(getObjectCall())
+				.append(".upsert(")
+				.append(entityVar)
+				.append(");\n");
 	}
 
 	private void delegateMergeBlockingly(StringBuilder declaration) {
@@ -332,6 +352,10 @@ public class LifecycleMethod extends AbstractAnnotatedMethod {
 	}
 
 	private void delegateReactively(StringBuilder declaration) {
+		if ( isGeneratedIdUpsert() && parameterKind != ParameterKind.NORMAL ) {
+			delegateGeneratedIdUpsertManyReactively( declaration );
+			return;
+		}
 		declaration
 				.append("\treturn ");
 		if ( isReactiveSessionAccess() ) {
@@ -342,34 +366,78 @@ public class LifecycleMethod extends AbstractAnnotatedMethod {
 					.append(" -> ");
 		}
 		if ( isGeneratedIdUpsert() ) {
-			declaration
-					.append("(")
-					.append(localSessionName())
-					.append(".getIdentifier(")
-					.append(parameterName)
-					.append(") == null ? ")
-					.append(localSessionName())
-					.append('.')
-					.append("insert")
-					.append('(')
-					.append(parameterName)
-					.append(')')
-					.append(" : ");
+			declaration.append("(");
+			upsertOrInsertByGeneratedIdReactively( declaration, parameterName );
+			declaration.append(")");
 		}
-		declaration
-				.append(localSessionName())
-				.append( '.' )
-				.append( operationName );
-		// note that there is no upsertAll() method
-		argument( declaration );
-		if ( isGeneratedIdUpsert() ) {
+		else {
 			declaration
-					.append(')');
+					.append(localSessionName())
+					.append( '.' )
+					.append( operationName );
+			// note that there is no upsertAll() method
+			argument( declaration );
 		}
 		if ( isReactiveSessionAccess() ) {
 			declaration
 					.append(')');
 		}
+	}
+
+	private void delegateGeneratedIdUpsertManyReactively(StringBuilder declaration) {
+		final var uni = annotationMetaEntity.importType( UNI );
+		final var session = localSessionName();
+		if ( isReactiveSessionAccess() ) {
+			declaration
+					.append("\treturn ")
+					.append(sessionName)
+					.append(".chain(")
+					.append(session)
+					.append(" -> {\n");
+		}
+		final var indent = isReactiveSessionAccess() ? "\t\t" : "\t";
+		declaration
+				.append(indent)
+				.append("var _chain = ")
+				.append(uni)
+				.append(".createFrom().voidItem();\n")
+				.append(indent)
+				.append("for (var _entity : ")
+				.append(parameterName)
+				.append(") {\n")
+				.append(indent)
+				.append("\t_chain = _chain.chain(() -> ");
+		upsertOrInsertByGeneratedIdReactively( declaration, "_entity" );
+		declaration
+				.append(");\n")
+				.append(indent)
+				.append("}\n");
+		if ( isReactiveSessionAccess() ) {
+			declaration
+					.append("\t\treturn _chain;\n")
+					.append("\t})");
+		}
+		else {
+			declaration
+					.append("\treturn _chain");
+		}
+	}
+
+	private void upsertOrInsertByGeneratedIdReactively(StringBuilder declaration, String entityVar) {
+		final var session = localSessionName();
+		declaration
+				.append(session)
+				.append(".getIdentifier(")
+				.append(entityVar)
+				.append(") == null ? ")
+				.append(session)
+				.append(".insert(")
+				.append(entityVar)
+				.append(") : ")
+				.append(session)
+				.append(".upsert(")
+				.append(entityVar)
+				.append(")");
 	}
 
 	private boolean isGeneratedIdUpsert() {


### PR DESCRIPTION
Backport of #12957 to branch 8.0

https://hibernate.atlassian.net/browse/HHH-20509


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20509 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->