### PR TITLE
HHH-20661 Return shared DateJavaType instances per temporal precision

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
@@ -26,6 +26,10 @@ import org.hibernate.type.spi.TypeConfiguration;
  */
 public class DateJavaType extends AbstractTemporalJavaType<Date> implements VersionJavaType<Date> {
 	public static final DateJavaType INSTANCE = new DateJavaType();
+	@SuppressWarnings("deprecation")
+	private static final DateJavaType DATE_INSTANCE = new DateJavaType( TemporalType.DATE );
+	@SuppressWarnings("deprecation")
+	private static final DateJavaType TIME_INSTANCE = new DateJavaType( TemporalType.TIME );
 	private final @SuppressWarnings("deprecation") TemporalType precision;
 
 	public static class DateMutabilityPlan extends MutableMutabilityPlan<Date> {
@@ -92,10 +96,18 @@ public class DateJavaType extends AbstractTemporalJavaType<Date> implements Vers
 	}
 
 	@Override
-	public TemporalJavaType<Date> resolveTypeForPrecision(
-			@SuppressWarnings("deprecation") TemporalType precision,
-			TypeConfiguration typeConfiguration) {
-		return precision == null ? this : new DateJavaType( precision );
+	protected TemporalJavaType<Date> forDatePrecision(TypeConfiguration typeConfiguration) {
+		return DATE_INSTANCE;
+	}
+
+	@Override
+	protected TemporalJavaType<Date> forTimePrecision(TypeConfiguration typeConfiguration) {
+		return TIME_INSTANCE;
+	}
+
+	@Override
+	protected TemporalJavaType<Date> forTimestampPrecision(TypeConfiguration typeConfiguration) {
+		return INSTANCE;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/UnionSameJavaTypeDifferentPathTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/UnionSameJavaTypeDifferentPathTest.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.hql;
+
+import java.util.Date;
+import java.util.List;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DomainModel(annotatedClasses = UnionSameJavaTypeDifferentPathTest.EntityA.class)
+@SessionFactory
+@JiraKey("HHH-20661")
+public class UnionSameJavaTypeDifferentPathTest {
+
+	@Test
+	public void testUnionOfSameJavaTypeFromDifferentPaths(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final List<Object[]> results = session.createQuery(
+					"select a.code, a.eventDate as d from EntityA a " +
+					"union " +
+					"select a2.code, a2.createdAt as d from EntityA a2",
+					Object[].class
+			).list();
+			assertThat( results ).isNotNull();
+		} );
+	}
+
+	@Test
+	public void testUnionOfGenuinelyDifferentJavaTypesStillRejected(SessionFactoryScope scope) {
+		scope.inTransaction( session -> assertThatThrownBy( () -> session.createQuery(
+				"select a.code from EntityA a " +
+				"union " +
+				"select a2.eventDate from EntityA a2",
+				Object.class
+		).list() ).hasMessageContaining( "must have the same java type across all query parts" ) );
+	}
+
+	@MappedSuperclass
+	public static class BaseAuditable {
+		private Date createdAt;
+
+		public Date getCreatedAt() {
+			return createdAt;
+		}
+
+		public void setCreatedAt(Date createdAt) {
+			this.createdAt = createdAt;
+		}
+	}
+
+	@Entity(name = "EntityA")
+	public static class EntityA extends BaseAuditable {
+		@Id
+		private Long id;
+
+		private String code;
+
+		private Date eventDate;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getCode() {
+			return code;
+		}
+
+		public void setCode(String code) {
+			this.code = code;
+		}
+
+		public Date getEventDate() {
+			return eventDate;
+		}
+
+		public void setEventDate(Date eventDate) {
+			this.eventDate = eventDate;
+		}
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/13050

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20661 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20661
<!-- Hibernate GitHub Bot issue links end -->