### PR TITLE
HHH-20743 Use fileSet base directory for class name resolution in maven plugin

### DIFF
--- a/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
+++ b/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
@@ -25,6 +25,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -36,7 +37,9 @@ import java.util.Set;
 		requiresDependencyResolution = ResolutionScope.COMPILE)
 public class HibernateEnhancerMojo extends AbstractMojo {
 
-	final private List<File> sourceSet = new ArrayList<File>();
+	record SourceEntry(File baseDir, File classFile) {}
+
+	final private List<SourceEntry> sourceSet = new ArrayList<>();
 	private Enhancer enhancer;
 
 	/**
@@ -156,7 +159,7 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 		for (String fileName : fileSetManager.getIncludedFiles(fileSet)) {
 			File candidateFile = new File(baseDir, fileName);
 			if (fileName.endsWith(".class")) {
-				sourceSet.add(candidateFile);
+				sourceSet.add(new SourceEntry(baseDir, candidateFile));
 				getLog().info(ADDED_FILE_TO_SOURCE_SET.formatted(candidateFile));
 			}
 			else {
@@ -222,17 +225,17 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 
 	private void discoverTypes() throws MojoExecutionException {
 		getLog().debug(STARTING_TYPE_DISCOVERY) ;
-		for (File classFile : sourceSet) {
-			discoverTypesForClass(classFile);
+		for (SourceEntry entry : sourceSet) {
+			discoverTypesForClass(entry.baseDir(), entry.classFile());
 		}
 		getLog().debug(ENDING_TYPE_DISCOVERY) ;
 	}
 
-	private void discoverTypesForClass(File classFile) throws MojoExecutionException {
+	private void discoverTypesForClass(File baseDir, File classFile) throws MojoExecutionException {
 		getLog().debug(TRYING_TO_DISCOVER_TYPES_FOR_CLASS_FILE.formatted(classFile));
 		try {
 			enhancer.discoverTypes(
-					determineClassName(classFile),
+					determineClassName(baseDir, classFile),
 					Files.readAllBytes(classFile.toPath()));
 			getLog().info(SUCCESSFULLY_DISCOVERED_TYPES_FOR_CLASS_FILE.formatted(classFile));
 		}
@@ -241,22 +244,24 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 		}
 	}
 
-	private String determineClassName(File classFile) {
+	private String determineClassName(File baseDir, File classFile) {
 		getLog().debug(DETERMINE_CLASS_NAME_FOR_FILE.formatted(classFile));
-		String classFilePath = classFile.getAbsolutePath();
-		String classesDirectoryPath = classesDirectory.getAbsolutePath();
-		return classFilePath.substring(
-						classesDirectoryPath.length() + 1,
-						classFilePath.length() - ".class".length())
-				.replace(File.separatorChar, '.');
+		final Path relativeClassPath = baseDir.toPath().relativize(classFile.toPath());
+		final String relativeClassPathString = relativeClassPath.toString();
+		final String classNameBase = relativeClassPathString.substring(
+				0,
+				relativeClassPathString.length() - ".class".length()
+		);
+		return classNameBase.replace(File.separatorChar, '.');
 	}
 
 	private void performEnhancement() throws MojoExecutionException {
 		getLog().debug(STARTING_CLASS_ENHANCEMENT) ;
 		boolean success = true;
-		for (File classFile : sourceSet) {
+		for (SourceEntry entry : sourceSet) {
+			var classFile = entry.classFile();
 			long lastModified = classFile.lastModified();
-			success = enhanceClass(classFile) & success;
+			success = enhanceClass(entry.baseDir(), classFile) & success;
 			final boolean timestampReset = classFile.setLastModified( lastModified );
 			if ( !timestampReset ) {
 				getLog().debug(SETTING_LASTMODIFIED_FAILED_FOR_CLASS_FILE.formatted(classFile));
@@ -268,11 +273,11 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 		getLog().debug(ENDING_CLASS_ENHANCEMENT) ;
 	}
 
-	private boolean enhanceClass(File classFile) throws MojoExecutionException {
+	private boolean enhanceClass(File baseDir, File classFile) throws MojoExecutionException {
 		getLog().debug(TRYING_TO_ENHANCE_CLASS_FILE.formatted(classFile));
 		try {
 			byte[] newBytes = enhancer.enhance(
-					determineClassName(classFile),
+					determineClassName(baseDir, classFile),
 					Files.readAllBytes(classFile.toPath()));
 			if (newBytes != null) {
 				writeByteCodeToFile(newBytes, classFile);

--- a/tooling/hibernate-maven-plugin/src/test/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojoTest.java
+++ b/tooling/hibernate-maven-plugin/src/test/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojoTest.java
@@ -102,9 +102,10 @@ public class HibernateEnhancerMojoTest {
 		assertTrue(sourceSet.isEmpty());
 		assembleSourceSetMethod.invoke(enhanceMojo);
 		assertFalse(sourceSet.isEmpty());
-		assertTrue(sourceSet.contains(barClassFile));
-		assertFalse(sourceSet.contains(fooTxtFile));
 		assertEquals(1, sourceSet.size());
+		var entry = (HibernateEnhancerMojo.SourceEntry) sourceSet.get(0);
+		assertEquals(barClassFile, entry.classFile());
+		assertEquals(classesDirectory, entry.baseDir());
 		// verify the log messages
 		assertEquals(7, logMessages.size());
 		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_ASSEMBLY_OF_SOURCESET));
@@ -134,6 +135,13 @@ public class HibernateEnhancerMojoTest {
 		fileSet.addInclude("**/*.class");
 		fileSet.addExclude("**/baz/**");
 		addFileSetToSourceSetMethod.invoke(enhanceMojo, fileSet);
+		@SuppressWarnings("unchecked")
+		List<HibernateEnhancerMojo.SourceEntry> sourceSet =
+				(List<HibernateEnhancerMojo.SourceEntry>) sourceSetField.get(enhanceMojo);
+		var classFiles = sourceSet.stream().map(HibernateEnhancerMojo.SourceEntry::classFile).toList();
+		assertTrue(classFiles.contains(barClassFile));
+		assertTrue(classFiles.contains(fooClassFile));
+		assertFalse(classFiles.contains(bazClassFile));
 		// verify log messages
 		assertEquals(6, logMessages.size());
 		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.PROCESSING_FILE_SET));
