### PR TITLE
HHH-20707 Fix missing import for inner interface CDI accessors in metamodel

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -720,8 +720,9 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		// turn the name into lowercase
 		// FIXME: this is wrong for types like STEFQueries
 		final var propertyName = decapitalize( name );
+		final var qualifiedName = ((TypeElement) enclosedElement).getQualifiedName().toString();
 		members.put( propertyName,
-				new CDIAccessorMetaAttribute( this, propertyName, name ) );
+				new CDIAccessorMetaAttribute( this, propertyName, qualifiedName ) );
 		// keep it
 		return true;
 	}
@@ -864,7 +865,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		final var finalPrimaryEntity = primaryEntity;
 		if ( repositoryType != null ) {
 			addRepositoryAccessor( repositoryAccessor,
-					repositoryType.getSimpleName().toString() );
+					((TypeElement) repositoryType).getQualifiedName().toString() );
 		}
 		else if ( idType != null && finalPrimaryEntity != null ) {
 			final var repositoryTypeName =

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/CDIAccessorMetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/CDIAccessorMetaAttribute.java
@@ -44,7 +44,7 @@ public class CDIAccessorMetaAttribute implements MetaAttribute {
 		annotationMetaEntity.importType("jakarta.enterprise.inject.spi.CDI");
 		declaration
 		.append("\treturn CDI.current().select(")
-		.append(typeName)
+		.append(annotationMetaEntity.importType(typeName))
 		.append(".class).get();\n");
 	}
 
@@ -54,7 +54,7 @@ public class CDIAccessorMetaAttribute implements MetaAttribute {
 
 	void preamble(StringBuilder declaration) {
 		declaration
-		.append(typeName)
+		.append(annotationMetaEntity.importType(typeName))
 				.append(" ")
 				.append( getPropertyName() );
 		declaration


### PR DESCRIPTION
## Problem

`CDIAccessorMetaAttribute` emits unqualified type names for inner interface accessors in generated metamodel classes without registering them via `importType()`. This causes compilation failures when the metamodel class references an inner interface that is not in its scope.

### Reproducer

Given a Quarkus Data entity with an inner interface extending a non-Panache type:

```java
@Entity
public class Bird extends PanacheEntity {
    public String species;
    public int wingspan;

    public interface Qubit extends QubitQueries { }
}
```

The Hibernate Processor generates `Bird_` with an accessor:

```java
// Generated Bird_.java — FAILS TO COMPILE
public abstract class Bird_ extends AutoLong_ {
    public static Qubit qubit() {                    // ERROR: cannot find symbol 'Qubit'
        return CDI.current().select(Qubit.class).get();
    }
}
```

The `Qubit` type (which is `Bird.Qubit`) is used without an import statement, causing `javac` to fail with "cannot find symbol".

### Why it works for PanacheRepository inner interfaces

When an inner interface extends `PanacheRepository` and has `@Find`/`@HQL` methods, the Hibernate Processor generates an implementation class (`Qubit_`) with an `implements Qubit` clause. That `implements` clause triggers `importType()` as a **side effect**, adding the required import. Inner interfaces without `@Find`/`@HQL` methods (and without Panache repository base types) never trigger this side effect.

### Root Cause

Two issues:

1. **`CDIAccessorMetaAttribute.preamble()` and `returnCDI()`** use `typeName` directly without calling `annotationMetaEntity.importType(typeName)`. The CDI import is correctly registered, but the inner interface type is not.

2. **`AnnotationMetaEntity.addRepositoryAccessor()`** passes `enclosedElement.getSimpleName()` (e.g., `"Qubit"`) to the constructor instead of the qualified name (e.g., `"com.example.Bird.Qubit"`). Without the qualified name, `importType()` cannot generate the correct import.

## Fix

**`CDIAccessorMetaAttribute.java`** — call `importType()` when emitting the type name in both `preamble()` (return type) and `returnCDI()` (`.select()` argument).

**`AnnotationMetaEntity.java`** — pass `TypeElement.getQualifiedName()` instead of `getSimpleName()` in `addRepositoryAccessor()` and `addAccessors()`.

For generated inner types (e.g., `PanacheManagedBlockingRepository_`) that have no package qualifier, `importType()` returns them unchanged — no behavioral change for existing code paths.

## Impact

- Fixes compilation of metamodel classes for entities with inner interfaces extending non-Panache types
- No change to existing behavior for Panache repository inner interfaces (import was already being generated as a side effect)
- No change for generated inner types without dots in their names
- Enables Quarkus extensions to define custom inner interface types (e.g., `QubitQueries`) that integrate with the metamodel accessor pattern

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20707 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20707
<!-- Hibernate GitHub Bot issue links end -->