### PR TITLE
HHH-20658 Preserve index gaps for null elements of inverse indexed lists

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/queue/internal/decompose/collection/AbstractOneToManyDecomposer.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/queue/internal/decompose/collection/AbstractOneToManyDecomposer.java
@@ -154,7 +154,9 @@ public abstract class AbstractOneToManyDecomposer implements OneToManyDecomposer
 				);
 			}
 
-			if ( jdbcOperations.updateIndexPlan() != null ) {
+			if ( jdbcOperations.updateIndexPlan() != null
+					&& entry != null
+					&& collection.entryExists( entry, entryCount ) ) {
 				final var writeIndexFlushOp = new FlushOperation(
 						jdbcOperations.tableDescriptor(),
 						MutationKind.UPDATE_ORDER,

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/WriteIndexCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/WriteIndexCoordinatorStandard.java
@@ -107,8 +107,9 @@ public class WriteIndexCoordinatorStandard implements WriteIndexCoordinator {
 							jdbcValueBindings
 					);
 					mutationExecutor.execute( collection, null, null, null, session );
-					nextIndex++;
 				}
+				// a null element occupies its position, leaving a gap in the order column
+				nextIndex++;
 			}
 		}
 		finally {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/list/AbstractInverseListNullElementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/list/AbstractInverseListNullElementTest.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.collection.list;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A null element of an inverse indexed one-to-many collection leaves a gap in the order column, and the gap is
+ * padded back into a null element when the collection is loaded ({@code ListInitializer#readCollectionRow}).
+ * <p>
+ * Both {@code ActionQueue} implementations write the order column from the unowned side (see HHH-5732 and
+ * HHH-18830), so both are exercised here.
+ *
+ * @author Donghwan Kim
+ */
+@JiraKey("HHH-20658")
+public abstract class AbstractInverseListNullElementTest {
+
+	@Test
+	public void testNullElementLeavesIndexGap(SessionFactoryScope scope) {
+		final Long parentId = scope.fromTransaction( session -> {
+			final ListParent parent = new ListParent();
+			final ListChild first = new ListChild( parent );
+			final ListChild last = new ListChild( parent );
+
+			parent.children.add( first );
+			parent.children.add( null );
+			parent.children.add( last );
+
+			session.persist( parent );
+			session.persist( first );
+			session.persist( last );
+
+			return parent.id;
+		} );
+
+		scope.inTransaction( session -> {
+			final List<Integer> positions = session.createNativeQuery(
+					"select pos from ListChild where pos is not null order by pos",
+					Integer.class
+			).getResultList();
+			assertThat( positions ).containsExactly( 0, 2 );
+		} );
+
+		scope.inTransaction( session -> {
+			final ListParent parent = session.find( ListParent.class, parentId );
+			assertThat( parent.children ).hasSize( 3 );
+			assertThat( parent.children.get( 1 ) ).isNull();
+		} );
+	}
+
+	@Entity(name = "ListParent")
+	static class ListParent {
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+		@OrderColumn(name = "pos")
+		List<ListChild> children = new ArrayList<>();
+	}
+
+	@Entity(name = "ListChild")
+	static class ListChild {
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@ManyToOne
+		ListParent parent;
+
+		ListChild() {
+		}
+
+		ListChild(ListParent parent) {
+			this.parent = parent;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/list/InverseListNullElementLegacyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/list/InverseListNullElementLegacyTest.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.collection.list;
+
+import org.hibernate.cfg.FlushSettings;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.Setting;
+
+/**
+ * Tests the legacy {@code ActionQueue}, which writes the order column from
+ * {@code WriteIndexCoordinatorStandard}.
+ *
+ * @author Donghwan Kim
+ */
+@DomainModel(
+		annotatedClasses = {
+				AbstractInverseListNullElementTest.ListParent.class,
+				AbstractInverseListNullElementTest.ListChild.class
+		}
+)
+@SessionFactory
+@ServiceRegistry(
+		settings = @Setting(name = FlushSettings.FLUSH_QUEUE_TYPE, value = "legacy")
+)
+public class InverseListNullElementLegacyTest extends AbstractInverseListNullElementTest {
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/list/InverseListNullElementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/list/InverseListNullElementTest.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.collection.list;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+
+/**
+ * Tests the graph-based {@code ActionQueue}, which writes the order column from
+ * {@code AbstractOneToManyDecomposer}.
+ *
+ * @author Donghwan Kim
+ */
+@DomainModel(
+		annotatedClasses = {
+				AbstractInverseListNullElementTest.ListParent.class,
+				AbstractInverseListNullElementTest.ListChild.class
+		}
+)
+@SessionFactory
+public class InverseListNullElementTest extends AbstractInverseListNullElementTest {
+}

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -106,6 +106,21 @@ entity.getData().getBinaryStream(); // works — connection held by the transact
 session.getTransaction().commit();
 ----
 
+[[inverse-list-null-elements]]
+=== Null elements of inverse indexed lists
+
+A null element of an inverse `@OneToMany` list mapped with `@OrderColumn` again leaves a gap in the order
+column, so that the element is read back as null and the elements after it keep their list positions.
+
+Since 6.2 the order column was instead written compacted, and a list persisted as `[a, null, b]` was stored
+with the index values `0,1` rather than `0,2` and loaded back as `[a, b]`, silently shifting the elements
+after the null. Applications that came to rely on that compaction — for example by treating the reloaded list
+size as the number of non-null elements — will now see the null elements preserved across a round-trip, as
+they were through 5.x and 6.1.
+
+Element collections are unaffected: a null element of an `@ElementCollection` list has never been persisted,
+and such lists still load back without it.
+
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // XSD changes


### PR DESCRIPTION
A null element of an inverse `@OneToMany` list mapped with `@OrderColumn` has no row of its own, but it still occupies a list position, so the order column around it should leave a gap — `ListInitializer#readCollectionRow` pads that gap back into a null when the collection is loaded. Neither `ActionQueue` does that today, and they fail differently.

**Graph-based queue (default since 8.0)** — it throws rather than compacting:

```
org.hibernate.property.access.spi.PropertyAccessException: Error accessing field
[java.lang.Long ListChild.id] by reflection for persistent property [ListChild#id] : null
	at org.hibernate.action.queue.internal.decompose.collection.AbstractOneToManyDecomposer.applyWriteIndexRestrictions(AbstractOneToManyDecomposer.java:1059)
Caused by: java.lang.NullPointerException
```

`decomposeRecreate` plans a write-index operation for every entry, so `applyWriteIndexRestrictions` ends up reading the element identifier off a null entry. The queued-additions path a bit further down in the same class already guards with `entry != null && collection.entryExists( entry, ... )`, so I used the same guard there. `entryCount` is already incremented outside the check, so the gap falls out of it.

**Legacy queue** (`hibernate.flush.queue.type=legacy`) — no exception, but the index is written compacted, which is what HHH-20658 reports. `WriteIndexCoordinatorStandard#writeIndex` increments `nextIndex` inside the null check, so `[a, null, b]` is stored with indices 0,1 instead of 0,2 and reloads as `[a, b]`. `OneToManyPersister#writeIndex` incremented it for every entry through 6.1.7 and the increment moved inside the check in 6.2, so I moved it back out.

Tests cover both queue types (`InverseListNullElementTest`, `InverseListNullElementLegacyTest`), asserting the order column holds 0,2 and that the list round-trips as `[a, null, b]`. Both fail on main and pass with the fix; `:hibernate-core:test` is green on H2 (17330 tests).

`ListElementNullBasicTest` still passes — this doesn't change how owned `@ElementCollection` lists drop nulls.

I used Claude Code to help write this; I reviewed the change and verified it locally.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20658 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20658
<!-- Hibernate GitHub Bot issue links end -->