### PR TITLE
Few bug fixes for HbmXmlTransformer 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1618,7 +1618,31 @@ public class HbmXmlTransformer {
 			if ( column.getLength() != null ) {
 				jaxbColumn.setLength( column.getLength().intValue() );
 			}
+			else if ( discriminatorType == DiscriminatorType.STRING ) {
+				final Integer length = determineDiscriminatorLength( bootEntityInfo.getPersistentClass() );
+				if ( length != null ) {
+					jaxbColumn.setLength( length );
+				}
+			}
 		}
+	}
+
+	// The JPA default for @DiscriminatorColumn.length is 31. HBM mappings have no such
+	// limit and often use fully-qualified class names as discriminator values. When the
+	// longest value exceeds 31 we must set the length explicitly to avoid truncation.
+	private static Integer determineDiscriminatorLength(PersistentClass rootClass) {
+		int maxLength = 0;
+		final String rootValue = rootClass.getDiscriminatorValue();
+		if ( rootValue != null ) {
+			maxLength = rootValue.length();
+		}
+		for ( var subclass : rootClass.getSubclasses() ) {
+			final String value = subclass.getDiscriminatorValue();
+			if ( value != null && value.length() > maxLength ) {
+				maxLength = value.length();
+			}
+		}
+		return maxLength > 31 ? maxLength : null;
 	}
 
 	private static DiscriminatorType determineDiscriminatorType(Value discriminatorBinding) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -861,11 +861,7 @@ public class HbmXmlTransformer {
 
 		final var key = hbmSubclass.getKey();
 		if ( key != null ) {
-			final var joinColumn = new JaxbPrimaryKeyJoinColumnImpl();
-			// todo (7.0) : formula and multiple columns
-			joinColumn.setName( key.getColumnAttribute() );
-			subclassEntity.getPrimaryKeyJoinColumns().add( joinColumn );
-			joinColumn.setForeignKey( transformForeignKey( key.getForeignKey() ) );
+			transferKeyColumns( key, subclassEntity.getPrimaryKeyJoinColumns() );
 		}
 
 		if ( !hbmSubclass.getJoinedSubclass().isEmpty() ) {
@@ -3990,6 +3986,28 @@ public class HbmXmlTransformer {
 		mappingEntity.getSecondaryTables().add( secondaryTable );
 	}
 
+
+	private void transferKeyColumns(JaxbHbmKeyType key, List<JaxbPrimaryKeyJoinColumnImpl> targetColumns) {
+		final String columnName = key.getColumnAttribute();
+		if ( columnName != null || key.getColumn().size() <= 1 ) {
+			final var joinColumn = new JaxbPrimaryKeyJoinColumnImpl();
+			if ( columnName == null && !key.getColumn().isEmpty() ) {
+				joinColumn.setName( key.getColumn().get( 0 ).getName() );
+			}
+			else {
+				joinColumn.setName( columnName );
+			}
+			joinColumn.setForeignKey( transformForeignKey( key.getForeignKey() ) );
+			targetColumns.add( joinColumn );
+		}
+		else {
+			for ( JaxbHbmColumnType column : key.getColumn() ) {
+				final var joinColumn = new JaxbPrimaryKeyJoinColumnImpl();
+				joinColumn.setName( column.getName() );
+				targetColumns.add( joinColumn );
+			}
+		}
+	}
 
 	// ToOne
 	private void transferFetchable(

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -101,6 +101,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbCascadeTypeImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCheckConstraintImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCollectionTableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCollectionUserTypeImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbCollectionIdImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbColumnImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbColumnResultImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbConfigurationParameterImpl;
@@ -2431,9 +2432,11 @@ public class HbmXmlTransformer {
 			transferMapKey( map, target, propertyInfo );
 			target.setClassification( LimitedCollectionClassification.MAP );
 		}
-		else if ( source instanceof JaxbHbmIdBagCollectionType ) {
-			handleUnsupported( "collection-id is not supported for transformation" );
-
+		else if ( source instanceof JaxbHbmIdBagCollectionType idBag ) {
+			// Do not set classification to BAG — the presence of <collection-id> on
+			// the target will cause CollectionBinder to classify it as ID_BAG.
+			// Setting BAG explicitly would bypass the CollectionId annotation check.
+			transferCollectionId( idBag, target );
 		}
 		else if ( source instanceof JaxbHbmBagCollectionType ) {
 			target.setClassification( LimitedCollectionClassification.BAG );
@@ -2462,6 +2465,57 @@ public class HbmXmlTransformer {
 			);
 			target.setClassification( LimitedCollectionClassification.LIST );
 		}
+	}
+
+	private void transferCollectionId(JaxbHbmIdBagCollectionType idBag, JaxbPluralAttribute target) {
+		final var hbmCollectionId = idBag.getCollectionId();
+		if ( hbmCollectionId == null ) {
+			return;
+		}
+
+		final var collectionId = new JaxbCollectionIdImpl();
+
+		final var column = new JaxbColumnImpl();
+		column.setName( hbmCollectionId.getColumnAttribute() );
+		if ( hbmCollectionId.getLength() != null ) {
+			column.setLength( hbmCollectionId.getLength() );
+		}
+		collectionId.setColumn( column );
+
+		final var hbmGenerator = hbmCollectionId.getGenerator();
+		if ( hbmGenerator != null ) {
+			final var generatedValue = new JaxbGeneratedValueImpl();
+			final String generatorClass = hbmGenerator.getClazz();
+			final var hbmParams = hbmGenerator.getConfigParameters();
+
+			if ( !hbmParams.isEmpty() ) {
+				final var generatorName = target.getName() + "-collection-id-generator";
+				generatedValue.setGenerator( generatorName );
+
+				final var genDef = new JaxbGenericIdGeneratorImpl();
+				genDef.setName( generatorName );
+				genDef.setClazz( generatorClass );
+				for ( var hbmParam : hbmParams ) {
+					final var param = new JaxbConfigurationParameterImpl();
+					param.setName( hbmParam.getName() );
+					param.setValue( hbmParam.getValue() );
+					genDef.getParameters().add( param );
+				}
+				mappingXmlBinding.getRoot().getGenericGenerators().add( genDef );
+			}
+			else {
+				generatedValue.setGenerator( generatorClass );
+			}
+
+			collectionId.setGenerator( generatedValue );
+		}
+
+		final String hbmType = hbmCollectionId.getType();
+		if ( isNotEmpty( hbmType ) ) {
+			collectionId.setTarget( Character.toUpperCase( hbmType.charAt( 0 ) ) + hbmType.substring( 1 ) );
+		}
+
+		target.setCollectionId( collectionId );
 	}
 
 	private void transferSort(String sort, JaxbPluralAttribute target) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -3977,11 +3977,7 @@ public class HbmXmlTransformer {
 		secondaryTable.setOwned( !hbmJoin.isInverse() );
 		final JaxbHbmKeyType key = hbmJoin.getKey();
 		if ( key != null ) {
-			final var joinColumn = new JaxbPrimaryKeyJoinColumnImpl();
-			joinColumn.setName( key.getColumnAttribute() );
-			secondaryTable.getPrimaryKeyJoinColumn().add( joinColumn );
-
-			joinColumn.setForeignKey( transformForeignKey( key.getForeignKey() ) );
+			transferKeyColumns( key, secondaryTable.getPrimaryKeyJoinColumn() );
 		}
 		mappingEntity.getSecondaryTables().add( secondaryTable );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/DiscriminatorLengthBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/DiscriminatorLengthBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class DiscriminatorLengthBase {
+	private long id;
+	private String name;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/DiscriminatorLengthChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/DiscriminatorLengthChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class DiscriminatorLengthChild extends DiscriminatorLengthBase {
+	private String detail;
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1287,6 +1287,57 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20724" )
+	public void testSubclassJoinForeignKeyNameTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/subclass-join-fk/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl childEntity = transformed.getEntities().stream()
+					.filter( e -> "SubclassJoinFkChild".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( childEntity.getSecondaryTables() ).hasSize( 1 );
+
+			final var secondaryTable = childEntity.getSecondaryTables().get( 0 );
+			assertThat( secondaryTable.getName() ).isEqualTo( "SJ_FK_CHILD" );
+			assertThat( secondaryTable.getPrimaryKeyJoinColumn() ).hasSize( 1 );
+
+			final var joinColumn = secondaryTable.getPrimaryKeyJoinColumn().get( 0 );
+			assertThat( joinColumn.getName() )
+					.isEqualTo( "CHILD_BASE_ID" );
+			assertThat( joinColumn.getForeignKey() )
+					.as( "Foreign key should be set on the join column from <key foreign-key='...'>" )
+					.isNotNull();
+			assertThat( joinColumn.getForeignKey().getName() )
+					.as( "Foreign key name should be preserved" )
+					.isEqualTo( "FK_CHILD_SJ" );
+		} );
+	}
+
+	@Test
+	public void testSecondaryTableMultipleKeyColumns(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/subclass-join-composite-key/hbm.xml", scope, transformed -> {
+			final JaxbEntityImpl childEntity = transformed.getEntities().stream()
+					.filter( e -> "SubclassJoinCompositeChild".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( childEntity.getSecondaryTables() ).hasSize( 1 );
+
+			final var secondaryTable = childEntity.getSecondaryTables().get( 0 );
+			assertThat( secondaryTable.getName() ).isEqualTo( "SJ_CK_CHILD" );
+			assertThat( secondaryTable.getPrimaryKeyJoinColumn() )
+					.as( "All <column> elements in the composite <key> should be transferred" )
+					.hasSize( 2 );
+			assertThat( secondaryTable.getPrimaryKeyJoinColumn().get( 0 ).getName() )
+					.isEqualTo( "CHILD_COL_1" );
+			assertThat( secondaryTable.getPrimaryKeyJoinColumn().get( 1 ).getName() )
+					.isEqualTo( "CHILD_COL_2" );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20687" )
 	public void testSharedPkOneToOneTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/one-to-one-shared-pk/hbm.xml", scope, transformed -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1287,6 +1287,26 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20726" )
+	public void testDiscriminatorColumnLengthForLongValues(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/discriminator-length/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl baseEntity = transformed.getEntities().stream()
+					.filter( e -> "DiscriminatorLengthBase".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( baseEntity.getDiscriminatorColumn() ).isNotNull();
+			assertThat( baseEntity.getDiscriminatorColumn().getLength() )
+					.as( "Discriminator column length should accommodate the longest discriminator value" )
+					.isGreaterThanOrEqualTo(
+							"org.hibernate.orm.test.boot.jaxb.mapping.DiscriminatorLengthChild".length()
+					);
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20724" )
 	public void testSubclassJoinForeignKeyNameTransformation(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/subclass-join-fk/hbm.xml", scope, transformed -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -218,6 +218,48 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20723" )
+	public void testJoinedSubclassForeignKeyNameWithNestedColumn(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/joined-subclass-fk/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl childEntity = transformed.getEntities().stream()
+					.filter( e -> "JoinedSubclassFkChild".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( childEntity.getPrimaryKeyJoinColumns() ).hasSize( 1 );
+
+			final var joinColumn = childEntity.getPrimaryKeyJoinColumns().get( 0 );
+			assertThat( joinColumn.getName() )
+					.as( "Column name from nested <column> element should be preserved" )
+					.isEqualTo( "CHILD_BASE_ID" );
+			assertThat( joinColumn.getForeignKey() )
+					.as( "Foreign key should be set" )
+					.isNotNull();
+			assertThat( joinColumn.getForeignKey().getName() )
+					.as( "Foreign key name from <key foreign-key='...'> should be preserved" )
+					.isEqualTo( "FK_CHILD_BASE" );
+		} );
+	}
+
+	@Test
+	public void testJoinedSubclassMultipleKeyColumns(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/joined-subclass-composite-key/hbm.xml", scope, transformed -> {
+			final JaxbEntityImpl childEntity = transformed.getEntities().stream()
+					.filter( e -> "JoinedSubclassCompositeChild".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+			assertThat( childEntity.getPrimaryKeyJoinColumns() )
+					.as( "All <column> elements in the composite <key> should be transferred" )
+					.hasSize( 2 );
+			assertThat( childEntity.getPrimaryKeyJoinColumns().get( 0 ).getName() )
+					.isEqualTo( "CHILD_TENANT_ID" );
+			assertThat( childEntity.getPrimaryKeyJoinColumns().get( 1 ).getName() )
+					.isEqualTo( "CHILD_BASE_ID" );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20566" )
 	public void testJoinedSubclassInheritanceStrategy(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/joined-subclass/hbm.xml", scope, transformed -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1545,6 +1545,48 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20751" )
+	public void testIdBagCollectionIdTransformation(ServiceRegistryScope scope) {
+		// An <idbag> with a <collection-id> using a sequence generator should be
+		// transformed into a <many-to-many> with a <collection-id> element containing
+		// the column, generator reference, and target type.
+		transformAndVerify( "xml/jaxb/mapping/idbag-collection-id/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 1 );
+
+			final JaxbEntityImpl entity = transformed.getEntities().get( 0 );
+
+			// The many-to-many should have a collection-id
+			assertThat( entity.getAttributes().getManyToManyAttributes() ).hasSize( 1 );
+			final var manyToMany = entity.getAttributes().getManyToManyAttributes().get( 0 );
+			assertThat( manyToMany.getName() ).isEqualTo( "children" );
+
+			final var collectionId = manyToMany.getCollectionId();
+			assertThat( collectionId )
+					.as( "collection-id should be present on the idbag many-to-many" )
+					.isNotNull();
+
+			// Column
+			assertThat( collectionId.getColumn() ).isNotNull();
+			assertThat( collectionId.getColumn().getName() ).isEqualTo( "bag_id" );
+
+			// Generator reference
+			assertThat( collectionId.getGenerator() ).isNotNull();
+			assertThat( collectionId.getGenerator().getGenerator() )
+					.as( "Generator should reference a named generic-generator" )
+					.isEqualTo( "children-collection-id-generator" );
+
+			// Target type
+			assertThat( collectionId.getTarget() ).isEqualTo( "Long" );
+
+			// The named generic-generator should be registered at entity-mappings level
+			assertThat( transformed.getGenericGenerators() )
+					.as( "A generic-generator for the collection-id should be at entity-mappings level" )
+					.anyMatch( g -> "children-collection-id-generator".equals( g.getName() )
+									&& "sequence".equals( g.getClazz() ) );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20717" )
 	public void testImportWithoutRenameDefaultsToUnqualifiedClassName(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/import-no-rename/hbm.xml", scope, transformed -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassCompositeBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassCompositeBase.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class JoinedSubclassCompositeBase {
+	private int tenantId;
+	private int id;
+	private String name;
+
+	public int getTenantId() {
+		return tenantId;
+	}
+
+	public void setTenantId(int tenantId) {
+		this.tenantId = tenantId;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassCompositeChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassCompositeChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class JoinedSubclassCompositeChild extends JoinedSubclassCompositeBase {
+	private String detail;
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassFkBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassFkBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class JoinedSubclassFkBase {
+	private int id;
+	private String name;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassFkChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/JoinedSubclassFkChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class JoinedSubclassFkChild extends JoinedSubclassFkBase {
+	private String detail;
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubclassJoinCompositeBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubclassJoinCompositeBase.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+import java.io.Serializable;
+
+public class SubclassJoinCompositeBase implements Serializable {
+	private int tenantId;
+	private long id;
+	private String name;
+
+	public int getTenantId() {
+		return tenantId;
+	}
+
+	public void setTenantId(int tenantId) {
+		this.tenantId = tenantId;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubclassJoinCompositeChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubclassJoinCompositeChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class SubclassJoinCompositeChild extends SubclassJoinCompositeBase {
+	private String detail;
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubclassJoinFkBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubclassJoinFkBase.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class SubclassJoinFkBase {
+	private long id;
+	private String type;
+	private String name;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubclassJoinFkChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/SubclassJoinFkChild.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping;
+
+public class SubclassJoinFkChild extends SubclassJoinFkBase {
+	private String detail;
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/idbag/IdBagEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/idbag/IdBagEntity.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.idbag;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IdBagEntity {
+	private long id;
+	private List<IdBagEntity> children = new ArrayList<>();
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public List<IdBagEntity> getChildren() {
+		return children;
+	}
+
+	public void setChildren(List<IdBagEntity> children) {
+		this.children = children;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/discriminator-length/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/discriminator-length/hbm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="DiscriminatorLengthBase" table="DISC_LENGTH_BASE">
+        <id name="id" type="long" column="ID">
+            <generator class="native"/>
+        </id>
+        <discriminator column="DISC_TYPE" type="string"/>
+        <property name="name" column="NAME"/>
+        <subclass name="DiscriminatorLengthChild"
+                  discriminator-value="org.hibernate.orm.test.boot.jaxb.mapping.DiscriminatorLengthChild">
+            <property name="detail" column="DETAIL"/>
+        </subclass>
+    </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/idbag-collection-id/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/idbag-collection-id/hbm.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.idbag">
+
+    <class name="IdBagEntity">
+        <id name="id" column="id">
+            <generator class="sequence">
+                <param name="sequence_name">seq_owner_id</param>
+            </generator>
+        </id>
+
+        <idbag name="children" cascade="all" table="idbag_children">
+            <collection-id type="long" column="bag_id">
+                <generator class="sequence">
+                    <param name="sequence_name">seq_child_id</param>
+                </generator>
+            </collection-id>
+            <key column="PARENT_FK"/>
+            <many-to-many column="CHILD_FK" class="IdBagEntity"/>
+        </idbag>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/joined-subclass-composite-key/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/joined-subclass-composite-key/hbm.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="JoinedSubclassCompositeBase" table="JS_CK_BASE">
+        <composite-id>
+            <key-property name="tenantId" type="int">
+                <column name="TENANT_ID"/>
+            </key-property>
+            <key-property name="id" type="int">
+                <column name="BASE_ID"/>
+            </key-property>
+        </composite-id>
+        <property name="name">
+            <column name="NAME"/>
+        </property>
+        <joined-subclass name="JoinedSubclassCompositeChild" table="JS_CK_CHILD">
+            <key>
+                <column name="CHILD_TENANT_ID"/>
+                <column name="CHILD_BASE_ID"/>
+            </key>
+            <property name="detail"/>
+        </joined-subclass>
+    </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/joined-subclass-fk/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/joined-subclass-fk/hbm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="JoinedSubclassFkBase" table="JS_FK_BASE">
+        <id name="id" type="int">
+            <column name="BASE_ID"/>
+            <generator class="native"/>
+        </id>
+        <property name="name">
+            <column name="NAME"/>
+        </property>
+        <joined-subclass name="JoinedSubclassFkChild" table="JS_FK_CHILD">
+            <key foreign-key="FK_CHILD_BASE">
+                <column name="CHILD_BASE_ID"/>
+            </key>
+            <property name="detail"/>
+        </joined-subclass>
+    </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/subclass-join-composite-key/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/subclass-join-composite-key/hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="SubclassJoinCompositeBase" table="SJ_CK_BASE">
+        <composite-id>
+            <key-property name="tenantId" type="int" column="TENANT_ID"/>
+            <key-property name="id" type="long" column="BASE_ID"/>
+        </composite-id>
+        <discriminator column="DISC_TYPE" type="string"/>
+        <property name="name" column="NAME"/>
+        <subclass name="SubclassJoinCompositeChild" discriminator-value="CHILD">
+            <join table="SJ_CK_CHILD">
+                <key>
+                    <column name="CHILD_COL_1"/>
+                    <column name="CHILD_COL_2"/>
+                </key>
+                <property name="detail" column="DETAIL"/>
+            </join>
+        </subclass>
+    </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/subclass-join-fk/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/subclass-join-fk/hbm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm"
+                   package="org.hibernate.orm.test.boot.jaxb.mapping">
+    <class name="SubclassJoinFkBase" table="SJ_FK_BASE">
+        <id name="id" type="long" column="BASE_ID">
+            <generator class="native"/>
+        </id>
+        <discriminator column="DISC_TYPE" type="string"/>
+        <property name="name" column="NAME"/>
+        <subclass name="SubclassJoinFkChild" discriminator-value="CHILD">
+            <join table="SJ_FK_CHILD">
+                <key foreign-key="FK_CHILD_SJ">
+                    <column name="CHILD_BASE_ID"/>
+                </key>
+                <property name="detail" column="DETAIL"/>
+            </join>
+        </subclass>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
- [HHH-20723](https://hibernate.atlassian.net/browse/HHH-20723) HbmXmlTransformer loses column name from nested <column> element in joined-subclass <key>
- [HHH-20724](https://hibernate.atlassian.net/browse/HHH-20724) HbmXmlTransformer loses secondary table key column name from nested <column> element
- [HHH-20726](https://hibernate.atlassian.net/browse/HHH-20726) HbmXmlTransformer does not set discriminator column length when values exceed JPA default
- [HHH-20751](https://hibernate.atlassian.net/browse/HHH-20751) HbmXmlTransformer does not transform <idbag> collection-id elements



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20751 (New Feature):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)

Tasks specific to HHH-20726 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20724 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20723 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

[HHH-20723]: https://hibernate.atlassian.net/browse/HHH-20723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20724]: https://hibernate.atlassian.net/browse/HHH-20724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20726]: https://hibernate.atlassian.net/browse/HHH-20726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20751]: https://hibernate.atlassian.net/browse/HHH-20751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