### PR TITLE
HHH-20452 Don't stamp synthetic @Access when applying a partial XML overlay

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/ManagedTypeProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/ManagedTypeProcessor.java
@@ -148,6 +148,11 @@ public class ManagedTypeProcessor {
 
 		classDetails.clearAnnotationUsages();
 
+		// In metadata-complete mode the XML is the sole source of truth — annotations have just
+		// been cleared, so the chosen access type must be stamped on the class regardless of
+		// whether it came from XML or from a fallback.
+		applyAccessAnnotation( classAccessType, classDetails, xmlDocumentContext );
+
 		// from here, processing is the same between override and metadata-complete modes
 		// (aside from the dynamic model handling)
 
@@ -196,7 +201,6 @@ public class ManagedTypeProcessor {
 			XmlDocumentContext xmlDocumentContext) {
 		XmlAnnotationHelper.applyEntity( jaxbEntity, classDetails, xmlDocumentContext );
 		XmlAnnotationHelper.applyInheritance( jaxbEntity, classDetails, xmlDocumentContext );
-		applyAccessAnnotation( classAccessType, classDetails, xmlDocumentContext );
 		applyCaching( jaxbEntity, classDetails, xmlDocumentContext );
 		applyFetchProfileAnnotation( jaxbEntity, classDetails, xmlDocumentContext );
 
@@ -484,20 +488,34 @@ public class ManagedTypeProcessor {
 					getMutableClassDetails( xmlDocumentContext,
 							XmlProcessingHelper.determineClassName( jaxbRoot, jaxbEntity ) );
 
-			final var classAccessType = coalesceSuppliedValues(
+			// Access type that has been explicitly requested via XML or via PU-defaults — if any.
+			// Only an explicit access type is stamped onto the class as @Access; stamping a
+			// fallback would force the chosen strategy and mask the natural annotation-driven
+			// detection (e.g. an @Id inherited from a @MappedSuperclass field), which causes
+			// field-level association mappings such as @OneToMany to be silently dropped.
+			final AccessType explicitAccessType = coalesceSuppliedValues(
 					// look on this <entity/>
 					jaxbEntity::getAccess,
 					// look on the root <entity/>
 					jaxbRoot::getAccess,
+					// look for a default (PU metadata default) access
+					xmlDocumentContext.getEffectiveDefaults()::getDefaultPropertyAccessType
+			);
+
+			// Access type used internally for XML attribute processing, with a fallback chain.
+			final var classAccessType = coalesceSuppliedValues(
+					() -> explicitAccessType,
 					// look for @Access on the entity class
 					() -> determineAccessTypeFromClassAnnotations( classDetails ),
-					// look for a default (PU metadata default) access
-					xmlDocumentContext.getEffectiveDefaults()::getDefaultPropertyAccessType,
 					// look at @Id/@EmbeddedId
 					() -> determineAccessTypeFromClassMembers( classDetails ),
 					// fallback to PROPERTY
 					() -> AccessType.PROPERTY
 			);
+
+			if ( explicitAccessType != null ) {
+				applyAccessAnnotation( explicitAccessType, classDetails, xmlDocumentContext );
+			}
 
 			// from here, processing is the same between override and metadata-complete modes
 			processEntityMetadata(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayBaseEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayBaseEntity.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.callbacks.xml.partial;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class PartialOverlayBaseEntity {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayChild.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.callbacks.xml.partial;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity(name = "PartialOverlayChild")
+public class PartialOverlayChild extends PartialOverlayBaseEntity {
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "parent_id", nullable = false)
+	private PartialOverlayParent parent;
+
+	public PartialOverlayParent getParent() {
+		return parent;
+	}
+
+	public void setParent(PartialOverlayParent parent) {
+		this.parent = parent;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayEntityListenerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayEntityListenerTest.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.callbacks.xml.partial;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for partial XML overlays that contribute only an
+ * {@code <entity-listeners>} block to an entity which otherwise relies on
+ * annotation-based mapping. Prior to the fix, the overlay caused the access
+ * type to fall back to {@link jakarta.persistence.AccessType#PROPERTY} and be
+ * stamped onto the entity via a synthetic {@code @Access}, which masked the
+ * natural {@link jakarta.persistence.AccessType#FIELD} detection driven by an
+ * {@code @Id} inherited from a {@code @MappedSuperclass} field. Field-level
+ * associations such as {@code @OneToMany} on {@link PartialOverlayParent}
+ * then became invisible to the binder and the collection element type was
+ * processed as a basic type, failing boot with {@code MappingException}
+ * / {@code JdbcTypeRecommendationException}.
+ */
+@Jpa(
+		annotatedClasses = {
+				PartialOverlayBaseEntity.class,
+				PartialOverlayParent.class,
+				PartialOverlayChild.class
+		},
+		xmlMappings = "mappings/callbacks/partial-overlay.xml"
+)
+public class PartialOverlayEntityListenerTest {
+
+	@AfterEach
+	void tearDown(EntityManagerFactoryScope scope) {
+		scope.getEntityManagerFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	void bootAndPersistThroughAnnotationDrivenAssociation(EntityManagerFactoryScope scope) {
+		PartialOverlayListener.reset();
+
+		final Long parentId = scope.fromTransaction( em -> {
+			final PartialOverlayParent parent = new PartialOverlayParent();
+			final PartialOverlayChild child = new PartialOverlayChild();
+			child.setParent( parent );
+			parent.getChildren().add( child );
+
+			em.persist( parent );
+			em.persist( child );
+			return parent.getId();
+		} );
+
+		assertThat( PartialOverlayListener.getPrePersistCount() ).isEqualTo( 1 );
+
+		scope.inTransaction( em -> {
+			final PartialOverlayParent loaded = em.find( PartialOverlayParent.class, parentId );
+			assertThat( loaded ).isNotNull();
+			assertThat( loaded.getChildren() ).hasSize( 1 );
+			assertThat( loaded.getChildren().get( 0 ).getParent() ).isSameAs( loaded );
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayListener.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayListener.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.callbacks.xml.partial;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.persistence.PrePersist;
+
+public class PartialOverlayListener {
+
+	private static final AtomicInteger PRE_PERSIST_COUNT = new AtomicInteger();
+
+	public static void reset() {
+		PRE_PERSIST_COUNT.set( 0 );
+	}
+
+	public static int getPrePersistCount() {
+		return PRE_PERSIST_COUNT.get();
+	}
+
+	@PrePersist
+	void onPrePersist(PartialOverlayParent entity) {
+		PRE_PERSIST_COUNT.incrementAndGet();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayParent.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/xml/partial/PartialOverlayParent.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.callbacks.xml.partial;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+
+@Entity(name = "PartialOverlayParent")
+public class PartialOverlayParent extends PartialOverlayBaseEntity {
+
+	@OneToMany(mappedBy = "parent")
+	private List<PartialOverlayChild> children = new ArrayList<>();
+
+	public List<PartialOverlayChild> getChildren() {
+		return children;
+	}
+}

--- a/hibernate-core/src/test/resources/mappings/callbacks/partial-overlay.xml
+++ b/hibernate-core/src/test/resources/mappings/callbacks/partial-overlay.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="https://jakarta.ee/xml/ns/persistence/orm"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm https://jakarta.ee/xml/ns/persistence/orm/orm_3_2.xsd"
+                 version="3.2">
+
+    <package>org.hibernate.orm.test.jpa.callbacks.xml.partial</package>
+
+    <!--
+        Partial XML overlay: only an <entity-listeners> block is declared for the entity,
+        no <attributes>. The entity's annotation-based mapping (including its @OneToMany)
+        must remain intact.
+     -->
+    <entity class="PartialOverlayParent">
+        <entity-listeners>
+            <entity-listener class="PartialOverlayListener"/>
+        </entity-listeners>
+    </entity>
+
+</entity-mappings>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/12469

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20452 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20452
<!-- Hibernate GitHub Bot issue links end -->