### PR TITLE
HHH-20691 Subclass not-null check constraint is inverted for null discriminator value

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
@@ -55,7 +55,7 @@ public final class SingleTableSubclass extends Subclass {
 					final var check = new StringBuilder();
 					check.append( selectables.get( 0 ).getText( dialect ) );
 					if ( isDiscriminatorValueNull() ) {
-						check.append( " is " );
+						check.append( " is not " );
 					}
 					else if ( isDiscriminatorValueNotNull() ) {
 						check.append( " is " );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/NullDiscSubclassCheckBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/NullDiscSubclassCheckBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.inheritance.discriminator;
+
+public class NullDiscSubclassCheckBase {
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/NullDiscSubclassCheckChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/NullDiscSubclassCheckChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.inheritance.discriminator;
+
+public class NullDiscSubclassCheckChild extends NullDiscSubclassCheckBase {
+	private String requiredProp;
+
+	public String getRequiredProp() {
+		return requiredProp;
+	}
+
+	public void setRequiredProp(String requiredProp) {
+		this.requiredProp = requiredProp;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/NullDiscSubclassCheckOther.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/NullDiscSubclassCheckOther.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.inheritance.discriminator;
+
+public class NullDiscSubclassCheckOther extends NullDiscSubclassCheckChild {
+	private String otherProp;
+
+	public String getOtherProp() {
+		return otherProp;
+	}
+
+	public void setOtherProp(String otherProp) {
+		this.otherProp = otherProp;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/NullDiscriminatorSubclassCheckConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/NullDiscriminatorSubclassCheckConstraintTest.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.inheritance.discriminator;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies that inserting entities works correctly when a subclass uses
+ * {@code discriminator-value="null"} and has a not-null property.
+ * <p>
+ * The subclass not-null check constraint must use "is not null" (meaning
+ * "if you're NOT this subclass, skip the check") rather than "is null"
+ * (which would fail for all other subclasses).
+ */
+@JiraKey("HHH-20691")
+@DomainModel(xmlMappings = "org/hibernate/orm/test/mapping/inheritance/discriminator/null-disc-subclass-check.orm.xml")
+@SessionFactory
+public class NullDiscriminatorSubclassCheckConstraintTest {
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testInsertBase(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var base = new NullDiscSubclassCheckBase();
+			base.setId( 1L );
+			base.setName( "base" );
+			session.persist( base );
+		} );
+	}
+
+	@Test
+	public void testInsertChild(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var child = new NullDiscSubclassCheckChild();
+			child.setId( 2L );
+			child.setName( "child" );
+			child.setRequiredProp( "required" );
+			session.persist( child );
+		} );
+	}
+
+	@Test
+	public void testInsertOther(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var other = new NullDiscSubclassCheckOther();
+			other.setId( 3L );
+			other.setName( "other" );
+			other.setRequiredProp("required");
+			other.setOtherProp( "otherValue" );
+			session.persist( other );
+		} );
+	}
+
+	@Test
+	public void testInsertAllAndRead(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var base = new NullDiscSubclassCheckBase();
+			base.setId( 1L );
+			base.setName( "base" );
+			session.persist( base );
+
+			final var child = new NullDiscSubclassCheckChild();
+			child.setId( 2L );
+			child.setName( "child" );
+			child.setRequiredProp( "required" );
+			session.persist( child );
+
+			final var other = new NullDiscSubclassCheckOther();
+			other.setId( 3L );
+			other.setName( "other" );
+			other.setRequiredProp("required");
+			other.setOtherProp( "otherValue" );
+			session.persist( other );
+		} );
+
+		scope.inTransaction( session -> {
+			final var base = session.find( NullDiscSubclassCheckBase.class, 1L );
+			assertNotNull( base );
+			assertEquals( "base", base.getName() );
+			assertFalse( base instanceof NullDiscSubclassCheckChild );
+			assertFalse( base instanceof NullDiscSubclassCheckOther );
+
+			final var child = session.find( NullDiscSubclassCheckChild.class, 2L );
+			assertNotNull( child );
+			assertEquals( "child", child.getName() );
+			assertEquals( "required", child.getRequiredProp() );
+
+			final var other = session.find( NullDiscSubclassCheckOther.class, 3L );
+			assertNotNull( other );
+			assertEquals( "other", other.getName() );
+			assertEquals( "otherValue", other.getOtherProp() );
+		} );
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/mapping/inheritance/discriminator/null-disc-subclass-check.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/mapping/inheritance/discriminator/null-disc-subclass-check.orm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <package>org.hibernate.orm.test.mapping.inheritance.discriminator</package>
+    <attribute-accessor>property</attribute-accessor>
+    <default-cascade>none</default-cascade>
+    <default-lazy>false</default-lazy>
+    <entity class="NullDiscSubclassCheckBase" metadata-complete="true">
+        <table name="null_disc_check"/>
+        <inheritance strategy="SINGLE_TABLE"/>
+        <discriminator-value>-1</discriminator-value>
+        <discriminator-column name="disc_type" discriminator-type="STRING" force-selection="false"/>
+        <attributes>
+            <id name="id">
+                <column name="id" />
+            </id>
+            <basic name="name" />
+        </attributes>
+    </entity>
+    <entity class="NullDiscSubclassCheckChild" metadata-complete="true">
+        <extends>org.hibernate.orm.test.mapping.inheritance.discriminator.NullDiscSubclassCheckBase</extends>
+        <discriminator-value>null</discriminator-value>
+        <attributes>
+            <basic name="requiredProp" optional="false"/>
+        </attributes>
+    </entity>
+    <entity class="NullDiscSubclassCheckOther" metadata-complete="true">
+        <extends>org.hibernate.orm.test.mapping.inheritance.discriminator.NullDiscSubclassCheckChild</extends>
+        <discriminator-value>1</discriminator-value>
+        <attributes>
+            <basic name="otherProp" />
+        </attributes>
+    </entity>
+</entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20691

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20691 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->