### PR TITLE
@Audited.CollectionTable without @JoinColumn

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/temporal/audit/collection/AuditUnidirectionalOneToManyCollectionTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/temporal/audit/collection/AuditUnidirectionalOneToManyCollectionTableTest.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.temporal.audit.collection;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.annotations.Audited;
+import org.hibernate.cfg.StateManagementSettings;
+import org.hibernate.mapping.Table;
+import org.hibernate.temporal.spi.ChangesetIdentifierSupplier;
+import org.hibernate.testing.orm.junit.AuditedTest;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * Tests unidirectional @OneToMany without @JoinColumn auditing.
+ */
+@AuditedTest
+@SessionFactory
+@DomainModel(annotatedClasses = {
+		AuditUnidirectionalOneToManyCollectionTableTest.Department.class,
+		AuditUnidirectionalOneToManyCollectionTableTest.Employee.class
+})
+@ServiceRegistry(settings = @Setting(name = StateManagementSettings.CHANGESET_ID_SUPPLIER,
+		value = "org.hibernate.temporal.audit.collection.AuditUnidirectionalOneToManyJoinColumnTest$TxIdSupplier"))
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AuditUnidirectionalOneToManyCollectionTableTest {
+	private static int currentTxId;
+
+	public static class TxIdSupplier implements ChangesetIdentifierSupplier<Integer> {
+		@Override
+		public Integer generateIdentifier(SharedSessionContract session) {
+			return ++currentTxId;
+		}
+	}
+
+
+	@Test
+	void testWriteSide(SessionFactoryScope scope, DomainModelScope domainModelScope) {
+		var tablesNames = domainModelScope.getDomainModel().collectTableMappings().stream().map( Table::getName ).collect( Collectors.toSet());
+		assertTrue( tablesNames.contains( "my_custom_employees_audited" ) );
+	}
+
+	// ---- Entity classes ----
+
+	@Audited
+	@Entity(name = "Department")
+	static class Department {
+		@Id
+		long id;
+		String name;
+		@OneToMany
+//		@JoinColumn(name = "department_id")
+		@Audited.CollectionTable( name = "my_custom_employees_audited" )
+		List<Employee> employees = new ArrayList<>();
+
+		Department() {
+		}
+
+		Department(long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+
+	@Audited
+	@Entity(name = "Employee")
+	static class Employee {
+		@Id
+		long id;
+		String name;
+
+		Employee() {
+		}
+
+		Employee(long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Hi guys,
while implementing `@AuditOverrides`, I discovered that @Audited.CollectionTable(name = "my_aud") is **ignored** when applied **without** a `@JoinColumn` annotation. 

When adding a `@JoinColumn(name = "department_id")`, the new name "my_aud" is suddenly applied correctly.

Is this a bug?

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
