### PR TITLE
HHH-20736 Tune the content of javadocs to reduce the size of files published to Maven Central

### DIFF
--- a/local-build-plugins/src/main/groovy/local.publishing-java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.publishing-java-module.gradle
@@ -73,6 +73,22 @@ tasks.named("check") {
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Javadoc
+
+// Reduce the size of per-module javadoc jars published to Maven Central.
+// These options are intentionally NOT in local.javadoc.gradle,
+// so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+tasks.withType(Javadoc).configureEach {
+    exclude '**/spi/**' // SPI pages are ~7M in the jar; SPI is for integrators who read the source
+    configure( options ) {
+        addStringOption('-override-methods', 'summary') // don't repeat inherited method docs; link to the declaring type instead
+        use = false // class-use pages are ~10M in the jar; IDEs provide better "find usages"
+        splitIndex = true // avoid a single 17M index-all.html; split into per-letter files instead
+        noTree = true // class hierarchy is ~7M uncompressed; IDEs show this better
+    }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Publishing
 
 var publishingExtension = project.getExtensions().getByType(PublishingExtension) as PublishingExtension


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20736

This reduces the size of javadocs, in particular for hibernate-core (~30MB => ~20MB). I think the tradeoffs are reasonable considering how javadocs are used -- as a reference more than a way to explore relationships between classes (that's IDE business).

WDYT?

Changes:

1. `--override-methods summary`
    Overridden/implementing methods appear only in the summary table, not repeated in the method detail section. This is what the JDK's own javadoc uses. Saves ~1M compressed. Users can still click through to the declaring type for full docs.

2. `use = false`
    Removes class-use ("where is X used") pages. Saves ~10M from the compressed jar (30M → 20M). These pages are rarely consulted — modern IDEs handle "Find Usages" far better. 

3. `splitIndex = true`
    Splits the monolithic 17M `index-all.html` into per-letter files (largest ~3.2M). Doesn't reduce the jar but eliminates the single huge file problem. Most users search via the search box anyway.

4. `noTree = true`
    Removes the class hierarchy tree pages. Saves ~1M from the jar. Modern IDEs show class hierarchies better.


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20736 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->