### PR TITLE
HHH-20725 EntityBinder does not read FK name from individual <primary-key-join-column> elements

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BinderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BinderHelper.java
@@ -6,9 +6,12 @@ package org.hibernate.boot.model.internal;
 
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKeyJoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.PrimaryKeyJoinColumn;
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.MappingException;
@@ -67,7 +70,6 @@ import static org.hibernate.internal.util.StringHelper.nullIfEmpty;
 import static org.hibernate.internal.util.StringHelper.qualifier;
 import static org.hibernate.internal.util.StringHelper.qualify;
 import static org.hibernate.internal.util.collections.ArrayHelper.forEach;
-import static org.hibernate.internal.util.collections.ArrayHelper.isEmpty;
 import static org.hibernate.models.spi.TypeDetailsHelper.resolveRawClass;
 import static org.hibernate.property.access.spi.BuiltInPropertyAccessStrategies.EMBEDDED;
 import static org.hibernate.property.access.spi.BuiltInPropertyAccessStrategies.NOOP;
@@ -989,6 +991,30 @@ public class BinderHelper {
 			referencedClass = referencedClass.getSuperPersistentClass();
 		}
 		return false;
+	}
+
+	static ForeignKey resolveContainerForeignKey(ForeignKey containerFk, MapKeyJoinColumn[] columns) {
+		return resolveContainerForeignKey( containerFk, columns.length != 0 ? columns[0].foreignKey() : null );
+	}
+
+	static ForeignKey resolveContainerForeignKey(ForeignKey containerFk, JoinColumn[] columns) {
+		return resolveContainerForeignKey( containerFk, columns.length != 0 ? columns[0].foreignKey() : null );
+	}
+
+	static ForeignKey resolveContainerForeignKey(ForeignKey containerFk, PrimaryKeyJoinColumn[] columns) {
+		return resolveContainerForeignKey( containerFk, columns.length != 0 ? columns[0].foreignKey() : null );
+	}
+
+	static ForeignKey resolveContainerForeignKey(ForeignKey containerFk, ForeignKey... columnFks) {
+		if ( containerFk != null && !isEmpty( containerFk.name() ) ) {
+			return containerFk;
+		}
+		for ( var columnFk : columnFks ) {
+			if ( columnFk != null && !isEmpty( columnFk.name() ) ) {
+				return columnFk;
+			}
+		}
+		return containerFk;
 	}
 
 	static boolean noConstraint(ForeignKey foreignKey, boolean noConstraintByDefault) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -134,6 +134,7 @@ import static org.hibernate.boot.model.internal.BinderHelper.extractFromPackage;
 import static org.hibernate.boot.model.internal.BinderHelper.getMappedSuperclassOrNull;
 import static org.hibernate.boot.model.internal.BinderHelper.getPath;
 import static org.hibernate.boot.model.internal.BinderHelper.handleForeignKeyConstraint;
+import static org.hibernate.boot.model.internal.BinderHelper.resolveContainerForeignKey;
 import static org.hibernate.boot.model.internal.BinderHelper.hasToOneAnnotation;
 import static org.hibernate.boot.model.internal.BinderHelper.toAliasEntityMap;
 import static org.hibernate.boot.model.internal.BinderHelper.toAliasTableMap;
