### PR TITLE
escape like wildcards in single-argument Range.suffix

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/range/Range.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/range/Range.java
@@ -190,7 +190,7 @@ public interface Range<U> {
 	 * with case-sensitivity.
 	 */
 	static Range<String> suffix(String suffix) {
-		return pattern( suffix, true );
+		return suffix( suffix, true );
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/range/RangePatternEscapeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/range/RangePatternEscapeTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.range;
+
+import org.hibernate.query.range.Range;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The single-argument {@link Range#prefix}, {@link Range#suffix} and
+ * {@link Range#containing} factories are case-sensitive shorthands for their
+ * two-argument counterparts, so they must escape the wildcard characters
+ * {@code %}, {@code _} and {@code \} in the supplied literal exactly the same
+ * way. Verifies that {@code suffix} no longer forwards the raw literal as an
+ * unescaped LIKE pattern.
+ */
+public class RangePatternEscapeTest {
+
+	private static final String LITERAL = "a%b_c\\d";
+
+	@Test
+	void prefixMatchesExplicitForm() {
+		assertEquals( Range.prefix( LITERAL, true ), Range.prefix( LITERAL ) );
+	}
+
+	@Test
+	void suffixMatchesExplicitForm() {
+		assertEquals( Range.suffix( LITERAL, true ), Range.suffix( LITERAL ) );
+	}
+
+	@Test
+	void containingMatchesExplicitForm() {
+		assertEquals( Range.containing( LITERAL, true ), Range.containing( LITERAL ) );
+	}
+}


### PR DESCRIPTION
delegate the single-argument `Range.suffix(String)` to `suffix(value, true)` the way `prefix` and `containing` already do, so `%`, `_` and `\` in the literal are escaped instead of reaching the generated `like` predicate as active wildcards (and the leading `%` is no longer dropped).

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
