### PR TITLE
HHH-10815 FetchingScrollableResultsImpl should accept setRowNumber(0)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/scrollable/FetchingScrollableResultsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/scrollable/FetchingScrollableResultsImpl.java
@@ -279,6 +279,11 @@ public class FetchingScrollableResultsImpl<R> extends AbstractScrollableResults<
 
 	@Override
 	public boolean setRowNumber(int rowNumber) {
+		if ( rowNumber == 0 ) {
+			// there is no row 0: position before the first row, like ResultSet#absolute(0)
+			beforeFirst();
+			return false;
+		}
 		if ( rowNumber == 1 ) {
 			return first();
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ScrollableCollectionFetchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ScrollableCollectionFetchingTest.java
@@ -15,6 +15,7 @@ import org.hibernate.query.SemanticException;
 import org.hibernate.query.sqm.UnknownPathException;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -535,6 +536,88 @@ public class ScrollableCollectionFetchingTest {
 						animal = (Animal) results.get();
 						assertEquals( data.root2Id, animal.getId(), "position(2) did not return expected row" );
 						assertEquals( 2, results.getPosition() );
+					}
+				}
+		);
+	}
+
+	@Test
+	@JiraKey("HHH-10815")
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsBackwardsScrollableResultSets.class)
+	@SuppressWarnings("deprecation")
+	public void testScrollableResultsGetRowNumber(SessionFactoryScope scope) {
+		TestData data = new TestData();
+		data.prepare( scope );
+
+		scope.inTransaction(
+				session -> {
+					// getRowNumber() numbers the first result 0 (unlike JDBC) and returns -1 when
+					// there is no current row. The plain and the fetch-join implementations must
+					// report the same row number at the same position (HHH-10815).
+					try (
+							ScrollableResults<Animal> fetchResult = session.createQuery(
+									"from Animal a left join fetch a.offspring where a.description like :desc order by a.id", Animal.class )
+									.setParameter( "desc", "root%" ).scroll();
+							ScrollableResults<Animal> standardResult = session.createQuery(
+									"from Animal a where a.description like :desc order by a.id", Animal.class )
+									.setParameter( "desc", "root%" ).scroll()
+					) {
+						standardResult.first();
+						fetchResult.first();
+						assertEquals( 0, standardResult.getRowNumber(), "row number must be 0 on the first result" );
+						assertEquals( 0, fetchResult.getRowNumber(), "row number must be 0 on the first result" );
+						assertEquals( standardResult.getRowNumber(), fetchResult.getRowNumber(),
+								"both results must have the same row number" );
+
+						standardResult.next();
+						fetchResult.next();
+						assertEquals( 1, standardResult.getRowNumber(), "row number must be 1 on the next result" );
+						assertEquals( 1, fetchResult.getRowNumber(), "row number must be 1 on the next result" );
+						assertEquals( standardResult.getRowNumber(), fetchResult.getRowNumber(),
+								"both results must have the same row number" );
+
+						standardResult.last();
+						fetchResult.last();
+						assertEquals( standardResult.getRowNumber(), fetchResult.getRowNumber(),
+								"both results must have the same row number on the last result" );
+						assertEquals( standardResult.getPosition() - 1, standardResult.getRowNumber() );
+						assertEquals( fetchResult.getPosition() - 1, fetchResult.getRowNumber() );
+					}
+				}
+		);
+	}
+
+	@Test
+	@JiraKey("HHH-10815")
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsBackwardsScrollableResultSets.class)
+	@SuppressWarnings("deprecation")
+	public void testScrollableResultsSetRowNumber(SessionFactoryScope scope) {
+		TestData data = new TestData();
+		data.prepare( scope );
+
+		scope.inTransaction(
+				session -> {
+					// setRowNumber(i) must behave identically with and without a fetch join at every
+					// position. In particular setRowNumber(0) addresses the position before the first
+					// row and must be accepted (returning false), rather than throwing as the
+					// fetch-join implementation previously did (HHH-10815).
+					try (
+							ScrollableResults<Animal> fetchResult = session.createQuery(
+									"from Animal a left join fetch a.offspring where a.description like :desc order by a.id", Animal.class )
+									.setParameter( "desc", "root%" ).scroll();
+							ScrollableResults<Animal> standardResult = session.createQuery(
+									"from Animal a where a.description like :desc order by a.id", Animal.class )
+									.setParameter( "desc", "root%" ).scroll()
+					) {
+						// there are two "root%" rows, so positions 1 and 2 are rows and 0 is before the first
+						for ( int i = 0; i <= 2; i++ ) {
+							assertEquals( standardResult.setRowNumber( i ), fetchResult.setRowNumber( i ),
+									"setRowNumber(" + i + ") must return the same result with and without a fetch join" );
+							assertEquals( standardResult.getRowNumber(), fetchResult.getRowNumber(),
+									"row number at position " + i + " must be the same with and without a fetch join" );
+							assertEquals( standardResult.get(), fetchResult.get(),
+									"the row at position " + i + " must be the same with and without a fetch join" );
+						}
 					}
 				}
 		);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-10815

`ScrollableResults#setRowNumber(0)` should position before the first row and return `false`, the way `ScrollableResultsImpl` already does through `ResultSet.absolute(0)`. In `FetchingScrollableResultsImpl` a `rowNumber` of `0` fell through to `scroll(0)`, which throws `HibernateException("scroll(0) not valid")`. This handles `0` explicitly now by moving before the first row.

`position(int)` delegates to `setRowNumber(int)` in this class, so `position(0)` is covered by the same change.

For the tests I started from the ones posted on the Jira ticket and moved them into `ScrollableCollectionFetchingTest` so they can reuse its `Animal` model. They scroll a fetch-join query and a plain query next to each other and assert that `getRowNumber()` and `setRowNumber(i)` return the same value at each position. I assert on `getRowNumber()`, which is 0-based, instead of `getPosition()`, which is 1-based, so that "the first row is 0" actually holds.

Checked against `ScrollableCollectionFetchingTest`, `HQLScrollFetchTest`, `QueryScrollingWithInheritanceTest` and `StatelessQueryScrollingTest`, and `spotlessCheck`/`enforceRules` pass.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-10815 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->