@@ -273,12 +281,28 @@ public class HibernateEnhancerMojoTest {
 	void testDetermineClassName() throws Exception {
 		Method determineClassNameMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
 				"determineClassName",
-				new Class[] { File.class });
+				new Class[] { File.class, File.class });
 		determineClassNameMethod.setAccessible(true);
-		assertEquals("org.foo.Bar", determineClassNameMethod.invoke(enhanceMojo, barClassFile));
+		assertEquals("org.foo.Bar", determineClassNameMethod.invoke(enhanceMojo, classesDirectory, barClassFile));
 		// check log messages
 		assertEquals(1, logMessages.size());
 		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
+	}
+
+	@Test
+	void testDetermineClassNameWithDifferentBaseDir() throws Exception {
+		Method determineClassNameMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+				"determineClassName",
+				new Class[] { File.class, File.class });
+		determineClassNameMethod.setAccessible(true);
+		File testClassesDirectory = new File(tempDir, "test-classes");
+		File testPackageDir = new File(testClassesDirectory, "org/hibernate/bugs");
+		testPackageDir.mkdirs();
+		File testClassFile = new File(testPackageDir, "TestEntity.class");
+		testClassFile.createNewFile();
+		assertEquals(
+				"org.hibernate.bugs.TestEntity",
+				determineClassNameMethod.invoke(enhanceMojo, testClassesDirectory, testClassFile));
 	}
 
 	@Test
@@ -286,7 +310,7 @@ public class HibernateEnhancerMojoTest {
 		final List<Boolean> hasRun = new ArrayList<Boolean>();
 		Method discoverTypesForClassMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
 				"discoverTypesForClass",
-				new Class[] { File.class });
+				new Class[] { File.class, File.class });
 		discoverTypesForClassMethod.setAccessible(true);
 		Enhancer enhancer = (Enhancer)Proxy.newProxyInstance(
 				getClass().getClassLoader(),
@@ -303,7 +327,7 @@ public class HibernateEnhancerMojoTest {
 				});
 		enhancerField.set(enhanceMojo, enhancer);
 		assertFalse(hasRun.contains(true));
-		discoverTypesForClassMethod.invoke(enhanceMojo, barClassFile);
+		discoverTypesForClassMethod.invoke(enhanceMojo, classesDirectory, barClassFile);
 		assertTrue(hasRun.contains(true));
 		// verify log messages
 		assertEquals(3, logMessages.size());
@@ -342,9 +366,10 @@ public class HibernateEnhancerMojoTest {
 		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ENDING_TYPE_DISCOVERY));
 		logMessages.clear();
 		@SuppressWarnings("unchecked")
-		List<File> sourceSet = (List<File>) sourceSetField.get(enhanceMojo);
+		List<HibernateEnhancerMojo.SourceEntry> sourceSet =
+				(List<HibernateEnhancerMojo.SourceEntry>) sourceSetField.get(enhanceMojo);
 		sourceSet.clear();
-		sourceSet.add(barClassFile);
+		sourceSet.add(new HibernateEnhancerMojo.SourceEntry(classesDirectory, barClassFile));
 		discoverTypesMethod.invoke(enhanceMojo);
 		assertTrue(hasRun.contains(true));
 		// verify the log messages
