### PR TITLE
HHH-20721 Avoid allocating CoercionException for instanceof check

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
@@ -1036,8 +1036,8 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 			final var hibernateType = parameter.getHibernateType();
 			return hibernateType == null
 				|| values.isEmpty()
-				|| !isInstance( hibernateType, value, getNodeBuilder() )
-				|| isInstance( hibernateType, values.iterator().next(), getNodeBuilder() );
+				|| isInstance( hibernateType, values.iterator().next(), getNodeBuilder() )
+				|| !isInstance( hibernateType, value, getNodeBuilder() );
 		}
 		else {
 			return false;

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractCommonQueryContract.java
@@ -1036,8 +1036,8 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 			final var hibernateType = parameter.getHibernateType();
 			return hibernateType == null
 				|| values.isEmpty()
-				|| isInstance( hibernateType, values.iterator().next(), getNodeBuilder() )
-				|| !isInstance( hibernateType, value, getNodeBuilder() );
+				|| !isInstance( hibernateType, value, getNodeBuilder() )
+				|| isInstance( hibernateType, values.iterator().next(), getNodeBuilder() );
 		}
 		else {
 			return false;

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryArguments.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryArguments.java
@@ -40,7 +40,8 @@ public class QueryArguments {
 			}
 			else {
 				// require that the argument be assignable to the parameter
-				return javaType.isInstance( javaType.coerce( value ) );
+				final var coerced = javaType.coerceOrNull( value );
+				return coerced != null && javaType.isInstance( coerced );
 			}
 		}
 		catch (HibernateException ce) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigDecimalJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigDecimalJavaType.java
@@ -8,6 +8,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -130,11 +132,26 @@ public class BigDecimalJavaType extends AbstractClassJavaType<BigDecimal> {
 	}
 
 	@Override
-	public BigDecimal coerce(Object value) {
+	public @Nullable BigDecimal coerce(@Nullable Object value) {
 		if ( value == null ) {
 			return null;
 		}
+		final var coerced = coerceOrNull( value );
+		if ( coerced == null ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Unable to coerce value [%s (%s)] to BigDecimal",
+							value,
+							value.getClass().getName()
+					)
+			);
+		}
+		return coerced;
+	}
 
+	@Override
+	public @Nullable BigDecimal coerceOrNull(@Nonnull Object value) {
 		if ( value instanceof BigDecimal bigDecimal ) {
 			return bigDecimal;
 		}
@@ -149,13 +166,6 @@ public class BigDecimalJavaType extends AbstractClassJavaType<BigDecimal> {
 			);
 		}
 
-		throw new CoercionException(
-				String.format(
-						Locale.ROOT,
-						"Unable to coerce value [%s (%s)] to BigDecimal",
-						value,
-						value.getClass().getName()
-				)
-		);
+		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerJavaType.java
@@ -8,6 +8,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -132,11 +134,26 @@ public class BigIntegerJavaType extends AbstractClassJavaType<BigInteger> {
 	}
 
 	@Override
-	public BigInteger coerce(Object value) {
+	public @Nullable BigInteger coerce(@Nullable Object value) {
 		if ( value == null ) {
 			return null;
 		}
+		final var coerced = coerceOrNull( value );
+		if ( coerced == null ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Unable to coerce value [%s (%s)] to BigInteger",
+							value,
+							value.getClass().getName()
+					)
+			);
+		}
+		return coerced;
+	}
 
+	@Override
+	public @Nullable BigInteger coerceOrNull(@Nonnull Object value) {
 		if ( value instanceof BigInteger bigInteger ) {
 			return bigInteger;
 		}
@@ -175,13 +192,6 @@ public class BigIntegerJavaType extends AbstractClassJavaType<BigInteger> {
 			);
 		}
 
-		throw new CoercionException(
-				String.format(
-						Locale.ROOT,
-						"Unable to coerce value [%s (%s)] to BigInteger",
-						value,
-						value.getClass().getName()
-				)
-		);
+		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteJavaType.java
@@ -7,6 +7,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -136,11 +138,26 @@ public class ByteJavaType extends AbstractClassJavaType<Byte>
 	}
 
 	@Override
