### PR TITLE
HHH-17548 Add LongRevisionMapping for long revision numbers

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/envers/Envers.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/envers/Envers.adoc
@@ -480,7 +480,7 @@ An integral value (`int/Integer` or `long/Long`). Essentially, the primary key o
 A revision number value should **always** be increasing and never overflows.
 
 The default implementations provided by Envers use an `int` data type which has an upper bounds of `Integer.MAX_VALUE`.
-It is critical that users consider whether this upper bounds is feasible for your application.  If a large range is needed, consider using a custom revision entity mapping using a `long` data type.
+It is critical that users consider whether this upper bounds is feasible for your application.  If a large range is needed, consider using a custom revision entity mapping using a `long` data type, for example by extending the `org.hibernate.envers.LongRevisionMapping` mapped superclass.
 
 In the event that the revision number reaches its upper bounds wrapping around becoming negative, an `AuditException` will be thrown causing the current transaction to be rolled back.
 This guarantees that the audit history remains in a valid state that can be queried by the Envers Query API.
@@ -525,6 +525,7 @@ It must define the two attributes described above annotated with `@org.hibernate
 You can extend from any of the revision mapped superclass types, if you wish, to inherit all these required behaviors:
 
     org.hibernate.envers.RevisionMapping
+    org.hibernate.envers.LongRevisionMapping
     org.hibernate.envers.TrackingModifiedEntitiesRevisionMapping
     org.hibernate.envers.enhanced.SequenceIdRevisionMapping
     org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionMapping

--- a/hibernate-envers/src/main/java/org/hibernate/envers/LongRevisionMapping.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/LongRevisionMapping.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.envers;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Transient;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * A base class for a custom revision entity whose revision number is a {@code long},
+ * for applications where the number of revisions may exceed {@link Integer#MAX_VALUE}.
+ * <p>
+ * The default revision entity mappings use an {@code int} revision number, which cannot
+ * be changed without breaking existing schemas. Applications that need the larger range
+ * can instead declare:
+ * <pre>
+ * &#64;Entity
+ * &#64;RevisionEntity
+ * public class MyRevisionEntity extends LongRevisionMapping {
+ * }
+ * </pre>
+ *
+ * @see RevisionMapping
+ */
+@MappedSuperclass
+public class LongRevisionMapping implements Serializable {
+	private static final long serialVersionUID = 4159156677698841902L;
+
+	@Id
+	@GeneratedValue
+	@RevisionNumber
+	private long id;
+
+	@RevisionTimestamp
+	private long timestamp;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	@Transient
+	public Date getRevisionDate() {
+		return new Date( timestamp );
+	}
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	public void setTimestamp(long timestamp) {
+		this.timestamp = timestamp;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( !(o instanceof LongRevisionMapping) ) {
+			return false;
+		}
+
+		final LongRevisionMapping that = (LongRevisionMapping) o;
+		return id == that.id
+				&& timestamp == that.timestamp;
+	}
+
+	@Override
+	public int hashCode() {
+		int result;
+		result = (int) (id ^ (id >>> 32));
+		result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "LongRevisionMapping(id = " + id
+				+ ", revisionDate = " + DateTimeFormatter.INSTANCE.format( getRevisionDate() ) + ")";
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/entities/reventity/LongRevisionMappingRevEntity.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/entities/reventity/LongRevisionMappingRevEntity.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.entities.reventity;
+
+import jakarta.persistence.Entity;
+
+import org.hibernate.envers.LongRevisionMapping;
+import org.hibernate.envers.RevisionEntity;
+
+/**
+ * A revision entity using a {@code long} revision number via {@link LongRevisionMapping}.
+ */
+@Entity
+@RevisionEntity
+public class LongRevisionMappingRevEntity extends LongRevisionMapping {
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/LongRevisionMappingTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/LongRevisionMappingTest.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.reventity;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.orm.test.envers.entities.StrTestEntity;
+import org.hibernate.orm.test.envers.entities.reventity.LongRevisionMappingRevEntity;
+import org.hibernate.testing.envers.junit.EnversTest;
+import org.hibernate.testing.orm.junit.BeforeClassTemplate;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that a revision entity extending {@link org.hibernate.envers.LongRevisionMapping}
+ * provides working {@code long} revision numbers.
+ */
+@EnversTest
+@Jpa(annotatedClasses = {StrTestEntity.class, LongRevisionMappingRevEntity.class})
+public class LongRevisionMappingTest {
+	private Integer id;
+
+	@BeforeClassTemplate
+	public void initData(EntityManagerFactoryScope scope) {
+		// Revision 1
+		scope.inTransaction( em -> {
+			StrTestEntity te = new StrTestEntity( "x" );
+			em.persist( te );
+			id = te.getId();
+		} );
+
+		// Revision 2
+		scope.inTransaction( em -> {
+			StrTestEntity te = em.find( StrTestEntity.class, id );
+			te.setStr( "y" );
+		} );
+	}
+
+	@Test
+	public void testFindRevision(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			AuditReader vr = AuditReaderFactory.get( em );
+
+			assertEquals( 1L, vr.findRevision( LongRevisionMappingRevEntity.class, 1L ).getId() );
+			assertEquals( 2L, vr.findRevision( LongRevisionMappingRevEntity.class, 2L ).getId() );
+		} );
+	}
+
+	@Test
+	public void testFindRevisions(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			AuditReader vr = AuditReaderFactory.get( em );
+
+			Set<Number> revNumbers = new HashSet<>();
+			revNumbers.add( 1L );
+			revNumbers.add( 2L );
+
+			Map<Number, LongRevisionMappingRevEntity> revisionMap = vr.findRevisions( LongRevisionMappingRevEntity.class, revNumbers );
+			assertEquals( 2, revisionMap.size() );
+			assertEquals( vr.findRevision( LongRevisionMappingRevEntity.class, 1L ), revisionMap.get( 1L ) );
+			assertEquals( vr.findRevision( LongRevisionMappingRevEntity.class, 2L ), revisionMap.get( 2L ) );
+		} );
+	}
+
+	@Test
+	public void testRevisionsCounts(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			assertEquals( Arrays.asList( 1L, 2L ), AuditReaderFactory.get( em ).getRevisions( StrTestEntity.class, id ) );
+		} );
+	}
+
+	@Test
+	public void testHistoryOfId1(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			StrTestEntity ver1 = new StrTestEntity( "x", id );
+			StrTestEntity ver2 = new StrTestEntity( "y", id );
+
+			final var auditReader = AuditReaderFactory.get( em );
+			assertEquals( ver1, auditReader.find( StrTestEntity.class, id, 1L ) );
+			assertEquals( ver2, auditReader.find( StrTestEntity.class, id, 2L ) );
+		} );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17548

Adds `org.hibernate.envers.LongRevisionMapping`, a `@MappedSuperclass` mirroring `RevisionMapping` but with a `long` revision number, so applications whose revision count may exceed `Integer.MAX_VALUE` can declare a custom revision entity by simply extending it:

```java
@Entity
@RevisionEntity
public class MyRevisionEntity extends LongRevisionMapping {
}
```

**Motivation.** As described in HHH-17548, the default revision entities use an `int` revision number. Since HHH-6615, overflow is detected and fails the transaction with an `AuditException`, and the documentation advises high-volume applications to use a custom revision entity with a `long` — but there is no ready-made base class for that; every affected application has to hand-write the id/timestamp mapping (we just hit this in production: our `REVINFO` auto-increment crossed 2,147,483,647 and every audited transaction started failing).

Rather than changing the default type (a breaking schema change for existing users), this adds an opt-in base class. Purely additive — no existing mapping, schema, or API is touched.

**Included:**
- `LongRevisionMapping` mapped superclass (main)
- Test: `LongRevisionMappingTest` + test revision entity, modeled on the existing `LongRevNumber` test
- User-guide update: `LongRevisionMapping` listed among the revision mapped superclasses, and the revision-number overflow WARNING now points to it

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

---


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-17548 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->