### PR TITLE
HHH-20760 Stop publishing relocation poms from `org.hibernate`

### DIFF
--- a/local-build-plugins/src/main/groovy/local.publishing-group-relocation.gradle
+++ b/local-build-plugins/src/main/groovy/local.publishing-group-relocation.gradle
@@ -9,25 +9,6 @@ plugins {
 
 def oldGroupId = "org.hibernate"
 
-var publishingExtension = project.getExtensions().getByType(PublishingExtension) as PublishingExtension
-publishingExtension.publications.create("groupRelocation", MavenPublication) {
-    groupId = oldGroupId
-    artifactId = project.name
-
-    pom {
-        name = "Relocation : ${oldGroupId}:${project.name} -> ${project.group}:${project.name}"
-        description = "The `${project.name}` module has been relocated to the `${project.group}` group"
-
-        distributionManagement {
-            relocation {
-                groupId = project.group
-                artifactId = project.name
-                version = project.version
-            }
-        }
-    }
-}
-
 // this should to stay, even if the publishing of
 // relocation artifacts gets stopped at some point
 // it ensures for Gradle consumers that you do not have

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -795,6 +795,19 @@ public class MyRevision extends ChangelogMapping { ... }
 
 No DDL changes are needed. The default `REV`/`REVTYPE` column names and encoding match between Envers and core. The `REVINFO` table rows continue the same sequence.
 
+[[artifact-changes]]
+== Changes in published artifacts
+
+[[dependency-changes-relocation]]
+=== Relocation POMs from `org.hibernate` are no longer published
+
+Previous releases published relocation POMs under the `org.hibernate` group id,
+directing consumers to the current `org.hibernate.orm` coordinates.
+Starting with this version -- these relocation POMs are no longer published.
+
+If your build still references Hibernate ORM modules using the old `org.hibernate` group id
+(e.g. `org.hibernate:hibernate-core`), you must update your dependency coordinates
+to use `org.hibernate.orm` (e.g. `org.hibernate.orm:hibernate-core`).
 
 [[dependency-changes]]
 == Changes in Dependencies

--- a/tooling/metamodel-generator/hibernate-processor.gradle
+++ b/tooling/metamodel-generator/hibernate-processor.gradle
@@ -230,16 +230,7 @@ processDataIntegrationTestResources {
 }
 
 var publishingExtension = project.getExtensions().getByType(PublishingExtension) as PublishingExtension
-def oldGroupId = "org.hibernate"
 def oldArtifactId = "hibernate-jpamodelgen"
-
-publishingExtension.publications.named("groupRelocation", MavenPublication) {
-	artifactId = oldArtifactId
-	pom {
-		name = "Relocation : ${oldGroupId}:${oldArtifactId} -> ${project.group}:${project.name}"
-		description = "The `${oldArtifactId}` module has been renamed `${project.name}` and moved to the `${project.group}` group-id"
-	}
-}
 
 publishingExtension.publications.register("renameRelocation", MavenPublication) {
 	artifactId = oldArtifactId


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20760



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20760 (Remove Feature):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->