### PR TITLE
HbmXmlTransformer issues

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -2922,7 +2922,7 @@ public class HbmXmlTransformer {
 			JaxbIdImpl target,
 			Property identifierProperty,
 			BasicValue basicValue) {
-		target.setName( source.getName() );
+		target.setName( isNotEmpty( source.getName() ) ? source.getName() : identifierProperty.getName() );
 		transferAccess(
 				source.getAccess(),
 				target::setAccess,
@@ -2933,7 +2933,7 @@ public class HbmXmlTransformer {
 
 		final var hbmGenerator = source.getGenerator();
 		if ( hbmGenerator != null && !"assigned".equals( hbmGenerator.getClazz() ) ) {
-			final var generatorName = source.getName() + "-id-generator";
+			final var generatorName = target.getName() + "-id-generator";
 			final var jaxbGeneratedValue = new JaxbGeneratedValueImpl();
 			jaxbGeneratedValue.setGenerator( generatorName );
 			target.setGeneratedValue( jaxbGeneratedValue );

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -524,7 +524,7 @@ public class HbmXmlTransformer {
 			JaxbEntityImpl subclassEntity,
 			EntityTypeInfo subclassEntityInfo) {
 		transferBaseEntityInformation( hbmSubclass, subclassEntity, subclassEntityInfo );
-		transferBaseEntityAttributes( hbmSubclass, subclassEntity, subclassEntityInfo );
+		transferEntityAttributes( hbmSubclass, subclassEntity, subclassEntityInfo );
 
 		if ( !hbmSubclass.getSubclass().isEmpty() ) {
 			for ( var nestedHbmSubclass : hbmSubclass.getSubclass() ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1114,4 +1114,22 @@ public class HbmTransformationJaxbTests {
 					.isNotNull();
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20684" )
+	public void testDiscriminatorSubclassTransientGeneration(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/subclass-transient/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 3 );
+
+			final JaxbEntityImpl employeeEntity = transformed.getEntities().stream()
+					.filter( e -> "Employee".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( employeeEntity.getAttributes().getTransients() )
+					.extracting( JaxbTransientImpl::getName )
+					.as( "Unmapped field 'manager' on discriminator subclass Employee should be marked transient" )
+					.contains( "manager" );
+		} );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1095,4 +1095,23 @@ public class HbmTransformationJaxbTests {
 			}
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20683" )
+	public void testDynamicEntityIdNameTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/dynamic-entity/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl baseEntity = transformed.getEntities().stream()
+					.filter( e -> "Base".equals( e.getName() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( baseEntity.getAttributes().getIdAttributes() ).hasSize( 1 );
+			final JaxbIdImpl id = baseEntity.getAttributes().getIdAttributes().get( 0 );
+			assertThat( id.getName() )
+					.as( "Dynamic entity <id/> without name should get a default name from the boot model" )
+					.isNotNull();
+		} );
+	}
 }

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/dynamic-entity/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/dynamic-entity/hbm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping
+    package="org.hibernate.orm.test.mapping.inheritance.dynamic"
+    default-access="field">
+
+    <class abstract="true" entity-name="Base" table="t_base">
+        <id type="integer" />
+        <property name="name" type="string"/>
+
+        <joined-subclass entity-name="Sub" table="t_sub">
+            <key column="sub_id"/>
+            <property name="subText" type="string"/>
+        </joined-subclass>
+    </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/subclass-transient/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/subclass-transient/hbm.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping
+    package="org.hibernate.orm.test.mapping.inheritance.discriminator"
+    default-access="field">
+
+    <class name="Person"
+        discriminator-value="P">
+
+        <id name="id"
+            column="person_id">
+            <generator class="assigned"/>
+        </id>
+
+        <discriminator column="`TYPE`" type="character"/>
+
+        <property name="name"
+            not-null="true"
+            length="80"/>
+
+        <property name="sex"
+            not-null="true"
+            update="false"/>
+
+        <subclass name="Employee"
+            discriminator-value="E">
+                <property name="title" length="20"/>
+                <property name="salary" />
+        </subclass>
+
+        <subclass name="Customer"
+            discriminator-value="C">
+                <property name="comments"/>
+        </subclass>
+
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
Fix for:

- [HHH-20683](https://hibernate.atlassian.net/browse/HHH-20683)  HbmXmlTransformer does not set name on id element for dynamic entities with unnamed id

- [HHH-20684](https://hibernate.atlassian.net/browse/HHH-20684) HbmXmlTransformer does not generate transient markers for unmapped fields on discriminator subclasses

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20684 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20683 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

[HHH-20683]: https://hibernate.atlassian.net/browse/HHH-20683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20684]: https://hibernate.atlassian.net/browse/HHH-20684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