### PR TITLE
HHH-20685 Treat Kotlin's covariant List<? extends X>

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -4195,8 +4195,14 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		if ( typeArgument.getKind() == TypeKind.WILDCARD ) {
 			final var wildcardType = (WildcardType) typeArgument;
 			final var superBound = wildcardType.getSuperBound();
-			return superBound != null
-				&& types.isAssignable( attributeType, boxedType( superBound ) );
+			if ( superBound != null ) {
+				return types.isAssignable( attributeType, boxedType( superBound ) );
+			}
+			else {
+				final var extendsBound = wildcardType.getExtendsBound();
+				return extendsBound != null
+					&& types.isAssignable( boxedType( extendsBound ), attributeType );
+			}
 		}
 		else {
 			return types.isSameType( boxedType( typeArgument ), attributeType );

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/wildcard/Book.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/wildcard/Book.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.wildcard;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Book {
+	@Id
+	String isbn;
+	String title;
+	// e.g. "crime", "romance", "fantasy"
+	String genre;
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/wildcard/BookRepository.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/wildcard/BookRepository.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.wildcard;
+
+import org.hibernate.StatelessSession;
+import org.hibernate.annotations.processing.Find;
+
+import java.util.List;
+
+/**
+ * A finder parameter may be an extends-bounded wildcard list
+ * {@code List<? extends String>} rather than a plain {@code List<String>}, for
+ * example when the element type comes from a covariantly-declared collection.
+ * Both forms must be treated as a multivalued {@code in} parameter.
+ */
+public interface BookRepository {
+
+	StatelessSession session();
+
+	// Baseline: a plain list parameter.
+	@Find
+	List<Book> findByGenre(List<String> genre);
+
+	// The extends-bounded wildcard form.
+	@Find
+	List<Book> findByGenreWildcard(List<? extends String> genre);
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/wildcard/ListExtendsParameterTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/wildcard/ListExtendsParameterTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.wildcard;
+
+import org.hibernate.internal.util.StringHelper;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that an extends-bounded wildcard list parameter
+ * {@code List<? extends X>} is recognized as a multivalued {@code in}
+ * parameter, exactly like a plain {@code List<X>} parameter.
+ *
+ * @see BookRepository
+ */
+@CompilationTest
+class ListExtendsParameterTest {
+
+	@Test
+	@WithClasses({ Book.class, BookRepository.class })
+	void testWildcardListParameterIsMultivalued() {
+		final String repository = getMetaModelSourceAsString( BookRepository.class, true );
+		System.out.println( repository );
+		assertMetamodelClassGeneratedFor( Book.class );
+		assertMetamodelClassGeneratedFor( BookRepository.class, true );
+
+		// Both the plain List<String> and the List<? extends String> parameter
+		// must be rendered as an 'in' condition, so '.in(genre)' appears once
+		// per finder method.
+		assertEquals( 2, StringHelper.count( repository, ".in(genre)" ),
+				"expected an 'in' condition for both the List<String> and the "
+						+ "List<? extends String> parameter" );
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Kotlin compiles a `List<X>` finder parameter to `List<? extends X>` because kotlin.collections.List is declared covariantly (List<out E>). The processor only recognized a plain `List<X>` or `a List<? super X>` wildcard as a multivalued 'in' parameter, so the extends-bounded form produced by Kotlin was rejected and the finder method implementation was not generated.

typeArgumentMatchesAttribute now also handles the extends bound, so a Kotlin List parameter reliably produces an 'in' condition like its Java equivalent.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20685 (Proposal):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20685
<!-- Hibernate GitHub Bot issue links end -->