### PR TITLE
HHH-20695 Fix array_contains against PostgreSQL text[] columns

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayContainsOperatorFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayContainsOperatorFunction.java
@@ -17,8 +17,9 @@ import org.hibernate.type.BasicPluralType;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
- * Special array contains function that also applies a cast to the element argument. PostgreSQL needs this,
- * because by default it assumes a {@code text[]}, which is not compatible with {@code varchar[]}.
+ * Special array contains implementation that uses the PostgreSQL {@code = any()} operator
+ * for scalar needles. Using {@code = any()} instead of {@code @> cast(array[?] as ...)}
+ * avoids incompatibilities between {@code text[]} and {@code varchar[]}.
  */
 public class ArrayContainsOperatorFunction extends ArrayContainsUnnestFunction {
 
@@ -56,29 +57,11 @@ public class ArrayContainsOperatorFunction extends ArrayContainsUnnestFunction {
 				sqlAppender.append( ") is not null" );
 			}
 			else {
+				needleExpression.accept( walker );
+				sqlAppender.append( "=any(" );
 				haystackExpression.accept( walker );
-				sqlAppender.append( "@>" );
-				if ( needsArrayCasting( needleExpression ) ) {
-					sqlAppender.append( "cast(array[" );
-					needleExpression.accept( walker );
-					sqlAppender.append( "] as " );
-					sqlAppender.append( DdlTypeHelper.getCastTypeName(
-							haystackExpression.getExpressionType(),
-							walker.getSessionFactory().getTypeConfiguration()
-					) );
-					sqlAppender.append( ')' );
-				}
-				else {
-					sqlAppender.append( "array[" );
-					needleExpression.accept( walker );
-					sqlAppender.append( ']' );
-				}
+				sqlAppender.append( ')' );
 			}
 		}
-	}
-
-	private static boolean needsArrayCasting(Expression elementExpression) {
-		// PostgreSQL doesn't do implicit conversion between text[] and varchar[], so we need casting
-		return elementExpression.getExpressionType().getSingleJdbcMapping().getJdbcType().isString();
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayContainsTextArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayContainsTextArrayTest.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.function.array;
+
+import java.util.List;
+
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.testing.jdbc.SharedDriverManagerTypeCacheClearingIntegrator;
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DomainModel(annotatedClasses = ArrayContainsTextArrayTest.Item.class)
+@SessionFactory
+@RequiresDialect(PostgreSQLDialect.class)
+@BootstrapServiceRegistry(integrators = SharedDriverManagerTypeCacheClearingIntegrator.class)
+@JiraKey("HHH-20695")
+public class ArrayContainsTextArrayTest {
+
+	@BeforeEach
+	public void prepareData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new Item( 1L, new String[]{ "alpha", "beta" } ) );
+			session.persist( new Item( 2L, new String[]{ "gamma" } ) );
+		} );
+	}
+
+	@AfterEach
+	public void cleanup(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testArrayContains(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			List<Item> results = session.createQuery(
+					"from Item i where array_contains(i.tags, :tag)",
+					Item.class
+			).setParameter( "tag", "alpha" ).getResultList();
+			assertEquals( 1, results.size() );
+			assertEquals( 1L, results.get( 0 ).getId() );
+
+			results = session.createQuery(
+					"from Item i where array_contains(i.tags, :tag)",
+					Item.class
+			).setParameter( "tag", "missing" ).getResultList();
+			assertEquals( 0, results.size() );
+		} );
+	}
+
+	@Test
+	public void testContainsSyntax(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			List<Item> results = session.createQuery(
+					"from Item i where i.tags contains 'beta'",
+					Item.class
+			).getResultList();
+			assertEquals( 1, results.size() );
+			assertEquals( 1L, results.get( 0 ).getId() );
+		} );
+	}
+
+	@Entity(name = "Item")
+	@Table(name = "hh20695_item")
+	public static class Item {
+		@Id
+		private Long id;
+
+		@Column(name = "tags", columnDefinition = "text[]")
+		private String[] tags;
+
+		public Item() {
+		}
+
+		public Item(Long id, String[] tags) {
+			this.id = id;
+			this.tags = tags;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String[] getTags() {
+			return tags;
+		}
+	}
+}


### PR DESCRIPTION
Fixes `array_contains` failing on PostgreSQL when the physical column type is `text[]`.

Previously the function was rendered as:

```sql
tags @> cast(array[?] as varchar array)
```

PostgreSQL does not coerce between `text[]` and `varchar[]`, so this fails with:

```
operator does not exist: text[] @> character varying[]
```

Scalar needles are now rendered as `? = any(tags)`, which works for both `text[]` and `varchar[]`.

Adds a PostgreSQL-only test with `columnDefinition = "text[]"`.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
- [x] Jira issue referenced ([HHH-20695](https://hibernate.atlassian.net/browse/HHH-20695))
- [x] Tests added (`ArrayContainsTextArrayTest`)

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20695 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

[HHH-20695]: https://hibernate.atlassian.net/browse/HHH-20695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