### PR TITLE
Backport HHH-20736 to branch 7.1 - Tune the content of javadocs to reduce the size of files published to Maven Central

### DIFF
--- a/local-build-plugins/src/main/groovy/local.publishing-java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.publishing-java-module.gradle
@@ -24,6 +24,22 @@ dependencies {
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Javadoc
+
+// Reduce the size of per-module javadoc jars published to Maven Central.
+// These options are intentionally NOT in local.javadoc.gradle,
+// so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+tasks.withType(Javadoc).configureEach {
+    exclude '**/spi/**' // SPI pages are ~7M in the jar; SPI is for integrators who read the source
+    configure( options ) {
+        addStringOption('-override-methods', 'summary') // don't repeat inherited method docs; link to the declaring type instead
+        use = false // class-use pages are ~10M in the jar; IDEs provide better "find usages"
+        splitIndex = true // avoid a single 17M index-all.html; split into per-letter files instead
+        noTree = true // class hierarchy is ~7M uncompressed; IDEs show this better
+    }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Publishing
 
 var publishingExtension = project.getExtensions().getByType(PublishingExtension) as PublishingExtension


### PR DESCRIPTION
Backport of #13116 to branch 7.1

https://hibernate.atlassian.net/browse/HHH-20736


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20736 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->