### PR TITLE
HHH-20675 Fix JOIN FETCH of JOINED inheritance with applyToLoadByKey filters

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -1313,8 +1313,8 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			JoinedSubclassEntityPersister persister,
 			Set<String> tablesToInnerJoin,
 			Set<TableReference> retainedTableReferences) {
+		final var subclassTableNames = persister.getSubclassTableNames();
 		if ( useKind == EntityNameUse.UseKind.TREAT || useKind == EntityNameUse.UseKind.FILTER ) {
-			final var subclassTableNames = persister.getSubclassTableNames();
 			// Build the intersection of all tables names that are of the class or super class
 			// These are the tables that can be safely inner joined
 			final Set<String> classOrSuperclassTables = new HashSet<>( subclassTableNames.length );
@@ -1343,6 +1343,21 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 									"Couldn't find table reference"
 							);
 						}
+						retainedTableReferences.add( mainTableReference );
+					}
+				}
+			}
+		}
+		else if ( useKind == EntityNameUse.UseKind.EXPRESSION
+				&& explicitDiscriminatorColumnName == null ) {
+			// Without a physical discriminator, keep subclass table joins that were already
+			// created for a join fetch / projection. Otherwise pruneForSubclasses may drop
+			// them while their columns remain in the select list (HHH-20675).
+			for ( int i = 0; i < subclassTableNames.length; i++ ) {
+				if ( !persister.isClassOrSuperclassTable[i] ) {
+					final var mainTableReference =
+							tableGroup.getTableReference( null, subclassTableNames[i], false );
+					if ( mainTableReference != null ) {
 						retainedTableReferences.add( mainTableReference );
 					}
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/ApplyToLoadByKeyJoinedInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/ApplyToLoadByKeyJoinedInheritanceTest.java
@@ -1,0 +1,149 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.filter;
+
+import java.util.List;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Table;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DomainModel(annotatedClasses = {
+		ApplyToLoadByKeyJoinedInheritanceTest.Wallet.class,
+		ApplyToLoadByKeyJoinedInheritanceTest.Payment.class,
+		ApplyToLoadByKeyJoinedInheritanceTest.CardPayment.class,
+		ApplyToLoadByKeyJoinedInheritanceTest.WirePayment.class
+})
+@SessionFactory
+@JiraKey("HHH-20675")
+public class ApplyToLoadByKeyJoinedInheritanceTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			CardPayment payment = new CardPayment();
+			payment.tenantId = 1L;
+			payment.cardNumber = "4111-1111-1111-1111";
+			session.persist( payment );
+
+			Wallet wallet = new Wallet();
+			wallet.tenantId = 1L;
+			wallet.payment = payment;
+			session.persist( wallet );
+		} );
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Test
+	public void testJoinFetchJoinedInheritanceWithLoadByKeyFilter(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.enableFilter( "tenantFilter" ).setParameter( "tenantId", 1L );
+
+			List<Wallet> wallets = session.createQuery(
+					"select w from Wallet w left join fetch w.payment",
+					Wallet.class
+			).getResultList();
+
+			assertEquals( 1, wallets.size() );
+			assertNotNull( wallets.get( 0 ).payment );
+			assertInstanceOf( CardPayment.class, wallets.get( 0 ).payment );
+			assertEquals( "4111-1111-1111-1111", ( (CardPayment) wallets.get( 0 ).payment ).cardNumber );
+		} );
+	}
+
+	@Test
+	public void testFindByIdWithLoadByKeyFilter(SessionFactoryScope scope) {
+		Long paymentId = scope.fromTransaction( session ->
+				session.createQuery( "select w.payment.id from Wallet w", Long.class ).getSingleResult()
+		);
+
+		scope.inTransaction( session -> {
+			session.enableFilter( "tenantFilter" ).setParameter( "tenantId", 1L );
+			Payment payment = session.find( Payment.class, paymentId );
+			assertNotNull( payment );
+			assertInstanceOf( CardPayment.class, payment );
+			assertEquals( "4111-1111-1111-1111", ( (CardPayment) payment ).cardNumber );
+		} );
+	}
+
+	@MappedSuperclass
+	@FilterDef(
+			name = "tenantFilter",
+			applyToLoadByKey = true,
+			defaultCondition = "tenant_id = :tenantId",
+			parameters = @ParamDef(name = "tenantId", type = Long.class)
+	)
+	public abstract static class TenantAware {
+		@Column(name = "tenant_id")
+		Long tenantId;
+	}
+
+	@Entity(name = "Payment")
+	@Table(name = "hh20675_payment")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	@Filter(name = "tenantFilter")
+	public abstract static class Payment extends TenantAware {
+		@Id
+		@GeneratedValue
+		Long id;
+	}
+
+	@Entity(name = "CardPayment")
+	@Table(name = "hh20675_card_payment")
+	@Filter(name = "tenantFilter")
+	public static class CardPayment extends Payment {
+		@Column(name = "card_number")
+		String cardNumber;
+	}
+
+	@Entity(name = "WirePayment")
+	@Table(name = "hh20675_wire_payment")
+	@Filter(name = "tenantFilter")
+	public static class WirePayment extends Payment {
+		@Column(name = "iban")
+		String iban;
+	}
+
+	@Entity(name = "Wallet")
+	@Table(name = "hh20675_wallet")
+	@Filter(name = "tenantFilter")
+	public static class Wallet extends TenantAware {
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "payment_id")
+		Payment payment;
+	}
+}


### PR DESCRIPTION
Fixes invalid SQL when a `@FilterDef(applyToLoadByKey = true)` is enabled and a query does `JOIN FETCH` of a `@ManyToOne` whose target uses `@Inheritance(JOINED)`.

### Problem

Subclass table joins (`card_payment`, `wire_payment`, …) were pruned from the FROM clause while their columns remained in the SELECT list, e.g.:

```sql
select ..., p1_1.card_number, p1_2.iban, case end, ...
from wallet w
left join payment p on p.id = w.payment_id and p.tenant_id = ?
-- missing left join card_payment / wire_payment
```

`find()` / by-id loads were unaffected.

### Cause

`pruneForSubclasses` kept only tables required by the registered entity-name uses. With `applyToLoadByKey`, one of the association table groups ended up with only an `EXPRESSION` use for the root type. Existing subclass joins were then removed even though the select list still needed them for the CASE discriminator and subclass attributes.

### Fix

For `EXPRESSION` uses on JOINED inheritance without a physical discriminator column, retain subclass table joins that were already created (same idea as the existing FILTER path, but only for joins that already exist).

### Test

`ApplyToLoadByKeyJoinedInheritanceTest` reproduces the JOIN FETCH failure and confirms `find()` still works.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
- [x] Jira issue referenced ([HHH-20675](https://hibernate.atlassian.net/browse/HHH-20675))
- [x] Tests added (`ApplyToLoadByKeyJoinedInheritanceTest`)

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20675 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

[HHH-20675]: https://hibernate.atlassian.net/browse/HHH-20675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