### PR TITLE
HHH-20666 HbmXmlTransformer generates invalid java-type and jdbc-type-code for converted properties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -652,8 +652,6 @@ public class HbmXmlTransformer {
 			if ( converterConsumer == null ) {
 				throw new AssertionFailure( "Unexpected context for converted value" );
 			}
-			jaxbBasicMapping.setJavaType( convertedType.getMappedJavaType().getClass().getName() );
-			jaxbBasicMapping.setJdbcTypeCode( convertedType.getJdbcType().getJdbcTypeCode() );
 			converterConsumer.accept( convertedType.getValueConverter() );
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/ConverterEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/ConverterEntity.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class ConverterEntity {
+	private Long id;
+	private String owner;
+	private Money balance;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getOwner() {
+		return owner;
+	}
+
+	public void setOwner(String owner) {
+		this.owner = owner;
+	}
+
+	public Money getBalance() {
+		return balance;
+	}
+
+	public void setBalance(Money balance) {
+		this.balance = balance;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -935,6 +935,35 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	public void testConverterPropertyNoJavaTypeTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/converter/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 1 );
+
+			final JaxbEntityImpl entity = transformed.getEntities().get( 0 );
+			final JaxbBasicImpl balanceAttr = entity.getAttributes().getBasicAttributes().stream()
+					.filter( b -> "balance".equals( b.getName() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( balanceAttr.getConvert() )
+					.as( "converted:: property should generate a <convert> element" )
+					.isNotNull();
+			assertThat( balanceAttr.getConvert().getConverter() )
+					.isEqualTo( "org.hibernate.orm.test.boot.jaxb.mapping.MoneyConverter" );
+
+			assertThat( balanceAttr.getJavaType() )
+					.as( "converted:: property should not have a java-type — the converter provides type information" )
+					.isNull();
+			assertThat( balanceAttr.getJdbcType() )
+					.as( "converted:: property should not have a jdbc-type" )
+					.isNull();
+			assertThat( balanceAttr.getJdbcTypeCode() )
+					.as( "converted:: property should not have a jdbc-type-code" )
+					.isNull();
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20640" )
 	public void testInverseManyToManyMappedByTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/many-to-many-inverse/hbm.xml", scope, (transformed) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/Money.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/Money.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class Money {
+	private long cents;
+
+	public Money(long cents) {
+		this.cents = cents;
+	}
+
+	public long getCents() {
+		return cents;
+	}
+
+	public void setCents(long cents) {
+		this.cents = cents;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/MoneyConverter.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/MoneyConverter.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+import jakarta.persistence.AttributeConverter;
+
+public class MoneyConverter implements AttributeConverter<Money, Long> {
+	@Override
+	public Long convertToDatabaseColumn(Money attribute) {
+		return attribute == null ? null : attribute.getCents();
+	}
+
+	@Override
+	public Money convertToEntityAttribute(Long dbData) {
+		return dbData == null ? null : new Money( dbData );
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/converter/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/converter/hbm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="ConverterEntity" table="account">
+        <id name="id"/>
+
+        <property name="owner"/>
+
+        <property name="balance"
+            type="converted::org.hibernate.orm.test.boot.jaxb.mapping.MoneyConverter"/>
+
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/13020 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20666 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20666
<!-- Hibernate GitHub Bot issue links end -->