### PR TITLE
Update Data companion interface to remove now non-existing findByIdGreaterThanEqual

### DIFF
--- a/hibernate-tck-data-runner/src/test/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers$.java
+++ b/hibernate-tck-data-runner/src/test/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers$.java
@@ -35,10 +35,6 @@ interface NaturalNumbers$ extends NaturalNumbers {
 	public java.util.stream.Stream<ee.jakarta.tck.data.framework.read.only.NaturalNumber> findByIdBetweenOrderByNumTypeOrdinalAsc(long minimum, long maximum, jakarta.data.Order<ee.jakarta.tck.data.framework.read.only.NaturalNumber> sorts);
 
 	@Override
-	@Query("where id >= ?1")
-	public java.util.List<ee.jakarta.tck.data.framework.read.only.NaturalNumber> findByIdGreaterThanEqual(long minimum, jakarta.data.Limit limit, jakarta.data.Order<ee.jakarta.tck.data.framework.read.only.NaturalNumber> sorts);
-
-	@Override
 	@Query("where id < ?1")
 	public ee.jakarta.tck.data.framework.read.only.NaturalNumber[] findByIdLessThan(long exclusiveMax, jakarta.data.Sort<ee.jakarta.tck.data.framework.read.only.NaturalNumber> primarySort, jakarta.data.Sort<ee.jakarta.tck.data.framework.read.only.NaturalNumber> secondarySort);
 


### PR DESCRIPTION
Since Data tests are now failing the builds 😖 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
