### PR TITLE
HbmXmlTransformer: Various bug fixes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -2058,7 +2058,20 @@ public class HbmXmlTransformer {
 		if ( isNotEmpty( source.getCollectionType() ) ) {
 			final var jaxbCollectionUserType = new JaxbCollectionUserTypeImpl();
 			target.setCollectionType( jaxbCollectionUserType );
-			jaxbCollectionUserType.setType( source.getCollectionType() );
+			// resolve typedef alias to the actual implementation class and transfer parameters
+			final var typeDef = transformationState.getTypeDefMap().get( source.getCollectionType() );
+			if ( typeDef != null ) {
+				jaxbCollectionUserType.setType( typeDef.getClazz() );
+				for ( var param : typeDef.getConfigParameters() ) {
+					final var jaxbParam = new JaxbConfigurationParameterImpl();
+					jaxbParam.setName( param.getName() );
+					jaxbParam.setValue( param.getValue() );
+					jaxbCollectionUserType.getParameters().add( jaxbParam );
+				}
+			}
+			else {
+				jaxbCollectionUserType.setType( source.getCollectionType() );
+			}
 		}
 
 		if ( source instanceof JaxbHbmSetType set ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -3255,7 +3255,7 @@ public class HbmXmlTransformer {
 		}
 
 		jaxbKyManyToOne.setOptional( false );
-		jaxbKyManyToOne.setFetch( FetchType.EAGER );
+		jaxbKyManyToOne.setFetch( FetchType.LAZY );
 		jaxbKyManyToOne.setFetchMode( JaxbSingularFetchModeImpl.SELECT );
 		jaxbKyManyToOne.setNotFound( NotFoundAction.EXCEPTION );
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -2050,8 +2050,17 @@ public class HbmXmlTransformer {
 				target::setAccess,
 				target::setAttributeAccessor
 		);
-		target.setFetchMode( convert( source.getFetch(), source.getOuterJoin() ) );
-		target.setFetch( convert( source.getLazy() ) );
+		final var fetchMode = convert( source.getFetch(), source.getOuterJoin() );
+		final var fetchType = convert( source.getLazy() );
+		// In hbm.xml, fetch="join" and lazy="true" are independent: the collection stays lazy
+		// and uses join fetching only when initialized. In orm.xml, fetch-mode="JOIN" maps to
+		// @Fetch(FetchMode.JOIN) which forces eager loading (CollectionBinder overrides lazy to
+		// false for JOIN). Since a lazy collection uses a separate SELECT regardless of fetch
+		// style, we drop fetch-mode="JOIN" for lazy collections to preserve the lazy semantics.
+		if ( fetchMode != JaxbPluralFetchModeImpl.JOIN || fetchType != FetchType.LAZY ) {
+			target.setFetchMode( fetchMode );
+		}
+		target.setFetch( fetchType );
 		target.setOptimisticLock( source.isOptimisticLock() );
 		target.setMutable( source.isMutable() );
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -126,6 +126,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbGeneratedValueImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbGenericIdGeneratorImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbHqlImportImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbIdImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbIdClassImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbIndexImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbInheritanceImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbJoinTableImpl;
@@ -3391,7 +3392,9 @@ public class HbmXmlTransformer {
 			JaxbHbmCompositeIdType hbmCompositeId,
 			Component idClassMapping,
 			JaxbEntityImpl mappingXmlEntity) {
-		throw new UnsupportedOperationException( "Not implemented yet" );
+		final var idClass = new JaxbIdClassImpl();
+		idClass.setClazz( getFullyQualifiedClassName( hbmCompositeId.getClazz() ) );
+		mappingXmlEntity.setIdClass( idClass );
 	}
 
 	private JaxbIdImpl transformNonAggregatedKeyProperty(

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -779,7 +779,9 @@ public class HbmXmlTransformer {
 				final var ormImport = new JaxbHqlImportImpl();
 				ormRoot.getHqlImports().add( ormImport );
 				ormImport.setClazz( hbmImport.getClazz() );
-				ormImport.setRename( hbmImport.getRename() );
+				final String rename = hbmImport.getRename();
+				// In hbm.xml rename is optional and defaults to the unqualified class name
+				ormImport.setRename( rename != null ? rename : StringHelper.unqualify( hbmImport.getClazz() ) );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.boot.MappingException;
 import org.hibernate.boot.internal.LimitedCollectionClassification;
 import org.hibernate.boot.jaxb.Origin;
@@ -58,6 +59,7 @@ import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmListType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToAnyCollectionElementType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToManyCollectionElementType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToOneType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOnDeleteEnum;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapKeyBasicType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmMapType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmNamedNativeQueryType;
@@ -1903,6 +1905,10 @@ public class HbmXmlTransformer {
 		}
 
 		jaxbManyToOne.setForeignKey( transformForeignKey( hbmNode.getForeignKey() ) );
+
+		if ( hbmNode.getOnDelete() == JaxbHbmOnDeleteEnum.CASCADE ) {
+			jaxbManyToOne.setOnDelete( OnDeleteAction.CASCADE );
+		}
 
 		if ( hbmNode.getNotFound() != null ) {
 			jaxbManyToOne.setNotFound( interpretNotFoundAction( hbmNode.getNotFound() ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -777,6 +777,50 @@ public class HbmTransformationJaxbTests {
 		} );
 	}
 
+	@Test
+	@JiraKey( "HHH-20709" )
+	public void testCollectionFetchJoinLazyTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/collection-fetch-join-lazy/hbm.xml", scope, (transformed) -> {
+			final JaxbEntityImpl userEntity = transformed.getEntities().stream()
+					.filter( e -> "User".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( userEntity.getAttributes().getOneToManyAttributes() ).hasSize( 1 );
+
+			final JaxbOneToManyImpl emailAddresses = userEntity.getAttributes().getOneToManyAttributes().get( 0 );
+			assertThat( emailAddresses.getName() ).isEqualTo( "emailAddresses" );
+			assertThat( emailAddresses.getFetchMode() )
+					.as( "Lazy collection with fetch='join' should not have fetch-mode=JOIN" )
+					.isNotEqualTo( org.hibernate.boot.jaxb.mapping.spi.JaxbPluralFetchModeImpl.JOIN );
+			assertThat( emailAddresses.getFetch() )
+					.as( "Collection with default lazy='true' should have fetch=LAZY" )
+					.isEqualTo( jakarta.persistence.FetchType.LAZY );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20709" )
+	public void testCollectionFetchJoinEagerTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/collection-fetch-join-eager/hbm.xml", scope, (transformed) -> {
+			final JaxbEntityImpl userEntity = transformed.getEntities().stream()
+					.filter( e -> "User".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( userEntity.getAttributes().getOneToManyAttributes() ).hasSize( 1 );
+
+			final JaxbOneToManyImpl emailAddresses = userEntity.getAttributes().getOneToManyAttributes().get( 0 );
+			assertThat( emailAddresses.getName() ).isEqualTo( "emailAddresses" );
+			assertThat( emailAddresses.getFetchMode() )
+					.as( "Eager collection with fetch='join' should have fetch-mode=JOIN" )
+					.isEqualTo( org.hibernate.boot.jaxb.mapping.spi.JaxbPluralFetchModeImpl.JOIN );
+			assertThat( emailAddresses.getFetch() )
+					.as( "Collection with lazy='false' should have fetch=EAGER" )
+					.isEqualTo( jakarta.persistence.FetchType.EAGER );
+		} );
+	}
+
 	private void transformAndVerify(
 			String resourceName,
 			ServiceRegistryScope scope,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1236,4 +1236,25 @@ public class HbmTransformationJaxbTests {
 			}
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20699" )
+	public void testCompositeKeyManyToOneFetchLazy(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/composite-key-many-to-one-fetch/hbm.xml", scope, transformed -> {
+			final JaxbEntityImpl addressEntity = transformed.getEntities().stream()
+					.filter( e -> "Address".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( addressEntity.getAttributes().getManyToOneAttributes() )
+					.hasSize( 1 );
+
+			final JaxbManyToOneImpl personManyToOne = addressEntity.getAttributes().getManyToOneAttributes().get( 0 );
+			assertThat( personManyToOne.getName() ).isEqualTo( "person" );
+			assertThat( personManyToOne.isId() ).isTrue();
+			assertThat( personManyToOne.getFetch() )
+					.as( "Composite-id key-many-to-one should have fetch=LAZY" )
+					.isEqualTo( jakarta.persistence.FetchType.LAZY );
+		} );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -821,6 +821,28 @@ public class HbmTransformationJaxbTests {
 		} );
 	}
 
+	@Test
+	@JiraKey( "HHH-20711" )
+	public void testIdClassTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/id-class/hbm.xml", scope, (transformed) -> {
+			final JaxbEntityImpl customerEntity = transformed.getEntities().stream()
+					.filter( e -> "Customer".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( customerEntity.getIdClass() )
+					.as( "Entity with composite-id class should have id-class" )
+					.isNotNull();
+			assertThat( customerEntity.getIdClass().getClazz() )
+					.as( "id-class should reference the fully qualified CustomerId class" )
+					.isEqualTo( "org.hibernate.orm.test.idclass.CustomerId" );
+
+			assertThat( customerEntity.getAttributes().getIdAttributes() )
+					.as( "Entity should have 2 id attributes" )
+					.hasSize( 2 );
+		} );
+	}
+
 	private void transformAndVerify(
 			String resourceName,
 			ServiceRegistryScope scope,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1257,4 +1257,25 @@ public class HbmTransformationJaxbTests {
 					.isEqualTo( jakarta.persistence.FetchType.LAZY );
 		} );
 	}
