### PR TITLE
HHH-20715  HbmXmlTransformer does not generate mapped-superclass for entities with inherited members

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -38,7 +39,6 @@ import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmConfigParameterContainer;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmCustomSqlDmlType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDiscriminatorSubclassEntityType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDynamicComponentType;
-import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDiscriminatorSubclassEntityType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmEntityBaseDefinition;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchProfileType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchStyleEnum;
@@ -133,6 +133,8 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToOneImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbMapKeyColumnImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbMapKeyJoinColumnImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbMappedSuperclassImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbPersistentAttribute;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNamedNativeQueryImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNamedHqlQueryImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNaturalIdImpl;
@@ -366,8 +368,313 @@ public class HbmXmlTransformer {
 			defineInheritance( rootMappingEntity, InheritanceType.TABLE_PER_CLASS );
 		} );
 
+		generateMappedSuperclassesForUnmappedSuperclasses( mappingXmlRoot );
+
 		if ( TRANSFORMATION_LOGGER.isDebugEnabled() ) {
 			dumpTransformed( origin(), mappingXmlRoot );
+		}
+	}
+
+	/**
+	 * Bridges the gap between hbm.xml and orm.xml attribute-member resolution.
+	 * <p>
+	 * In hbm.xml, an entity can map properties whose Java member is declared on a plain
+	 * (unmapped) superclass — the hbm processor walks the class hierarchy via reflection.
+	 * In orm.xml, the XML processor requires each attribute's member to be declared on
+	 * the entity class itself or on an explicitly declared {@code <mapped-superclass>}.
+	 * <p>
+	 * This method detects inherited attributes, generates {@code <mapped-superclass>}
+	 * elements for unmapped Java superclasses, moves the inherited attributes there,
+	 * and marks remaining unmapped properties as {@code <transient/>}.
+	 */
+	private void generateMappedSuperclassesForUnmappedSuperclasses(JaxbEntityMappingsImpl mappingXmlRoot) {
+		final Set<String> mappedEntityClassNames = collectMappedEntityClassNames();
+		final boolean fieldAccess = isFieldAccessDefault();
+
+		final Map<String, JaxbMappedSuperclassImpl> generatedSuperclasses = new HashMap<>();
+		final Map<String, Class<?>> superclassJavaTypes = new HashMap<>();
+
+		for ( var entry : transformationState.getEntityInfoByName().entrySet() ) {
+			final Class<?> javaClass = resolveMappedClass( entry.getValue().getPersistentClass() );
+			final var entity = transformationState.getMappingEntityByName().get( entry.getKey() );
+			final var attrs = entity != null ? entity.getAttributes() : null;
+
+			if ( javaClass != null && attrs != null ) {
+				Class<?> currentSuperclass = javaClass.getSuperclass();
+				while ( currentSuperclass != null
+						&& currentSuperclass != Object.class
+						&& !mappedEntityClassNames.contains( currentSuperclass.getName() ) ) {
+					final var mappedSuperclass = getOrCreateMappedSuperclass(
+							currentSuperclass, fieldAccess,
+							generatedSuperclasses, superclassJavaTypes, mappingXmlRoot );
+					moveInheritedAttributesToSuperclass(
+							entity, attrs, mappedSuperclass, currentSuperclass, fieldAccess );
+					currentSuperclass = currentSuperclass.getSuperclass();
+				}
+			}
+		}
+
+		addTransientsForUnmappedProperties( generatedSuperclasses, superclassJavaTypes, fieldAccess );
+	}
+
+	/**
+	 * Collects the class names of all already-mapped entities so that we never
+	 * generate a {@code <mapped-superclass>} for a class that is itself an entity.
+	 */
+	private Set<String> collectMappedEntityClassNames() {
+		final Set<String> classNames = new HashSet<>();
+		for ( var entityInfo : transformationState.getEntityInfoByName().values() ) {
+			final String className = entityInfo.getPersistentClass().getClassName();
+			if ( className != null ) {
+				classNames.add( className );
+			}
+		}
+		return classNames;
+	}
+
+	/**
+	 * Returns {@code true} when the hbm.xml mapping's default access type is {@code "field"}.
+	 */
+	private boolean isFieldAccessDefault() {
+		final String access = hbmXmlBinding.getRoot().getDefaultAccess();
+		return "field".equals( access != null ? access.toLowerCase( Locale.ROOT ) : "property" );
+	}
+
+	/**
+	 * Resolves the Java class mapped by the given {@link PersistentClass},
+	 * returning {@code null} when the class is not on the classpath
+	 * (e.g. in the reverse-engineering tooling scenario).
+	 */
+	private static Class<?> resolveMappedClass(PersistentClass persistentClass) {
+		try {
+			return persistentClass.getMappedClass();
+		}
+		catch (org.hibernate.MappingException e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Looks up or creates a {@link JaxbMappedSuperclassImpl} for the given unmapped
+	 * superclass, registering it in the tracking maps and adding it to the mapping root.
+	 * When multiple entities share the same superclass, the existing instance is returned.
+	 */
+	private static JaxbMappedSuperclassImpl getOrCreateMappedSuperclass(
+			Class<?> superclass,
+			boolean fieldAccess,
+			Map<String, JaxbMappedSuperclassImpl> generatedSuperclasses,
+			Map<String, Class<?>> superclassJavaTypes,
+			JaxbEntityMappingsImpl mappingXmlRoot) {
+		final String superclassName = superclass.getName();
+		var mappedSuperclass = generatedSuperclasses.get( superclassName );
+		if ( mappedSuperclass == null ) {
+			mappedSuperclass = new JaxbMappedSuperclassImpl();
+			mappedSuperclass.setClazz( superclassName );
+			mappedSuperclass.setMetadataComplete( true );
+			mappedSuperclass.setAccess( fieldAccess
+					? jakarta.persistence.AccessType.FIELD
+					: jakarta.persistence.AccessType.PROPERTY );
+			mappedSuperclass.setAttributes( new JaxbAttributesContainerImpl() );
+			generatedSuperclasses.put( superclassName, mappedSuperclass );
+			superclassJavaTypes.put( superclassName, superclass );
+			mappingXmlRoot.getMappedSuperclasses().add( mappedSuperclass );
+		}
+		return mappedSuperclass;
+	}
+
+	/**
+	 * Moves attributes (id, basic, associations, embedded, version, embedded-id)
+	 * from the entity to the mapped-superclass when the member is declared on the
+	 * given Java superclass. Also relocates the id-class when all id attributes
+	 * have been moved, and removes entity-level transients for members that now
+	 * belong to the superclass.
+	 */
+	private static void moveInheritedAttributesToSuperclass(
+			JaxbEntityImpl entity,
+			JaxbAttributesContainerImpl attrs,
+			JaxbMappedSuperclassImpl mappedSuperclass,
+			Class<?> superclass,
+			boolean fieldAccess) {
+		final var superAttrs = mappedSuperclass.getAttributes();
+
+		moveInheritedAttributes( attrs.getIdAttributes(), superAttrs.getIdAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getBasicAttributes(), superAttrs.getBasicAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getManyToOneAttributes(), superAttrs.getManyToOneAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getOneToManyAttributes(), superAttrs.getOneToManyAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getOneToOneAttributes(), superAttrs.getOneToOneAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getManyToManyAttributes(), superAttrs.getManyToManyAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getEmbeddedAttributes(), superAttrs.getEmbeddedAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getElementCollectionAttributes(), superAttrs.getElementCollectionAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getAnyMappingAttributes(), superAttrs.getAnyMappingAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getPluralAnyMappingAttributes(), superAttrs.getPluralAnyMappingAttributes(), superclass, fieldAccess );
+
+		moveVersionIfInherited( attrs, superAttrs, superclass, fieldAccess );
+		moveEmbeddedIdIfInherited( attrs, superAttrs, superclass, fieldAccess );
+		moveIdClassIfAllIdsMoved( entity, attrs, mappedSuperclass, superAttrs );
+
+		attrs.getTransients().removeIf( t -> isMemberDeclaredOnClass( t.getName(), superclass, fieldAccess ) );
+	}
+
+	/**
+	 * Moves the version attribute from the entity to the mapped-superclass
+	 * when the version member is declared on the given superclass.
+	 */
+	private static void moveVersionIfInherited(
+			JaxbAttributesContainerImpl attrs,
+			JaxbAttributesContainerImpl superAttrs,
+			Class<?> superclass,
+			boolean fieldAccess) {
+		final var version = attrs.getVersion();
+		if ( version != null
+				&& isMemberDeclaredOnClass( version.getName(), superclass, fieldAccess ) ) {
+			if ( superAttrs.getVersion() == null ) {
+				superAttrs.setVersion( version );
+			}
+			attrs.setVersion( null );
+		}
+	}
+
+	/**
+	 * Moves the embedded-id attribute from the entity to the mapped-superclass
+	 * when the embedded-id member is declared on the given superclass.
+	 */
+	private static void moveEmbeddedIdIfInherited(
+			JaxbAttributesContainerImpl attrs,
+			JaxbAttributesContainerImpl superAttrs,
+			Class<?> superclass,
+			boolean fieldAccess) {
+		final var embeddedId = attrs.getEmbeddedIdAttribute();
+		if ( embeddedId != null
+				&& isMemberDeclaredOnClass( embeddedId.getName(), superclass, fieldAccess ) ) {
+			if ( superAttrs.getEmbeddedIdAttribute() == null ) {
+				superAttrs.setEmbeddedIdAttribute( embeddedId );
+			}
+			attrs.setEmbeddedIdAttribute( null );
+		}
+	}
+
+	/**
+	 * Relocates the id-class declaration from the entity to the mapped-superclass
+	 * when all id attributes have already been moved there.
+	 */
+	private static void moveIdClassIfAllIdsMoved(
+			JaxbEntityImpl entity,
+			JaxbAttributesContainerImpl attrs,
+			JaxbMappedSuperclassImpl mappedSuperclass,
+			JaxbAttributesContainerImpl superAttrs) {
+		if ( entity.getIdClass() != null
+				&& mappedSuperclass.getIdClass() == null
+				&& attrs.getIdAttributes().isEmpty()
+				&& attrs.getEmbeddedIdAttribute() == null
+				&& !superAttrs.getIdAttributes().isEmpty() ) {
+			mappedSuperclass.setIdClass( entity.getIdClass() );
+			entity.setIdClass( null );
+		}
+	}
+
+	/**
+	 * Adds {@code <transient/>} declarations for properties on each generated
+	 * mapped-superclass that are not mapped by any entity.
+	 */
+	private static void addTransientsForUnmappedProperties(
+			Map<String, JaxbMappedSuperclassImpl> generatedSuperclasses,
+			Map<String, Class<?>> superclassJavaTypes,
+			boolean fieldAccess) {
+		for ( var entry : generatedSuperclasses.entrySet() ) {
+			final var mappedSuperclass = entry.getValue();
+			final var superAttrs = mappedSuperclass.getAttributes();
+			final Set<String> mappedNames = collectMappedAttributeNames( superAttrs );
+			final Class<?> superclass = superclassJavaTypes.get( entry.getKey() );
+			if ( superclass != null ) {
+				final Set<String> transientNames = TransformationHelper.discoverUnmappedPropertyNames(
+						superclass, mappedNames, fieldAccess
+				);
+				TransformationHelper.addTransients( transientNames, superAttrs.getTransients() );
+			}
+		}
+	}
+
+	/**
+	 * Moves attributes whose member is declared on the given Java superclass
+	 * from the entity's attribute list to the mapped-superclass attribute list.
+	 * Duplicates (already present in the superclass) are skipped.
+	 */
+	private static <T extends JaxbPersistentAttribute> void moveInheritedAttributes(
+			List<T> entityAttrs,
+			List<T> superAttrs,
+			Class<?> javaSuperclass,
+			boolean fieldAccess) {
+		final var toMove = new ArrayList<T>();
+		for ( var attr : entityAttrs ) {
+			if ( isMemberDeclaredOnClass( attr.getName(), javaSuperclass, fieldAccess ) ) {
+				toMove.add( attr );
+			}
+		}
+		final Set<String> existingNames = new HashSet<>();
+		for ( var attr : superAttrs ) {
+			existingNames.add( attr.getName() );
+		}
+		for ( var attr : toMove ) {
+			entityAttrs.remove( attr );
+			if ( existingNames.add( attr.getName() ) ) {
+				superAttrs.add( attr );
+			}
+		}
+	}
+
+	private static Set<String> collectMappedAttributeNames(JaxbAttributesContainerImpl attrs) {
+		final Set<String> names = new HashSet<>();
+		addAttributeNames( names,
+				attrs.getIdAttributes(),
+				attrs.getBasicAttributes(),
+				attrs.getManyToOneAttributes(),
+				attrs.getOneToManyAttributes(),
+				attrs.getOneToOneAttributes(),
+				attrs.getManyToManyAttributes(),
+				attrs.getEmbeddedAttributes(),
+				attrs.getElementCollectionAttributes(),
+				attrs.getAnyMappingAttributes(),
+				attrs.getPluralAnyMappingAttributes()
+		);
+		if ( attrs.getVersion() != null ) {
+			names.add( attrs.getVersion().getName() );
+		}
+		if ( attrs.getEmbeddedIdAttribute() != null ) {
+			names.add( attrs.getEmbeddedIdAttribute().getName() );
+		}
+		return names;
+	}
+
+	@SafeVarargs
+	private static void addAttributeNames(Set<String> names, List<? extends JaxbPersistentAttribute>... attrLists) {
+		for ( var attrList : attrLists ) {
+			for ( var attr : attrList ) {
+				names.add( attr.getName() );
+			}
+		}
+	}
+
+	/**
+	 * Check if a field or getter for the given property name is declared directly
+	 * on the given class (not inherited).
+	 */
+	private static boolean isMemberDeclaredOnClass(String propertyName, Class<?> clazz, boolean fieldAccess) {
+		if ( fieldAccess ) {
+			try {
+				clazz.getDeclaredField( propertyName );
+				return true;
+			}
+			catch (NoSuchFieldException ignored) {
+				return false;
+			}
+		}
+		else {
+			for ( var method : clazz.getDeclaredMethods() ) {
+				if ( propertyName.equals( TransformationHelper.extractPropertyName( method ) ) ) {
+					return true;
+				}
+			}
+			return false;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/TransformationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/TransformationHelper.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.boot.jaxb.hbm.transform;
 
+import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -47,6 +48,21 @@ public class TransformationHelper {
 		return discoverUnmappedPropertyNames( javaClass, Set.of(), fieldAccess );
 	}
 
+	static String extractPropertyName(Method method) {
+		if ( method.getParameterCount() != 0 ) {
+			return null;
+		}
+		final String methodName = method.getName();
+		if ( methodName.startsWith( "get" ) && methodName.length() > 3 ) {
+			return StringHelper.decapitalize( methodName.substring( 3 ) );
+		}
+		if ( methodName.startsWith( "is" ) && methodName.length() > 2
+				&& ( method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class ) ) {
+			return StringHelper.decapitalize( methodName.substring( 2 ) );
+		}
+		return null;
+	}
+
 	static Set<String> discoverUnmappedPropertyNames(
 			Class<?> javaClass,
 			Set<String> mappedPropertyNames,
@@ -68,18 +84,7 @@ public class TransformationHelper {
 				effectiveMappedNames.add( StringHelper.decapitalize( name ) );
 			}
 			for ( var method : javaClass.getMethods() ) {
-				if ( method.getParameterCount() != 0 ) {
-					continue;
-				}
-				String propertyName = null;
-				final String methodName = method.getName();
-				if ( methodName.startsWith( "get" ) && methodName.length() > 3 ) {
-					propertyName = StringHelper.decapitalize( methodName.substring( 3 ) );
-				}
-				else if ( methodName.startsWith( "is" ) && methodName.length() > 2
-						&& ( method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class ) ) {
-					propertyName = StringHelper.decapitalize( methodName.substring( 2 ) );
-				}
+				final String propertyName = extractPropertyName( method );
 				if ( propertyName != null
 						&& !effectiveMappedNames.contains( propertyName )
 						&& !propertyName.equals( "class" ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -29,6 +29,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbIdImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbMappedSuperclassImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToOneImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbOneToManyImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbOneToOneImpl;
@@ -1213,6 +1214,92 @@ public class HbmTransformationJaxbTests {
 			assertThat( employments.getMappedBy() )
 					.as( "Inverse one-to-many should resolve mapped-by to composite-id key-property 'personName'" )
 					.isEqualTo( "personName" );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20715" )
+	public void testUnmappedSuperclassGeneratesMappedSuperclass(ServiceRegistryScope scope) {
+		// ConcreteEntity and AnotherEntity both extend AbstractBase (a plain Java class, not an entity).
+		// The hbm.xml maps properties (id, version, name, relatedBase) declared on AbstractBase.
+		// The transformer should generate a single <mapped-superclass> for AbstractBase,
+		// move the inherited attributes there, and mark unmapped superclass properties as transient.
+		transformAndVerify( "xml/jaxb/mapping/unmapped-superclass/hbm.xml", scope, (transformed) -> {
+			// A single mapped-superclass should be generated even though two entities share the same superclass
+			assertThat( transformed.getMappedSuperclasses() )
+					.as( "Exactly one <mapped-superclass> should be generated for the shared AbstractBase" )
+					.hasSize( 1 );
+
+			final JaxbMappedSuperclassImpl mappedSuperclass = transformed.getMappedSuperclasses().get( 0 );
+			assertThat( mappedSuperclass.getClazz() )
+					.isEqualTo( "org.hibernate.orm.test.boot.jaxb.mapping.unmappedsuperclass.AbstractBase" );
+			assertThat( mappedSuperclass.isMetadataComplete() ).isTrue();
+
+			final var superAttrs = mappedSuperclass.getAttributes();
+
+			// Id attribute should be on the mapped-superclass
+			assertThat( superAttrs.getIdAttributes() )
+					.extracting( JaxbIdImpl::getName )
+					.containsExactly( "id" );
+
+			// Version attribute should be on the mapped-superclass
+			assertThat( superAttrs.getVersion() )
+					.as( "version should be moved to the mapped-superclass" )
+					.isNotNull();
+			assertThat( superAttrs.getVersion().getName() )
+					.isEqualTo( "version" );
+
+			// Basic attribute 'name' should be on the mapped-superclass
+			assertThat( superAttrs.getBasicAttributes() )
+					.extracting( JaxbBasicImpl::getName )
+					.containsExactly( "name" );
+
+			// Many-to-one attribute 'relatedBase' should be on the mapped-superclass
+			assertThat( superAttrs.getManyToOneAttributes() )
+					.extracting( JaxbManyToOneImpl::getName )
+					.containsExactly( "relatedBase" );
+
+			// Unmapped property should be declared as transient
+			assertThat( superAttrs.getTransients() )
+					.extracting( JaxbTransientImpl::getName )
+					.contains( "unmappedProperty" );
+
+			// --- ConcreteEntity assertions ---
+			final JaxbEntityImpl concreteEntity = transformed.getEntities().stream()
+					.filter( e -> "ConcreteEntity".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			// Inherited attributes should NOT be on the entity
+			assertThat( concreteEntity.getAttributes().getIdAttributes() )
+					.as( "Entity should not have id — inherited from mapped-superclass" )
+					.isEmpty();
+			assertThat( concreteEntity.getAttributes().getVersion() )
+					.as( "Entity should not have version — inherited from mapped-superclass" )
+					.isNull();
+			assertThat( concreteEntity.getAttributes().getManyToOneAttributes() )
+					.as( "Entity should not have relatedBase — inherited from mapped-superclass" )
+					.isEmpty();
+
+			// Entity's own attribute should remain
+			assertThat( concreteEntity.getAttributes().getBasicAttributes() )
+					.extracting( JaxbBasicImpl::getName )
+					.containsExactly( "description" );
+
+			// --- AnotherEntity assertions ---
+			final JaxbEntityImpl anotherEntity = transformed.getEntities().stream()
+					.filter( e -> "AnotherEntity".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			// Inherited attributes should NOT be on the entity
+			assertThat( anotherEntity.getAttributes().getIdAttributes() ).isEmpty();
+			assertThat( anotherEntity.getAttributes().getVersion() ).isNull();
+
+			// Entity's own attribute should remain
+			assertThat( anotherEntity.getAttributes().getBasicAttributes() )
+					.extracting( JaxbBasicImpl::getName )
+					.containsExactly( "code" );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/unmappedsuperclass/AbstractBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/unmappedsuperclass/AbstractBase.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.unmappedsuperclass;
+
+public class AbstractBase {
+	private Long id;
+	private String name;
+	private int version;
+	private AbstractBase relatedBase;
+	private String unmappedProperty;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public int getVersion() {
+		return version;
+	}
+
+	public void setVersion(int version) {
+		this.version = version;
+	}
+
+	public AbstractBase getRelatedBase() {
+		return relatedBase;
+	}
+
+	public void setRelatedBase(AbstractBase relatedBase) {
+		this.relatedBase = relatedBase;
+	}
+
+	public String getUnmappedProperty() {
+		return unmappedProperty;
+	}
+
+	public void setUnmappedProperty(String unmappedProperty) {
+		this.unmappedProperty = unmappedProperty;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/unmappedsuperclass/AnotherEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/unmappedsuperclass/AnotherEntity.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.unmappedsuperclass;
+
+public class AnotherEntity extends AbstractBase {
+	private String code;
+
+	public String getCode() {
+		return code;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/unmappedsuperclass/ConcreteEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/unmappedsuperclass/ConcreteEntity.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.unmappedsuperclass;
+
+public class ConcreteEntity extends AbstractBase {
+	private String description;
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/unmapped-superclass/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/unmapped-superclass/hbm.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.unmappedsuperclass">
+
+    <class name="ConcreteEntity">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <version name="version"/>
+        <property name="name"/>
+        <many-to-one name="relatedBase" class="ConcreteEntity"/>
+        <property name="description"/>
+    </class>
+
+    <class name="AnotherEntity">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <version name="version"/>
+        <property name="name"/>
+        <property name="code"/>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20715 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20715
<!-- Hibernate GitHub Bot issue links end -->