### PR TITLE
Fix strict JAXP test failures in hibernate-reveng tests

### DIFF
--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/hbm2x/GenerateFromJDBC/TestCase.java
@@ -104,7 +104,11 @@ public class TestCase {
 		exporter.getProperties().put(ExporterConstants.DESTINATION_FOLDER, outputDir);
 		exporter.start();
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "hibernate.cfg.xml"));
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance(
+				"com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+				Thread.currentThread().getContextClassLoader());
+		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 		DocumentBuilder  db = dbf.newDocumentBuilder();
 		Document document = db.parse(new File(outputDir, "hibernate.cfg.xml"));
 		XPath xpath = XPathFactory.newInstance().newXPath();
@@ -131,7 +135,11 @@ public class TestCase {
 		exporter.getProperties().setProperty("ejb3", "true");
 		exporter.start();
 		JUnitUtil.assertIsNonEmptyFile(new File(outputDir, "hibernate.cfg.xml"));
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance(
+				"com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+				Thread.currentThread().getContextClassLoader());
+		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 		DocumentBuilder  db = dbf.newDocumentBuilder();
 		Document document = db.parse(new File(outputDir, "hibernate.cfg.xml"));
 		XPath xpath = XPathFactory.newInstance().newXPath();


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
