### PR TITLE
Remove test task dependency on :hibernate-testing:test

### DIFF
--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -226,10 +226,6 @@ tasks.withType( Test.class ).configureEach { test ->
 
     test.enableAssertions = true
 
-    if ( project.name != 'hibernate-testing' ) {
-        test.dependsOn ':hibernate-testing:test'
-    }
-
     // Allow to exclude specific tests
     if ( project.hasProperty( 'excludeTests' ) ) {
         test.filter {


### PR DESCRIPTION
so that "some random" tests are not executed when one tries running a single test from an IDE

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
