### PR TITLE
HHH-20663 `@UpdateTimestamp` should respect insertable

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/generator/internal/CurrentTimestampGeneration.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/internal/CurrentTimestampGeneration.java
@@ -50,6 +50,7 @@ import static java.sql.Types.TIMESTAMP;
 import static org.hibernate.engine.jdbc.JdbcLogging.JDBC_LOGGER;
 import static org.hibernate.generator.EventTypeSets.INSERT_AND_UPDATE;
 import static org.hibernate.generator.EventTypeSets.INSERT_ONLY;
+import static org.hibernate.generator.EventTypeSets.UPDATE_ONLY;
 import static org.hibernate.generator.EventTypeSets.fromArray;
 
 /**
@@ -72,6 +73,7 @@ import static org.hibernate.generator.EventTypeSets.fromArray;
  *
  * @author Steve Ebersole
  * @author Gavin King
+ * @author Yanming Zhou
  */
 public class CurrentTimestampGeneration implements BeforeExecutionGenerator, OnExecutionGenerator {
 
@@ -111,10 +113,12 @@ public class CurrentTimestampGeneration implements BeforeExecutionGenerator, OnE
 
 	public CurrentTimestampGeneration(UpdateTimestamp annotation, GeneratorCreationContext context) {
 		delegate = getGeneratorDelegate( annotation.source(), context.getType(), context );
-		eventTypes = INSERT_AND_UPDATE;
+		eventTypes = context.getProperty().isInsertable() ? INSERT_AND_UPDATE : UPDATE_ONLY;
 		propertyType = getPropertyType( context );
 		version = isVersion( context );
-		notNull( context );
+		if ( eventTypes.contains( EventType.INSERT ) ) {
+			notNull( context );
+		}
 	}
 
 	private static boolean isVersion(GeneratorCreationContext context) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/UpdateTimestampTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/UpdateTimestampTest.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.annotations;
 
 import org.hibernate.Session;
 import org.hibernate.StatelessSession;
+import org.hibernate.annotations.SourceType;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
@@ -24,9 +25,11 @@ import java.util.Date;
 import org.hibernate.testing.orm.junit.JiraKey;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Borys Piela
+ * @author Yanming Zhou
  */
 @Jpa( annotatedClasses = {UpdateTimestampTest.Event.class} )
 public class UpdateTimestampTest {
@@ -98,6 +101,14 @@ public class UpdateTimestampTest {
 		@UpdateTimestamp
 		private ZonedDateTime zonedDateTime;
 
+		@Column(insertable = false)
+		@UpdateTimestamp
+		private LocalDateTime uninsertableLocalDateTime;
+
+		@Column(insertable = false)
+		@UpdateTimestamp(source = SourceType.DB)
+		private LocalDateTime uninsertableLocalDateTimeWithDB;
+
 		public Event() {
 		}
 
@@ -164,6 +175,14 @@ public class UpdateTimestampTest {
 		public ZonedDateTime getZonedDateTime() {
 			return zonedDateTime;
 		}
+
+		public LocalDateTime getUninsertableLocalDateTime() {
+			return uninsertableLocalDateTime;
+		}
+
+		public LocalDateTime getUninsertableLocalDateTimeWithDB() {
+			return uninsertableLocalDateTimeWithDB;
+		}
 	}
 
 	@Test
@@ -188,6 +207,28 @@ public class UpdateTimestampTest {
 				statelessSession.getTransaction().commit();
 				check( event );
 			}
+		});
+	}
+
+	@Test
+	@JiraKey( value = "HHH-20663")
+	public void uninsertableUpdateTimestamp(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			Event event = new Event();
+			entityManager.persist( event );
+			entityManager.flush();
+			assertNull( event.getUninsertableLocalDateTime() );
+		});
+	}
+
+	@Test
+	@JiraKey( value = "HHH-20663")
+	public void uninsertableUpdateTimestampWithDB(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			Event event = new Event();
+			entityManager.persist( event );
+			entityManager.flush();
+			assertNull( event.getUninsertableLocalDateTimeWithDB() );
 		});
 	}
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20663 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20663
<!-- Hibernate GitHub Bot issue links end -->