-	public Byte coerce(Object value) {
+	public @Nullable Byte coerce(@Nullable Object value) {
 		if ( value == null ) {
 			return null;
 		}
+		final var coerced = coerceOrNull( value );
+		if ( coerced == null ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce value '%s' [%s] to Byte",
+							value,
+							value.getClass().getName()
+					)
+			);
+		}
+		return coerced;
+	}
 
+	@Override
+	public @Nullable Byte coerceOrNull(@Nonnull Object value) {
 		if ( value instanceof Byte byteValue ) {
 			return byteValue;
 		}
@@ -179,14 +196,7 @@ public class ByteJavaType extends AbstractClassJavaType<Byte>
 			);
 		}
 
-		throw new CoercionException(
-				String.format(
-						Locale.ROOT,
-						"Cannot coerce value '%s' [%s] to Byte",
-						value,
-						value.getClass().getName()
-				)
-		);
+		return null;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
@@ -9,6 +9,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.dialect.Dialect;
@@ -17,6 +19,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.spi.TypeConfiguration;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Descriptor for {@link Calendar} handling, but just for the date (month, day, year) portion.
@@ -100,13 +103,18 @@ public class CalendarDateJavaType extends AbstractTemporalJavaType<Calendar> {
 	}
 
 	@Override
-	public Calendar coerce(Object value) {
+	public @Nullable Calendar coerce(@Nullable Object value) {
 		try {
 			return wrap( value, null );
 		}
 		catch (Exception e) {
 			throw CoercionHelper.coercionException( e );
 		}
+	}
+
+	@Override
+	public @Nullable Object coerceOrNull(@NotNull Object value) {
+		return wrapOrNull( value );
 	}
 
 	public <X> X unwrap(Calendar value, Class<X> type, WrapperOptions options) {
@@ -135,7 +143,17 @@ public class CalendarDateJavaType extends AbstractTemporalJavaType<Calendar> {
 		if ( value == null ) {
 			return null;
 		}
-		else if (value instanceof Calendar calendar) {
+		else {
+			final var wrapped = wrapOrNull( value );
+			if ( wrapped == null ) {
+				throw unknownWrap( value.getClass() );
+			}
+			return wrapped;
+		}
+	}
+
+	private <X> @Nullable Calendar wrapOrNull(@Nonnull X value) {
+		if (value instanceof Calendar calendar) {
 			return calendar;
 		}
 		else if ( value instanceof Date date ) {
@@ -144,7 +162,7 @@ public class CalendarDateJavaType extends AbstractTemporalJavaType<Calendar> {
 			return cal;
 		}
 		else {
-			throw unknownWrap( value.getClass() );
+			return null;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
@@ -9,6 +9,8 @@ import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.dialect.Dialect;
@@ -18,6 +20,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.spi.TypeConfiguration;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Descriptor for {@link Calendar} handling.
@@ -116,13 +119,18 @@ public class CalendarJavaType extends AbstractTemporalJavaType<Calendar> impleme
 	}
 
 	@Override
-	public Calendar coerce(Object value) {
+	public @Nullable Calendar coerce(@Nullable Object value) {
 		try {
 			return wrap( value, null );
 		}
 		catch (Exception e) {
 			throw CoercionHelper.coercionException( e );
 		}
+	}
+
+	@Override
+	public @Nullable Object coerceOrNull(@NotNull Object value) {
+		return wrapOrNull( value );
 	}
 
 	public <X> X unwrap(Calendar value, Class<X> type, WrapperOptions options) {
@@ -151,7 +159,17 @@ public class CalendarJavaType extends AbstractTemporalJavaType<Calendar> impleme
 		if ( value == null ) {
 			return null;
 		}
-		else if (value instanceof Calendar calendar) {
+		else {
+			final var wrapped = wrapOrNull( value );
+			if ( wrapped == null ) {
+				throw unknownWrap( value.getClass() );
+			}
+			return wrapped;
+		}
+	}
+
+	private <X> @Nullable Calendar wrapOrNull(@Nonnull X value) {
+		if (value instanceof Calendar calendar) {
 			return calendar;
 		}
 		else if ( value instanceof java.util.Date date ) {
@@ -160,7 +178,7 @@ public class CalendarJavaType extends AbstractTemporalJavaType<Calendar> impleme
 			return cal;
 		}
 		else {
-			throw unknownWrap( value.getClass() );
+			return null;
 		}
 
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
@@ -10,6 +10,8 @@ import java.sql.Types;
 import java.util.Calendar;
 import java.util.Date;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.dialect.Dialect;
@@ -203,14 +205,27 @@ public class DateJavaType extends AbstractTemporalJavaType<Date> implements Vers
 		};
 	}
 
+	private <X> @Nullable Date wrapOrNull(@Nonnull X value) {
+		return switch ( precision ) {
+			case TIMESTAMP -> JdbcTimestampJavaType.INSTANCE.wrapOrNull( value );
+			case DATE -> JdbcDateJavaType.INSTANCE.wrapOrNull( value );
+			case TIME -> JdbcTimeJavaType.INSTANCE.wrapOrNull( value );
+		};
+	}
+
 	@Override
-	public Object coerce(Object value) {
+	public @Nullable Object coerce(@Nullable Object value) {
 		try {
 			return wrap( value, null );
 		}
 		catch (Exception e) {
 			throw CoercionHelper.coercionException( e );
 		}
+	}
+
+	@Override
+	public @Nullable Object coerceOrNull(@Nonnull Object value) {
+		return wrapOrNull( value );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleJavaType.java
@@ -8,6 +8,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
@@ -164,11 +166,26 @@ public class DoubleJavaType extends AbstractClassJavaType<Double> implements
 	}
 
 	@Override
-	public Double coerce(Object value) {
+	public @Nullable Double coerce(@Nullable Object value) {
 		if ( value == null ) {
 			return null;
 		}
+		final var coerced = coerceOrNull( value );
+		if ( coerced == null ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce value '%s' [%s] to Double",
+							value,
+							value.getClass().getName()
+					)
+			);
+		}
+		return coerced;
+	}
 
+	@Override
+	public @Nullable Double coerceOrNull(@Nonnull Object value) {
 		if ( value instanceof Double doubleValue ) {
 			return doubleValue;
 		}
@@ -195,14 +212,7 @@ public class DoubleJavaType extends AbstractClassJavaType<Double> implements
 			);
 		}
 
-		throw new CoercionException(
-				String.format(
-						Locale.ROOT,
-						"Cannot coerce value '%s' [%s] to Double",
-						value,
-						value.getClass().getName()
-				)
-		);
+		return null;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatJavaType.java
@@ -8,6 +8,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -162,11 +164,26 @@ public class FloatJavaType extends AbstractClassJavaType<Float> implements Primi
 	}
 
 	@Override
-	public Float coerce(Object value) {
+	public @Nullable Float coerce(@Nullable Object value) {
 		if ( value == null ) {
 			return null;
 		}
+		final var coerced = coerceOrNull( value );
+		if ( coerced == null ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce value '%s' [%s] to Float",
+							value,
+							value.getClass().getName()
+					)
+			);
+		}
+		return coerced;
+	}
 
+	@Override
+	public @Nullable Float coerceOrNull(@Nonnull Object value) {
 		if ( value instanceof Float floatValue ) {
 			return floatValue;
 		}
@@ -181,14 +198,7 @@ public class FloatJavaType extends AbstractClassJavaType<Float> implements Primi
 			);
 		}
 
-		throw new CoercionException(
-				String.format(
-						Locale.ROOT,
-						"Cannot coerce value '%s' [%s] to Float",
-						value,
-						value.getClass().getName()
-				)
-		);
+		return null;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
@@ -8,6 +8,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -152,11 +154,26 @@ public class IntegerJavaType extends AbstractClassJavaType<Integer>
 	}
 
 	@Override
-	public Integer coerce(Object value) {
+	public @Nullable Integer coerce(@Nullable Object value) {
 		if ( value == null ) {
 			return null;
 		}
+		final var coerced = coerceOrNull( value );
+		if ( coerced == null ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce value '%s' [%s] to Integer",
+							value,
+							value.getClass().getName()
+					)
+			);
+		}
+		return coerced;
+	}
 
