### PR TITLE
HHH-20674 HbmXmlTransformer does not transfer callable attribute for custom SQL statements

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -413,21 +413,21 @@ public class HbmXmlTransformer {
 			final var sqlInsert = new JaxbCustomSqlImpl();
 			sqlInsert.setValue( hbmClass.getSqlInsert().getValue() );
 			sqlInsert.setResultCheck( hbmClass.getSqlInsert().getCheck() );
-			sqlInsert.setValue( hbmClass.getSqlInsert().getValue() );
+			sqlInsert.setCallable( hbmClass.getSqlInsert().isCallable() );
 			mappingEntity.setSqlInsert( sqlInsert );
 		}
 		if ( hbmClass.getSqlUpdate() != null ) {
 			final var sqlUpdate = new JaxbCustomSqlImpl();
 			sqlUpdate.setValue( hbmClass.getSqlUpdate().getValue() );
 			sqlUpdate.setResultCheck( hbmClass.getSqlUpdate().getCheck() );
-			sqlUpdate.setValue( hbmClass.getSqlUpdate().getValue() );
+			sqlUpdate.setCallable( hbmClass.getSqlUpdate().isCallable() );
 			mappingEntity.setSqlUpdate( sqlUpdate );
 		}
 		if ( hbmClass.getSqlDelete() != null ) {
 			final var sqlDelete = new JaxbCustomSqlImpl();
 			sqlDelete.setValue( hbmClass.getSqlDelete().getValue() );
 			sqlDelete.setResultCheck( hbmClass.getSqlDelete().getCheck() );
-			sqlDelete.setValue( hbmClass.getSqlDelete().getValue() );
+			sqlDelete.setCallable( hbmClass.getSqlDelete().isCallable() );
 			mappingEntity.setSqlDelete( sqlDelete );
 		}
 		mappingEntity.setRowid( hbmClass.getRowid() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -825,6 +825,36 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	public void testCustomSqlCallableTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/custom-sql/hbm.xml", scope, (transformed) -> {
+			assertThat( transformed.getEntities() ).hasSize( 1 );
+
+			final JaxbEntityImpl entity = transformed.getEntities().get( 0 );
+
+			assertThat( entity.getSqlInsert() )
+					.as( "sql-insert should be present" )
+					.isNotNull();
+			assertThat( entity.getSqlInsert().isCallable() )
+					.as( "sql-insert should have callable=true" )
+					.isTrue();
+
+			assertThat( entity.getSqlUpdate() )
+					.as( "sql-update should be present" )
+					.isNotNull();
+			assertThat( entity.getSqlUpdate().isCallable() )
+					.as( "sql-update should have callable=true" )
+					.isTrue();
+
+			assertThat( entity.getSqlDelete() )
+					.as( "sql-delete should be present" )
+					.isNotNull();
+			assertThat( entity.getSqlDelete().isCallable() )
+					.as( "sql-delete should have callable=true" )
+					.isTrue();
+		} );
+	}
+
+	@Test
 	public void testPropertyUniqueTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/property-unique/hbm.xml", scope, transformed -> {
 			assertThat( transformed.getEntities() ).hasSize( 1 );

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/custom-sql/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/custom-sql/hbm.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping">
+
+    <class name="SimpleEntity">
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name" not-null="true"/>
+        <sql-insert callable="true" check="none">{call insertEntity(?,?)}</sql-insert>
+        <sql-update callable="true" check="param">{? = call updateEntity(?,?)}</sql-update>
+        <sql-delete callable="true" check="none">{call deleteEntity(?)}</sql-delete>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20674

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20674 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->