### PR TITLE
HHH-20721 Avoid coercing multi-valued query parameters as scalars

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
@@ -1036,8 +1036,8 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 			final var hibernateType = parameter.getHibernateType();
 			return hibernateType == null
 				|| values.isEmpty()
-				|| !isInstance( hibernateType, value, getNodeBuilder() )
-				|| isInstance( hibernateType, values.iterator().next(), getNodeBuilder() );
+				|| isInstance( hibernateType, values.iterator().next(), getNodeBuilder() )
+				|| !isInstance( hibernateType, value, getNodeBuilder() );
 		}
 		else {
 			return false;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/MultiValuedParameterCoercionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/MultiValuedParameterCoercionTest.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.hql;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.JavaType;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.type.descriptor.java.StringJavaType;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel( annotatedClasses = MultiValuedParameterCoercionTest.TestEntity.class )
+@SessionFactory
+@JiraKey( "HHH-20721" )
+class MultiValuedParameterCoercionTest {
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	void collectionIsNotCoercedToElementType(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new TestEntity( 1L, "first" ) );
+			session.persist( new TestEntity( 2L, "second" ) );
+			session.flush();
+
+			TrackingStringJavaType.COLLECTION_COERCIONS.set( 0 );
+
+			final var result = session.createQuery(
+						"from TestEntity where name in :names",
+						TestEntity.class
+				)
+					.setParameter( "names", Set.of( "first", "second" ) )
+					.getResultList();
+
+			assertThat( result )
+					.extracting( TestEntity::getName )
+					.containsExactlyInAnyOrder( "first", "second" );
+			assertThat( TrackingStringJavaType.COLLECTION_COERCIONS ).hasValue( 0 );
+		} );
+	}
+
+	@Entity( name = "TestEntity" )
+	static class TestEntity {
+		@Id
+		private Long id;
+
+		@JavaType( TrackingStringJavaType.class )
+		private String name;
+
+		TestEntity() {
+		}
+
+		TestEntity(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		String getName() {
+			return name;
+		}
+	}
+
+	public static class TrackingStringJavaType extends StringJavaType {
+		private static final AtomicInteger COLLECTION_COERCIONS = new AtomicInteger();
+
+		@Override
+		public String coerce(Object value) {
+			if ( value instanceof Collection<?> ) {
+				COLLECTION_COERCIONS.incrementAndGet();
+			}
+			return super.coerce( value );
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20721

When deciding whether a parameter should use multi-valued binding, the collection itself was checked against the element Hibernate type before inspecting an element. That check attempts scalar coercion and catches the resulting exception, allocating an exception for every execution of an ordinary JPQL IN query.

This reorders the existing OR conditions so a valid first element short-circuits before the collection is passed to scalar coercion. The boolean classification remains unchanged, including the fallback for ambiguous values.

The regression test uses a custom String Java type to verify that the query returns the expected rows without ever receiving the collection in its coercion method.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20721 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->
