### PR TITLE
HHH-20659 HbmXmlTransformer loses immutability for properties using `imm_` type aliases

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -264,6 +264,17 @@ public class HbmXmlTransformer {
 
 	private Table currentBaseTable;
 
+	private static final Set<String> IMMUTABLE_TYPE_ALIASES = Set.of(
+			"imm_date",
+			"imm_time",
+			"imm_timestamp",
+			"imm_calendar",
+			"imm_calendar_date",
+			"imm_calendar_time",
+			"imm_binary",
+			"imm_serializable"
+	);
+
 	private HbmXmlTransformer(
 			Binding<JaxbHbmHibernateMapping> hbmXmlBinding,
 			Binding<JaxbEntityMappingsImpl> mappingXmlBinding,
@@ -655,6 +666,13 @@ public class HbmXmlTransformer {
 			jaxbBasicMapping.setJavaType( convertedType.getMappedJavaType().getClass().getName() );
 			jaxbBasicMapping.setJdbcTypeCode( convertedType.getJdbcType().getJdbcTypeCode() );
 			converterConsumer.accept( convertedType.getValueConverter() );
+		}
+
+		// The hbm immutable type aliases register a BasicType with ImmutableMutabilityPlan
+		// for types that are mutable by nature (Date, Calendar, byte[], Serializable).
+		// Mark the property as not mutable so the orm.xml processing applies @Immutable.
+		if ( isNotEmpty( hbmTypeAttribute ) && IMMUTABLE_TYPE_ALIASES.contains( hbmTypeAttribute ) ) {
+			jaxbBasicMapping.setMutable( false );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -688,6 +688,25 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	public void testImmutableTypeTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/immutable-type/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 1 );
+
+			final JaxbEntityImpl entity = transformed.getEntities().get( 0 );
+			final JaxbBasicImpl createdAttr = entity.getAttributes().getBasicAttributes().stream()
+					.filter( b -> "created".equals( b.getName() ) )
+					.findFirst()
+					.orElseThrow();
+
+			// imm_date type should generate <mutable>false</mutable>
+			// to avoid false dirty-checks during merge
+			assertThat( createdAttr.isMutable() )
+					.as( "Property with imm_date type should have mutable=false" )
+					.isFalse();
+		} );
+	}
+
+	@Test
 	public void testOneToOnePropertyRefTransformation(ServiceRegistryScope scope) {
 		transformAndVerifyMultiple(
 				new String[] { "xml/jaxb/mapping/one-to-one-property-ref/hbm.xml" },

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/immutable-type/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/immutable-type/hbm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.ops">
+
+    <class name="NumberedNode" polymorphism="explicit">
+        <id name="id" unsaved-value="0">
+            <generator class="native"/>
+        </id>
+        <property name="name" not-null="true"/>
+        <property name="description"/>
+        <property name="created" not-null="true" type="imm_date"/>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20659

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20659 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->