### PR TITLE
HHH-20704 - [Oracle Test Pilot] Integrate 26ai Real Application Cluster database for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,7 @@ jobs:
           - rdbms: base-database-service-19c
           - rdbms: base-database-service-21c
           - rdbms: base-database-service-26ai
+          - rdbms: base-database-service-26ai-rac
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/ci/db-params.sh
+++ b/ci/db-params.sh
@@ -86,6 +86,9 @@ elif [ "$RDBMS" == "base-database-service-21c" ]; then
 elif [ "$RDBMS" == "base-database-service-26ai" ]; then
   echo "Managing OTP Database..."
   goal="-Pdb=oracle_test_pilot_database -PdbVersion=26 -DrunID=$RUNID -DdbPassword=$TESTPILOT_PASSWORD -DdbConnectionStringSuffix=$TESTPILOT_CONNECTION_STRING_SUFFIX"
+elif [ "$RDBMS" == "base-database-service-26ai-rac" ]; then
+  echo "Managing OTP Database..."
+  goal="-Pdb=oracle_test_pilot_database -PdbVersion=26 -DrunID=$RUNID -DdbPassword=$TESTPILOT_PASSWORD -DdbConnectionStringSuffix=$TESTPILOT_CONNECTION_STRING_SUFFIX"
 elif [ "$RDBMS" == "db2" ]; then
   goal="-Pdb=db2"
 elif [ "$RDBMS" == "db2_11_5" ]; then


### PR DESCRIPTION
This PR is the first step to make Hibernate ORM run tests with an Oracle Real Application Cluster (RAC) database 26ai.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20704 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20704
<!-- Hibernate GitHub Bot issue links end -->