### PR TITLE
HHH-12016 Support non-primary table columns in @SQLRestriction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLRestriction.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLRestriction.java
@@ -47,6 +47,20 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * List&lt;Document&gt; documents;
  * </pre>
  * <p>
+ * By default, the restriction is applied to the primary table of the
+ * entity. When the restriction involves columns of other tables, for
+ * example, columns mapped by a superclass in a {@linkplain
+ * jakarta.persistence.InheritanceType#JOINED joined inheritance}
+ * hierarchy, the tables holding the columns must be identified using
+ * {@linkplain #aliases alias placeholders} of the form {@code {name}}:
+ * <pre>
+ * &#64;OneToMany(mappedBy = "application")
+ * &#64;SQLRestriction(value = "{version}.effective_to is null",
+ *                 aliases = &#64;SqlFragmentAlias(alias = "version",
+ *                                              entity = AbstractVersion.class))
+ * List&lt;ApplicationVersion&gt; versions;
+ * </pre>
+ * <p>
  * Note that {@code @SQLRestriction}s are always applied and cannot be
  * disabled. Nor may they be parameterized. They're therefore <em>much</em>
  * less flexible than {@linkplain Filter filters}.
@@ -67,4 +81,16 @@ public @interface SQLRestriction {
 	 * A predicate, written in native SQL.
 	 */
 	String value();
+
+	/**
+	 * Explicitly specifies how aliases are interpolated into
+	 * the {@link #value} SQL expression. Each {@link
+	 * SqlFragmentAlias} specifies a placeholder name and the
+	 * table whose alias should be interpolated. Placeholders
+	 * are of form {@code {name}} where {@code name} matches
+	 * a {@link SqlFragmentAlias#alias}.
+	 *
+	 * @since 8.1
+	 */
+	SqlFragmentAlias[] aliases() default {};
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SqlFragmentAlias.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SqlFragmentAlias.java
@@ -11,7 +11,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Defines an interpolated alias occurring in a SQL
- * {@linkplain Filter#condition() filter condition}.
+ * {@linkplain Filter#condition() filter condition} or
+ * {@linkplain SQLRestriction#value() restriction}.
  * Aliases are interpolated where placeholders of the
  * form {@code {name}} occur, where {@code name} is
  * the value specified by {@link #alias}.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -155,6 +155,8 @@ import static org.hibernate.boot.model.internal.BinderHelper.getFetchStyle;
 import static org.hibernate.boot.model.internal.BinderHelper.getPath;
 import static org.hibernate.boot.model.internal.BinderHelper.isDefault;
 import static org.hibernate.boot.model.internal.BinderHelper.isPrimitive;
+import static org.hibernate.boot.model.internal.BinderHelper.toAliasEntityMap;
+import static org.hibernate.boot.model.internal.BinderHelper.toAliasTableMap;
 import static org.hibernate.boot.model.internal.DialectOverridesAnnotationHelper.getOverridableAnnotation;
 import static org.hibernate.boot.model.internal.EmbeddableBinder.fillEmbeddable;
 import static org.hibernate.boot.model.internal.EntityBinder.isEntity;
@@ -1758,17 +1760,14 @@ public abstract class CollectionBinder {
 	}
 
 	private void addFilter(boolean hasAssociationTable, Filter filter) {
-		final Map<String,String> aliasTableMap = new HashMap<>();
-		final Map<String,String> aliasEntityMap = new HashMap<>();
-		fillAliasMaps( filter.aliases(), aliasTableMap, aliasEntityMap );
 		final String filterCondition = getFilterCondition( filter );
 		if ( hasAssociationTable ) {
 			collection.addManyToManyFilter(
 					filter.name(),
 					filterCondition,
 					filter.deduceAliasInjectionPoints(),
-					aliasTableMap,
-					aliasEntityMap
+					toAliasTableMap( filter.aliases() ),
+					toAliasEntityMap( filter.aliases() )
 			);
 		}
 		else {
@@ -1776,25 +1775,33 @@ public abstract class CollectionBinder {
 					filter.name(),
 					filterCondition,
 					filter.deduceAliasInjectionPoints(),
-					aliasTableMap,
-					aliasEntityMap
+					toAliasTableMap( filter.aliases() ),
+					toAliasEntityMap( filter.aliases() )
 			);
 		}
 	}
 
 	private void handleWhere(boolean hasAssociationTable) {
 		final String whereClause = getWhereClause();
+		final var restrictionOnCollection =
+			getOverridableAnnotation( property, SQLRestriction.class, getBuildingContext() );
+		final var whereAliases =
+			restrictionOnCollection == null
+				? List.<org.hibernate.mapping.SqlFragmentAlias>of()
+				: org.hibernate.mapping.SqlFragmentAlias.from( restrictionOnCollection.aliases() );
 		if ( hasAssociationTable ) {
 			// A many-to-many association has an association (join) table
 			// Collection#setManytoManyWhere is used to set the "where" clause that applies
 			// to the many-to-many associated entity table (not the join table).
 			collection.setManyToManyWhere( whereClause );
+			collection.setManyToManyWhereAliases( whereAliases );
 		}
 		else {
 			// A one-to-many association does not have an association (join) table.
 			// Collection#setWhere is used to set the "where" clause that applies to the collection table
 			// (which is the associated entity table for a one-to-many association).
 			collection.setWhere( whereClause );
+			collection.setWhereAliases( whereAliases );
 		}
 
 		final String whereJoinTableClause = getWhereJoinTableClause();
@@ -1807,8 +1814,8 @@ public abstract class CollectionBinder {
 			}
 			else {
 				throw new AnnotationException(
-						"Collection '" + qualify( propertyHolder.getPath(), propertyName )
-								+ "' is an association with no join table and may not have a 'WhereJoinTable'"
+					"Collection '" + qualify( propertyHolder.getPath(), propertyName )
+						+ "' is an association with no join table and may not have a '@SQLJoinTableRestriction'"
 				);
 			}
 		}
@@ -1821,11 +1828,11 @@ public abstract class CollectionBinder {
 
 	private String getWhereClause() {
 		// There are 2 possible sources of "where" clauses that apply to the associated entity table:
-		// 1) from the associated entity mapping; i.e., @Entity @Where(clause="...")
+		// 1) from the associated entity mapping; i.e., @Entity @SQLRestriction(clause="...")
 		//    (ignored if useEntityWhereClauseForCollections == false)
 		// 2) from the collection mapping;
-		//    for one-to-many, e.g., @OneToMany @JoinColumn @Where(clause="...") public Set<Rating> getRatings();
-		//    for many-to-many e.g., @ManyToMany @Where(clause="...") public Set<Rating> getRatings();
+		//    for one-to-many, e.g., @OneToMany @JoinColumn @SQLRestriction(clause="...") public Set<Rating> getRatings();
+		//    for many-to-many e.g., @ManyToMany @SQLRestriction(clause="...") public Set<Rating> getRatings();
 		return getNonEmptyOrConjunctionIfBothNonEmpty( getWhereOnClassClause(), getWhereOnCollectionClause() );
 	}
 
@@ -1846,15 +1853,12 @@ public abstract class CollectionBinder {
 
 	private void addFilterJoinTable(boolean hasAssociationTable, FilterJoinTable filter) {
 		if ( hasAssociationTable ) {
-			final Map<String,String> aliasTableMap = new HashMap<>();
-			final Map<String,String> aliasEntityMap = new HashMap<>();
-			fillAliasMaps( filter.aliases(), aliasTableMap, aliasEntityMap );
 			collection.addFilter(
-					filter.name(),
-					getFilterConditionForJoinTable( filter ),
-					filter.deduceAliasInjectionPoints(),
-					aliasTableMap,
-					aliasEntityMap
+				filter.name(),
+				getFilterConditionForJoinTable( filter ),
+				filter.deduceAliasInjectionPoints(),
+				toAliasTableMap( filter.aliases() ),
+				toAliasEntityMap( filter.aliases() )
 			);
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -1835,6 +1835,11 @@ public class EntityBinder {
 	private void bindSqlRestriction() {
 		final var restriction = extractSQLRestriction( annotatedClass );
 		if ( restriction != null ) {
+			if ( restriction.aliases().length > 0 ) {
+				throw new AnnotationException( "Entity class '" + annotatedClass.getName()
+					+ "' specifies an '@SQLRestriction' with 'aliases'"
+					+ " (aliases are only supported for restrictions on collections)" );
+			}
 			where = restriction.value();
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLRestrictionAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLRestrictionAnnotation.java
@@ -8,17 +8,22 @@ import java.lang.annotation.Annotation;
 import java.util.Map;
 
 import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.SqlFragmentAlias;
+import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.ModelsContext;
+
+import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
 public class SQLRestrictionAnnotation implements SQLRestriction {
 	private String value;
-
+	private SqlFragmentAlias[] aliases;
 	/**
 	 * Used in creating dynamic annotation instances (e.g. from XML)
 	 */
 	public SQLRestrictionAnnotation(ModelsContext modelContext) {
+		this.aliases = new SqlFragmentAlias[]{};
 	}
 
 	/**
@@ -26,6 +31,7 @@ public class SQLRestrictionAnnotation implements SQLRestriction {
 	 */
 	public SQLRestrictionAnnotation(SQLRestriction annotation, ModelsContext modelContext) {
 		this.value = annotation.value();
+		this.aliases = extractJdkValue( annotation, HibernateAnnotations.SQL_RESTRICTION, "aliases", modelContext );
 	}
 
 	/**
@@ -33,6 +39,7 @@ public class SQLRestrictionAnnotation implements SQLRestriction {
 	 */
 	public SQLRestrictionAnnotation(Map<String, Object> attributeValues, ModelsContext modelContext) {
 		this.value = (String) attributeValues.get( "value" );
+		this.aliases = (SqlFragmentAlias[]) attributeValues.get( "aliases" );
 	}
 
 	@Override
@@ -49,5 +56,11 @@ public class SQLRestrictionAnnotation implements SQLRestriction {
 		this.value = value;
 	}
 
+	public SqlFragmentAlias[] aliases() {
+		return aliases;
+	}
 
+	public void aliases(SqlFragmentAlias[] aliases) {
+		this.aliases = aliases;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
@@ -72,7 +72,9 @@ public abstract sealed class Collection
 	private CacheLayout queryCacheLayout;
 	private String orderBy;
 	private String where;
+	private List<SqlFragmentAlias> whereAliases = emptyList();
 	private String manyToManyWhere;
+	private List<SqlFragmentAlias> manyToManyWhereAliases = emptyList();
 	private String manyToManyOrderBy;
 	private String referencedPropertyName;
 	private String mappedByProperty;
@@ -155,7 +157,9 @@ public abstract sealed class Collection
 		this.cacheRegionName = original.cacheRegionName;
 		this.orderBy = original.orderBy;
 		this.where = original.where;
+		this.whereAliases = original.whereAliases;
 		this.manyToManyWhere = original.manyToManyWhere;
+		this.manyToManyWhereAliases = original.manyToManyWhereAliases;
 		this.manyToManyOrderBy = original.manyToManyOrderBy;
 		this.referencedPropertyName = original.referencedPropertyName;
 		this.mappedByProperty = original.mappedByProperty;
@@ -345,12 +349,28 @@ public abstract sealed class Collection
 		this.where = where;
 	}
 
+	public List<SqlFragmentAlias> getWhereAliases() {
+		return whereAliases;
+	}
+
+	public void setWhereAliases(List<SqlFragmentAlias> whereAliases) {
+		this.whereAliases = whereAliases;
+	}
+
 	public String getManyToManyWhere() {
 		return manyToManyWhere;
 	}
 
 	public void setManyToManyWhere(String manyToManyWhere) {
 		this.manyToManyWhere = manyToManyWhere;
+	}
+
+	public List<SqlFragmentAlias> getManyToManyWhereAliases() {
+		return manyToManyWhereAliases;
+	}
+
+	public void setManyToManyWhereAliases(List<SqlFragmentAlias> manyToManyWhereAliases) {
+		this.manyToManyWhereAliases = manyToManyWhereAliases;
 	}
 
 	public String getManyToManyOrdering() {
@@ -556,7 +576,9 @@ public abstract sealed class Collection
 			&& isSame( element, other.element )
 			&& Objects.equals( collectionTable, other.collectionTable )
 			&& Objects.equals( where, other.where )
+			&& Objects.equals( whereAliases, other.whereAliases )
 			&& Objects.equals( manyToManyWhere, other.manyToManyWhere )
+			&& Objects.equals( manyToManyWhereAliases, other.manyToManyWhereAliases )
 			&& Objects.equals( referencedPropertyName, other.referencedPropertyName )
 			&& Objects.equals( mappedByProperty, other.mappedByProperty )
 			&& Objects.equals( typeName, other.typeName )

--- a/hibernate-core/src/main/java/org/hibernate/mapping/FilterConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/FilterConfiguration.java
@@ -4,10 +4,10 @@
  */
 package org.hibernate.mapping;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.internal.SqlFragmentAliasHelper;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
@@ -51,9 +51,9 @@ public class FilterConfiguration {
 	}
 
 	public Map<String, String> getAliasTableMap(SessionFactoryImplementor factory) {
-		final var mergedAliasTableMap = mergeAliasMaps( factory );
-		if ( !mergedAliasTableMap.isEmpty() ) {
-			return mergedAliasTableMap;
+		final var resolvedAliasTableMap = resolveAliasTableMap( factory );
+		if ( !resolvedAliasTableMap.isEmpty() ) {
+			return resolvedAliasTableMap;
 		}
 		else if ( persistentClass != null ) {
 			final String tableName =
@@ -66,21 +66,7 @@ public class FilterConfiguration {
 		}
 	}
 
-	private Map<String, String> mergeAliasMaps(SessionFactoryImplementor factory) {
-		final Map<String, String> result = new HashMap<>();
-		if ( aliasTableMap != null ) {
-			result.putAll( aliasTableMap );
-		}
-
-		if ( aliasEntityMap != null ) {
-			for ( var entry : aliasEntityMap.entrySet() ) {
-				final var joinable =
-						factory.getMappingMetamodel()
-								.getEntityDescriptor( entry.getValue() );
-				result.put( entry.getKey(), joinable.getTableName() );
-			}
-		}
-
-		return result;
+	private Map<String, String> resolveAliasTableMap(SessionFactoryImplementor factory) {
+		return SqlFragmentAliasHelper.resolveAliasTableMap( aliasTableMap, aliasEntityMap, factory );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SqlFragmentAlias.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SqlFragmentAlias.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.mapping;
+
+import org.hibernate.annotations.SQLRestriction;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A mapping model object representing a
+ * {@linkplain org.hibernate.annotations.SqlFragmentAlias sql fragment alias},
+ * which binds an {@code {alias}} placeholder occurring in a
+ * {@linkplain SQLRestriction restriction} to a table,
+ * named either directly or via the entity mapped to it.
+ *
+ * @since 8.1
+ */
+public record SqlFragmentAlias(String alias, String table, String entityName) implements Serializable {
+	/**
+	 * Extracts mapping model objects from the given
+	 * {@link org.hibernate.annotations.SqlFragmentAlias} annotations,
+	 * omitting any alias which specifies neither a table nor an entity.
+	 */
+	public static List<SqlFragmentAlias> from(org.hibernate.annotations.SqlFragmentAlias[] aliases) {
+		final List<SqlFragmentAlias> result = new ArrayList<>( aliases.length );
+		for ( var aliasAnnotation : aliases ) {
+			final String table = aliasAnnotation.table().isBlank() ? null : aliasAnnotation.table();
+			final var entityClass = aliasAnnotation.entity();
+			final String entityName = entityClass == void.class ? null : entityClass.getName();
+			if ( table != null || entityName != null ) {
+				result.add( new SqlFragmentAlias( aliasAnnotation.alias(), table, entityName ) );
+			}
+		}
+		return result;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -80,12 +80,12 @@ import org.hibernate.persister.entity.Joinable;
 import org.hibernate.persister.filter.FilterAliasGenerator;
 import org.hibernate.persister.filter.internal.FilterHelper;
 import org.hibernate.persister.internal.SqlFragmentPredicate;
+import org.hibernate.persister.internal.SqlRestriction;
 import org.hibernate.query.named.spi.NamedQueryMemento;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.Alias;
 import org.hibernate.sql.SimpleSelect;
-import org.hibernate.sql.Template;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SimpleFromClauseAccessImpl;
 import org.hibernate.sql.ast.spi.SqlAliasBaseConstant;
@@ -133,14 +133,11 @@ import java.util.function.UnaryOperator;
 import static java.util.Collections.emptyList;
 import static org.hibernate.internal.util.StringHelper.getNonEmptyOrConjunctionIfBothNonEmpty;
 import static org.hibernate.internal.util.StringHelper.isEmpty;
-import static org.hibernate.internal.util.StringHelper.isNotEmpty;
-import static org.hibernate.internal.util.StringHelper.replace;
 import static org.hibernate.internal.util.StringHelper.unqualify;
 import static org.hibernate.internal.util.collections.CollectionHelper.arrayList;
 import static org.hibernate.jdbc.Expectations.createExpectation;
 import static org.hibernate.metamodel.mapping.internal.MappingModelCreationHelper.getTableIdentifierExpression;
 import static org.hibernate.pretty.MessageHelper.collectionInfoString;
-import static org.hibernate.sql.Template.renderWhereStringTemplate;
 import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER;
 import static org.hibernate.temporal.TemporalTableStrategy.HISTORY_TABLE;
 
@@ -170,8 +167,10 @@ public abstract class AbstractCollectionPersister
 	private String sqlDetectRowByElementString;
 
 	protected boolean hasWhere;
+	// the restriction for use in single-table contexts, which cannot
+	// interpolate table aliases; for other uses see sqlRestriction
 	protected String sqlWhereString;
-	private String sqlWhereStringTemplate;
+	private SqlRestriction sqlRestriction;
 
 	private final boolean hasOrder;
 	private final boolean hasManyToManyOrder;
@@ -233,8 +232,7 @@ public abstract class AbstractCollectionPersister
 	// dynamic filters specifically for many-to-many inside the collection
 	private final FilterHelper manyToManyFilterHelper;
 
-	private final String manyToManyWhereString;
-	private final String manyToManyWhereTemplate;
+	private final SqlRestriction manyToManySqlRestriction;
 
 	private final String[] spaces;
 
@@ -482,16 +480,12 @@ public abstract class AbstractCollectionPersister
 		// Handle any filters applied to this collectionBinding for many-to-many
 		manyToManyFilterHelper = manyToManyFilterHelper( collectionBootDescriptor, creationContext );
 
-		final String manyToManyWhere = collectionBootDescriptor.getManyToManyWhere();
-		if ( isEmpty( manyToManyWhere ) ) {
-			manyToManyWhereString = null;
-			manyToManyWhereTemplate = null;
-		}
-		else {
-			manyToManyWhereString = "( " + manyToManyWhere + ")";
-			manyToManyWhereTemplate =
-					renderWhereStringTemplate( manyToManyWhereString, creationContext.getDialect(), typeConfiguration );
-		}
+		manyToManySqlRestriction = SqlRestriction.create(
+			collectionBootDescriptor.getManyToManyWhere(),
+			collectionBootDescriptor.getManyToManyWhereAliases(),
+			() -> entityNameByTableNameMap( elementPersister, creationContext ),
+			creationContext.getSessionFactory()
+		);
 
 		comparator = collectionBootDescriptor.getComparator();
 
@@ -589,13 +583,7 @@ public abstract class AbstractCollectionPersister
 			}
 		}
 
-		if ( isNotEmpty( bootCollectionDescriptor.getWhere() ) ) {
-			hasWhere = true;
-			sqlWhereString = "(" + bootCollectionDescriptor.getWhere() + ")";
-			sqlWhereStringTemplate =
-					renderWhereStringTemplate( sqlWhereString, dialect,
-							creationContext.getTypeConfiguration() );
-		}
+		processWhereRestriction( bootCollectionDescriptor.getWhere(), bootCollectionDescriptor, creationContext );
 		buildStaticWhereFragmentSensitiveSql();
 	}
 
@@ -605,12 +593,22 @@ public abstract class AbstractCollectionPersister
 			Collection bootDescriptor,
 			RuntimeModelCreationContext creationContext) {
 		final String where = getWhere( entityPersister, mappedByProperty, bootDescriptor, creationContext );
-		if ( isNotEmpty( where ) ) {
+		processWhereRestriction( where, bootDescriptor, creationContext );
+	}
+
+	private void processWhereRestriction(
+			String where,
+			Collection bootDescriptor,
+			RuntimeModelCreationContext creationContext) {
+		sqlRestriction = SqlRestriction.create(
+			where,
+			bootDescriptor.getWhereAliases(),
+			() -> entityNameByTableNameMap( elementPersister, creationContext ),
+			creationContext.getSessionFactory()
+		);
+		if ( sqlRestriction != null ) {
 			hasWhere = true;
-			sqlWhereString = "(" + where + ")";
-			sqlWhereStringTemplate =
-					renderWhereStringTemplate( sqlWhereString, dialect,
-							creationContext.getTypeConfiguration() );
+			sqlWhereString = sqlRestriction.getSingleTableFragment();
 		}
 	}
 
@@ -1199,7 +1197,7 @@ public abstract class AbstractCollectionPersister
 
 	@Override
 	public boolean hasWhereRestrictions() {
-		return hasWhere || manyToManyWhereTemplate != null;
+		return hasWhere || manyToManySqlRestriction != null;
 	}
 
 	private static String aliasForWhereRestriction(TableReference tableReference, boolean useQualifier) {
@@ -1234,18 +1232,21 @@ public abstract class AbstractCollectionPersister
 			String alias,
 			TableGroup tableGroup,
 			SqlAstCreationState astCreationState) {
-		applyWhereFragments( predicateConsumer, alias, sqlWhereStringTemplate );
+		if ( sqlRestriction != null ) {
+			final String fragment =
+				sqlRestriction.isAliasBased()
+					? sqlRestriction.render( getFilterAliasGenerator( tableGroup ), tableGroup, astCreationState )
+					: sqlRestriction.render( alias );
+			applyWhereFragment( predicateConsumer, fragment );
+		}
 	}
 
 	/**
 	 * Applies all defined {@link org.hibernate.annotations.SQLRestriction}
 	 */
-	private static void applyWhereFragments(Consumer<Predicate> predicateConsumer, String alias, String template) {
-		if ( template != null ) {
-			final String fragment = replace( template, Template.TEMPLATE, alias );
-			if ( !isEmpty( fragment ) ) {
-				predicateConsumer.accept( new SqlFragmentPredicate( fragment ) );
-			}
+	private static void applyWhereFragment(Consumer<Predicate> predicateConsumer, String fragment) {
+		if ( !isEmpty( fragment ) ) {
+			predicateConsumer.accept( new SqlFragmentPredicate( fragment ) );
 		}
 	}
 
@@ -1280,7 +1281,7 @@ public abstract class AbstractCollectionPersister
 			Map<String, Filter> enabledFilters,
 			Set<String> treatAsDeclarations,
 			SqlAstCreationState creationState) {
-		if ( manyToManyFilterHelper != null || manyToManyWhereTemplate != null ) {
+		if ( manyToManyFilterHelper != null || manyToManySqlRestriction != null ) {
 			if ( manyToManyFilterHelper != null ) {
 				manyToManyFilterHelper.applyEnabledFilters(
 						predicateConsumer,
@@ -1291,10 +1292,22 @@ public abstract class AbstractCollectionPersister
 						creationState
 				);
 			}
-			if ( manyToManyWhereString != null ) {
-				final var tableReference = tableGroup.resolveTableReference( elementPersister.getTableName() );
-				final String alias = aliasForWhereRestriction( tableReference, useQualifier );
-				applyWhereFragments( predicateConsumer, alias, manyToManyWhereTemplate );
+			if ( manyToManySqlRestriction != null ) {
+				final String fragment;
+				if ( manyToManySqlRestriction.isAliasBased() ) {
+					fragment = manyToManySqlRestriction.render(
+						elementPersister.getFilterAliasGenerator( tableGroup ),
+						tableGroup,
+						creationState
+					);
+				}
+				else {
+					final var tableReference = tableGroup.resolveTableReference( elementPersister.getTableName() );
+					fragment = manyToManySqlRestriction.render(
+						aliasForWhereRestriction( tableReference, useQualifier )
+					);
+				}
+				applyWhereFragment( predicateConsumer, fragment );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/internal/SqlFragmentAliasHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/internal/SqlFragmentAliasHelper.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.persister.internal;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.SqlFragmentAlias;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.entity.EntityNameUse;
+import org.hibernate.persister.filter.FilterAliasGenerator;
+import org.hibernate.persister.filter.internal.FilterHelper;
+import org.hibernate.sql.ast.spi.SqlAstCreationState;
+import org.hibernate.sql.ast.tree.from.TableGroup;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.hibernate.internal.util.StringHelper.replace;
+
+/**
+ * Utility methods for dealing with {@link SqlFragmentAlias}
+ * placeholders occurring in {@linkplain Filter filter
+ * conditions} and {@linkplain SQLRestriction restrictions}.
+ *
+ * @see FilterHelper
+ * @see SqlRestriction
+ */
+public class SqlFragmentAliasHelper {
+
+	private SqlFragmentAliasHelper() {
+	}
+
+	/**
+	 * Interpolates the {@code {alias}} placeholders of a SQL fragment with the aliases
+	 * of the tables they refer to, as resolved by the given {@link FilterAliasGenerator},
+	 * registering an {@linkplain EntityNameUse#EXPRESSION expression use} of the entity
+	 * mapped to each referenced table so that its table is retained in the generated SQL.
+	 * Placeholders whose table cannot be resolved to an alias are left in place.
+	 *
+	 * @param fragment a SQL fragment containing {@code {alias}} placeholders
+	 * @param aliasTableMap the placeholder aliases mapped to the tables they refer to
+	 * @param entityNameByTableName table names mapped to entity names, or {@code null}
+	 */
+	public static String interpolateAliases(
+			String fragment,
+			Map<String, String> aliasTableMap,
+			FilterAliasGenerator aliasGenerator,
+			Map<String, String> entityNameByTableName,
+			TableGroup tableGroup,
+			SqlAstCreationState creationState) {
+		String result = fragment;
+		for ( var entry : aliasTableMap.entrySet() ) {
+			final String tableName = entry.getValue();
+			final String tableAlias = aliasGenerator.getAlias( tableName );
+			if ( tableAlias != null ) {
+				final String interpolated = replace( result, "{" + entry.getKey() + "}", tableAlias );
+				if ( creationState != null
+						&& entityNameByTableName != null
+						&& !interpolated.equals( result ) ) {
+					final String entityName = entityNameByTableName.get( tableName );
+					if ( entityName != null ) {
+						creationState.registerEntityNameUsage( tableGroup, EntityNameUse.EXPRESSION, entityName );
+					}
+				}
+				result = interpolated;
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Removes the {@code {alias}.} qualifiers of a SQL fragment, for use in
+	 * single-table contexts where no alias can be interpolated.
+	 */
+	public static String stripAliasQualifiers(String fragment, Map<String, String> aliasTableMap) {
+		String result = fragment;
+		for ( String alias : aliasTableMap.keySet() ) {
+			result = replace( result, "{" + alias + "}.", "" );
+		}
+		return result;
+	}
+
+	/**
+	 * Resolves an alias-to-table map and an alias-to-entity-name map into a single
+	 * alias-to-table map, resolving each entity to its primary table.
+	 */
+	public static Map<String, String> resolveAliasTableMap(
+			Map<String, String> aliasTableMap,
+			Map<String, String> aliasEntityMap,
+			SessionFactoryImplementor factory) {
+		if ( ( aliasTableMap == null || aliasTableMap.isEmpty() )
+				&& ( aliasEntityMap == null || aliasEntityMap.isEmpty() ) ) {
+			return emptyMap();
+		}
+		final Map<String, String> result = new HashMap<>();
+		if ( aliasTableMap != null ) {
+			result.putAll( aliasTableMap );
+		}
+		if ( aliasEntityMap != null ) {
+			for ( var entry : aliasEntityMap.entrySet() ) {
+				final var entityDescriptor =
+						factory.getMappingMetamodel()
+								.getEntityDescriptor( entry.getValue() );
+				result.put( entry.getKey(), entityDescriptor.getTableName() );
+			}
+		}
+		return result;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/persister/internal/SqlRestriction.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/internal/SqlRestriction.java
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.persister.internal;
+
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.mapping.SqlFragmentAlias;
+import org.hibernate.persister.filter.FilterAliasGenerator;
+import org.hibernate.persister.filter.internal.FilterHelper;
+import org.hibernate.sql.Template;
+import org.hibernate.sql.ast.spi.SqlAstCreationState;
+import org.hibernate.sql.ast.tree.from.TableGroup;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
+import static org.hibernate.internal.util.StringHelper.isEmpty;
+import static org.hibernate.internal.util.StringHelper.replace;
+import static org.hibernate.persister.internal.SqlFragmentAliasHelper.interpolateAliases;
+import static org.hibernate.persister.internal.SqlFragmentAliasHelper.stripAliasQualifiers;
+import static org.hibernate.sql.Template.renderWhereStringTemplate;
+
+/**
+ * Encapsulates the rendering of a {@linkplain SQLRestriction
+ * where restriction}, the static counterpart to the
+ * {@linkplain FilterHelper handling of filters}.
+ * <p>
+ * A restriction is rendered in one of two modes:
+ * <ul>
+ * <li>without {@linkplain SqlFragmentAlias aliases}, every
+ *     unqualified column reference is qualified with the alias of a single table,
+ *     determined by the caller; or
+ * <li>with aliases, each {@code {alias}} placeholder is interpolated with the alias of
+ *     the table it refers to, which need not be the primary table of the restricted
+ *     element.
+ * </ul>
+ *
+ * @see SQLRestriction#aliases()
+ */
+public class SqlRestriction {
+
+	private final String fragment;
+	private final String template;
+	private final Map<String, String> aliasTableMap;
+	private final Map<String, String> entityNameByTableName;
+	private final String singleTableFragment;
+
+	private SqlRestriction(
+			String fragment,
+			String template,
+			Map<String, String> aliasTableMap,
+			Map<String, String> entityNameByTableName,
+			String singleTableFragment) {
+		this.fragment = fragment;
+		this.template = template;
+		this.aliasTableMap = aliasTableMap;
+		this.entityNameByTableName = entityNameByTableName;
+		this.singleTableFragment = singleTableFragment;
+	}
+
+	/**
+	 * Creates a restriction, or returns {@code null} if the given clause is empty.
+	 *
+	 * @param clause the restriction, as specified in the mapping
+	 * @param aliases the {@linkplain SqlFragmentAlias
+	 *        alias placeholders} of the restriction, possibly {@code null}
+	 * @param entityNameByTableNameSupplier table names mapped to entity names,
+	 *        resolved only for an alias-based restriction
+	 */
+	public static SqlRestriction create(
+			String clause,
+			List<SqlFragmentAlias> aliases,
+			Supplier<Map<String, String>> entityNameByTableNameSupplier,
+			SessionFactoryImplementor factory) {
+		if ( isEmpty( clause ) ) {
+			return null;
+		}
+		final String fragment = "(" + clause + ")";
+		final var aliasTableMap = resolveAliasTableMap( aliases, factory );
+		if ( aliasTableMap.isEmpty() ) {
+			final String template = renderWhereStringTemplate(
+				fragment,
+				factory.getJdbcServices().getDialect(),
+				factory.getTypeConfiguration()
+			);
+			return new SqlRestriction( fragment, template, aliasTableMap, null, fragment );
+		}
+		else {
+			return new SqlRestriction(
+				fragment,
+				null,
+				aliasTableMap,
+				entityNameByTableNameSupplier.get(),
+				// single-table contexts cannot interpolate table aliases,
+				// so fall back to unqualified column references there
+				stripAliasQualifiers( fragment, aliasTableMap )
+			);
+		}
+	}
+
+	/**
+	 * Resolves each alias placeholder to the name of the table it refers to,
+	 * resolving an alias given as an entity to the entity's primary table.
+	 */
+	private static Map<String, String> resolveAliasTableMap(
+			List<SqlFragmentAlias> aliases,
+			SessionFactoryImplementor factory) {
+		if ( aliases == null || aliases.isEmpty() ) {
+			return emptyMap();
+		}
+		final Map<String, String> result = new HashMap<>();
+		for ( var alias : aliases ) {
+			result.put( alias.alias(), alias.entityName() != null
+				? factory.getMappingMetamodel()
+					.getEntityDescriptor( alias.entityName() )
+					.getTableName()
+				: alias.table() );
+		}
+		return result;
+	}
+
+	public boolean isAliasBased() {
+		return template == null;
+	}
+
+	/**
+	 * The restriction for use in single-table contexts, with alias
+	 * placeholders removed if the restriction is alias-based.
+	 */
+	public String getSingleTableFragment() {
+		return singleTableFragment;
+	}
+
+	/**
+	 * Renders a non-alias-based restriction, qualifying every unqualified
+	 * column reference with the given alias.
+	 */
+	public String render(String alias) {
+		return replace( template, Template.TEMPLATE, alias );
+	}
+
+	/**
+	 * Renders an alias-based restriction, interpolating each {@code {alias}}
+	 * placeholder with the alias of the table it refers to.
+	 */
+	public String render(
+			FilterAliasGenerator aliasGenerator,
+			TableGroup tableGroup,
+			SqlAstCreationState creationState) {
+		return interpolateAliases(
+			fragment,
+			aliasTableMap,
+			aliasGenerator,
+			entityNameByTableName,
+			tableGroup,
+			creationState
+		);
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/AliasEntityLevelTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/AliasEntityLevelTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.where.annotations;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.AnnotationException;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.SqlFragmentAlias;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests that {@linkplain SqlFragmentAlias aliases} are rejected for
+ * an entity-level {@link SQLRestriction}, where they are unsupported.
+ */
+@BaseUnitTest
+@Jira( "https://hibernate.atlassian.net/browse/HHH-12016" )
+public class AliasEntityLevelTest {
+	@Test
+	public void testEntityLevelAliasesRejected() {
+		final var annotationException = assertThrows( AnnotationException.class, () -> {
+			try (var serviceRegistry = ServiceRegistryUtil.serviceRegistry()) {
+				new MetadataSources( serviceRegistry )
+					.addAnnotatedClass( Person.class )
+					.buildMetadata();
+			}
+		} );
+		assertThat( annotationException.getMessage() )
+			.contains( "Person" )
+			.contains( "aliases" );
+	}
+
+	@Entity
+	@SQLRestriction(
+		value = "{r}.deleted = false",
+		aliases = @SqlFragmentAlias( alias = "r", entity = Person.class )
+	)
+	public static class Person {
+		@Id
+		Long id;
+		boolean deleted;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/AliasJoinedInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/AliasJoinedInheritanceTest.java
@@ -1,0 +1,352 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.where.annotations;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.SqlFragmentAlias;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SessionFactory
+@DomainModel( annotatedClasses = {
+	AliasJoinedInheritanceTest.Company.class,
+	AliasJoinedInheritanceTest.Person.class,
+	AliasJoinedInheritanceTest.Employee.class
+} )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-12016" )
+public class AliasJoinedInheritanceTest {
+
+	@BeforeEach
+	public void createTestData(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var company = new Company( 1L, "company" );
+			var named = new Employee( 2L, "named employee", "senior" );
+			var unnamed = new Employee( 3L, null, "junior" );
+			var untitled = new Employee( 4L, "untitled employee", null );
+			var inactive = new Employee( 5L, "inactive employee", "principal", false );
+
+			company.employees.add( named );
+			company.employees.add( unnamed );
+			company.employees.add( untitled );
+
+			company.people.add( named );
+			company.people.add( unnamed );
+			company.people.add( untitled );
+			company.people.add( inactive );
+
+			company.titledEmployees.add( named );
+			company.titledEmployees.add( unnamed );
+			company.titledEmployees.add( untitled );
+
+			company.namedAndTitledEmployees.add( named );
+			company.namedAndTitledEmployees.add( unnamed );
+			company.namedAndTitledEmployees.add( untitled );
+
+			company.tableAliasedEmployees.add( named );
+			company.tableAliasedEmployees.add( unnamed );
+			company.tableAliasedEmployees.add( untitled );
+
+			company.contractors.add( named );
+			company.contractors.add( unnamed );
+			company.contractors.add( untitled );
+
+			company.directEmployees.add( named );
+			company.directEmployees.add( unnamed );
+			company.directEmployees.add( untitled );
+
+			named.employer = company;
+			unnamed.employer = company;
+			untitled.employer = company;
+
+			session.persist( company );
+			session.persist( named );
+			session.persist( unnamed );
+			session.persist( untitled );
+			session.persist( inactive );
+		} );
+	}
+
+	@AfterEach
+	public void dropTestData(SessionFactoryScope factoryScope) {
+		factoryScope.dropData();
+	}
+
+	@Test
+	public void testRootEntityAliasWithJoinTable(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertNotNull( company );
+			assertEquals( 2, company.employees.size() );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testJoinFetch(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.createQuery(
+			"from Company c left join fetch c.employees where c.id = :id",
+					Company.class
+				)
+				.setParameter( "id", 1L )
+				.getSingleResult();
+			assertEquals( 2, company.employees.size() );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testSubclassEntityAlias(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.titledEmployees.size() );
+			assertTrue( company.titledEmployees.stream().allMatch( employee -> employee.title != null ) );
+		} );
+	}
+
+	@Test
+	public void testMultipleAliases(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 1, company.namedAndTitledEmployees.size() );
+			var employee = company.namedAndTitledEmployees.iterator().next();
+			assertNotNull( employee.getName() );
+			assertNotNull( employee.title );
+		} );
+	}
+
+	@Test
+	public void testTableAlias(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.tableAliasedEmployees.size() );
+			assertTrue( company.tableAliasedEmployees.stream().allMatch( employee -> employee.getName() != null ) );
+		} );
+	}
+
+	@Test
+	public void testManyToMany(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.contractors.size() );
+			assertTrue( company.contractors.stream().allMatch( employee -> employee.getName() != null ) );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testOneToManyWithoutJoinTable(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.directEmployees.size() );
+			assertTrue( company.directEmployees.stream().allMatch( employee -> employee.title != null ) );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testOneToManyMappedBy(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.staff.size() );
+			assertTrue( company.staff.stream().allMatch( employee -> employee.getName() != null ) );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testMixedAliasAndNonAliasRestrictions(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			// the aliased restriction on the collection and the plain restriction
+			// on the Person class are combined: the inactive person satisfies
+			// "{p}.name is not null" but is excluded by "active = true"
+			assertEquals( 2, company.people.size() );
+			assertTrue( company.people.stream().allMatch( person -> person.getName() != null ) );
+			assertTrue( company.people.stream().noneMatch( person -> "inactive employee".equals( person.getName() ) ) );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testCollectionMutation(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.employees.size() );
+			company.employees.removeIf( employee -> "named employee".equals( employee.getName() ) );
+		} );
+
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 1, company.employees.size() );
+			assertEquals( "untitled employee", company.employees.iterator().next().getName() );
+		} );
+	}
+
+	private static void assertAliasesInterpolated(org.hibernate.testing.jdbc.SQLStatementInspector statementInspector) {
+		for ( String sql : statementInspector.getSqlQueries() ) {
+			assertFalse( sql.contains( "{p}" ) || sql.contains( "{e}" ),
+					"alias placeholder was not interpolated in: " + sql );
+		}
+	}
+
+	@Entity(name = "Company")
+	public static class Company {
+		@Id
+		private Long id;
+		private String name;
+
+		@OneToMany
+		@SQLRestriction(
+			value = "{p}.name is not null",
+			aliases = @SqlFragmentAlias( alias = "p", entity = Person.class )
+		)
+		private Set<Employee> employees = new HashSet<>();
+
+		@OneToMany
+		@JoinTable(name = "company_titled_employees")
+		@SQLRestriction(
+			value = "{e}.title is not null",
+			aliases = @SqlFragmentAlias( alias = "e", entity = Employee.class )
+		)
+		private Set<Employee> titledEmployees = new HashSet<>();
+
+		@OneToMany
+		@JoinTable(name = "company_named_titled")
+		@SQLRestriction(
+			value = "{p}.name is not null and {e}.title is not null",
+			aliases = {
+				@SqlFragmentAlias( alias = "p", entity = Person.class ),
+				@SqlFragmentAlias( alias = "e", entity = Employee.class )
+			}
+		)
+		private Set<Employee> namedAndTitledEmployees = new HashSet<>();
+
+		@OneToMany
+		@JoinTable(name = "company_table_aliased")
+		@SQLRestriction(
+			value = "{p}.name is not null",
+			aliases = @SqlFragmentAlias( alias = "p", table = "Person" )
+		)
+		private Set<Employee> tableAliasedEmployees = new HashSet<>();
+
+		@ManyToMany
+		@JoinTable(name = "company_contractors")
+		@SQLRestriction(
+			value = "{p}.name is not null",
+			aliases = @SqlFragmentAlias( alias = "p", entity = Person.class )
+		)
+		private Set<Employee> contractors = new HashSet<>();
+
+		@OneToMany
+		@JoinColumn(name = "company_id")
+		@SQLRestriction(
+			value = "{e}.title is not null",
+			aliases = @SqlFragmentAlias( alias = "e", entity = Employee.class )
+		)
+		private Set<Employee> directEmployees = new HashSet<>();
+
+		@OneToMany(mappedBy = "employer")
+		@SQLRestriction(
+			value = "{p}.name is not null",
+			aliases = @SqlFragmentAlias( alias = "p", entity = Person.class )
+		)
+		private Set<Employee> staff = new HashSet<>();
+
+		// combined with the plain "active = true" restriction on the Person class
+		@OneToMany
+		@JoinTable(name = "company_people")
+		@SQLRestriction(
+			value = "{p}.name is not null",
+			aliases = @SqlFragmentAlias( alias = "p", entity = Person.class )
+		)
+		private Set<Person> people = new HashSet<>();
+
+		public Company() {
+		}
+		public Company(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "Person")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	@SQLRestriction("active = true")
+	public static class Person {
+		@Id
+		private Long id;
+		private String name;
+		private boolean active = true;
+
+		public Person() {
+		}
+		public Person(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+		public Person(Long id, String name, boolean active) {
+			this( id, name );
+			this.active = active;
+		}
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Entity(name = "Employee")
+	public static class Employee extends Person {
+		private String title;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Company employer;
+
+		public Employee() {
+		}
+		public Employee(Long id, String name, String title) {
+			super( id, name );
+			this.title = title;
+		}
+		public Employee(Long id, String name, String title, boolean active) {
+			super( id, name, active );
+			this.title = title;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/AliasSecondaryTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/AliasSecondaryTableTest.java
@@ -1,0 +1,257 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.where.annotations;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SecondaryTable;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.SqlFragmentAlias;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SessionFactory(useCollectingStatementInspector = true)
+@DomainModel( annotatedClasses = {
+	AliasSecondaryTableTest.Company.class,
+	AliasSecondaryTableTest.Employee.class
+} )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-12016" )
+public class AliasSecondaryTableTest {
+
+	@BeforeEach
+	public void createTestData(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var company = new Company( 1L, "company" );
+			var named = new Employee( 2L, "named employee", "senior" );
+			var unnamed = new Employee( 3L, null, "junior" );
+			var untitled = new Employee( 4L, "untitled employee", null );
+
+			company.employees.add( named );
+			company.employees.add( unnamed );
+			company.employees.add( untitled );
+
+			company.namedAndTitledEmployees.add( named );
+			company.namedAndTitledEmployees.add( unnamed );
+			company.namedAndTitledEmployees.add( untitled );
+
+			company.contractors.add( named );
+			company.contractors.add( unnamed );
+			company.contractors.add( untitled );
+
+			company.directEmployees.add( named );
+			company.directEmployees.add( unnamed );
+			company.directEmployees.add( untitled );
+
+			named.employer = company;
+			unnamed.employer = company;
+			untitled.employer = company;
+
+			session.persist( company );
+			session.persist( named );
+			session.persist( unnamed );
+			session.persist( untitled );
+		} );
+	}
+
+	@AfterEach
+	public void dropTestData(SessionFactoryScope factoryScope) {
+		factoryScope.dropData();
+	}
+
+	@Test
+	public void testSecondaryTableAliasWithJoinTable(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertNotNull( company );
+			assertEquals( 2, company.employees.size() );
+			assertTrue( company.employees.stream().allMatch( employee -> employee.title != null ) );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testJoinFetch(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.createQuery(
+			"from Company c left join fetch c.employees where c.id = :id",
+					Company.class
+				)
+				.setParameter( "id", 1L )
+				.getSingleResult();
+			assertEquals( 2, company.employees.size() );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testMultipleAliases(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 1, company.namedAndTitledEmployees.size() );
+			var employee = company.namedAndTitledEmployees.iterator().next();
+			assertNotNull( employee.name );
+			assertNotNull( employee.title );
+		} );
+	}
+
+	@Test
+	public void testManyToMany(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.contractors.size() );
+			assertTrue( company.contractors.stream().allMatch( employee -> employee.title != null ) );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testOneToManyWithoutJoinTable(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.directEmployees.size() );
+			assertTrue( company.directEmployees.stream().allMatch( employee -> employee.name != null ) );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testOneToManyMappedBy(SessionFactoryScope factoryScope) {
+		final var statementInspector = factoryScope.getCollectingStatementInspector();
+		statementInspector.clear();
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.staff.size() );
+			assertTrue( company.staff.stream().allMatch( employee -> employee.title != null ) );
+		} );
+		assertAliasesInterpolated( statementInspector );
+	}
+
+	@Test
+	public void testCollectionMutation(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 2, company.employees.size() );
+			company.employees.removeIf( employee -> "named employee".equals( employee.name ) );
+		} );
+
+		factoryScope.inTransaction( (session) -> {
+			var company = session.find( Company.class, 1L );
+			assertEquals( 1, company.employees.size() );
+			assertEquals( "junior", company.employees.iterator().next().title );
+		} );
+	}
+
+	private static void assertAliasesInterpolated(org.hibernate.testing.jdbc.SQLStatementInspector statementInspector) {
+		for ( String sql : statementInspector.getSqlQueries() ) {
+			assertFalse( sql.contains( "{e}" ) || sql.contains( "{d}" ),
+					"alias placeholder was not interpolated in: " + sql );
+		}
+	}
+
+	@Entity(name = "Company")
+	public static class Company {
+		@Id
+		private Long id;
+		private String name;
+
+		@OneToMany
+		@SQLRestriction(
+			value = "{d}.title is not null",
+			aliases = @SqlFragmentAlias( alias = "d", table = "employee_details" )
+		)
+		private Set<Employee> employees = new HashSet<>();
+
+		@OneToMany
+		@JoinTable(name = "company_named_titled")
+		@SQLRestriction(
+			value = "{e}.name is not null and {d}.title is not null",
+			aliases = {
+				@SqlFragmentAlias( alias = "e", entity = Employee.class ),
+				@SqlFragmentAlias( alias = "d", table = "employee_details" )
+			}
+		)
+		private Set<Employee> namedAndTitledEmployees = new HashSet<>();
+
+		@ManyToMany
+		@JoinTable(name = "company_contractors")
+		@SQLRestriction(
+			value = "{d}.title is not null",
+			aliases = @SqlFragmentAlias( alias = "d", table = "employee_details" )
+		)
+		private Set<Employee> contractors = new HashSet<>();
+
+		@OneToMany
+		@JoinColumn(name = "company_id")
+		@SQLRestriction(
+			value = "{e}.name is not null",
+			aliases = @SqlFragmentAlias( alias = "e", entity = Employee.class )
+		)
+		private Set<Employee> directEmployees = new HashSet<>();
+
+		@OneToMany(mappedBy = "employer")
+		@SQLRestriction(
+			value = "{d}.title is not null",
+			aliases = @SqlFragmentAlias( alias = "d", table = "employee_details" )
+		)
+		private Set<Employee> staff = new HashSet<>();
+
+		public Company() {
+		}
+		public Company(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "Employee")
+	@SecondaryTable(name = "employee_details")
+	public static class Employee {
+		@Id
+		private Long id;
+		private String name;
+
+		@Column(table = "employee_details")
+		private String title;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Company employer;
+
+		public Employee() {
+		}
+		public Employee(Long id, String name, String title) {
+			this.id = id;
+			this.name = name;
+			this.title = title;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12016

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->
Adds support for aliases on @SQLRestriction while only allowing support for collections.
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-12016 (New Feature):
- [x] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->