### PR TITLE
HHH-20660 Improve AttributeConverterManager to fix wrong formatted exception message

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/convert/internal/AttributeConverterManager.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/convert/internal/AttributeConverterManager.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.AttributeConverter;
 import org.hibernate.AnnotationException;
@@ -23,13 +24,10 @@ import org.hibernate.boot.model.convert.spi.RegisteredConversion;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.models.spi.MemberDetails;
 
-
-
 import static java.util.Collections.emptyList;
 import static org.hibernate.boot.BootLogging.BOOT_LOGGER;
 import static org.hibernate.internal.util.GenericsHelper.typeArguments;
 import static org.hibernate.internal.util.GenericsHelper.actualMemberType;
-import static org.hibernate.internal.util.StringHelper.join;
 
 /**
  * @implNote It is important that all {@link RegisteredConversion} be registered
@@ -197,7 +195,8 @@ public class AttributeConverterManager implements ConverterAutoApplyHandler {
 									conversionSite.getSiteDescriptor(),
 									memberDetails.getDeclaringType().getName(),
 									memberDetails.getName(),
-									join( matches, value -> value.getAttributeConverterClass().getName() )
+									matches.stream().map( value -> value.getAttributeConverterClass().getName() )
+											.collect( Collectors.joining( ", " ) )
 							)
 					);
 				}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -7,7 +7,6 @@ package org.hibernate.internal.util;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -848,14 +847,6 @@ public final class StringHelper {
 		return incomingString==null || incomingString.isBlank()
 				? EMPTY_STRINGS
 				: COMMA_SEPARATED_PATTERN.split( incomingString );
-	}
-
-	public static <T> String join(Collection<T> values, Renderer<T> renderer) {
-		final StringBuilder buffer = new StringBuilder();
-		for ( T value : values ) {
-			buffer.append( String.join(", ", renderer.render( value ) ) );
-		}
-		return buffer.toString();
 	}
 
 	public static String coalesce(@Nonnull String fallbackValue, @Nonnull String... values) {


### PR DESCRIPTION
Before this commit, class names are not joined by delimiter `, ` due to bug of `StringHelper.join(Collection<T>, Renderer<T>)`.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20660 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20660
<!-- Hibernate GitHub Bot issue links end -->