### PR TITLE
HHH-20716 xml <hql-import> elements are parsed but never processed

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
@@ -134,6 +134,10 @@ public class AnnotationMetadataSourceProcessorImpl implements MetadataSourceProc
 
 	@Override
 	public void processQueryRenames() {
+		final var importedRenames = domainModelSource.getGlobalRegistrations().getImportedRenames();
+		for ( var entry : importedRenames.entrySet() ) {
+			rootMetadataBuildingContext.getMetadataCollector().addImport( entry.getKey(), entry.getValue() );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -87,6 +87,9 @@ public class DomainModelCategorizationCollector {
 		getGlobalRegistrations().collectQueryReferences( jaxbRoot, xmlDocumentContext );
 
 		getGlobalRegistrations().collectDataBaseObject( jaxbRoot.getDatabaseObjects() );
+
+		getGlobalRegistrations().collectHqlImports( jaxbRoot.getHqlImports(), jaxbRoot.getPackage() );
+
 		// todo (7.0) : named graphs?
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/GlobalRegistrationsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/GlobalRegistrationsImpl.java
@@ -30,6 +30,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappingsImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbFetchProfileImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbFilterDefImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbGenericIdGeneratorImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbHqlImportImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbJavaTypeRegistrationImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbJdbcTypeRegistrationImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNamedNativeStatementImpl;
@@ -126,6 +127,7 @@ import static org.hibernate.boot.models.HibernateAnnotations.TYPE_REGISTRATION;
 import static org.hibernate.boot.models.xml.internal.QueryProcessing.collectResultClasses;
 import static org.hibernate.boot.BootLogging.BOOT_LOGGER;
 import static org.hibernate.internal.util.StringHelper.isNotEmpty;
+import static org.hibernate.internal.util.StringHelper.qualifyConditionallyIfNot;
 import static org.hibernate.internal.util.StringHelper.unqualify;
 import static org.hibernate.internal.util.collections.CollectionHelper.isEmpty;
 import static org.hibernate.internal.util.collections.CollectionHelper.isNotEmpty;
@@ -689,6 +691,16 @@ public class GlobalRegistrationsImpl implements GlobalRegistrations, GlobalRegis
 							? explicitRename
 							: unqualify( classDetails.getName() );
 			collectImportRename( rename, classDetails.getName() );
+		}
+	}
+
+	public void collectHqlImports(List<JaxbHqlImportImpl> hqlImports, String packageName) {
+		for ( var hqlImport : hqlImports ) {
+			final String className = qualifyConditionallyIfNot( packageName, hqlImport.getClazz() );
+			final String rename = hqlImport.getRename() != null
+					? hqlImport.getRename()
+					: unqualify( className );
+			collectImportRename( rename, className );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hqlimport/Animal.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hqlimport/Animal.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.hqlimport;
+
+public class Animal {
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hqlimport/Cat.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hqlimport/Cat.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.hqlimport;
+
+public class Cat extends Animal {
+	private boolean indoor;
+
+	public boolean isIndoor() {
+		return indoor;
+	}
+
+	public void setIndoor(boolean indoor) {
+		this.indoor = indoor;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hqlimport/Dog.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hqlimport/Dog.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.hqlimport;
+
+public class Dog extends Animal {
+	private String breed;
+
+	public String getBreed() {
+		return breed;
+	}
+
+	public void setBreed(String breed) {
+		this.breed = breed;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hqlimport/HqlImportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hqlimport/HqlImportTest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.hqlimport;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code <import>} (hql-import) elements in orm.xml are processed
+ * and register class names for use in HQL polymorphic queries.
+ */
+@JiraKey("HHH-20716")
+@DomainModel(xmlMappings = "org/hibernate/orm/test/hqlimport/Mappings.orm.xml")
+@SessionFactory
+public class HqlImportTest {
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	void testPolymorphicQueryUsingImportedName(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Dog dog = new Dog();
+			dog.setName( "Rex" );
+			dog.setBreed( "Labrador" );
+			session.persist( dog );
+
+			Cat cat = new Cat();
+			cat.setName( "Whiskers" );
+			cat.setIndoor( true );
+			session.persist( cat );
+		} );
+
+		scope.inTransaction( session -> {
+			// "Animal" is not an entity — it's imported via <import class="Animal"/>
+			// so it can be used as an HQL name for polymorphic queries
+			List<Animal> animals = session.createQuery( "from Animal", Animal.class ).list();
+			assertThat( animals ).hasSize( 2 );
+			assertThat( animals ).extracting( Animal::getName ).containsExactlyInAnyOrder( "Rex", "Whiskers" );
+		} );
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/hqlimport/Mappings.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/hqlimport/Mappings.orm.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <package>org.hibernate.orm.test.hqlimport</package>
+    <attribute-accessor>property</attribute-accessor>
+
+
+    <mapped-superclass class="org.hibernate.orm.test.hqlimport.Animal" access="PROPERTY" metadata-complete="true">
+        <attributes>
+            <id name="id">
+                <generated-value strategy="IDENTITY"/>
+            </id>
+            <basic name="name"/>
+        </attributes>
+    </mapped-superclass>
+
+
+    <entity class="Dog" metadata-complete="true">
+        <table name="Dog"/>
+        <attributes>
+            <basic name="breed"/>
+        </attributes>
+    </entity>
+
+    <entity class="Cat" metadata-complete="true">
+        <table name="Cat"/>
+        <attributes>
+            <basic name="indoor"/>
+        </attributes>
+    </entity>
+
+    <!-- Register Animal as an HQL name for polymorphic queries -->
+    <import class="Animal" rename="Animal"/>
+
+</entity-mappings>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/13106 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20716 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20716
<!-- Hibernate GitHub Bot issue links end -->