### PR TITLE
Fix strict JAXP test failures in hibernate-reveng tests

### DIFF
--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/hbm2x/GenerateFromJDBC/TestCase.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/hbm2x/GenerateFromJDBC/TestCase.java
@@ -109,6 +109,7 @@ public class TestCase {
 				Thread.currentThread().getContextClassLoader());
 		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
 		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 		DocumentBuilder  db = dbf.newDocumentBuilder();
 		Document document = db.parse(new File(outputDir, "hibernate.cfg.xml"));
 		XPath xpath = XPathFactory.newInstance().newXPath();
@@ -140,6 +141,7 @@ public class TestCase {
 				Thread.currentThread().getContextClassLoader());
 		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
 		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 		DocumentBuilder  db = dbf.newDocumentBuilder();
 		Document document = db.parse(new File(outputDir, "hibernate.cfg.xml"));
 		XPath xpath = XPathFactory.newInstance().newXPath();


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
