### PR TITLE
HHH-20682 HbmXmlTransformer drops nullable column for natural-id properties without explicit column element

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1171,6 +1171,7 @@ public class HbmXmlTransformer {
 	}
 
 	private void transferColumnsAndFormulas(
+			PropertyInfo propertyInfo,
 			ColumnAndFormulaSource source,
 			ColumnAndFormulaTarget target,
 			ColumnDefaults columnDefaults,
@@ -1209,10 +1210,11 @@ public class HbmXmlTransformer {
 				|| Boolean.FALSE.equals( columnDefaults.isInsertable() )
 				|| Boolean.FALSE.equals( columnDefaults.isUpdatable() )
 				|| Boolean.TRUE.equals( columnDefaults.isUnique() )
-				|| Boolean.FALSE.equals( columnDefaults.isNullable() ) ) {
+				|| propertyInfo != null && propertyInfo.bootModelProperty().isNaturalIdentifier() ) {
 			// No explicit column/formula specified, but we still need to generate a column to carry
 			// the secondary table name (for <join/>) or non-default insertable/updatable settings
 			// (e.g. <property update="false"/> inside a <component/>) or unique/not-null constraints
+			// or explicit nullable override (e.g. natural-id properties with not-null="false")
 			final var targetColumnAdapter = target.makeColumnAdapter( columnDefaults );
 			targetColumnAdapter.setTable( tableName );
 			target.addColumn( targetColumnAdapter );
@@ -1621,6 +1623,7 @@ public class HbmXmlTransformer {
 		);
 
 		transferColumnsAndFormulas(
+				propertyInfo,
 				new ColumnAndFormulaSource() {
 					@Override
 					public String getColumnAttribute() {
@@ -1661,6 +1664,7 @@ public class HbmXmlTransformer {
 				new ColumnDefaults() {
 					@Override
 					public Boolean isNullable() {
+						final boolean optional = propertyInfo.bootModelProperty().isOptional();
 						return propertyInfo.bootModelProperty().isOptional();
 					}
 
@@ -1972,6 +1976,7 @@ public class HbmXmlTransformer {
 		if ( key != null ) {
 			collectionTable.setForeignKeys( transformForeignKey( key.getForeignKey() ) );
 			transferColumnsAndFormulas(
+					null,
 					new ColumnAndFormulaSource() {
 						@Override
 						public String getColumnAttribute() {
@@ -2285,6 +2290,7 @@ public class HbmXmlTransformer {
 		transferElementTypeInfo( hbmCollection, element, propertyInfo, target );
 
 		transferColumnsAndFormulas(
+				propertyInfo,
 				new ColumnAndFormulaSource() {
 					@Override
 					public String getColumnAttribute() {
@@ -2481,6 +2487,7 @@ public class HbmXmlTransformer {
 			if ( key != null ) {
 				target.setForeignKey( transformForeignKey( key.getForeignKey() ) );
 				transferColumnsAndFormulas(
+						propertyInfo,
 						new ColumnAndFormulaSource() {
 							@Override
 							public String getColumnAttribute() {
@@ -2729,6 +2736,7 @@ public class HbmXmlTransformer {
 
 		if ( key != null ) {
 			transferColumnsAndFormulas(
+					propertyInfo,
 					new ColumnAndFormulaSource() {
 						@Override
 						public String getColumnAttribute() {
@@ -2772,6 +2780,7 @@ public class HbmXmlTransformer {
 		}
 
 		transferColumnsAndFormulas(
+				propertyInfo,
 				new ColumnAndFormulaSource() {
 					@Override
 					public String getColumnAttribute() {
@@ -3109,6 +3118,7 @@ public class HbmXmlTransformer {
 		);
 
 		transferColumnsAndFormulas(
+				keyPropertyInfo,
 				new ColumnAndFormulaSource() {
 					@Override
 					public String getColumnAttribute() {
@@ -3213,6 +3223,7 @@ public class HbmXmlTransformer {
 		);
 
 		transferColumnsAndFormulas(
+				keyManyToOneInfo,
 				new ColumnAndFormulaSource() {
 					@Override
 					public String getColumnAttribute() {
@@ -3341,6 +3352,7 @@ public class HbmXmlTransformer {
 		);
 
 		transferColumnsAndFormulas(
+				idPropertyInfo,
 				new ColumnAndFormulaSource() {
 					@Override
 					public String getColumnAttribute() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1070,4 +1070,29 @@ public class HbmTransformationJaxbTests {
 					.isNull();
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20682" )
+	public void testNaturalIdNullablePropertyTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/natural-id-nullable/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 1 );
+
+			final JaxbEntityImpl userEntity = transformed.getEntities().get( 0 );
+			assertThat( userEntity.getAttributes().getNaturalId() ).isNotNull();
+			assertThat( userEntity.getAttributes().getNaturalId().isMutable() ).isTrue();
+
+			final var naturalIdBasics = userEntity.getAttributes().getNaturalId().getBasicAttributes();
+			assertThat( naturalIdBasics ).hasSize( 3 );
+
+			for ( JaxbBasicImpl basic : naturalIdBasics ) {
+				assertThat( basic.getColumn() )
+						.as( "Natural-id property '%s' with not-null='false' should generate a column element",
+								basic.getName() )
+						.isNotNull();
+				assertThat( basic.getColumn().isNullable() )
+						.as( "Natural-id property '%s' should have nullable=true", basic.getName() )
+						.isTrue();
+			}
+		} );
+	}
 }

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/natural-id-nullable/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/natural-id-nullable/hbm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping
+    package="org.hibernate.orm.test.mapping.naturalid.nullable"
+    default-access="field">
+
+    <class name="User" table="SystemUserInfo">
+        <id name="id" />
+        <natural-id mutable="true">
+            <property name="name" not-null="false"/>
+            <property name="org" not-null="false"/>
+            <property name="intVal" not-null="false"/>
+        </natural-id>
+        <property name="password" column="`password`"/>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/13051 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20682 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20682
<!-- Hibernate GitHub Bot issue links end -->