### PR TITLE
[8.0] HHH-20472 Add missing java.util.List import in generated CursoredPage code

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/cursoredpage/CursoredBookRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/cursoredpage/CursoredBookRepository.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.cursoredpage;
+
+import jakarta.data.page.CursoredPage;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Repository;
+import org.hibernate.processor.test.data.namedquery.Book;
+
+@Repository
+public interface CursoredBookRepository {
+	@Find
+	@OrderBy("title")
+	CursoredPage<Book> allBooks(PageRequest pageRequest);
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/cursoredpage/CursoredBookRepositoryTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/cursoredpage/CursoredBookRepositoryTest.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.cursoredpage;
+
+import org.hibernate.processor.test.data.namedquery.Author;
+import org.hibernate.processor.test.data.namedquery.Book;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@CompilationTest
+class CursoredBookRepositoryTest {
+	@Test
+	@WithClasses({ Book.class, Author.class, CursoredBookRepository.class })
+	void test() {
+		assertMetamodelClassGeneratedFor( CursoredBookRepository.class, true );
+		final String source = getMetaModelSourceAsString( CursoredBookRepository.class, true );
+		System.out.println( source );
+		assertTrue( source.contains( "import java.util.List" ) );
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractQueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractQueryMethod.java
@@ -618,6 +618,7 @@ public abstract class AbstractQueryMethod extends AbstractAnnotatedMethod {
 		annotationMetaEntity.staticImport(HIB_PAGE, "page");
 		annotationMetaEntity.staticImport("org.hibernate.query.KeyedPage.KeyInterpretation", "*");
 		annotationMetaEntity.staticImport(COLLECTORS, "toList");
+		annotationMetaEntity.importType(LIST);
 		if ( returnTypeName == null ) {
 			throw new AssertionFailure("entity class cannot be null");
 		}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/12961

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20472 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20472
<!-- Hibernate GitHub Bot issue links end -->