+
+	@Test
+	@JiraKey( "HHH-20703" )
+	public void testCollectionTypeTypedefResolution(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/collection-type-typedef/hbm.xml", scope, transformed -> {
+			final JaxbEntityImpl entity = transformed.getEntities().get( 0 );
+
+			assertThat( entity.getAttributes().getElementCollectionAttributes() ).hasSize( 1 );
+			final var elementCollection = entity.getAttributes().getElementCollectionAttributes().get( 0 );
+			assertThat( elementCollection.getName() ).isEqualTo( "values" );
+			assertThat( elementCollection.getCollectionType() )
+					.as( "collection-type referencing a typedef should be resolved" )
+					.isNotNull();
+			assertThat( elementCollection.getCollectionType().getType() )
+					.as( "collection-type should use the typedef class, not the typedef name" )
+					.isEqualTo( "org.hibernate.orm.test.mapping.collections.custom.parameterized.DefaultableListType" );
+			assertThat( elementCollection.getCollectionType().getParameters() )
+					.as( "collection-type should include typedef parameters" )
+					.hasSize( 1 );
+		} );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -800,6 +800,25 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20712" )
+	public void testOnDeleteCascadeTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/on-delete-toone/hbm.xml", scope, (transformed) -> {
+			final JaxbEntityImpl childEntity = transformed.getEntities().stream()
+					.filter( e -> "Child".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( childEntity.getAttributes().getManyToOneAttributes() ).hasSize( 1 );
+
+			final JaxbManyToOneImpl parentManyToOne = childEntity.getAttributes().getManyToOneAttributes().get( 0 );
+			assertThat( parentManyToOne.getName() ).isEqualTo( "parent" );
+			assertThat( parentManyToOne.getOnDelete() )
+					.as( "many-to-one with on-delete='cascade' should have on-delete=CASCADE" )
+					.isEqualTo( org.hibernate.annotations.OnDeleteAction.CASCADE );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20709" )
 	public void testCollectionFetchJoinEagerTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/collection-fetch-join-eager/hbm.xml", scope, (transformed) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -26,6 +26,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbCompositeUserTypeRegistrationImpl
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbHqlImportImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbIdImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
@@ -1340,6 +1341,19 @@ public class HbmTransformationJaxbTests {
 			assertThat( personManyToOne.getFetch() )
 					.as( "Composite-id key-many-to-one should have fetch=LAZY" )
 					.isEqualTo( jakarta.persistence.FetchType.LAZY );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20717" )
+	public void testImportWithoutRenameDefaultsToUnqualifiedClassName(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/import-no-rename/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getHqlImports() ).hasSize( 1 );
+			final JaxbHqlImportImpl hqlImport = (JaxbHqlImportImpl) transformed.getHqlImports().get( 0 );
+			assertThat( hqlImport.getClazz() ).isEqualTo( "Animal" );
+			assertThat( hqlImport.getRename() )
+					.as( "When hbm.xml import has no rename, transformer should default to unqualified class name" )
+					.isEqualTo( "Animal" );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/hqlimport/Dog.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/hqlimport/Dog.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.hqlimport;
+
+public class Dog {
+	Long id;
+	String name;
+	String breed;
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-fetch-join-eager/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-fetch-join-eager/hbm.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.mapping.collections.custom.basic" default-access="field">
+
+    <class name="User" table="UC_BSC_USER">
+        <id name="id"/>
+        <property name="userName"/>
+        <list name="emailAddresses" fetch="join" lazy="false" cascade="all, delete-orphan" collection-type="MyListType">
+            <key column="userName"/>
+            <list-index column="displayOrder" base="1"/>
+            <one-to-many class="Email"/>
+        </list>
+    </class>
+
+    <class name="Email">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="address"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-fetch-join-lazy/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-fetch-join-lazy/hbm.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.mapping.collections.custom.basic" default-access="field">
+
+    <class name="User" table="UC_BSC_USER">
+        <id name="id"/>
+        <property name="userName"/>
+        <list name="emailAddresses" fetch="join" cascade="all, delete-orphan" collection-type="MyListType">
+            <key column="userName"/>
+            <list-index column="displayOrder" base="1"/>
+            <one-to-many class="Email"/>
+        </list>
+    </class>
+
+    <class name="Email">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="address"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-type-typedef/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-type-typedef/hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.orm.test.mapping.collections.custom.parameterized" default-access="field">
+
+    <typedef name="DefaultableList" class="org.hibernate.orm.test.mapping.collections.custom.parameterized.DefaultableListType">
+        <param name="default">Hello</param>
+    </typedef>
+
+    <class name="Entity">
+        <id name="name" type="string"/>
+        <list name="values" fetch="join" lazy="false" table="ENT_VAL" collection-type="DefaultableList">
+            <key column="ENT_ID"/>
+            <list-index column="POS"/>
+            <element type="string" column="VAL"/>
+        </list>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-key-many-to-one-fetch/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/composite-key-many-to-one-fetch/hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.orm.test.onetoone.formula">
+
+    <class name="Person" table="ck_fetch_person">
+        <id name="name"/>
+    </class>
+
+    <class name="Address" table="ck_fetch_address">
+        <composite-id>
+            <key-many-to-one name="person" column="personName"/>
+            <key-property name="type" column="addressType"/>
+        </composite-id>
+        <property name="street"/>
+        <property name="zip"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/id-class/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/id-class/hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.idclass">
+
+    <class name="Customer">
+        <composite-id class="CustomerId" mapped="true">
+            <key-property name="orgName" column="org_name"/>
+            <key-property name="customerName" column="cust_name"/>
+        </composite-id>
+        <discriminator column="disc"/>
+        <property name="address"/>
+        <subclass name="FavoriteCustomer"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/import-no-rename/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/import-no-rename/hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.hqlimport">
+
+    <import class="Animal"/>
+
+    <class name="Dog">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+        <property name="breed"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/on-delete-toone/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/on-delete-toone/hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping package="org.hibernate.orm.test.ondelete.toone.hbm">
+
+    <class name="Parent">
+        <id name="id" type="long">
+            <generator class="assigned"/>
+        </id>
+    </class>
+
+    <class name="Child">
+        <id name="id" type="long">
+            <generator class="assigned"/>
+        </id>
+        <many-to-one name="parent" class="Parent" on-delete="cascade"/>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
- [HHH-20699](https://hibernate.atlassian.net/browse/HHH-20699) HbmXmlTransformer sets EAGER fetch on composite-id key-many-to-one instead of LAZY

- [HHH-20703](https://hibernate.atlassian.net/browse/HHH-20703) HbmXmlTransformer does not resolve typedef alias for collection-type attribute

- [HHH-20709](https://hibernate.atlassian.net/browse/HHH-20709) HbmXmlTransformer generates fetch-mode=JOIN for lazy collections causing eager initialization

- [HHH-20711](https://hibernate.atlassian.net/browse/HHH-20711) HbmXmlTransformer does not support composite-id with id-class 

- [HHH-20712](https://hibernate.atlassian.net/browse/HHH-20712) HbmXmlTransformer does not transfer on-delete="cascade" for many-to-one associations

- [HHH-20717](https://hibernate.atlassian.net/browse/HHH-20717) HbmXmlTransformer does not set the required rename attribute for <import>


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-20699]: https://hibernate.atlassian.net/browse/HHH-20699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20703]: https://hibernate.atlassian.net/browse/HHH-20703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20709]: https://hibernate.atlassian.net/browse/HHH-20709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20711]: https://hibernate.atlassian.net/browse/HHH-20711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20712]: https://hibernate.atlassian.net/browse/HHH-20712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20717]: https://hibernate.atlassian.net/browse/HHH-20717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20717 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20712 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20711 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20709 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20703 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20699 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->