@@ -987,7 +988,7 @@ public class EntityBinder {
 			return pkJoinColumn.foreignKey();
 		}
 		else if ( pkJoinColumns != null ) {
-			return pkJoinColumns.foreignKey();
+			return resolveContainerForeignKey( pkJoinColumns.foreignKey(), pkJoinColumns.value() );
 		}
 		else {
 			return null;
@@ -2225,7 +2226,7 @@ public class EntityBinder {
 		final var jpaSecondaryTable = findMatchingSecondaryTable( join );
 		if ( jpaSecondaryTable != null ) {
 			final boolean noConstraintByDefault = context.getBuildingOptions().isNoConstraintByDefault();
-			final var foreignKey = jpaSecondaryTable.foreignKey();
+			final var foreignKey = resolveSecondaryTableForeignKey( jpaSecondaryTable );
 			final var constraintMode = foreignKey.value();
 			if ( constraintMode == ConstraintMode.NO_CONSTRAINT
 				|| constraintMode == ConstraintMode.PROVIDER_DEFAULT && noConstraintByDefault ) {
@@ -2237,6 +2238,10 @@ public class EntityBinder {
 				key.setForeignKeyOptions( foreignKey.options() );
 			}
 		}
+	}
+
+	private static jakarta.persistence.ForeignKey resolveSecondaryTableForeignKey(SecondaryTable table) {
+		return resolveContainerForeignKey( table.foreignKey(), table.pkJoinColumns() );
 	}
 
 	private SecondaryTable findMatchingSecondaryTable(Join join) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/MapBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/MapBinder.java
@@ -52,6 +52,7 @@ import jakarta.persistence.MapKeyJoinColumns;
 import static org.hibernate.boot.model.internal.AnnotatedClassType.EMBEDDABLE;
 import static org.hibernate.boot.model.internal.AnnotatedClassType.NONE;
 import static org.hibernate.boot.model.internal.BasicValueBinder.Kind.MAP_KEY;
+import static org.hibernate.boot.model.internal.BinderHelper.resolveContainerForeignKey;
 import static org.hibernate.boot.model.internal.BinderHelper.findPropertyByName;
 import static org.hibernate.boot.model.internal.BinderHelper.isPrimitive;
 import static org.hibernate.boot.model.internal.EmbeddableBinder.fillEmbeddable;
@@ -435,7 +436,7 @@ public class MapBinder extends CollectionBinder {
 	private jakarta.persistence.ForeignKey getMapKeyForeignKey(MemberDetails property) {
 		final var mapKeyJoinColumns = property.getDirectAnnotationUsage( MapKeyJoinColumns.class );
 		if ( mapKeyJoinColumns != null ) {
-			return mapKeyJoinColumns.foreignKey();
+			return resolveContainerForeignKey( mapKeyJoinColumns.foreignKey(), mapKeyJoinColumns.value() );
 		}
 
 		final var mapKeyJoinColumn = property.getDirectAnnotationUsage( MapKeyJoinColumn.class );

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ToOneBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ToOneBinder.java
@@ -47,6 +47,7 @@ import static org.hibernate.boot.model.internal.BinderHelper.getFetchStyle;
 import static org.hibernate.boot.model.internal.BinderHelper.getPath;
 import static org.hibernate.boot.model.internal.BinderHelper.isDefault;
 import static org.hibernate.boot.model.internal.BinderHelper.handleForeignKeyConstraint;
+import static org.hibernate.boot.model.internal.BinderHelper.resolveContainerForeignKey;
 import static org.hibernate.boot.BootLogging.BOOT_LOGGER;
 import static org.hibernate.boot.model.internal.EntityBinder.isEntity;
 import static org.hibernate.boot.model.internal.PropertyBinder.isNonnull;
@@ -674,7 +675,7 @@ public class ToOneBinder {
 			return joinColumn.foreignKey();
 		}
 		else if ( joinColumns != null ) {
-			return joinColumns.foreignKey();
+			return resolveContainerForeignKey( joinColumns.foreignKey(), joinColumns.value() );
 		}
 		else {
 			return null;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/inheritance/ForeignKeyNameOrmXmlTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/inheritance/ForeignKeyNameOrmXmlTest.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.schemaupdate.inheritance;
+
+import org.hamcrest.MatcherAssert;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.schema.TargetType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.EnumSet;
+
+import static org.hamcrest.core.Is.is;
+import static org.hibernate.cfg.SchemaToolingSettings.HBM2DDL_AUTO;
+
+@SuppressWarnings("JUnitMalformedDeclaration")
+@JiraKey("HHH-20725")
+@ServiceRegistry(settings = @Setting(name = HBM2DDL_AUTO, value = "none"))
+public class ForeignKeyNameOrmXmlTest {
+
+	@Test
+	@DomainModel(xmlMappings = {
+			"org/hibernate/orm/test/schemaupdate/inheritance/Employee.orm.xml",
+			"org/hibernate/orm/test/schemaupdate/inheritance/Person.orm.xml",
+			"org/hibernate/orm/test/schemaupdate/inheritance/Manager.orm.xml",
+			"org/hibernate/orm/test/schemaupdate/inheritance/Payment.orm.xml"
+	})
+	public void testJoinedSubclassForeignKeyNameFromOrmXml(
+			DomainModelScope modelScope,
+			@TempDir File tmpDir) throws Exception {
+		final var scriptFile = new File( tmpDir, "update_script.sql" );
+
+		final var metadata = modelScope.getDomainModel();
+		metadata.orderColumns( false );
+		metadata.validate();
+
+		new SchemaUpdate()
+				.setHaltOnError( true )
+				.setOutputFile( scriptFile.getAbsolutePath() )
+				.setDelimiter( ";" )
+				.setFormat( true )
+				.execute( EnumSet.of( TargetType.SCRIPT ), metadata );
+
+		String fileContent = new String( Files.readAllBytes( scriptFile.toPath() ) );
+		MatcherAssert.assertThat( fileContent.toLowerCase().contains( "fk_emp_per" ), is( true ) );
+	}
+
+	@Test
+	@DomainModel(xmlMappings = "org/hibernate/orm/test/schemaupdate/inheritance/Payment.orm.xml")
+	public void testSecondaryTableForeignKeyNameFromOrmXml(
+			DomainModelScope modelScope,
+			@TempDir File tmpDir) throws Exception {
+		final var scriptFile = new File( tmpDir, "update_script.sql" );
+
+		final var metadata = modelScope.getDomainModel();
+		metadata.orderColumns( false );
+		metadata.validate();
+
+		new SchemaUpdate()
+				.setHaltOnError( true )
+				.setOutputFile( scriptFile.getAbsolutePath() )
+				.setDelimiter( ";" )
+				.setFormat( true )
+				.execute( EnumSet.of( TargetType.SCRIPT ), metadata );
+
+		String fileContent = new String( Files.readAllBytes( scriptFile.toPath() ) );
+		MatcherAssert.assertThat( fileContent.toLowerCase().contains( "fk_cc_pay" ), is( true ) );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/Company.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/Company.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.schemaupdate.joincolumnfk;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class Company implements Serializable {
+
+	private int id;
+	private String name;
+	private Map<Division, VicePresident> organization;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Map<Division, VicePresident> getOrganization() {
+		return organization;
+	}
+
+	public void setOrganization(Map<Division, VicePresident> organization) {
+		this.organization = organization;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/Department.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/Department.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.schemaupdate.joincolumnfk;
+
+import java.io.Serializable;
+
+public class Department implements Serializable {
+
+	private int id;
+	private String name;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/Division.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/Division.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.schemaupdate.joincolumnfk;
+
+import java.io.Serializable;
+
+public class Division implements Serializable {
+
+	private int id;
+	private String name;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/JoinColumnForeignKeyNameOrmXmlTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/JoinColumnForeignKeyNameOrmXmlTest.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.schemaupdate.joincolumnfk;
+
+import org.hamcrest.MatcherAssert;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.schema.TargetType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.EnumSet;
+
+import static org.hamcrest.core.Is.is;
+import static org.hibernate.cfg.SchemaToolingSettings.HBM2DDL_AUTO;
+
+@SuppressWarnings("JUnitMalformedDeclaration")
+@JiraKey("HHH-20725")
+@ServiceRegistry(settings = @Setting(name = HBM2DDL_AUTO, value = "none"))
+public class JoinColumnForeignKeyNameOrmXmlTest {
+
+	@Test
+	@DomainModel(xmlMappings = {
+			"org/hibernate/orm/test/schemaupdate/joincolumnfk/Department.orm.xml",
+			"org/hibernate/orm/test/schemaupdate/joincolumnfk/Worker.orm.xml"
+	})
+	public void testManyToOneForeignKeyNameFromJoinColumn(
+			DomainModelScope modelScope,
+			@TempDir File tmpDir) throws Exception {
+		final var scriptFile = new File( tmpDir, "update_script.sql" );
+
+		final var metadata = modelScope.getDomainModel();
+		metadata.orderColumns( false );
+		metadata.validate();
+
+		new SchemaUpdate()
+				.setHaltOnError( true )
+				.setOutputFile( scriptFile.getAbsolutePath() )
+				.setDelimiter( ";" )
+				.setFormat( true )
+				.execute( EnumSet.of( TargetType.SCRIPT ), metadata );
+
+		String fileContent = new String( Files.readAllBytes( scriptFile.toPath() ) );
+		MatcherAssert.assertThat( fileContent.toLowerCase().contains( "fk_worker_dept" ), is( true ) );
+	}
+
+	@Test
+	@DomainModel(xmlMappings = {
+			"org/hibernate/orm/test/schemaupdate/joincolumnfk/Division.orm.xml",
+			"org/hibernate/orm/test/schemaupdate/joincolumnfk/VicePresident.orm.xml",
+			"org/hibernate/orm/test/schemaupdate/joincolumnfk/Company.orm.xml"
+	})
+	public void testMapKeyJoinColumnForeignKeyNameFromOrmXml(
+			DomainModelScope modelScope,
+			@TempDir File tmpDir) throws Exception {
+		final var scriptFile = new File( tmpDir, "update_script.sql" );
+
+		final var metadata = modelScope.getDomainModel();
+		metadata.orderColumns( false );
+		metadata.validate();
+
+		new SchemaUpdate()
+				.setHaltOnError( true )
+				.setOutputFile( scriptFile.getAbsolutePath() )
+				.setDelimiter( ";" )
+				.setFormat( true )
+				.execute( EnumSet.of( TargetType.SCRIPT ), metadata );
+
+		String fileContent = new String( Files.readAllBytes( scriptFile.toPath() ) );
+		MatcherAssert.assertThat( fileContent.toLowerCase().contains( "fk_org_div" ), is( true ) );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/VicePresident.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/VicePresident.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.schemaupdate.joincolumnfk;
+
+import java.io.Serializable;
+
+public class VicePresident implements Serializable {
+
+	private int id;
+	private String name;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/Worker.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/joincolumnfk/Worker.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.schemaupdate.joincolumnfk;
+
+import java.io.Serializable;
+
+public class Worker implements Serializable {
+
+	private int id;
+	private String name;
+	private Department department;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Department getDepartment() {
+		return department;
+	}
+
+	public void setDepartment(Department department) {
+		this.department = department;
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/inheritance/Employee.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/inheritance/Employee.orm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <package>org.hibernate.orm.test.schemaupdate.joinedsubclass</package>
+    <entity class="org.hibernate.orm.test.schemaupdate.inheritance.Employee" metadata-complete="true">
+        <extends>org.hibernate.orm.test.schemaupdate.inheritance.Person</extends>
+        <table name="EMPLOYEES"/>
+        <primary-key-join-column name="EMP_ID">
+            <foreign-key name="FK_EMP_PER"/>
+        </primary-key-join-column>
+        <lazy>false</lazy>
+        <attributes/>
+    </entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/inheritance/Manager.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/inheritance/Manager.orm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <package>org.hibernate.orm.test.schemaupdate.joinedsubclass</package>
+    <entity class="org.hibernate.orm.test.schemaupdate.inheritance.Manager" metadata-complete="true">
+        <extends>org.hibernate.orm.test.schemaupdate.inheritance.Person</extends>
+        <table name="MANAGER"/>
+        <primary-key-join-column name="ID"/>
+        <lazy>false</lazy>
+        <attributes/>
+    </entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/inheritance/Payment.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/inheritance/Payment.orm.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <package>org.hibernate.orm.test.schemaupdate.joinedsubclass</package>
+    <entity class="org.hibernate.orm.test.schemaupdate.inheritance.Payment" metadata-complete="true">
+        <table name="PAYMENT"/>
+        <inheritance strategy="SINGLE_TABLE"/>
+        <discriminator-column name="PAYMENT_TYPE" discriminator-type="STRING"/>
+        <attributes>
+            <id name="id">
+                <column name="PAYMENT_ID"/>
+            </id>
+            <basic name="amount">
+                <column name="AMOUNT"/>
+            </basic>
+        </attributes>
+    </entity>
+    <entity class="org.hibernate.orm.test.schemaupdate.inheritance.CreditCardPayment" metadata-complete="true">
+        <extends>org.hibernate.orm.test.schemaupdate.inheritance.Payment</extends>
+        <secondary-table name="CREDIT_PAYMENT" optional="false" owned="true">
+            <primary-key-join-column name="PAYMENT_ID">
+                <foreign-key name="FK_CC_PAY"/>
+            </primary-key-join-column>
+        </secondary-table>
+        <discriminator-value>CREDIT</discriminator-value>
+        <attributes>
+            <basic name="creditCardType">
+                <column name="CCTYPE" table="CREDIT_PAYMENT"/>
+            </basic>
+        </attributes>
+    </entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/inheritance/Person.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/inheritance/Person.orm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <package>org.hibernate.orm.test.schemaupdate.joinedsubclass</package>
+    <entity class="org.hibernate.orm.test.schemaupdate.inheritance.Person" metadata-complete="true">
+        <table name="PERSONS"/>
+        <inheritance strategy="JOINED"/>
+        <attributes>
+            <id name="id">
+                <column name="PER_ID"/>
+            </id>
+            <basic name="name">
+                <column name="NAME"/>
+            </basic>
+        </attributes>
+    </entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/Company.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/Company.orm.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <entity class="org.hibernate.orm.test.schemaupdate.joincolumnfk.Company" metadata-complete="true">
+        <table name="COMPANY"/>
+        <attributes>
+            <id name="id">
+                <column name="COMP_ID"/>
+            </id>
+            <basic name="name">
+                <column name="NAME"/>
+            </basic>
+            <many-to-many name="organization"
+                          target-entity="org.hibernate.orm.test.schemaupdate.joincolumnfk.VicePresident"
+                          fetch="LAZY"
+                          classification="MAP">
+                <map-key-join-column name="DIV_ID">
+                    <foreign-key name="FK_ORG_DIV"/>
+                </map-key-join-column>
+                <join-table name="COMPANY_ORGANIZATION">
+                    <join-column name="COMP_ID"/>
+                    <inverse-join-column name="VP_ID"/>
+                </join-table>
+            </many-to-many>
+        </attributes>
+    </entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/Department.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/Department.orm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <entity class="org.hibernate.orm.test.schemaupdate.joincolumnfk.Department" metadata-complete="true">
+        <table name="DEPARTMENT"/>
+        <attributes>
+            <id name="id">
+                <column name="DEPT_ID"/>
+            </id>
+            <basic name="name">
+                <column name="NAME"/>
+            </basic>
+        </attributes>
+    </entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/Division.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/Division.orm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <entity class="org.hibernate.orm.test.schemaupdate.joincolumnfk.Division" metadata-complete="true">
+        <table name="DIVISION"/>
+        <attributes>
+            <id name="id">
+                <column name="DIV_ID"/>
+            </id>
+            <basic name="name">
+                <column name="NAME"/>
+            </basic>
+        </attributes>
+    </entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/VicePresident.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/VicePresident.orm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <entity class="org.hibernate.orm.test.schemaupdate.joincolumnfk.VicePresident" metadata-complete="true">
+        <table name="VICE_PRESIDENT"/>
+        <attributes>
+            <id name="id">
+                <column name="VP_ID"/>
+            </id>
+            <basic name="name">
+                <column name="NAME"/>
+            </basic>
+        </attributes>
+    </entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/Worker.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/schemaupdate/joincolumnfk/Worker.orm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <entity class="org.hibernate.orm.test.schemaupdate.joincolumnfk.Worker" metadata-complete="true">
+        <table name="WORKER"/>
+        <attributes>
+            <id name="id">
+                <column name="WORKER_ID"/>
+            </id>
+            <basic name="name">
+                <column name="NAME"/>
+            </basic>
+            <many-to-one name="department"
+                         target-entity="org.hibernate.orm.test.schemaupdate.joincolumnfk.Department">
+                <join-column name="DEPT_ID">
+                    <foreign-key name="FK_WORKER_DEPT"/>
+                </join-column>
+            </many-to-one>
+        </attributes>
+    </entity>
+</entity-mappings>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/13118 for 8.0

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20725 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20725
<!-- Hibernate GitHub Bot issue links end -->