+	@Override
+	public @Nullable Integer coerceOrNull(@Nonnull Object value) {
 		if ( value instanceof Integer integer ) {
 			return integer;
 		}
@@ -195,14 +212,7 @@ public class IntegerJavaType extends AbstractClassJavaType<Integer>
 			);
 		}
 
-		throw new CoercionException(
-				String.format(
-						Locale.ROOT,
-						"Cannot coerce value '%s' [%s] to Integer",
-						value,
-						value.getClass().getName()
-				)
-		);
+		return null;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Type;
 import java.util.Comparator;
 import java.util.Objects;
 
+import jakarta.annotation.Nonnull;
 import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.Size;
@@ -357,8 +358,27 @@ public interface JavaType<T> extends Serializable {
 	 * @throws CoercionException if coercion fails
 	 */
 	@Incubating
-	default Object coerce(Object value) {
+	default @Nullable Object coerce(@Nullable Object value) {
 		return value;
+	}
+
+	/**
+	 * Like {@link #coerce(Object)} but returns {@code null} instead of throwing an exception
+	 * when coercion fails.
+	 *
+	 * @param value The value to coerce
+	 * @return The coerced value, or the given value if no coercion was
+	 *         possible
+	 * @since 8.0
+	 */
+	@Incubating
+	default @Nullable Object coerceOrNull(@Nonnull Object value) {
+		try {
+			return coerce( value );
+		}
+		catch ( CoercionException ex ) {
+			return null;
+		}
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcDateJavaType.java
@@ -15,6 +15,8 @@ import java.util.Calendar;
 import java.sql.Date;
 import java.util.GregorianCalendar;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.HibernateException;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -123,6 +125,11 @@ public class JdbcDateJavaType extends AbstractTemporalJavaType<Date> {
 	}
 
 	@Override
+	public @Nullable Object coerceOrNull(@Nonnull Object value) {
+		return wrapOrNull( value );
+	}
+
+	@Override
 	public <X> X unwrap(Date value, Class<X> type, WrapperOptions options) {
 		if ( value == null ) {
 			return null;
@@ -172,11 +179,18 @@ public class JdbcDateJavaType extends AbstractTemporalJavaType<Date> {
 	}
 
 	@Override
-	public Date wrap(Object value, WrapperOptions options) {
+	public @Nullable Date wrap(@Nullable Object value, WrapperOptions options) {
 		if ( value == null ) {
 			return null;
 		}
+		final var wrapped = wrapOrNull( value );
+		if ( wrapped == null ) {
+			throw unknownWrap( value.getClass() );
+		}
+		return wrapped;
+	}
 
+	public @Nullable Date wrapOrNull(@Nonnull Object value) {
 		if ( value instanceof java.sql.Date date ) {
 			return date;
 		}
@@ -197,7 +211,7 @@ public class JdbcDateJavaType extends AbstractTemporalJavaType<Date> {
 			return java.sql.Date.valueOf( localDate );
 		}
 
-		throw unknownWrap( value.getClass() );
+		return null;
 	}
 
 	static java.sql.Date toDate(java.util.Date value) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimeJavaType.java
@@ -16,6 +16,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.HibernateException;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.sql.ast.spi.SqlAppender;
@@ -115,13 +117,18 @@ public class JdbcTimeJavaType extends AbstractTemporalJavaType<Time> {
 	}
 
 	@Override
-	public Time coerce(Object value) {
+	public @Nullable Time coerce(@Nullable Object value) {
 		try {
 			return wrap( value, null );
 		}
 		catch (Exception e) {
 			throw CoercionHelper.coercionException( e );
 		}
+	}
+
+	@Override
+	public @Nullable Object coerceOrNull(@Nonnull Object value) {
+		return wrapOrNull( value );
 	}
 
 	@Override
@@ -184,11 +191,18 @@ public class JdbcTimeJavaType extends AbstractTemporalJavaType<Time> {
 	}
 
 	@Override
-	public Time wrap(Object value, WrapperOptions options) {
+	public @Nullable Time wrap(@Nullable Object value, WrapperOptions options) {
 		if ( value == null ) {
 			return null;
 		}
+		final var wrapped = wrapOrNull( value );
+		if ( wrapped == null ) {
+			throw unknownWrap( value.getClass() );
+		}
+		return wrapped;
+	}
 
+	public @Nullable Time wrapOrNull(@Nonnull Object value) {
 		if ( value instanceof Time time ) {
 			return time;
 		}
@@ -214,7 +228,7 @@ public class JdbcTimeJavaType extends AbstractTemporalJavaType<Time> {
 			return new Time( calendar.getTimeInMillis() % 86_400_000 );
 		}
 
-		throw unknownWrap( value.getClass() );
+		return null;
 	}
 
 	static Time toTime(Date date) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
@@ -17,6 +17,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.HibernateException;
@@ -116,6 +118,11 @@ public class JdbcTimestampJavaType extends AbstractTemporalJavaType<Timestamp>
 	}
 
 	@Override
+	public @Nullable Object coerceOrNull(@Nonnull Object value) {
+		return wrapOrNull( value );
+	}
+
+	@Override
 	public <X> X unwrap(Timestamp value, Class<X> type, WrapperOptions options) {
 		if ( value == null ) {
 			return null;
@@ -156,10 +163,18 @@ public class JdbcTimestampJavaType extends AbstractTemporalJavaType<Timestamp>
 	}
 
 	@Override
-	public <X> Timestamp wrap(X value, WrapperOptions options) {
+	public <X> @Nullable Timestamp wrap(@Nullable X value, WrapperOptions options) {
 		if ( value == null ) {
 			return null;
 		}
+		final var wrapped = wrapOrNull( value );
+		if ( wrapped == null ) {
+			throw unknownWrap( value.getClass() );
+		}
+		return wrapped;
+	}
+
+	public <X> @Nullable Timestamp wrapOrNull(@Nonnull X value) {
 		if ( value instanceof Timestamp timestamp ) {
 			return timestamp;
 		}
@@ -180,7 +195,7 @@ public class JdbcTimestampJavaType extends AbstractTemporalJavaType<Timestamp>
 			return new Timestamp( calendar.getTimeInMillis() );
 		}
 
-		throw unknownWrap( value.getClass() );
+		return null;
 	}
 
 	static Timestamp wrapSqlTimestamp(Date date) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongJavaType.java
@@ -8,6 +8,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -118,11 +120,26 @@ public class LongJavaType extends AbstractClassJavaType<Long>
 	}
 
 	@Override
-	public Long coerce(Object value) {
+	public @Nullable Long coerce(@Nullable Object value) {
 		if ( value == null ) {
 			return null;
 		}
+		final var coerced = coerceOrNull(  value );
+		if (coerced == null) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce value '%s' [%s] to Long",
+							value,
+							value.getClass().getName()
+					)
+			);
+		}
+		return coerced;
+	}
 
+	@Override
+	public @Nullable Long coerceOrNull(@Nonnull Object value) {
 		if ( value instanceof Long longValue ) {
 			return longValue;
 		}
@@ -161,14 +178,7 @@ public class LongJavaType extends AbstractClassJavaType<Long>
 			);
 		}
 
-		throw new CoercionException(
-				String.format(
-						Locale.ROOT,
-						"Cannot coerce value '%s' [%s] to Long",
-						value,
-						value.getClass().getName()
-				)
-		);
+		return null;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveByteArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveByteArrayJavaType.java
@@ -10,6 +10,8 @@ import java.sql.Blob;
 import java.sql.SQLException;
 import java.util.Arrays;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
@@ -131,10 +133,18 @@ public class PrimitiveByteArrayJavaType extends AbstractClassJavaType<byte[]>
 		throw unknownUnwrap( type );
 	}
 
-	public <X> byte[] wrap(X value, WrapperOptions options) {
+	public <X> @Nullable byte[] wrap(@Nullable X value, WrapperOptions options) {
 		if ( value == null ) {
 			return null;
 		}
+		final var wrapped = wrapOrNull( value );
+		if ( wrapped == null ) {
+			throw unknownWrap( value.getClass() );
+		}
+		return wrapped;
+	}
+
+	private <X> @Nullable byte[] wrapOrNull(@Nonnull X value) {
 		if (value instanceof byte[] bytes) {
 			return bytes;
 		}
@@ -160,18 +170,22 @@ public class PrimitiveByteArrayJavaType extends AbstractClassJavaType<byte[]>
 			}
 			return bytes;
 		}
-
-		throw unknownWrap( value.getClass() );
+		return null;
 	}
 
 	@Override
-	public byte[] coerce(Object value) {
+	public @Nullable byte[] coerce(@Nullable Object value) {
 		try {
 			return wrap( value, null );
 		}
 		catch (Exception e) {
 			throw CoercionHelper.coercionException( e );
 		}
+	}
+
+	@Override
+	public @Nullable Object coerceOrNull(@Nonnull Object value) {
+		return wrapOrNull( value );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveCharacterArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveCharacterArrayJavaType.java
@@ -10,6 +10,8 @@ import java.sql.Clob;
 import java.sql.NClob;
 import java.util.Arrays;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.engine.jdbc.internal.CharacterStreamImpl;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -85,10 +87,18 @@ public class PrimitiveCharacterArrayJavaType extends AbstractClassJavaType<char[
 		throw unknownUnwrap( type );
 	}
 
-	public <X> char[] wrap(X value, WrapperOptions options) {
+	public <X> @Nullable char[] wrap(@Nullable X value, WrapperOptions options) {
 		if ( value == null ) {
 			return null;
 		}
+		final var wrapped = wrapOrNull( value );
+		if ( wrapped == null ) {
+			throw unknownWrap( value.getClass() );
+		}
+		return wrapped;
+	}
+
+	private <X> @Nullable char[] wrapOrNull(@Nonnull X value) {
 		if (value instanceof char[] chars) {
 			return chars;
 		}
@@ -105,17 +115,24 @@ public class PrimitiveCharacterArrayJavaType extends AbstractClassJavaType<char[
 			// Support binding a single element as parameter value
 			return new char[]{ character };
 		}
-		throw unknownWrap( value.getClass() );
+		else {
+			return null;
+		}
 	}
 
 	@Override
-	public char[] coerce(Object value) {
+	public @Nullable char[] coerce(@Nullable Object value) {
 		try {
 			return wrap( value, null );
 		}
 		catch (Exception e) {
 			throw CoercionHelper.coercionException( e );
 		}
+	}
+
+	@Override
+	public @Nullable Object coerceOrNull(@Nonnull Object value) {
+		return wrapOrNull( value );
 	}
 
 	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<char[]> {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortJavaType.java
@@ -7,6 +7,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -143,11 +145,26 @@ public class ShortJavaType extends AbstractClassJavaType<Short>
 	}
 
 	@Override
-	public Short coerce(Object value) {
+	public @Nullable Short coerce(@Nullable Object value) {
 		if ( value == null ) {
 			return null;
 		}
+		final var coerced = coerceOrNull( value );
+		if ( coerced == null ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce value '%s' [%s] to Short",
+							value,
+							value.getClass().getName()
+					)
+			);
+		}
+		return coerced;
+	}
 
+	@Override
+	public @Nullable Short coerceOrNull(@Nonnull Object value) {
 		if ( value instanceof Short shortValue ) {
 			return shortValue;
 		}
@@ -186,14 +203,7 @@ public class ShortJavaType extends AbstractClassJavaType<Short>
 			);
 		}
 
-		throw new CoercionException(
-				String.format(
-						Locale.ROOT,
-						"Cannot coerce value '%s' [%s] to Short",
-						value,
-						value.getClass().getName()
-				)
-		);
+		return null;
 	}
 	@Override
 	public Short seed(

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/StringJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/StringJavaType.java
@@ -10,6 +10,8 @@ import java.sql.Clob;
 import java.sql.NClob;
 import java.sql.Types;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.engine.jdbc.internal.CharacterStreamImpl;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -105,10 +107,18 @@ public class StringJavaType extends AbstractClassJavaType<String> {
 		throw unknownUnwrap( type );
 	}
 
-	public <X> String wrap(X value, WrapperOptions options) {
+	public <X> @Nullable String wrap(@Nullable X value, WrapperOptions options) {
 		if ( value == null ) {
 			return null;
 		}
+		final var wrapped = wrapOrNull( value );
+		if ( wrapped == null ) {
+			throw unknownWrap( value.getClass() );
+		}
+		return wrapped;
+	}
+
+	private <X> @Nullable String wrapOrNull(@Nonnull X value) {
 		if (value instanceof String string) {
 			return string;
 		}
@@ -130,8 +140,7 @@ public class StringJavaType extends AbstractClassJavaType<String> {
 		if (value instanceof Long) {
 			return value.toString();
 		}
-
-		throw unknownWrap( value.getClass() );
+		return null;
 	}
 
 	@Override
@@ -147,9 +156,19 @@ public class StringJavaType extends AbstractClassJavaType<String> {
 	}
 
 	@Override
-	public String coerce(Object value) {
+	public @Nullable String coerce(@Nullable Object value) {
 		try {
 			return wrap( value, null );
+		}
+		catch (Exception e) {
+			throw CoercionHelper.coercionException( e );
+		}
+	}
+
+	@Override
+	public @Nullable String coerceOrNull(@Nonnull Object value) {
+		try {
+			return wrapOrNull( value );
 		}
 		catch (Exception e) {
 			throw CoercionHelper.coercionException( e );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/MultiValuedParameterCoercionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/MultiValuedParameterCoercionTest.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.hql;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.JavaType;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.type.descriptor.java.StringJavaType;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel( annotatedClasses = MultiValuedParameterCoercionTest.TestEntity.class )
+@SessionFactory
+@JiraKey( "HHH-20721" )
+class MultiValuedParameterCoercionTest {
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	void collectionIsNotCoercedToElementType(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new TestEntity( 1L, "first" ) );
+			session.persist( new TestEntity( 2L, "second" ) );
+			session.flush();
+
+			TrackingStringJavaType.COLLECTION_COERCIONS.set( 0 );
+
+			final var result = session.createQuery(
+						"from TestEntity where name in :names",
+						TestEntity.class
+				)
+					.setParameter( "names", Set.of( "first", "second" ) )
+					.getResultList();
+
+			assertThat( result )
+					.extracting( TestEntity::getName )
+					.containsExactlyInAnyOrder( "first", "second" );
+			assertThat( TrackingStringJavaType.COLLECTION_COERCIONS ).hasValue( 0 );
+		} );
+	}
+
+	@Entity( name = "TestEntity" )
+	static class TestEntity {
+		@Id
+		private Long id;
+
+		@JavaType( TrackingStringJavaType.class )
+		private String name;
+
+		TestEntity() {
+		}
+
+		TestEntity(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		String getName() {
+			return name;
+		}
+	}
+
+	public static class TrackingStringJavaType extends StringJavaType {
+		private static final AtomicInteger COLLECTION_COERCIONS = new AtomicInteger();
+
+		@Override
+		public String coerce(Object value) {
+			if ( value instanceof Collection<?> ) {
+				COLLECTION_COERCIONS.incrementAndGet();
+			}
+			return super.coerce( value );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/MultiValuedParameterCoercionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/MultiValuedParameterCoercionTest.java
@@ -8,6 +8,8 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
@@ -81,7 +83,7 @@ class MultiValuedParameterCoercionTest {
 		private static final AtomicInteger COLLECTION_COERCIONS = new AtomicInteger();
 
 		@Override
-		public String coerce(Object value) {
+		public @Nullable String coerce(@Nonnull Object value) {
 			if ( value instanceof Collection<?> ) {
 				COLLECTION_COERCIONS.incrementAndGet();
 			}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20721 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20721
<!-- Hibernate GitHub Bot issue links end -->