### PR TITLE
HbmXmlTransformer fixes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -2586,20 +2586,54 @@ public class HbmXmlTransformer {
 		}
 
 		final var element = (OneToMany) bootModelValue.getElement();
-		final String referencedEntityName = element.getReferencedEntityName();
-		final var attributeMap = transformationState.getMappableAttributesByColumns( referencedEntityName );
-		return resolveMappedBy( bootModelProperty, bootModelValue, attributeMap );
+		final var referencedEntityName = element.getReferencedEntityName();
+		return resolveMappedBy(
+				bootModelProperty,
+				bootModelValue,
+				transformationState.getMappableAttributesByColumns( referencedEntityName ),
+				referencedEntityName,
+				bootModelProperty.getPersistentClass().getEntityName() );
 	}
 
 	private String resolveMappedBy(
 			Property bootModelProperty,
 			Collection bootModelValue,
-			Map<List<Selectable>, String> attributeMap) {
+			Map<List<Selectable>, String> attributeMap,
+			String referencedEntityName,
+			String ownerEntityName) {
+		// first, try to find the owning many-to-one on the target entity by matching key columns
 		if ( attributeMap != null ) {
 			final KeyValue collectionKey = bootModelValue.getKey();
+			final var targetEntity = transformationState.getEntityInfoByName().get( referencedEntityName );
 			for ( var attributeEntry : attributeMap.entrySet() ) {
 				if ( matches( collectionKey, attributeEntry.getKey() ) ) {
+					// verify the candidate many-to-one actually points back to the owning entity;
+					// skip self-referential associations that happen to share the same column
+					if ( targetEntity != null ) {
+						final var candidateProp = targetEntity.getPersistentClass()
+								.getProperty( attributeEntry.getValue() );
+						if ( candidateProp.getValue() instanceof ToOne toOne
+								&& !ownerEntityName.equals( toOne.getReferencedEntityName() ) ) {
+							continue;
+						}
+					}
 					return attributeEntry.getValue();
+				}
+			}
+		}
+
+		// the FK may map to a composite-id key-property (basic, not many-to-one) on the
+		// target entity — these are not registered in the attributeMap, so search directly
+		final var targetEntity = transformationState.getEntityInfoByName().get( referencedEntityName );
+		if ( targetEntity != null ) {
+			final var targetClass = targetEntity.getPersistentClass();
+			if ( targetClass instanceof RootClass rootClass
+					&& rootClass.getIdentifier() instanceof Component compositeId ) {
+				final var collectionKey = bootModelValue.getKey();
+				for ( Property idProp : compositeId.getProperties() ) {
+					if ( matches( collectionKey, idProp.getValue().getSelectables() ) ) {
+						return idProp.getName();
+					}
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -3457,7 +3457,7 @@ public class HbmXmlTransformer {
 
 					@Override
 					public Boolean isUnique() {
-						return true;
+						return null;
 					}
 
 					@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1215,4 +1215,25 @@ public class HbmTransformationJaxbTests {
 					.isEqualTo( "personName" );
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20697" )
+	public void testNonAggregatedCompositeIdColumnsNotUnique(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/inverse-composite-key/hbm.xml", scope, transformed -> {
+			final JaxbEntityImpl employmentEntity = transformed.getEntities().stream()
+					.filter( e -> "Employment".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			for ( JaxbIdImpl id : employmentEntity.getAttributes().getIdAttributes() ) {
+				if ( id.getColumn() != null ) {
+					assertThat( id.getColumn().isUnique() )
+							.as( "Composite-id key-property '%s' should not have unique=true — " +
+									"uniqueness is guaranteed by the composite PK, not individual columns",
+									id.getName() )
+							.isNotEqualTo( true );
+				}
+			}
+		} );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1195,4 +1195,24 @@ public class HbmTransformationJaxbTests {
 					.doesNotContain( "c1Name" );
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20694" )
+	public void testInverseOneToManyWithCompositeKeyPropertyMappedBy(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/inverse-composite-key/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl employeeEntity = transformed.getEntities().stream()
+					.filter( e -> "Employee".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( employeeEntity.getAttributes().getOneToManyAttributes() ).hasSize( 1 );
+			final JaxbOneToManyImpl employments = employeeEntity.getAttributes().getOneToManyAttributes().get( 0 );
+			assertThat( employments.getName() ).isEqualTo( "employments" );
+			assertThat( employments.getMappedBy() )
+					.as( "Inverse one-to-many should resolve mapped-by to composite-id key-property 'personName'" )
+					.isEqualTo( "personName" );
+		} );
+	}
 }

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/inverse-composite-key/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/inverse-composite-key/hbm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.orm.test.lazyonetoone">
+
+    <class name="Employee">
+        <id name="personName"/>
+        <bag name="employments"
+                inverse="true"
+                fetch="join"
+                lazy="false"
+                cascade="persist,delete">
+            <key column="personName"/>
+            <one-to-many class="Employment"/>
+        </bag>
+    </class>
+
+    <class name="Employment">
+        <composite-id>
+            <key-property name="personName"/>
+            <key-property name="organizationName"/>
+        </composite-id>
+        <property name="startDate" update="false"/>
+        <property name="endDate"/>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
- [HHH-20694](https://hibernate.atlassian.net/browse/HHH-20694)  HbmXmlTransformer fails to resolve mapped-by for inverse one-to-many when FK maps to composite-id key-property

- [[HHH-20697](https://hibernate.atlassian.net/browse/HHH-20697)](https://hibernate.atlassian.net/browse/HHH-20697 ) HbmXmlTransformer generates spurious unique constraint on individual composite-id key-property column

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20697 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20694 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

[HHH-20694]: https://hibernate.atlassian.net/browse/HHH-20694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20697]: https://hibernate.atlassian.net/browse/HHH-20697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