### PR TITLE
HHH-20583 Stop warn and force execute afterTransactionCompletions unless JTA TX is NOT_ACTIVE

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -403,8 +403,9 @@ public class SessionImpl
 		finally {
 			// E.g. When we are in the JTA context, the session can get closed while the
 			// transaction is still active and JTA will call the AfterCompletion itself.
+			// Also, some JTA environments close the Session through a Synchronization that is executed before ours.
 			// Hence, we don't want to clear out the action queue callbacks at this point:
-			if ( !getTransactionCoordinator().isTransactionActive()
+			if ( !isJtaTransactionCompletionProcessing()
 					&& actionQueue.hasAfterTransactionActions() ) {
 				SESSION_LOGGER.closingSessionWithUnprocessedBulkOperations();
 				actionQueue.executePendingBulkOperationCleanUpActions();
@@ -432,11 +433,24 @@ public class SessionImpl
 			&& transactionCoordinator.getTransactionDriverControl().isActiveAndNoMarkedForRollback();
 	}
 
+	private boolean isJtaTransactionCompletionProcessing() {
+		final var transactionCoordinator = getTransactionCoordinator();
+		return transactionCoordinator.getTransactionCoordinatorBuilder().isJta()
+			// Our Synchronization has been registered
+				&& transactionCoordinator.isJoined()
+			// Any transaction status other than NOT_ACTIVE indicates that the synchronizations are still running
+				&& transactionCoordinator.getTransactionDriverControl().getStatus() != TransactionStatus.NOT_ACTIVE;
+	}
+
 	@Override
 	protected void checkBeforeClosingJdbcCoordinator() {
-		final var actionQueue = getActionQueue();
-		if ( actionQueue.hasBeforeTransactionActions() || actionQueue.hasAfterTransactionActions() ) {
-			SESSION_LOGGER.closingSharedSessionWithUnprocessedTxCompletions();
+		// In a JTA environment the Session is usually closed through a Synchronization, that is invoked before ours,
+		// so only check for pending actions if we're not in a JTA transaction completion processing state
+		if ( !isJtaTransactionCompletionProcessing() ) {
+			final var actionQueue = getActionQueue();
+			if ( actionQueue.hasBeforeTransactionActions() || actionQueue.hasAfterTransactionActions() ) {
+				SESSION_LOGGER.closingSharedSessionWithUnprocessedTxCompletions();
+			}
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/JtaSessionCloseBulkCleanupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/actionqueue/JtaSessionCloseBulkCleanupTest.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.actionqueue;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionManager;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.orm.test.jpa.transaction.JtaPlatformSettingProvider;
+import org.hibernate.testing.jta.TestingJtaBootstrap;
+import org.hibernate.testing.jta.TestingJtaPlatformImpl;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Logger;
+import org.hibernate.testing.orm.junit.MessageKeyInspection;
+import org.hibernate.testing.orm.junit.MessageKeyWatcher;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingConfiguration;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * In a container-managed JTA context the session is closed from within an <em>interposed</em>
+ * {@link Synchronization#afterCompletion(int)} (e.g. WildFly's
+ * {@code TransactionUtil$SessionSynchronization}). Per the JTA contract interposed
+ * {@code afterCompletion} callbacks run before regular ones, while Hibernate registers its own
+ * callback-processing synchronization as a regular one. So the session is closed while the
+ * transaction is no longer active but before Hibernate has processed the bulk-operation cleanup
+ * callbacks; {@code SessionImpl}'s close guard then force-executes them and logs HHH90010101 /
+ * HHH90010108, even though the (regular) synchronization processes them moments later.
+ *
+ * @see <a href="https://hibernate.atlassian.net/browse/HHH-20583">HHH-20583</a>
+ */
+@RequiresDialect(H2Dialect.class)
+@Jpa(
+		annotatedClasses = JtaSessionCloseBulkCleanupTest.Author.class,
+		settingProviders = @SettingProvider(
+				settingName = AvailableSettings.JTA_PLATFORM,
+				provider = JtaPlatformSettingProvider.class
+		),
+		integrationSettings = {
+				@Setting(name = AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, value = "jta"),
+				@Setting(name = AvailableSettings.ALLOW_JTA_TRANSACTION_ACCESS, value = "true"),
+				@Setting(name = AvailableSettings.JPA_TRANSACTION_COMPLIANCE, value = "true"),
+				@Setting(name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true"),
+				@Setting(
+						name = AvailableSettings.CACHE_REGION_FACTORY,
+						value = "org.hibernate.testing.cache.CachingRegionFactory"
+				)
+		}
+)
+@ServiceRegistry(settingConfigurations = @SettingConfiguration(configurer = TestingJtaBootstrap.class))
+@MessageKeyInspection(
+		messageKey = "HHH90010108",
+		logger = @Logger(loggerName = "org.hibernate.orm.session")
+)
+public class JtaSessionCloseBulkCleanupTest {
+
+	@Test
+	void bulkNativeUpdateClosedDuringAfterCompletionDoesNotWarn(
+			EntityManagerFactoryScope scope,
+			MessageKeyWatcher watcher) throws Exception {
+
+		final SessionFactory sessionFactory = scope.getEntityManagerFactory().unwrap( SessionFactory.class );
+		final TransactionManager tm = TestingJtaPlatformImpl.INSTANCE.getTransactionManager();
+
+		tm.begin();
+		final Session session = sessionFactory.openSession();
+
+		// No synchronized query spaces -> the bulk cleanup is treated as affecting all cacheable
+		// entities, so it is non-empty and registers an after-completion callback.
+		session.createNativeMutationQuery( "update AUTHORS set NAME = NAME where 1=1" ).executeUpdate();
+
+		// Mimic the container: close the session from an interposed afterCompletion (runs before
+		// Hibernate's own regular synchronization).
+		TestingJtaPlatformImpl.synchronizationRegistry().registerInterposedSynchronization( new Synchronization() {
+			@Override
+			public void beforeCompletion() {
+			}
+
+			@Override
+			public void afterCompletion(int status) {
+				session.close();
+			}
+		} );
+
+		tm.commit();
+
+		assertFalse(
+				watcher.wasTriggered(),
+				"Spurious unprocessed-completion warning(s): " + watcher.getTriggeredMessages()
+		);
+	}
+
+	@Entity(name = "Author")
+	@Table(name = "AUTHORS")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	static class Author {
+		@Id
+		Long id;
+		@Column(name = "NAME")
+		String name;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20583 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20583
<!-- Hibernate GitHub Bot issue links end -->