### PR TITLE
HHH-20720 Copy @InterceptorBinding annotations for all repository types, not just @Repository

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
@@ -101,7 +101,7 @@ public final class ClassWriter {
 			if ( context.addComponentAnnotation() && entity.isInjectable() ) {
 				pw.println( writeComponentAnnotation( entity ) );
 			}
-			if ( context.addDependentAnnotation() && entity.isInjectable() ) {
+			if ( context.isCdiAvailable() && entity.isInjectable() ) {
 				pw.println( writeScopeAnnotation( entity ) );
 			}
 			if ( isLifecycleEventListener( entity ) ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
@@ -87,7 +87,7 @@ public final class Context {
 	 */
 	private @Nullable Boolean fullyXmlConfigured;
 	private boolean addInjectAnnotation = false;
-	private boolean addDependentAnnotation = false;
+	private boolean cdiAvailable = false;
 	private boolean addComponentAnnotation = false;
 	private boolean addNonnullAnnotation = false;
 	private boolean addGeneratedAnnotation = true;
@@ -193,12 +193,12 @@ public final class Context {
 		this.addInjectAnnotation = addInjectAnnotation;
 	}
 
-	public boolean addDependentAnnotation() {
-		return addDependentAnnotation;
+	public boolean isCdiAvailable() {
+		return cdiAvailable;
 	}
 
-	public void setAddDependentAnnotation(boolean addDependentAnnotation) {
-		this.addDependentAnnotation = addDependentAnnotation;
+	public void setCdiAvailable(boolean cdiAvailable) {
+		this.cdiAvailable = cdiAvailable;
 	}
 
 	public boolean addComponentAnnotation() {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
@@ -93,7 +93,7 @@ public final class Context {
 	 */
 	private @Nullable Boolean fullyXmlConfigured;
 	private boolean addInjectAnnotation = false;
-	private boolean addDependentAnnotation = false;
+	private boolean cdiAvailable = false;
 	private boolean addComponentAnnotation = false;
 	private boolean addNonnullAnnotation = false;
 	private boolean addGeneratedAnnotation = true;
@@ -208,12 +208,12 @@ public final class Context {
 		this.addInjectAnnotation = addInjectAnnotation;
 	}
 
-	public boolean addDependentAnnotation() {
-		return addDependentAnnotation;
+	public boolean isCdiAvailable() {
+		return cdiAvailable;
 	}
 
-	public void setAddDependentAnnotation(boolean addDependentAnnotation) {
-		this.addDependentAnnotation = addDependentAnnotation;
+	public void setCdiAvailable(boolean cdiAvailable) {
+		this.cdiAvailable = cdiAvailable;
 	}
 
 	public boolean addComponentAnnotation() {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -348,7 +348,7 @@ public class HibernateProcessor extends AbstractProcessor {
 		context.setAddInjectAnnotation( packagePresent(jakartaInjectPackage) );
 		context.setAddNonnullAnnotation( packagePresent(jakartaAnnotationPackage) );
 		context.setAddGeneratedAnnotation( packagePresent(jakartaAnnotationPackage) );
-		context.setAddDependentAnnotation( packagePresent(jakartaContextPackage) );
+		context.setCdiAvailable( packagePresent(jakartaContextPackage) );
 		context.setAddTransactionScopedAnnotation( packagePresent(jakartaTransactionPackage) );
 		context.setDataEventPackageAvailable( packagePresent(dataEventPackage) );
 		context.setQuarkusInjection( packagePresent(quarkusOrmPackage) || packagePresent(quarkusReactivePackage) );

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -328,7 +328,7 @@ public class HibernateProcessor extends AbstractProcessor {
 		context.setAddInjectAnnotation( packagePresent(jakartaInjectPackage) );
 		context.setAddNonnullAnnotation( packagePresent(jakartaAnnotationPackage) );
 		context.setAddGeneratedAnnotation( packagePresent(jakartaAnnotationPackage) );
-		context.setAddDependentAnnotation( packagePresent(jakartaContextPackage) );
+		context.setCdiAvailable( packagePresent(jakartaContextPackage) );
 		context.setAddTransactionScopedAnnotation( packagePresent(jakartaTransactionPackage) );
 		context.setDataEventPackageAvailable( packagePresent(dataEventPackage) );
 		context.setQuarkusInjection( packagePresent(quarkusOrmPackage) || packagePresent(quarkusReactivePackage) );

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractAnnotatedMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractAnnotatedMethod.java
@@ -103,7 +103,7 @@ public abstract class AbstractAnnotatedMethod implements MetaAttribute {
 
 	@Override
 	public List<AnnotationMirror> inheritedAnnotations() {
-		if ( annotationMetaEntity.isJakartaDataRepository() ) {
+		if ( annotationMetaEntity.isRepository() ) {
 			final var context = annotationMetaEntity.getContext();
 			return method.getAnnotationMirrors().stream()
 					.filter( a -> TypeUtils.isInheritedAnnotation( a, context ) )

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractAnnotatedMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractAnnotatedMethod.java
@@ -103,7 +103,7 @@ public abstract class AbstractAnnotatedMethod implements MetaAttribute {
 
 	@Override
 	public List<AnnotationMirror> inheritedAnnotations() {
-		if ( annotationMetaEntity.isRepository() ) {
+		if ( annotationMetaEntity.isRepository() && annotationMetaEntity.getContext().isCdiAvailable() ) {
 			final var context = annotationMetaEntity.getContext();
 			return method.getAnnotationMirrors().stream()
 					.filter( a -> TypeUtils.isInheritedAnnotation( a, context ) )

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -5908,7 +5908,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 	@Override
 	public List<AnnotationMirror> inheritedAnnotations() {
-		if ( jakartaDataRepository ) {
+		if ( repository ) {
 			List<AnnotationMirror> list = new ArrayList<>();
 			for ( var annotationMirror : element.getAnnotationMirrors() ) {
 				if ( isInheritedAnnotation( annotationMirror, context ) ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -1211,7 +1211,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			&& hasAnnotation( element, ENTITY )
 			&& context.isDataEventPackageAvailable() // events
 			&& context.addInjectAnnotation() // @Inject
-			&& context.addDependentAnnotation(); // CDI
+			&& context.isCdiAvailable(); // CDI
 	}
 
 	void addEventBus() {
@@ -1237,7 +1237,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		return jakartaDataRepository
 			&& !quarkusInjection
 			&& !springInjection
-			&& context.addDependentAnnotation();
+			&& context.isCdiAvailable();
 	}
 
 	private @Nullable ExecutableElement findSessionGetter(TypeElement type) {
@@ -5908,7 +5908,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 	@Override
 	public List<AnnotationMirror> inheritedAnnotations() {
-		if ( repository ) {
+		if ( repository && context.isCdiAvailable() ) {
 			List<AnnotationMirror> list = new ArrayList<>();
 			for ( var annotationMirror : element.getAnnotationMirrors() ) {
 				if ( isInheritedAnnotation( annotationMirror, context ) ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -5909,7 +5909,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 	@Override
 	public List<AnnotationMirror> inheritedAnnotations() {
-		if ( jakartaDataRepository ) {
+		if ( repository ) {
 			List<AnnotationMirror> list = new ArrayList<>();
 			for ( var annotationMirror : element.getAnnotationMirrors() ) {
 				if ( isInheritedAnnotation( annotationMirror, context ) ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -1211,7 +1211,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			&& hasAnnotation( element, ENTITY )
 			&& context.isDataEventPackageAvailable() // events
 			&& context.addInjectAnnotation() // @Inject
-			&& context.addDependentAnnotation(); // CDI
+			&& context.isCdiAvailable(); // CDI
 	}
 
 	void addEventBus() {
@@ -1237,7 +1237,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		return jakartaDataRepository
 			&& !quarkusInjection
 			&& !springInjection
-			&& context.addDependentAnnotation();
+			&& context.isCdiAvailable();
 	}
 
 	private @Nullable ExecutableElement findSessionGetter(TypeElement type) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
@@ -295,8 +295,18 @@ public final class TypeUtils {
 
 	public static boolean isInheritedAnnotation(AnnotationMirror annotationMirror, Context context) {
 		final Element annotationType = annotationMirror.getAnnotationType().asElement();
-		return hasAnnotation( annotationType, "jakarta.interceptor.InterceptorBinding" )
-			|| context.propagateSecurityAnnotations() && isSecurityAnnotation( annotationType );
+		// Interceptor bindings (e.g. @Transactional) let the generated repository implementation
+		// participate in interception. They only make sense when CDI is on the build path — without
+		// a container there is nothing to honor them — so guard on CDI availability.
+		return isInterceptorBinding( annotationType ) && context.isCdiAvailable()
+			// Security annotations (@RolesAllowed, @PermitAll, ...) are a Hibernate ORM specific
+			// extension for repository interfaces, copied unless explicitly suppressed. They do not
+			// depend on CDI.
+			|| isSecurityAnnotation( annotationType ) && context.propagateSecurityAnnotations();
+	}
+
+	private static boolean isInterceptorBinding(Element annotationType) {
+		return hasAnnotation( annotationType, "jakarta.interceptor.InterceptorBinding" );
 	}
 
 	private static boolean isSecurityAnnotation(Element annotationType) {


### PR DESCRIPTION
Previously, inheritedAnnotations() only copied annotations with @InterceptorBinding (such as @Transactional) to the generated implementation class when the interface was annotated with Jakarta Data's @Repository. Quarkus Data repositories without @Repository were excluded, so @Transactional on their methods was silently lost.

Widen the check from isJakartaDataRepository()/jakartaDataRepository to isRepository()/repository so that all processor-generated repository implementations inherit interceptor binding annotations.

Upstream issue: https://github.com/quarkusio/quarkus/issues/53622

Test is on Quarkus project, as usual.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20720 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20720
<!-- Hibernate GitHub Bot issue links end -->