### PR TITLE
Missing AUD table ?

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/temporal/audit/inheritance/AuditSingleTableInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/temporal/audit/inheritance/AuditSingleTableInheritanceTest.java
@@ -6,6 +6,7 @@ package org.hibernate.temporal.audit.inheritance;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorValue;
@@ -15,12 +16,14 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.hibernate.annotations.Audited;
 import org.hibernate.audit.AuditLogFactory;
 import org.hibernate.cfg.StateManagementSettings;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.temporal.spi.ChangesetIdentifierSupplier;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.AuditedTest;
 import org.hibernate.testing.orm.junit.BeforeClassTemplate;
@@ -46,7 +49,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 		AuditSingleTableInheritanceTest.SportsCar.class,
 		AuditSingleTableInheritanceTest.Truck.class,
 		AuditSingleTableInheritanceTest.Driver.class,
-		AuditSingleTableInheritanceTest.Team.class
+		AuditSingleTableInheritanceTest.Team.class,
+		AuditSingleTableInheritanceTest.NotAuditedParent.class,
+		AuditSingleTableInheritanceTest.AuditedChild.class,
 })
 @ServiceRegistry(settings = @Setting(name = StateManagementSettings.CHANGESET_ID_SUPPLIER,
 		value = "org.hibernate.temporal.audit.inheritance.AuditSingleTableInheritanceTest$TxIdSupplier"))
@@ -390,5 +395,31 @@ class AuditSingleTableInheritanceTest {
 			this.id = id;
 			this.teamName = teamName;
 		}
+	}
+
+	/**
+	 * Tests where just the Subclass is @Audited but not the parent class
+	 */
+
+	@Entity
+	@Table(name = "NotAuditedParent")
+	static class NotAuditedParent {
+		@Id
+		long id;
+	}
+
+	@Audited
+	@Entity
+	static class AuditedChild extends NotAuditedParent {
+		String str1;
+	}
+
+	@Test
+	@Order(6)
+	void notAuditedParent(DomainModelScope scope) {
+		var tables = scope.getDomainModel().collectTableMappings();
+		var tableNames = tables.stream().map( org.hibernate.mapping.Table::getName ).collect( Collectors.toSet());
+		assertThat( tableNames ).contains( "NotAuditedParent" );
+		assertThat( tableNames ).contains( "NotAuditedParent_AUD" );
 	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

I expected hibernate to create an AUD table for a child entity which aus @Audited but the parent entity is not (see test case). 

But the AUD table is not created. Neither for the parent nor for the child entity.

Can you confirm this is a bug?


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
