### PR TITLE
HHH-14256 Fix broken toLocalDate()/toLocalDateTime() conversions for BCE dates

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaType.java
@@ -24,6 +24,8 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.spi.TypeConfiguration;
 
+import static org.hibernate.type.descriptor.java.SqlDateTimeHelper.toLocalDateTime;
+
 /**
  * Java type descriptor for the Java {@link Instant} type.
  *
@@ -175,7 +177,7 @@ public class InstantJavaType extends AbstractTemporalJavaType<Instant>
 			 * - around 1905, both methods are equally valid, so we don't really care which one is used.
 			 */
 			if ( timestamp.getYear() < 5 ) { // Timestamp year 0 is 1900
-				return timestamp.toLocalDateTime().atZone( ZoneId.systemDefault() ).toInstant();
+				return toLocalDateTime( timestamp ).atZone( ZoneId.systemDefault() ).toInstant();
 			}
 			else {
 				return timestamp.toInstant();

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcDateJavaType.java
@@ -25,6 +25,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 import jakarta.persistence.TemporalType;
 
 import static org.hibernate.internal.util.CharSequenceHelper.subSequence;
+import static org.hibernate.type.descriptor.java.SqlDateTimeHelper.toLocalDate;
 
 /**
  * Descriptor for {@link java.sql.Date} handling.
@@ -167,8 +168,8 @@ public class JdbcDateJavaType extends AbstractTemporalJavaType<Date> {
 
 	private LocalDate unwrapLocalDate(java.util.Date value) {
 		return value instanceof java.sql.Date date
-				? date.toLocalDate()
-				: new java.sql.Date( toDateEpoch( value ) ).toLocalDate();
+				? toLocalDate( date )
+				: toLocalDate( new java.sql.Date( toDateEpoch( value ) ) );
 	}
 
 	@Override
@@ -227,7 +228,7 @@ public class JdbcDateJavaType extends AbstractTemporalJavaType<Date> {
 
 	private static TemporalAccessor fromDate(java.util.Date value) {
 		return value instanceof java.sql.Date date
-				? date.toLocalDate()
+				? toLocalDate( date )
 				: LocalDate.ofInstant( value.toInstant(), ZoneOffset.systemDefault() );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaType.java
@@ -23,6 +23,9 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.spi.TypeConfiguration;
 
+import static org.hibernate.type.descriptor.java.SqlDateTimeHelper.toLocalDate;
+import static org.hibernate.type.descriptor.java.SqlDateTimeHelper.toLocalDateTime;
+
 /**
  * Java type descriptor for the {@link LocalDate} type.
  *
@@ -140,7 +143,7 @@ public class LocalDateJavaType extends AbstractTemporalJavaType<LocalDate> {
 			// but on top of being more complex than the line below, it won't always work.
 			// ts.toInstant() assumes the number of milliseconds since the epoch means the
 			// same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
-			return timestamp.toLocalDateTime().toLocalDate();
+			return toLocalDateTime( timestamp ).toLocalDate();
 		}
 
 		if (value instanceof Long longValue) {
@@ -154,7 +157,7 @@ public class LocalDateJavaType extends AbstractTemporalJavaType<LocalDate> {
 
 		if (value instanceof Date date) {
 			return value instanceof java.sql.Date sqlDate
-					? sqlDate.toLocalDate()
+					? toLocalDate( sqlDate )
 					: Instant.ofEpochMilli( date.getTime() ).atZone( ZoneId.systemDefault() ).toLocalDate();
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
@@ -24,6 +24,8 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.spi.TypeConfiguration;
 
+import static org.hibernate.type.descriptor.java.SqlDateTimeHelper.toLocalDateTime;
+
 /**
  * Java type descriptor for the {@link LocalDateTime} type.
  *
@@ -144,7 +146,7 @@ public class LocalDateTimeJavaType extends AbstractTemporalJavaType<LocalDateTim
 			// but on top of being more complex than the line below, it won't always work.
 			// ts.toInstant() assumes the number of milliseconds since the epoch means the
 			// same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
-			return timestamp.toLocalDateTime();
+			return toLocalDateTime( timestamp );
 		}
 
 		if (value instanceof Long longValue) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
@@ -28,6 +28,8 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.spi.TypeConfiguration;
 
+import static org.hibernate.type.descriptor.java.SqlDateTimeHelper.toLocalDateTime;
+
 import jakarta.persistence.TemporalType;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
@@ -215,7 +217,7 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 			// - around 1905, both methods are equally valid, so we don't really care which
 			//   one is used.
 			return timestamp.getYear() < 5 // Timestamp year 0 is 1900
-					? timestamp.toLocalDateTime().atZone( ZoneId.systemDefault() ).toOffsetDateTime()
+					? toLocalDateTime( timestamp ).atZone( ZoneId.systemDefault() ).toOffsetDateTime()
 					: OffsetDateTime.ofInstant( timestamp.toInstant(), ZoneId.systemDefault() );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/SqlDateTimeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/SqlDateTimeHelper.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import org.hibernate.Internal;
+
+/**
+ * A helper for correctly converting {@link java.sql.Date} to {@link LocalDate}
+ * and {@link java.sql.Timestamp} to {@link LocalDateTime}.
+ * <p>
+ * This works around the JDK bug <a href="https://bugs.openjdk.org/browse/JDK-8272194">JDK-8272194</a>
+ * using the same <a href="https://github.com/openjdk/jdk/commit/2be8e88ce71704825c50246ba028153a5c0376db">fix that was used in the JDK</a>.
+ * </p>
+ */
+@Internal
+public final class SqlDateTimeHelper {
+
+	/**
+	 * The epoch millisecond value of 0002-01-01T00:00:00.000 at UTC in
+	 * the Julian-Gregorian hybrid calendar system.
+	 * We cannot use 1st January 1AD as different timezones could possibly
+	 * offset the date back into BC, thus resulting in the incorrect BC year.
+	 * While a one year margin is considerably larger than any possible
+	 * timezone offset, it gives us a comfortable distance while still
+	 * providing a faster code path for almost 1970 years.
+	 */
+	private static final long TWO_AD_AT_UTC_EPOCH_MILLIS = -62104233600000L;
+
+	/**
+	 * Should be used instead of {@link java.sql.Date#toLocalDate()} as that does NOT work for BC dates.
+	 * @param date The date to convert into a {@link LocalDate}.
+	 * @return The given date in the {@link LocalDate} form.
+	 */
+	@SuppressWarnings("deprecation")
+	static LocalDate toLocalDate(final java.sql.Date date) {
+		return LocalDate.of(
+			toGregorianProlepticYear(date.getYear() + 1900, date.getTime()),
+			date.getMonth() + 1,
+			date.getDate());
+	}
+
+	/**
+	 * Should be used instead of {@link java.sql.Timestamp#toLocalDateTime()} as that does NOT work for BC dates.
+	 * @param timestamp The timestamp to convert into a {@link LocalDateTime}.
+	 * @return The given timestamp in the {@link LocalDateTime} form.
+	 */
+	@SuppressWarnings("deprecation")
+	static LocalDateTime toLocalDateTime(final java.sql.Timestamp timestamp) {
+		return LocalDateTime.of(
+			toGregorianProlepticYear(timestamp.getYear() + 1900, timestamp.getTime()),
+			timestamp.getMonth() + 1,
+			timestamp.getDate(),
+			timestamp.getHours(),
+			timestamp.getMinutes(),
+			timestamp.getSeconds(),
+			timestamp.getNanos());
+	}
+
+	/**
+	 * Converts an era-relative calendar year into the correct proleptic year.
+	 * <p>
+	 * The milliseconds is required to determine if the given year is a BC or AD year.
+	 *
+	 * @param year the era-relative calendar year.
+	 * @param millis the epoch millisecond represented by the date with the given year
+	 * used to determine the calendar era.
+	 * @return the proleptic year corresponding to {@code year} and {@code millis}
+	 */
+	static int toGregorianProlepticYear(int year, long millis) {
+		// We need to determine the era of the year using the given millis.
+		// However, deriving a new calendar is a relatively expensive operation
+		// that we would ideally avoid if possible.
+		// Given that we can comfortably state that any dates on or after
+		// 0002-01-01 are AD, we only need to test dates earlier than this cutoff.
+		if (millis < TWO_AD_AT_UTC_EPOCH_MILLIS) {
+			final GregorianCalendar calendar = new GregorianCalendar();
+			calendar.setTimeInMillis(millis);
+			if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
+				// Adjust the BC date into a negative astronomical date.
+				// As there is no year 0 in the Gregorian calendar
+				// we also have to adjust the BC year by 1.
+				// 1 BC becomes year 0, 2 BC becomes year -1 and so on.
+				year = 1 - year;
+			}
+		}
+		return year;
+	}
+
+	private SqlDateTimeHelper() { }
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
@@ -26,6 +26,7 @@ import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.spi.TypeConfiguration;
 
 import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
+import static org.hibernate.type.descriptor.java.SqlDateTimeHelper.toLocalDateTime;
 
 /**
  * Java type descriptor for the {@link ZonedDateTime} type.
@@ -179,7 +180,7 @@ public class ZonedDateTimeJavaType extends AbstractTemporalJavaType<ZonedDateTim
 			// - around 1905, both methods are equally valid, so we don't really care which
 			//   one is used.
 			return timestamp.getYear() < 5 // Timestamp year 0 is 1900
-					? timestamp.toLocalDateTime().atZone( ZoneId.systemDefault() )
+					? toLocalDateTime( timestamp ).atZone( ZoneId.systemDefault() )
 					: timestamp.toInstant().atZone( ZoneId.systemDefault() );
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/InstantTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/InstantTests.java
@@ -104,6 +104,19 @@ public class InstantTests extends AbstractJavaTimeTypeTests<Instant, InstantTest
 				.add( 1904, 12, 31, 23, 0, 0, 0, Timezones.ZONE_PARIS )
 				.add( 1905, 1, 1, 0, 0, 0, 0, Timezones.ZONE_PARIS )
 				.add( 1905, 1, 1, 1, 0, 0, 0, Timezones.ZONE_PARIS )
+				// HHH-14256 / JDK-8249280: Confirm workaround for broken LocalDate/LocalDateTime conversion for BCE dates
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 0, 3, 15, 22, 3, 47, 999_999_999, Timezones.ZONE_GMT )
+						.add( -1, 11, 3, 8, 45, 12, 500_000_000, Timezones.ZONE_GMT )
+						.add( -100, 6, 20, 14, 27, 53, 123_456_789, Timezones.ZONE_GMT )
+				)
+				// Ensure behaviour for 2 AD fast path cutoff in SqlDateTimeHelper
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 1, 12, 1, 0, 0, 0, 0, Timezones.ZONE_GMT )
+						.add( 1, 12, 31, 23, 58, 30, 250_000_000, Timezones.ZONE_GMT )
+						.add( 2, 1, 1, 0, 1, 15, 750_000_000, Timezones.ZONE_GMT )
+						.add( 1, 1, 31, 0, 0, 0, 0, Timezones.ZONE_GMT )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/LocalDateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/LocalDateTest.java
@@ -109,6 +109,19 @@ public class LocalDateTest extends AbstractJavaTimeTypeTests<LocalDate, LocalDat
 				.add( 2018, 3, 25, ZONE_PARIS )
 				.add( 2018, 9, 30, ZONE_AUCKLAND )
 				.add( 2018, 8, 12, ZONE_SANTIAGO ) // DST start: 00:00 => 01:00
+				// HHH-14256 / JDK-8249280: Confirm workaround for broken LocalDate/LocalDateTime conversion for BCE dates
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 0, 3, 15, ZONE_GMT )
+						.add( -1, 11, 3, ZONE_GMT )
+						.add( -100, 6, 20, ZONE_GMT )
+				)
+				// Ensure behaviour for 2 AD fast path cutoff in SqlDateTimeHelper
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 1, 12, 1, ZONE_GMT )
+						.add( 1, 12, 31, ZONE_GMT )
+						.add( 2, 1, 1, ZONE_GMT )
+						.add( 1, 1, 31, ZONE_GMT )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/LocalDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/LocalDateTimeTest.java
@@ -107,6 +107,19 @@ public class LocalDateTimeTest
 				// This does not work, but it's unrelated to HHH-13379; see HHH-13515
 				//.add( 2018, 9, 30, 2, 0, 0, 0, ZONE_AUCKLAND )
 				.add( 2018, 9, 30, 3, 0, 0, 0, ZONE_AUCKLAND )
+				// HHH-14256 / JDK-8249280: Confirm workaround for broken LocalDate/LocalDateTime conversion for BCE dates
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 0, 3, 15, 22, 3, 47, 999_999_999, ZONE_GMT )
+						.add( -1, 11, 3, 8, 45, 12, 500_000_000, ZONE_GMT )
+						.add( -100, 6, 20, 14, 27, 53, 123_456_789, ZONE_GMT )
+				)
+				// Ensure behaviour for 2 AD fast path cutoff in SqlDateTimeHelper
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 1, 12, 1, 0, 0, 0, 0, ZONE_GMT )
+						.add( 1, 12, 31, 23, 58, 30, 250_000_000, ZONE_GMT )
+						.add( 2, 1, 1, 0, 1, 15, 750_000_000, ZONE_GMT )
+						.add( 1, 1, 31, 0, 0, 0, 0, ZONE_GMT )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/OffsetDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/OffsetDateTimeTest.java
@@ -139,6 +139,19 @@ public class OffsetDateTimeTest extends AbstractJavaTimeTypeTests<OffsetDateTime
 				.add( 1905, 1, 1, 0, 0, 0, 0, "-01:00", ZONE_PARIS )
 				.add( 1905, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_PARIS )
 				.add( 1905, 1, 1, 0, 0, 0, 0, "+01:00", ZONE_PARIS )
+				// HHH-14256 / JDK-8249280: Confirm workaround for broken LocalDate/LocalDateTime conversion for BCE dates
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 0, 3, 15, 22, 3, 47, 999_999_999, "+00:00", ZONE_GMT )
+						.add( -1, 11, 3, 8, 45, 12, 500_000_000, "+00:00", ZONE_GMT )
+						.add( -100, 6, 20, 14, 27, 53, 123_456_789, "+00:00", ZONE_GMT )
+				)
+				// Ensure behaviour for 2 AD fast path cutoff in SqlDateTimeHelper
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 1, 12, 1, 0, 0, 0, 0, "+00:00", ZONE_GMT )
+						.add( 1, 12, 31, 23, 58, 30, 250_000_000, "+00:00", ZONE_GMT )
+						.add( 2, 1, 1, 0, 1, 15, 750_000_000, "+00:00", ZONE_GMT )
+						.add( 1, 1, 31, 0, 0, 0, 0, "+00:00", ZONE_GMT )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/ZonedDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/ZonedDateTimeTest.java
@@ -152,6 +152,19 @@ public class ZonedDateTimeTest
 				.add( 1905, 1, 1, 0, 0, 0, 0, "-01:00", ZONE_PARIS )
 				.add( 1905, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_PARIS )
 				.add( 1905, 1, 1, 0, 0, 0, 0, "+01:00", ZONE_PARIS )
+				// HHH-14256 / JDK-8249280: Confirm workaround for broken LocalDate/LocalDateTime conversion for BCE dates
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 0, 3, 15, 22, 3, 47, 999_999_999, "GMT+00:00", ZONE_GMT )
+						.add( -1, 11, 3, 8, 45, 12, 500_000_000, "GMT+00:00", ZONE_GMT )
+						.add( -100, 6, 20, 14, 27, 53, 123_456_789, "GMT+00:00", ZONE_GMT )
+				)
+				// Ensure behaviour for 2 AD fast path cutoff in SqlDateTimeHelper
+				.withForcedJdbcTimezone( "UTC", b -> b
+						.add( 1, 12, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_GMT )
+						.add( 1, 12, 31, 23, 58, 30, 250_000_000, "GMT+00:00", ZONE_GMT )
+						.add( 2, 1, 1, 0, 1, 15, 750_000_000, "GMT+00:00", ZONE_GMT )
+						.add( 1, 1, 31, 0, 0, 0, 0, "GMT+00:00", ZONE_GMT )
+				)
 				.build();
 	}
 


### PR DESCRIPTION
Unfortunately, there is a bug in the JDK ([JDK-8249280](https://bugs.openjdk.org/browse/JDK-8249280)) where the `java.sql.Date#toLocalDate()` and the `java.sql.Timestamp#toLocalDateTime()` methods do not correctly convert BCE dates.
We have recently fixed this [here](https://github.com/openjdk/jdk/pull/31808), however it may be some time before Hibernate is on a Java release where the fix will be present.

In the interim, I have essentially copied the fix we did in the JDK and applied it here.

I have gone with the approach of a static helper `SqlDateTimeHelper`, which centralises this logic. I am not 100% happy with this name so suggestions are very welcome.

I have also expanded the test suites to confirm the now working BCE date behaviour, as well as tests to verify the BC cutoff fast path approach we used in `SqlDateTimeHelper` (as was also done in the JDK fix).

Just wondering, is it worth putting in a test to confirm the existing failing JDK behaviour so that people are alerted when this workaround is no longer needed?
Or should a TODO be added somewhere? 


PS. I notice that `JdbcTimestampJavaType#unwrap()` still seems to use the old (and I believe incorrect) approach of deriving an `Instant` from the `Timestamp`. This was was fixed in most other locations to work around `HHH-13266`. I just wanted to flag this to see if it was known about or if I was mistaken about it being an error.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-14256 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-14256
<!-- Hibernate GitHub Bot issue links end -->