### PR TITLE
HHH-20254 Add optional ObjectInputFilter for deserialization of Serializable basic values

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/MappingSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/MappingSettings.java
@@ -628,4 +628,20 @@ public interface MappingSettings {
 	 */
 	String USE_NATIONALIZED_CHARACTER_DATA = "hibernate.use_nationalized_character_data";
 
+	/**
+	 * Specifies a JEP-290 {@link java.io.ObjectInputFilter} pattern applied when deserializing
+	 * {@link java.io.Serializable} basic values read back from the database, for example values
+	 * mapped via {@link org.hibernate.type.SerializableType}. The value is a standard filter
+	 * pattern as accepted by {@link java.io.ObjectInputFilter.Config#createFilter(String)}.
+	 * <p>
+	 * This is opt-in, defense-in-depth protection against deserializing unexpected classes from a
+	 * shared or otherwise untrusted database. By default no filter is installed and behaviour is
+	 * unchanged.
+	 *
+	 * @settingDefault none (no filter is installed)
+	 *
+	 * @since 8.1
+	 */
+	String SERIALIZATION_DESERIALIZATION_FILTER = "hibernate.serialization.deserialization_filter";
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/SerializationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/SerializationHelper.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
@@ -191,13 +192,22 @@ public final class SerializationHelper {
 			ClassLoader loader,
 			ClassLoader fallbackLoader1,
 			ClassLoader fallbackLoader2) throws SerializationException {
+		return doDeserialize( inputStream, loader, fallbackLoader1, fallbackLoader2, null );
+	}
+
+	public static <T> T doDeserialize(
+			InputStream inputStream,
+			ClassLoader loader,
+			ClassLoader fallbackLoader1,
+			ClassLoader fallbackLoader2,
+			ObjectInputFilter filter) throws SerializationException {
 		if ( inputStream == null ) {
 			throw new IllegalArgumentException( "The InputStream must not be null" );
 		}
 
 		CORE_LOGGER.trace( "Starting deserialization of object" );
 
-		try ( var in = new CustomObjectInputStream( inputStream, loader, fallbackLoader1, fallbackLoader2 ) ) {
+		try ( var in = new CustomObjectInputStream( inputStream, loader, fallbackLoader1, fallbackLoader2, filter ) ) {
 			//noinspection unchecked
 			return (T) in.readObject();
 		}
@@ -249,6 +259,25 @@ public final class SerializationHelper {
 		return doDeserialize( wrap( objectData ), loader, defaultClassLoader(), hibernateClassLoader() );
 	}
 
+	/**
+	 * Deserializes an object from an array of bytes, applying the given JEP-290
+	 * {@link ObjectInputFilter} to the deserialization stream.
+	 *
+	 * @param objectData the serialized object, must not be null
+	 * @param loader The classloader to use
+	 * @param filter The {@link ObjectInputFilter} to apply, or {@code null} to apply none
+	 *
+	 * @return the deserialized object
+	 *
+	 * @throws IllegalArgumentException if <code>objectData</code> is <code>null</code>
+	 * @throws SerializationException (runtime) if the serialization fails
+	 *
+	 * @since 8.1
+	 */
+	public static Object deserialize(byte[] objectData, ClassLoader loader, ObjectInputFilter filter) throws SerializationException {
+		return doDeserialize( wrap( objectData ), loader, defaultClassLoader(), hibernateClassLoader(), filter );
+	}
+
 
 	/**
 	 * By default, to resolve the classes being deserialized JDK serialization uses the
@@ -267,11 +296,15 @@ public final class SerializationHelper {
 				InputStream in,
 				ClassLoader loader1,
 				ClassLoader loader2,
-				ClassLoader loader3) throws IOException {
+				ClassLoader loader3,
+				ObjectInputFilter filter) throws IOException {
 			super( in );
 			this.loader1 = loader1;
 			this.loader2 = loader2;
 			this.loader3 = loader3;
+			if ( filter != null ) {
+				setObjectInputFilter( filter );
+			}
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/SerializableJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/SerializableJavaType.java
@@ -6,14 +6,19 @@ package org.hibernate.type.descriptor.java;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.ObjectInputFilter;
 import java.io.Serializable;
 import java.sql.Blob;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.hibernate.HibernateException;
 import org.hibernate.annotations.Immutable;
+import org.hibernate.cfg.MappingSettings;
+import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
 import org.hibernate.internal.util.SerializationHelper;
@@ -119,14 +124,14 @@ public class SerializableJavaType<T extends Serializable> extends AbstractClassJ
 			return null;
 		}
 		else if (value instanceof byte[] bytes) {
-			return fromBytes( bytes );
+			return fromBytes( bytes, deserializationFilter( options ) );
 		}
 		else if (value instanceof InputStream inputStream) {
-			return fromBytes( DataHelper.extractBytes( inputStream ) );
+			return fromBytes( DataHelper.extractBytes( inputStream ), deserializationFilter( options ) );
 		}
 		else if (value instanceof Blob blob) {
 			try {
-				return fromBytes( DataHelper.extractBytes( blob.getBinaryStream() ) );
+				return fromBytes( DataHelper.extractBytes( blob.getBinaryStream() ), deserializationFilter( options ) );
 			}
 			catch ( SQLException e ) {
 				throw new HibernateException( e );
@@ -143,6 +148,26 @@ public class SerializableJavaType<T extends Serializable> extends AbstractClassJ
 	}
 
 	protected T fromBytes(byte[] bytes) {
-		return cast( SerializationHelper.deserialize( bytes, getJavaTypeClass().getClassLoader() ) );
+		return fromBytes( bytes, null );
+	}
+
+	protected T fromBytes(byte[] bytes, ObjectInputFilter filter) {
+		return cast( SerializationHelper.deserialize( bytes, getJavaTypeClass().getClassLoader(), filter ) );
+	}
+
+	private static final ConcurrentHashMap<String, ObjectInputFilter> DESERIALIZATION_FILTERS = new ConcurrentHashMap<>();
+
+	/**
+	 * Resolves the optional {@link ObjectInputFilter} configured via
+	 * {@link MappingSettings#SERIALIZATION_DESERIALIZATION_FILTER}. Returns {@code null} when no
+	 * filter is configured, preserving the previous (unfiltered) behaviour.
+	 */
+	private static ObjectInputFilter deserializationFilter(WrapperOptions options) {
+		final String pattern = options.getSessionFactory().getServiceRegistry()
+				.requireService( ConfigurationService.class )
+				.getSetting( MappingSettings.SERIALIZATION_DESERIALIZATION_FILTER, StandardConverters.STRING );
+		return pattern == null || pattern.isBlank()
+				? null
+				: DESERIALIZATION_FILTERS.computeIfAbsent( pattern, ObjectInputFilter.Config::createFilter );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/util/SerializationHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/util/SerializationHelperTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.orm.test.util;
 import java.io.InputStream;
+import java.io.ObjectInputFilter;
 import java.io.Serializable;
 
 import org.hibernate.testing.orm.junit.BaseUnitTest;
@@ -11,12 +12,14 @@ import org.hibernate.testing.orm.junit.BaseUnitTest;
 import org.hibernate.LockMode;
 import org.hibernate.bytecode.spi.ByteCodeHelper;
 import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.type.SerializationException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This is basically a test to assert the expectations of {@link org.hibernate.type.SerializableType}
@@ -79,6 +82,32 @@ public class SerializationHelperTest {
 
 		assertSame( instance.getClass(), instance2.getClass() );
 		assertSame( instance.getClass().getClassLoader(), instance2.getClass().getClassLoader() );
+	}
+
+
+	@Test
+	public void testDeserializeRejectedByFilter() {
+		final Serializable instance = LockMode.OPTIMISTIC;
+		final byte[] bytes = SerializationHelper.serialize( instance );
+
+		// a filter allowing only java.* classes rejects org.hibernate.LockMode
+		final ObjectInputFilter filter = ObjectInputFilter.Config.createFilter( "java.**;!*" );
+		assertThrows(
+				SerializationException.class,
+				() -> SerializationHelper.deserialize( bytes, SerializationHelper.hibernateClassLoader(), filter )
+		);
+	}
+
+	@Test
+	public void testDeserializeAllowedByFilter() {
+		final Serializable instance = LockMode.OPTIMISTIC;
+		final byte[] bytes = SerializationHelper.serialize( instance );
+
+		final ObjectInputFilter filter =
+				ObjectInputFilter.Config.createFilter( "org.hibernate.LockMode;java.**;!*" );
+		final Object instance2 =
+				SerializationHelper.deserialize( bytes, SerializationHelper.hibernateClassLoader(), filter );
+		assertSame( instance.getClass(), instance2.getClass() );
 	}
 
 

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -18,3 +18,10 @@ IMPORTANT: If migrating from earlier versions, be sure to also check out the lin
 Schema management DDL now uses `CREATE SCHEMA IF NOT EXISTS` and `DROP SCHEMA IF EXISTS` for dialects which support these clauses, avoiding warnings when a schema already exists or has already been dropped.
 
 Supported dialects: PostgreSQL, CockroachDB, H2, HSQLDB, SAP HANA, and SQL Server (DROP only, version 13+).
+
+[[serializable-deserialization-filter]]
+== Deserialization filter for `Serializable` basic values
+
+A new setting, `hibernate.serialization.deserialization_filter`, accepts a JEP-290 `java.io.ObjectInputFilter` pattern that is applied when deserializing basic values mapped as `Serializable` (for example, values stored as `VARBINARY` or `BLOB` and read back through `SerializableType`).
+
+The setting is opt-in and provides defense-in-depth: when it is unset there is no filter and behaviour is unchanged. When set, the configured filter constrains which classes may be deserialized from the database, which is useful when the database is shared or otherwise not fully trusted.


### PR DESCRIPTION
[HHH-20254](https://hibernate.atlassian.net/browse/HHH-20254)

## What / Why

When a domain model maps a basic value as `Serializable` (stored as `VARBINARY` / `BLOB`), Hibernate reads it back by deserializing the column bytes: `SerializableJavaType.wrap(...)` calls `SerializationHelper.deserialize(...)`, which calls `ObjectInputStream.readObject()`. `SerializationHelper.CustomObjectInputStream` overrides only `resolveClass(...)` for classloader resolution and installs no `java.io.ObjectInputFilter` (JEP-290), so any class on the classpath is deserialized from that column. As HHH-20254 notes, an actor able to modify the database could store a payload that triggers on deserialization.

This adds opt-in, defense-in-depth filtering scoped to exactly that path:

- A new setting `hibernate.serialization.deserialization_filter` (`MappingSettings.SERIALIZATION_DESERIALIZATION_FILTER`), taking a standard `ObjectInputFilter.Config.createFilter(String)` pattern.
- `SerializableJavaType.wrap(...)` resolves the configured filter and passes it to a new `SerializationHelper.deserialize(byte[], ClassLoader, ObjectInputFilter)` overload, which applies it to the stream. `resolveClass(...)` is unchanged.

## Non-breaking

The default is unchanged: with the setting unset, no filter is installed and behaviour is byte-for-byte as before. Existing `SerializationHelper` callers are unaffected.

## Tests

`SerializationHelperTest` adds two cases: a filter that disallows the class makes deserialization fail (surfaced as `SerializationException`), and a filter that allows the required type still round-trips. The existing cases are unchanged. Verified locally with `:hibernate-core:test --tests SerializationHelperTest` on JDK 25.

## Notes

Kept minimal and scoped to the `Serializable`-mapped-value path from HHH-20254. The filter is currently resolved from the `ConfigurationService` in `SerializableJavaType`; if you would prefer it resolved once at bootstrap and exposed via `SessionFactoryOptions`, or applied more broadly across `SerializationHelper`, I am happy to adjust. Whichever shape is preferred, the choke point stays in one place.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20254 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

[HHH-20254]: https://hibernate.atlassian.net/browse/HHH-20254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
