### PR TITLE
HHH-20691 Subclass not-null check constraint is inverted for null discriminator value

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
@@ -55,7 +55,7 @@ public final class SingleTableSubclass extends Subclass {
 					final var check = new StringBuilder();
 					check.append( selectables.get( 0 ).getText( dialect ) );
 					if ( isDiscriminatorValueNull() ) {
-						check.append( " is " );
+						check.append( " is not " );
 					}
 					else if ( isDiscriminatorValueNotNull() ) {
 						check.append( " is " );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/NullDiscSubclassCheckBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/NullDiscSubclassCheckBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class NullDiscSubclassCheckBase {
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/NullDiscSubclassCheckChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/NullDiscSubclassCheckChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class NullDiscSubclassCheckChild extends NullDiscSubclassCheckBase {
+	private String requiredProp;
+
+	public String getRequiredProp() {
+		return requiredProp;
+	}
+
+	public void setRequiredProp(String requiredProp) {
+		this.requiredProp = requiredProp;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/NullDiscriminatorSubclassCheckConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/NullDiscriminatorSubclassCheckConstraintTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.MappingSettings;
+import org.hibernate.mapping.CheckConstraint;
+import org.hibernate.mapping.RootClass;
+import org.hibernate.mapping.Table;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the subclass not-null check constraint is correct
+ * when a subclass uses {@code discriminator-value="null"}.
+ * <p>
+ * The constraint should use "is not null" (meaning "if you're NOT this subclass,
+ * skip the check") rather than "is null" (which would fail for all other subclasses).
+ */
+@JiraKey("HHH-20691")
+public class NullDiscriminatorSubclassCheckConstraintTest {
+
+	@Test
+	public void testSubclassCheckConstraint() {
+		try (var serviceRegistry = new StandardServiceRegistryBuilder()
+				.applySetting( MappingSettings.TRANSFORM_HBM_XML, true )
+				.build()) {
+			final MetadataImplementor metadata = (MetadataImplementor) new MetadataSources( serviceRegistry )
+					.addResource( "xml/jaxb/mapping/null-disc-subclass-check/hbm.xml" )
+					.buildMetadata();
+
+			final var binding = metadata.getEntityBinding(
+					"org.hibernate.orm.test.boot.jaxb.mapping.NullDiscSubclassCheckBase"
+			);
+			assertThat( binding ).isInstanceOf( RootClass.class );
+
+			final Table table = binding.getTable();
+			for ( CheckConstraint check : table.getChecks() ) {
+				final String constraint = check.getConstraint();
+				assertThat( constraint )
+						.as( "Subclass check constraint should not use 'disc_type is null' " +
+								"which would fail for non-null discriminator rows. " +
+								"Actual: " + constraint )
+						.doesNotContain( "disc_type is null" );
+			}
+		}
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/null-disc-subclass-check/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/null-disc-subclass-check/hbm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping default-lazy="false"
+    package="org.hibernate.orm.test.boot.jaxb.mapping">
+
+    <class name="NullDiscSubclassCheckBase" discriminator-value="B" table="null_disc_check">
+        <id name="id" column="id">
+            <generator class="assigned"/>
+        </id>
+        <discriminator column="disc_type" type="string" not-null="false"/>
+        <property name="name"/>
+
+        <subclass name="NullDiscSubclassCheckChild" discriminator-value="null">
+            <property name="requiredProp" not-null="true"/>
+        </subclass>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/13065 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20691 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20691
<!-- Hibernate GitHub Bot issue links end -->