### PR TITLE
HHH-20707 Fix missing import for inner interface CDI accessors in metamodel (8.0 backport)

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -714,8 +714,9 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		// turn the name into lowercase
 		// FIXME: this is wrong for types like STEFQueries
 		final var propertyName = decapitalize( name );
+		final var qualifiedName = ((TypeElement) enclosedElement).getQualifiedName().toString();
 		members.put( propertyName,
-				new CDIAccessorMetaAttribute( this, propertyName, name ) );
+				new CDIAccessorMetaAttribute( this, propertyName, qualifiedName ) );
 		// keep it
 		return true;
 	}
@@ -858,7 +859,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		final var finalPrimaryEntity = primaryEntity;
 		if ( repositoryType != null ) {
 			addRepositoryAccessor( repositoryAccessor,
-					repositoryType.getSimpleName().toString() );
+					((TypeElement) repositoryType).getQualifiedName().toString() );
 		}
 		else if ( idType != null && finalPrimaryEntity != null ) {
 			final var repositoryTypeName =

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/CDIAccessorMetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/CDIAccessorMetaAttribute.java
@@ -44,7 +44,7 @@ public class CDIAccessorMetaAttribute implements MetaAttribute {
 		annotationMetaEntity.importType("jakarta.enterprise.inject.spi.CDI");
 		declaration
 		.append("\treturn CDI.current().select(")
-		.append(typeName)
+		.append(annotationMetaEntity.importType(typeName))
 		.append(".class).get();\n");
 	}
 
@@ -54,7 +54,7 @@ public class CDIAccessorMetaAttribute implements MetaAttribute {
 
 	void preamble(StringBuilder declaration) {
 		declaration
-		.append(typeName)
+		.append(annotationMetaEntity.importType(typeName))
 				.append(" ")
 				.append( getPropertyName() );
 		declaration


### PR DESCRIPTION
## Problem

Backport of #13090 to the 8.0 branch.

`CDIAccessorMetaAttribute` emits unqualified type names for inner interface accessors in generated metamodel classes without registering them via `importType()`. This causes compilation failures when the metamodel class references an inner interface that is not in its scope.

### Root Cause

1. **`CDIAccessorMetaAttribute.preamble()` and `returnCDI()`** use `typeName` directly without calling `annotationMetaEntity.importType(typeName)`.

2. **`AnnotationMetaEntity.addRepositoryAccessor()` (both overloads) and `addAccessors()`** pass simple names instead of qualified names.

## Fix

**`CDIAccessorMetaAttribute.java`** — call `importType()` when emitting the type name in both `preamble()` (return type) and `returnCDI()` (`.select()` argument).

**`AnnotationMetaEntity.java`** — pass `TypeElement.getQualifiedName()` instead of `getSimpleName()` in both `addRepositoryAccessor()` overloads and `addAccessors()`.

### Differences from main branch fix

The 8.0 branch (like 7.4) has two overloads of `addRepositoryAccessor()`. The main branch consolidated these. This backport fixes all three call sites.

## Impact

- Fixes compilation of metamodel classes for entities with inner interfaces extending non-Panache types
- No change to existing behavior for Panache repository inner interfaces
- No change for generated inner types without dots in their names

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20707 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20707
<!-- Hibernate GitHub Bot issue links end -->