@@ -412,7 +437,7 @@ public class HibernateEnhancerMojoTest {
 		calls.add(0, 0);
 		Method enhanceClassMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
 				"enhanceClass",
-				new Class[] { File.class });
+				new Class[] { File.class, File.class });
 		enhanceClassMethod.setAccessible(true);
 		Enhancer enhancer = (Enhancer)Proxy.newProxyInstance(
 				getClass().getClassLoader(),
@@ -437,7 +462,7 @@ public class HibernateEnhancerMojoTest {
 		// First Run -> file is modified
 		enhancerField.set(enhanceMojo, enhancer);
 		assertEquals(0, calls.get(0));
-		enhanceClassMethod.invoke(enhanceMojo, barClassFile);
+		enhanceClassMethod.invoke(enhanceMojo, classesDirectory, barClassFile);
 		long afterFirstRun = barClassFile.lastModified();
 		assertEquals(1, calls.get(0));
 		assertTrue(afterFirstRun >= beforeRuns);
@@ -453,7 +478,7 @@ public class HibernateEnhancerMojoTest {
 		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SUCCESSFULLY_ENHANCED_CLASS_FILE.formatted(barClassFile)));
 		// Second Run -> file is not modified
 		logMessages.clear();
-		enhanceClassMethod.invoke(enhanceMojo, barClassFile);
+		enhanceClassMethod.invoke(enhanceMojo, classesDirectory, barClassFile);
 		long afterSecondRun = barClassFile.lastModified();
 		assertEquals(2, calls.get(0));
 		assertEquals(afterSecondRun, afterFirstRun);
@@ -466,7 +491,7 @@ public class HibernateEnhancerMojoTest {
 		// Third Run -> exception!
 		logMessages.clear();
 		try {
-			enhanceClassMethod.invoke(enhanceMojo, barClassFile);
+			enhanceClassMethod.invoke(enhanceMojo, classesDirectory, barClassFile);
 			fail();
 		} catch (Throwable e) {
 			long afterThirdRun = barClassFile.lastModified();
@@ -503,9 +528,10 @@ public class HibernateEnhancerMojoTest {
 				});
 		enhancerField.set(enhanceMojo, enhancer);
 		@SuppressWarnings("unchecked")
-		List<File> sourceSet = (List<File>) sourceSetField.get(enhanceMojo);
+		List<HibernateEnhancerMojo.SourceEntry> sourceSet =
+				(List<HibernateEnhancerMojo.SourceEntry>) sourceSetField.get(enhanceMojo);
 		sourceSet.clear();
-		sourceSet.add(barClassFile);
+		sourceSet.add(new HibernateEnhancerMojo.SourceEntry(classesDirectory, barClassFile));
 		long lastModified = barClassFile.lastModified();
 		assertFalse(hasRun.contains(true));
 		assertNotEquals("foobar", new String(Files.readAllBytes(barClassFile.toPath())));
@@ -565,10 +591,11 @@ public class HibernateEnhancerMojoTest {
 		String barBytesString = new String(Files.readAllBytes(barClassFile.toPath()));
 		String fooBytesString = new String(Files.readAllBytes(fooClassFile.toPath()));
 		@SuppressWarnings("unchecked")
-		List<File> sourceSet = (List<File>) sourceSetField.get(enhanceMojo);
+		List<HibernateEnhancerMojo.SourceEntry> sourceSet =
+				(List<HibernateEnhancerMojo.SourceEntry>) sourceSetField.get(enhanceMojo);
 		sourceSet.clear();
-		sourceSet.add(barClassFile);
-		sourceSet.add(fooClassFile);
+		sourceSet.add(new HibernateEnhancerMojo.SourceEntry(classesDirectory, barClassFile));
+		sourceSet.add(new HibernateEnhancerMojo.SourceEntry(classesDirectory, fooClassFile));
 		assertTrue(logMessages.isEmpty());
 		executeMethod.invoke(enhanceMojo);
 		assertNotEquals(barBytesString, new String(Files.readAllBytes(barClassFile.toPath())));


### PR DESCRIPTION
## Summary

- Track each collected class file's base directory using a `SourceEntry` record instead of a flat `List<File>`
- Use `Path.relativize()` in `determineClassName()` instead of substring arithmetic against `classesDirectory`, consistent with the Gradle plugin's `Helper.determineClassName(File root, File javaClassFile)`

`determineClassName()` always used `classesDirectory` (default `target/classes`) as the base for deriving class names from file paths. When a `fileSet` pointed to a different directory (e.g. `target/test-classes`), the substring arithmetic stripped the wrong prefix, producing corrupted class names like `sses.org.hibernate.bugs.TestEntity`.

https://hibernate.atlassian.net/browse/HHH-20743

## Test plan

- [x] Updated existing unit tests for new method signatures
- [x] Added `testDetermineClassNameWithDifferentBaseDir` to verify class name resolution with a non-default base directory
- [x] All 15 `HibernateEnhancerMojoTest` tests pass
- [x] End-to-end: published plugin to local Maven repo, tested against [hibernate-test-case-templates](https://github.com/hibernate/hibernate-test-case-templates) with a `fileSet` pointing to `target/test-classes` — enhancement succeeds without needing `<classesDirectory>` workaround

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20743 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->