### PR TITLE
HHH-3007 Clear dirty flag on PersistentCollection if replaceElements retains storedSnapshot state

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/ArrayType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ArrayType.java
@@ -119,6 +119,14 @@ public class ArrayType extends CollectionType {
 			Array.set( target, i, elemType.replace( Array.get(original, i), null, session, owner, copyCache ) );
 		}
 
+		if ( target instanceof PersistentCollection<?> targetPersistentCollection
+				&& targetPersistentCollection.wasInitialized()
+				&& targetPersistentCollection.isDirty()
+				&& targetPersistentCollection.getStoredSnapshot() != null
+				&& targetPersistentCollection.equalsSnapshot( getPersister( session.getFactory() ) ) ) {
+			targetPersistentCollection.clearDirty();
+		}
+
 		return target;
 
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -496,6 +496,14 @@ public abstract class CollectionType extends AbstractType implements Association
 			}
 		}
 
+		if ( target instanceof PersistentCollection<?> targetPersistentCollection
+				&& targetPersistentCollection.wasInitialized()
+				&& targetPersistentCollection.isDirty()
+				&& targetPersistentCollection.getStoredSnapshot() != null
+				&& targetPersistentCollection.equalsSnapshot( getPersister( session.getFactory() ) ) ) {
+			targetPersistentCollection.clearDirty();
+		}
+
 		return result;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/MapType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/MapType.java
@@ -78,6 +78,14 @@ public class MapType extends CollectionType {
 			result.put( key, value );
 		}
 
+		if ( target instanceof PersistentCollection<?> targetPersistentCollection
+				&& targetPersistentCollection.wasInitialized()
+				&& targetPersistentCollection.isDirty()
+				&& targetPersistentCollection.getStoredSnapshot() != null
+				&& targetPersistentCollection.equalsSnapshot( getPersister( session.getFactory() ) ) ) {
+			targetPersistentCollection.clearDirty();
+		}
+
 		return result;
 
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/collection/detached/MergeCollectionEventTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/collection/detached/MergeCollectionEventTest.java
@@ -98,6 +98,28 @@ public class MergeCollectionEventTest {
 
 		listener.reset();
 
+		Character paul2 = new Character( 3, "Paul Atreides 2" );
+		scope.inTransaction( s -> {
+			s.persist( paul2 );
+		} );
+
+		assertEquals( 2, listener.getEventEntryList().size() );
+		checkListener( 0, PreCollectionRecreateEvent.class, paul2, Collections.EMPTY_LIST );
+		checkListener( 1, PostCollectionRecreateEvent.class, paul2, Collections.EMPTY_LIST );
+
+		listener.reset();
+
+		Character paulo2 = new Character( 4, "Paulo Atreides 2" );
+		scope.inTransaction( s -> {
+			s.persist( paulo2 );
+		} );
+
+		assertEquals( 2, listener.getEventEntryList().size() );
+		checkListener( 0, PreCollectionRecreateEvent.class, paulo2, Collections.EMPTY_LIST );
+		checkListener( 1, PostCollectionRecreateEvent.class, paulo2, Collections.EMPTY_LIST );
+
+		listener.reset();
+
 		Alias alias1 = new Alias( 1, "Paul Muad'Dib" );
 		scope.inTransaction( s -> {
 			s.persist( alias1 );
@@ -132,7 +154,7 @@ public class MergeCollectionEventTest {
 		paulo.associateAlias( alias2 );
 
 		scope.inTransaction( s -> {
-			s.merge( alias1 );
+			Alias managedAlias1 = s.merge( alias1 );
 
 			assertEquals( 0, listener.getEventEntryList().size() );
 
@@ -177,9 +199,22 @@ public class MergeCollectionEventTest {
 
 			listener.reset();
 
-			s.merge( alias2 );
+			Alias managedAlias2 = s.merge( alias2 );
 
 			assertEquals( 0, listener.getEventEntryList().size() );
+
+			s.flush();
+
+			// Data didn't change compared to snapshot, so we get no events
+			assertEquals( 0, listener.getEventEntryList().size() );
+
+			Character managedPaul2 = s.find( Character.class, paul2.getId() );
+			managedPaul2.associateAlias( managedAlias1 );
+			managedPaul2.associateAlias( managedAlias2 );
+
+			Character managedPaulo2 = s.find( Character.class, paulo2.getId() );
+			managedPaulo2.associateAlias( managedAlias1 );
+			managedPaulo2.associateAlias( managedAlias2 );
 
 			s.flush();
 
@@ -199,7 +234,7 @@ public class MergeCollectionEventTest {
 			else {
 				// Legacy: PRE/POST paired per collection
 				checkListener( 0, PreCollectionUpdateEvent.class, alias1, alias1CharactersSnapshot );
-				checkListener( 1, PostCollectionUpdateEvent.class, alias1, alias1CharactersSnapshot );
+				checkListener( 1, PostCollectionUpdateEvent.class, alias1, alias1.getCharacters() );
 //		checkListener( 2, PreCollectionUpdateEvent.class, paul, Collections.EMPTY_LIST );
 //		checkListener( 3, PostCollectionUpdateEvent.class, paul, paul.getAliases() );
 				checkListener( 4, PreCollectionUpdateEvent.class, alias2, alias2CharactersSnapshot );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/merge/UnchangedCollectionMergeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/merge/UnchangedCollectionMergeTest.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.merge;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Version;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproducer for HHH-3007: merging a detached entity whose collection has
+ * not been changed causes the collection to be marked dirty, which in turn
+ * increments the {@code @Version} counter even though nothing actually changed.
+ */
+@Jpa(annotatedClasses = {
+		UnchangedCollectionMergeTest.Root.class,
+		UnchangedCollectionMergeTest.Leaf.class
+})
+@Jira("https://hibernate.atlassian.net/browse/HHH-3007")
+public class UnchangedCollectionMergeTest {
+
+	@Test
+	void mergingUnchangedCollectionMustNotIncrementVersion(EntityManagerFactoryScope scope) {
+		// Persist root with one leaf
+		scope.inTransaction( em -> {
+			Root root = new Root();
+			Leaf leaf = new Leaf();
+			root.leaves.add( leaf );
+			em.persist( root );
+		} );
+
+		Root detached = scope.fromTransaction( em -> em.find( Root.class, 1L ) );
+		long versionAfterPersist = detached.version;
+		detached.leaves = new HashSet<>( detached.leaves );
+
+		// Merge the detached root without touching the collection
+		long versionAfterMerge = scope.fromTransaction( em -> em.merge( detached ) ).version;
+
+		// The version must not have changed since nothing was modified
+		assertEquals( versionAfterPersist, versionAfterMerge,
+				"HHH-3007: version must not be incremented when the collection was not modified during merge" );
+	}
+
+	@Entity(name = "Root")
+	static class Root {
+		@Id
+		long id = 1L;
+
+		@Version
+		long version;
+
+		@OneToMany(cascade = ALL, fetch = FetchType.EAGER)
+		Set<Leaf> leaves = new HashSet<>();
+	}
+
+	@Entity(name = "Leaf")
+	static class Leaf {
+		@Id @GeneratedValue
+		Long id;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-3007 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-3007
<!-- Hibernate GitHub Bot issue links end -->