### PR TITLE
HHH-20749 HbmXmlTransformer: fix mapped-superclass generation for sibling entities with diverging mappings- #13146

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -101,6 +102,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbCascadeTypeImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCheckConstraintImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCollectionTableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCollectionUserTypeImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributeOverrideImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCollectionIdImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbColumnImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbColumnResultImpl;
@@ -399,6 +401,10 @@ public class HbmXmlTransformer {
 		final Map<String, Class<?>> superclassJavaTypes = new HashMap<>();
 
 		for ( var entry : transformationState.getEntityInfoByName().entrySet() ) {
+			final var entityMappingRoot = transformationState.getEntityToMappingXmlMap().get( entry.getKey() );
+			if ( entityMappingRoot != mappingXmlRoot ) {
+				continue;
+			}
 			final Class<?> javaClass = resolveMappedClass( entry.getValue().getPersistentClass() );
 			final var entity = transformationState.getMappingEntityByName().get( entry.getKey() );
 			final var attrs = entity != null ? entity.getAttributes() : null;
@@ -412,13 +418,310 @@ public class HbmXmlTransformer {
 							currentSuperclass, fieldAccess,
 							generatedSuperclasses, superclassJavaTypes, mappingXmlRoot );
 					moveInheritedAttributesToSuperclass(
-							entity, attrs, mappedSuperclass, currentSuperclass, fieldAccess );
+							entity, attrs, mappedSuperclass, currentSuperclass, javaClass, fieldAccess );
 					currentSuperclass = currentSuperclass.getSuperclass();
 				}
 			}
 		}
 
+		resolveOrReportAttributeConflicts( mappingXmlRoot, generatedSuperclasses, mappedEntityClassNames );
+
 		addTransientsForUnmappedProperties( generatedSuperclasses, superclassJavaTypes, fieldAccess );
+	}
+
+	/**
+	 * Resolves or reports attribute overlaps between entities and their generated
+	 * mapped-superclasses, produced by {@link #moveInheritedAttributesToSuperclass}.
+	 * <p>
+	 * In hbm.xml each {@code <class>} is self-contained, so sibling entities sharing
+	 * an unmapped Java superclass can freely diverge.  In orm.xml the generated
+	 * {@code <mapped-superclass>} is shared: one sibling's attribute is moved there,
+	 * and the other sibling keeps its own version because it redeclares the field.
+	 * <p>
+	 * This method handles five cases for such overlaps:
+	 * <ol>
+	 *   <li><b>Id — same generator:</b> the entity's id is removed (inherited from
+	 *       superclass).  If the column differs, an {@code <attribute-override>} is
+	 *       generated so the entity keeps its own column mapping.</li>
+	 *   <li><b>Basic attribute:</b> always resolvable — the entity's basic is removed
+	 *       (inherited from superclass).  If the column differs, an
+	 *       {@code <attribute-override>} is generated.</li>
+	 *   <li><b>Association — same type and target entity:</b> the entity's association
+	 *       is removed (inherited from superclass).</li>
+	 *   <li><b>Id — different generators:</b> unsupported — reported via
+	 *       {@link #handleUnsupported} because the generation strategy cannot be
+	 *       overridden with {@code <attribute-override>}.</li>
+	 *   <li><b>Association — different type or target:</b> unsupported — reported via
+	 *       {@link #handleUnsupported} because association type and target cannot be
+	 *       overridden.</li>
+	 * </ol>
+	 */
+	private void resolveOrReportAttributeConflicts(
+			JaxbEntityMappingsImpl mappingXmlRoot,
+			Map<String, JaxbMappedSuperclassImpl> generatedSuperclasses,
+			Set<String> mappedEntityClassNames) {
+		for ( var entry : transformationState.getEntityInfoByName().entrySet() ) {
+			final var entityMappingRoot = transformationState.getEntityToMappingXmlMap().get( entry.getKey() );
+			if ( entityMappingRoot != mappingXmlRoot ) {
+				continue;
+			}
+			final var entity = transformationState.getMappingEntityByName().get( entry.getKey() );
+			if ( entity == null || entity.getAttributes() == null ) {
+				continue;
+			}
+			final Class<?> javaClass = resolveMappedClass( entry.getValue().getPersistentClass() );
+			if ( javaClass == null ) {
+				continue;
+			}
+			Class<?> superclass = javaClass.getSuperclass();
+			while ( superclass != null
+					&& superclass != Object.class
+					&& !mappedEntityClassNames.contains( superclass.getName() ) ) {
+				final var mappedSuperclass = generatedSuperclasses.get( superclass.getName() );
+				if ( mappedSuperclass != null ) {
+					final var superAttrs = mappedSuperclass.getAttributes();
+					final var entityAttrs = entity.getAttributes();
+
+					resolveOrReportIdOverlaps( entity, entityAttrs, superAttrs, javaClass, superclass );
+					resolveBasicOverlaps( entity, entityAttrs, superAttrs );
+					resolveOrReportAssociationOverlaps(
+							entityAttrs.getOneToOneAttributes(), superAttrs.getOneToOneAttributes(),
+							JaxbOneToOneImpl::getTargetEntity, javaClass, superclass );
+					resolveOrReportAssociationOverlaps(
+							entityAttrs.getManyToOneAttributes(), superAttrs.getManyToOneAttributes(),
+							JaxbManyToOneImpl::getTargetEntity, javaClass, superclass );
+					resolveOrReportAssociationOverlaps(
+							entityAttrs.getOneToManyAttributes(), superAttrs.getOneToManyAttributes(),
+							JaxbOneToManyImpl::getTargetEntity, javaClass, superclass );
+					resolveOrReportAssociationOverlaps(
+							entityAttrs.getManyToManyAttributes(), superAttrs.getManyToManyAttributes(),
+							JaxbManyToManyImpl::getTargetEntity, javaClass, superclass );
+				}
+				superclass = superclass.getSuperclass();
+			}
+		}
+	}
+
+	private void resolveOrReportIdOverlaps(
+			JaxbEntityImpl entity,
+			JaxbAttributesContainerImpl entityAttrs,
+			JaxbAttributesContainerImpl superAttrs,
+			Class<?> entityClass,
+			Class<?> superclass) {
+		final var superIds = superAttrs.getIdAttributes();
+		if ( superIds.isEmpty() ) {
+			return;
+		}
+		final Map<String, JaxbIdImpl> superIdByName = new HashMap<>();
+		for ( var superId : superIds ) {
+			superIdByName.put( superId.getName(), superId );
+		}
+		final var entityIds = new ArrayList<>( entityAttrs.getIdAttributes() );
+		for ( var entityId : entityIds ) {
+			final var superId = superIdByName.get( entityId.getName() );
+			if ( superId == null ) {
+				continue;
+			}
+			if ( sameIdGenerationStrategy( entityId, superId ) ) {
+				entityAttrs.getIdAttributes().remove( entityId );
+				addColumnOverrideIfNeeded( entity, entityId.getName(),
+						entityId.getColumn(), superId.getColumn() );
+			}
+			else {
+				handleUnsupported(
+						"Entity '%s' and its mapped-superclass '%s' use different id generation "
+								+ "strategies for attribute '%s' — this cannot be resolved with "
+								+ "<attribute-override>. Declare the id field on each entity subclass "
+								+ "so each can define its own strategy",
+						entityClass.getName(), superclass.getName(), entityId.getName()
+				);
+			}
+		}
+	}
+
+	private static boolean sameIdGenerationStrategy(JaxbIdImpl a, JaxbIdImpl b) {
+		if ( !sameGeneratedValue( a.getGeneratedValue(), b.getGeneratedValue() ) ) {
+			return false;
+		}
+		return sameGenericGenerator( a.getGenericGenerator(), b.getGenericGenerator() );
+	}
+
+	private static boolean sameGeneratedValue(JaxbGeneratedValueImpl a, JaxbGeneratedValueImpl b) {
+		if ( a == b ) {
+			return true;
+		}
+		if ( a == null || b == null ) {
+			return false;
+		}
+		return Objects.equals( a.getStrategy(), b.getStrategy() )
+				&& Objects.equals( a.getGenerator(), b.getGenerator() );
+	}
+
+	private static boolean sameGenericGenerator(JaxbGenericIdGeneratorImpl a, JaxbGenericIdGeneratorImpl b) {
+		if ( a == b ) {
+			return true;
+		}
+		if ( a == null || b == null ) {
+			return false;
+		}
+		if ( !Objects.equals( a.getClazz(), b.getClazz() ) ) {
+			return false;
+		}
+		return generatorParameters( a )
+				.equals( generatorParameters( b ) );
+	}
+
+	private static List<String> generatorParameters(JaxbGenericIdGeneratorImpl generator) {
+		final List<String> normalized = new ArrayList<>();
+		for ( var parameter : generator.getParameters() ) {
+			normalized.add( parameter.getName() + "=" + parameter.getValue() );
+		}
+		Collections.sort( normalized );
+		return normalized;
+	}
+
+	private static void resolveBasicOverlaps(
+			JaxbEntityImpl entity,
+			JaxbAttributesContainerImpl entityAttrs,
+			JaxbAttributesContainerImpl superAttrs) {
+		final Map<String, JaxbBasicImpl> superBasicByName = new HashMap<>();
+		for ( var superBasic : superAttrs.getBasicAttributes() ) {
+			superBasicByName.put( superBasic.getName(), superBasic );
+		}
+		final var entityBasics = new ArrayList<>( entityAttrs.getBasicAttributes() );
+		for ( var entityBasic : entityBasics ) {
+			final var superBasic = superBasicByName.get( entityBasic.getName() );
+			if ( superBasic != null ) {
+				entityAttrs.getBasicAttributes().remove( entityBasic );
+				addColumnOverrideIfNeeded( entity, entityBasic.getName(),
+						entityBasic.getColumn(), superBasic.getColumn() );
+			}
+		}
+	}
+
+	private <T extends JaxbPersistentAttribute> void resolveOrReportAssociationOverlaps(
+			List<T> entityAssocs,
+			List<T> superAssocs,
+			java.util.function.Function<T, String> targetEntityExtractor,
+			Class<?> entityClass,
+			Class<?> superclass) {
+		if ( superAssocs.isEmpty() || entityAssocs.isEmpty() ) {
+			return;
+		}
+		final Map<String, T> superByName = new HashMap<>();
+		for ( var superAssoc : superAssocs ) {
+			superByName.put( superAssoc.getName(), superAssoc );
+		}
+		final var snapshot = new ArrayList<>( entityAssocs );
+		for ( var entityAssoc : snapshot ) {
+			final var superAssoc = superByName.get( entityAssoc.getName() );
+			if ( superAssoc == null ) {
+				continue;
+			}
+			if ( Objects.equals(
+					targetEntityExtractor.apply( entityAssoc ),
+					targetEntityExtractor.apply( superAssoc ) ) ) {
+				entityAssocs.remove( entityAssoc );
+			}
+			else {
+				handleUnsupported(
+						"Entity '%s' and its mapped-superclass '%s' map association '%s' to "
+								+ "different target entities — this cannot be resolved with "
+								+ "<attribute-override>. Declare the '%s' field on each entity "
+								+ "subclass so each can define its own mapping",
+						entityClass.getName(), superclass.getName(),
+						entityAssoc.getName(), entityAssoc.getName()
+				);
+			}
+		}
+	}
+
+	private static void addColumnOverrideIfNeeded(
+			JaxbEntityImpl entity,
+			String attrName,
+			JaxbColumnImpl entityColumn,
+			JaxbColumnImpl superColumn) {
+		// Nothing to preserve when the entity relies on the default column
+		if ( entityColumn == null ) {
+			return;
+		}
+		// if superclass has no explicit column, compare against defaults as needed;
+		// otherwise compare full explicit definitions
+		if ( sameEffectiveColumn( entityColumn, superColumn ) ) {
+			return;
+		}
+
+		final var override = new JaxbAttributeOverrideImpl();
+		override.setName( attrName );
+		override.setColumn( copyColumn( entityColumn ) );
+		entity.getAttributeOverrides().add( override );
+	}
+
+	private static boolean sameEffectiveColumn(JaxbColumnImpl a, JaxbColumnImpl b) {
+		if ( a == b ) {
+			return true;
+		}
+		if ( a == null || b == null ) {
+			return false;
+		}
+		return Objects.equals( a.getName(), b.getName() )
+				&& Objects.equals( a.getTable(), b.getTable() )
+				&& Objects.equals( a.isNullable(), b.isNullable() )
+				&& Objects.equals( a.isUnique(), b.isUnique() )
+				&& Objects.equals( a.isInsertable(), b.isInsertable() )
+				&& Objects.equals( a.isUpdatable(), b.isUpdatable() )
+				&& Objects.equals( a.getColumnDefinition(), b.getColumnDefinition() )
+				&& Objects.equals( a.getOptions(), b.getOptions() )
+				&& Objects.equals( a.getLength(), b.getLength() )
+				&& Objects.equals( a.getPrecision(), b.getPrecision() )
+				&& Objects.equals( a.getScale(), b.getScale() )
+				&& Objects.equals( a.getSecondPrecision(), b.getSecondPrecision() )
+				&& Objects.equals( a.getDefault(), b.getDefault() )
+				&& Objects.equals( a.getComment(), b.getComment() )
+				&& Objects.equals( a.getRead(), b.getRead() )
+				&& Objects.equals( a.getWrite(), b.getWrite() )
+				&& columnCheckConstraints( a ).equals( columnCheckConstraints( b ) );
+	}
+
+	private static List<String> columnCheckConstraints(JaxbColumnImpl column) {
+		final List<String> normalized = new ArrayList<>();
+		for ( var checkConstraint : column.getCheckConstraints() ) {
+			normalized.add(
+					checkConstraint.getName() + "="
+							+ checkConstraint.getConstraint() + "="
+							+ checkConstraint.getOptions()
+			);
+		}
+		Collections.sort( normalized );
+		return normalized;
+	}
+
+	private static JaxbColumnImpl copyColumn(JaxbColumnImpl source) {
+		final var copy = new JaxbColumnImpl();
+		copy.setName( source.getName() );
+		copy.setTable( source.getTable() );
+		copy.setNullable( source.isNullable() );
+		copy.setUnique( source.isUnique() );
+		copy.setInsertable( source.isInsertable() );
+		copy.setUpdatable( source.isUpdatable() );
+		copy.setColumnDefinition( source.getColumnDefinition() );
+		copy.setOptions( source.getOptions() );
+		copy.setLength( source.getLength() );
+		copy.setPrecision( source.getPrecision() );
+		copy.setScale( source.getScale() );
+		copy.setSecondPrecision( source.getSecondPrecision() );
+		copy.setDefault( source.getDefault() );
+		copy.setComment( source.getComment() );
+		copy.setRead( source.getRead() );
+		copy.setWrite( source.getWrite() );
+		for ( var sourceCheck : source.getCheckConstraints() ) {
+			final var copiedCheck = new JaxbCheckConstraintImpl();
+			copiedCheck.setName( sourceCheck.getName() );
+			copiedCheck.setConstraint( sourceCheck.getConstraint() );
+			copiedCheck.setOptions( sourceCheck.getOptions() );
+			copy.getCheckConstraints().add( copiedCheck );
+		}
+		return copy;
 	}
 
 	/**
@@ -498,22 +801,23 @@ public class HbmXmlTransformer {
 			JaxbAttributesContainerImpl attrs,
 			JaxbMappedSuperclassImpl mappedSuperclass,
 			Class<?> superclass,
+			Class<?> entityClass,
 			boolean fieldAccess) {
 		final var superAttrs = mappedSuperclass.getAttributes();
 
-		moveInheritedAttributes( attrs.getIdAttributes(), superAttrs.getIdAttributes(), superclass, fieldAccess );
-		moveInheritedAttributes( attrs.getBasicAttributes(), superAttrs.getBasicAttributes(), superclass, fieldAccess );
-		moveInheritedAttributes( attrs.getManyToOneAttributes(), superAttrs.getManyToOneAttributes(), superclass, fieldAccess );
-		moveInheritedAttributes( attrs.getOneToManyAttributes(), superAttrs.getOneToManyAttributes(), superclass, fieldAccess );
-		moveInheritedAttributes( attrs.getOneToOneAttributes(), superAttrs.getOneToOneAttributes(), superclass, fieldAccess );
-		moveInheritedAttributes( attrs.getManyToManyAttributes(), superAttrs.getManyToManyAttributes(), superclass, fieldAccess );
-		moveInheritedAttributes( attrs.getEmbeddedAttributes(), superAttrs.getEmbeddedAttributes(), superclass, fieldAccess );
-		moveInheritedAttributes( attrs.getElementCollectionAttributes(), superAttrs.getElementCollectionAttributes(), superclass, fieldAccess );
-		moveInheritedAttributes( attrs.getAnyMappingAttributes(), superAttrs.getAnyMappingAttributes(), superclass, fieldAccess );
-		moveInheritedAttributes( attrs.getPluralAnyMappingAttributes(), superAttrs.getPluralAnyMappingAttributes(), superclass, fieldAccess );
+		moveInheritedAttributes( attrs.getIdAttributes(), superAttrs.getIdAttributes(), superclass, entityClass, fieldAccess );
+		moveInheritedAttributes( attrs.getBasicAttributes(), superAttrs.getBasicAttributes(), superclass, entityClass, fieldAccess );
+		moveInheritedAttributes( attrs.getManyToOneAttributes(), superAttrs.getManyToOneAttributes(), superclass, entityClass, fieldAccess );
+		moveInheritedAttributes( attrs.getOneToManyAttributes(), superAttrs.getOneToManyAttributes(), superclass, entityClass, fieldAccess );
+		moveInheritedAttributes( attrs.getOneToOneAttributes(), superAttrs.getOneToOneAttributes(), superclass, entityClass, fieldAccess );
+		moveInheritedAttributes( attrs.getManyToManyAttributes(), superAttrs.getManyToManyAttributes(), superclass, entityClass, fieldAccess );
+		moveInheritedAttributes( attrs.getEmbeddedAttributes(), superAttrs.getEmbeddedAttributes(), superclass, entityClass, fieldAccess );
+		moveInheritedAttributes( attrs.getElementCollectionAttributes(), superAttrs.getElementCollectionAttributes(), superclass, entityClass, fieldAccess );
+		moveInheritedAttributes( attrs.getAnyMappingAttributes(), superAttrs.getAnyMappingAttributes(), superclass, entityClass, fieldAccess );
+		moveInheritedAttributes( attrs.getPluralAnyMappingAttributes(), superAttrs.getPluralAnyMappingAttributes(), superclass, entityClass, fieldAccess );
 
-		moveVersionIfInherited( attrs, superAttrs, superclass, fieldAccess );
-		moveEmbeddedIdIfInherited( attrs, superAttrs, superclass, fieldAccess );
+		moveVersionIfInherited( attrs, superAttrs, superclass, entityClass, fieldAccess );
+		moveEmbeddedIdIfInherited( attrs, superAttrs, superclass, entityClass, fieldAccess );
 		moveIdClassIfAllIdsMoved( entity, attrs, mappedSuperclass, superAttrs );
 
 		attrs.getTransients().removeIf( t -> isMemberDeclaredOnClass( t.getName(), superclass, fieldAccess ) );
@@ -527,10 +831,12 @@ public class HbmXmlTransformer {
 			JaxbAttributesContainerImpl attrs,
 			JaxbAttributesContainerImpl superAttrs,
 			Class<?> superclass,
+			Class<?> entityClass,
 			boolean fieldAccess) {
 		final var version = attrs.getVersion();
 		if ( version != null
-				&& isMemberDeclaredOnClass( version.getName(), superclass, fieldAccess ) ) {
+				&& isMemberDeclaredOnClass( version.getName(), superclass, fieldAccess )
+				&& !isMemberDeclaredOnClass( version.getName(), entityClass, fieldAccess ) ) {
 			if ( superAttrs.getVersion() == null ) {
 				superAttrs.setVersion( version );
 			}
@@ -546,10 +852,12 @@ public class HbmXmlTransformer {
 			JaxbAttributesContainerImpl attrs,
 			JaxbAttributesContainerImpl superAttrs,
 			Class<?> superclass,
+			Class<?> entityClass,
 			boolean fieldAccess) {
 		final var embeddedId = attrs.getEmbeddedIdAttribute();
 		if ( embeddedId != null
-				&& isMemberDeclaredOnClass( embeddedId.getName(), superclass, fieldAccess ) ) {
+				&& isMemberDeclaredOnClass( embeddedId.getName(), superclass, fieldAccess )
+				&& !isMemberDeclaredOnClass( embeddedId.getName(), entityClass, fieldAccess ) ) {
 			if ( superAttrs.getEmbeddedIdAttribute() == null ) {
 				superAttrs.setEmbeddedIdAttribute( embeddedId );
 			}
@@ -607,10 +915,12 @@ public class HbmXmlTransformer {
 			List<T> entityAttrs,
 			List<T> superAttrs,
 			Class<?> javaSuperclass,
+			Class<?> entityClass,
 			boolean fieldAccess) {
 		final var toMove = new ArrayList<T>();
 		for ( var attr : entityAttrs ) {
-			if ( isMemberDeclaredOnClass( attr.getName(), javaSuperclass, fieldAccess ) ) {
+			if ( isMemberDeclaredOnClass( attr.getName(), javaSuperclass, fieldAccess )
+					&& !isMemberDeclaredOnClass( attr.getName(), entityClass, fieldAccess ) ) {
 				toMove.add( attr );
 			}
 		}
@@ -658,10 +968,6 @@ public class HbmXmlTransformer {
 		}
 	}
 
-	/**
-	 * Check if a field or getter for the given property name is declared directly
-	 * on the given class (not inherited).
-	 */
 	private static boolean isMemberDeclaredOnClass(String propertyName, Class<?> clazz, boolean fieldAccess) {
 		if ( fieldAccess ) {
 			try {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -53,6 +53,7 @@ import jakarta.xml.bind.JAXBException;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.orm.test.boot.jaxb.JaxbHelper.withStaxEventReader;
 
 /**
@@ -1499,6 +1500,171 @@ public class HbmTransformationJaxbTests {
 			assertThat( anotherEntity.getAttributes().getBasicAttributes() )
 					.extracting( JaxbBasicImpl::getName )
 					.containsExactly( "code" );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20749" )
+	public void testSiblingEntitiesWithDifferentMappings(ServiceRegistryScope scope) {
+		// SiblingEntityA and SiblingEntityB both extend SiblingBase.
+		// Both redeclare 'id' so each keeps its own id on the entity.
+		// Only SiblingEntityA maps 'related' (and redeclares the field), so
+		// 'related' stays on the entity and becomes transient on the superclass.
+		// 'name' is shared by both — it moves to the mapped-superclass.
+		transformAndVerify( "xml/jaxb/mapping/sibling-mapping/hbm.xml", scope, transformed -> {
+			// One mapped-superclass for SiblingBase
+			assertThat( transformed.getMappedSuperclasses() )
+					.as( "One <mapped-superclass> should be generated for SiblingBase" )
+					.hasSize( 1 );
+
+			final JaxbMappedSuperclassImpl mappedSuperclass = transformed.getMappedSuperclasses().get( 0 );
+			assertThat( mappedSuperclass.getClazz() )
+					.endsWith( "SiblingBase" );
+
+			final var superAttrs = mappedSuperclass.getAttributes();
+
+			// 'name' should be on the mapped-superclass (shared by both siblings)
+			assertThat( superAttrs.getBasicAttributes() )
+					.extracting( JaxbBasicImpl::getName )
+					.containsExactly( "name" );
+
+			// 'id' and 'related' should be transient on the superclass
+			assertThat( superAttrs.getTransients() )
+					.extracting( JaxbTransientImpl::getName )
+					.contains( "id", "related" );
+
+			// No id on the superclass (both entities redeclare the field)
+			assertThat( superAttrs.getIdAttributes() )
+					.as( "Superclass should not have an id — both entities redeclare the field" )
+					.isEmpty();
+
+			// --- SiblingEntityA: has its own id and many-to-one related ---
+			final JaxbEntityImpl entityA = transformed.getEntities().stream()
+					.filter( e -> "SiblingEntityA".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( entityA.getAttributes().getIdAttributes() )
+					.extracting( JaxbIdImpl::getName )
+					.containsExactly( "id" );
+
+			assertThat( entityA.getAttributes().getManyToOneAttributes() )
+					.extracting( JaxbManyToOneImpl::getName )
+					.containsExactly( "related" );
+
+			// --- SiblingEntityB: has its own id, no 'related' ---
+			final JaxbEntityImpl entityB = transformed.getEntities().stream()
+					.filter( e -> "SiblingEntityB".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( entityB.getAttributes().getIdAttributes() )
+					.extracting( JaxbIdImpl::getName )
+					.containsExactly( "id" );
+
+			assertThat( entityB.getAttributes().getManyToOneAttributes() )
+					.as( "SiblingEntityB should not have 'related' — it was not mapped in the hbm.xml" )
+					.isEmpty();
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20749" )
+	public void testSiblingEntitiesWithConflictingIdStrategies(ServiceRegistryScope scope) {
+		// ConflictEntityA redeclares 'id' field → keeps its own id (sequence generator).
+		// ConflictEntityB does NOT redeclare 'id' → its id (native generator) moves to
+		// the ConflictBase mapped-superclass. ConflictEntityA then has its own id AND
+		// inherits one from the superclass — which JPA does not allow.
+		// The transformer should detect this and report it as unsupported.
+		assertThatThrownBy( () ->
+				transformAndVerify( "xml/jaxb/mapping/sibling-conflict/hbm.xml", scope, transformed -> {} )
+		)
+				.isInstanceOf( UnsupportedOperationException.class )
+				.hasMessageContaining( "different id generation strategies" );
+	}
+
+	@Test
+	@JiraKey( "HHH-20749" )
+	public void testSiblingEntitiesWithSameIdGeneratorDifferentColumns(ServiceRegistryScope scope) {
+		// OverrideEntityA and OverrideEntityB both extend OverrideBase and both use
+		// the native id generator, but OverrideEntityA maps the id to column "entity_a_id".
+		// OverrideEntityA redeclares the id field, so its id initially stays on the entity.
+		// Since the generators match, the transformer should resolve the overlap by removing
+		// the entity's id and generating an <attribute-override> for the different column.
+		transformAndVerify( "xml/jaxb/mapping/sibling-override/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getMappedSuperclasses() ).hasSize( 1 );
+
+			final JaxbMappedSuperclassImpl mappedSuperclass = transformed.getMappedSuperclasses().get( 0 );
+			assertThat( mappedSuperclass.getClazz() ).endsWith( "OverrideBase" );
+
+			// Id should be on the mapped-superclass (inherited by both entities)
+			assertThat( mappedSuperclass.getAttributes().getIdAttributes() )
+					.extracting( JaxbIdImpl::getName )
+					.containsExactly( "id" );
+
+			// --- OverrideEntityA: no id attributes, but has an attribute-override for the column ---
+			final JaxbEntityImpl entityA = transformed.getEntities().stream()
+					.filter( e -> "OverrideEntityA".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( entityA.getAttributes().getIdAttributes() )
+					.as( "EntityA should not have its own id — resolved by attribute-override" )
+					.isEmpty();
+
+			assertThat( entityA.getAttributeOverrides() )
+					.as( "EntityA should have an attribute-override for the id column" )
+					.hasSize( 1 );
+			assertThat( entityA.getAttributeOverrides().get( 0 ).getName() )
+					.isEqualTo( "id" );
+			assertThat( entityA.getAttributeOverrides().get( 0 ).getColumn().getName() )
+					.isEqualTo( "entity_a_id" );
+
+			// --- OverrideEntityB: no id attributes, no overrides (inherits as-is) ---
+			final JaxbEntityImpl entityB = transformed.getEntities().stream()
+					.filter( e -> "OverrideEntityB".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( entityB.getAttributes().getIdAttributes() )
+					.as( "EntityB should not have its own id — inherits from superclass" )
+					.isEmpty();
+
+			assertThat( entityB.getAttributeOverrides() )
+					.as( "EntityB should have no attribute-overrides" )
+					.isEmpty();
+		} );
+	}
+
+	@Test
+	public void testSiblingEntitiesWithSameGeneratorClassDifferentParameters(ServiceRegistryScope scope) {
+		assertThatThrownBy( () ->
+				transformAndVerify( "xml/jaxb/mapping/sibling-generator-params/hbm.xml", scope, transformed -> {} )
+		)
+				.isInstanceOf( UnsupportedOperationException.class )
+				.hasMessageContaining( "different id generation strategies" );
+	}
+
+	@Test
+	public void testSiblingEntitiesWithSameColumnNameDifferentColumnMetadata(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/sibling-column-override/hbm.xml", scope, transformed -> {
+			final JaxbEntityImpl entityA = transformed.getEntities().stream()
+					.filter( e -> "ColumnOverrideEntityA".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( entityA.getAttributes().getBasicAttributes() )
+					.extracting( JaxbBasicImpl::getName )
+					.doesNotContain( "name" );
+
+			final JaxbAttributeOverrideImpl override = entityA.getAttributeOverrides().stream()
+					.filter( candidate -> "name".equals( candidate.getName() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( override.getColumn() ).isNotNull();
+			assertThat( override.getColumn().getName() ).isEqualTo( "shared_name" );
+			assertThat( override.getColumn().getLength() ).isEqualTo( 77 );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingcolumnoverride/ColumnOverrideBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingcolumnoverride/ColumnOverrideBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingcolumnoverride;
+
+public abstract class ColumnOverrideBase {
+	private int id;
+	private String name;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingcolumnoverride/ColumnOverrideEntityA.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingcolumnoverride/ColumnOverrideEntityA.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingcolumnoverride;
+
+public class ColumnOverrideEntityA extends ColumnOverrideBase {
+	private String name;
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingcolumnoverride/ColumnOverrideEntityB.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingcolumnoverride/ColumnOverrideEntityB.java
@@ -1,0 +1,8 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingcolumnoverride;
+
+public class ColumnOverrideEntityB extends ColumnOverrideBase {
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingconflict/ConflictBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingconflict/ConflictBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingconflict;
+
+public abstract class ConflictBase {
+	private int id;
+	private String name;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingconflict/ConflictEntityA.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingconflict/ConflictEntityA.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingconflict;
+
+public class ConflictEntityA extends ConflictBase {
+	private int id;
+
+	@Override
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingconflict/ConflictEntityB.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingconflict/ConflictEntityB.java
@@ -1,0 +1,8 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingconflict;
+
+public class ConflictEntityB extends ConflictBase {
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblinggeneratorparams/GeneratorParamsBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblinggeneratorparams/GeneratorParamsBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblinggeneratorparams;
+
+public abstract class GeneratorParamsBase {
+	private int id;
+	private String name;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblinggeneratorparams/GeneratorParamsEntityA.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblinggeneratorparams/GeneratorParamsEntityA.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblinggeneratorparams;
+
+public class GeneratorParamsEntityA extends GeneratorParamsBase {
+	private int id;
+
+	@Override
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblinggeneratorparams/GeneratorParamsEntityB.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblinggeneratorparams/GeneratorParamsEntityB.java
@@ -1,0 +1,8 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblinggeneratorparams;
+
+public class GeneratorParamsEntityB extends GeneratorParamsBase {
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingmapping/SiblingBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingmapping/SiblingBase.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingmapping;
+
+public abstract class SiblingBase {
+	private int id;
+	private String name;
+	private SiblingRelated related;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public SiblingRelated getRelated() {
+		return related;
+	}
+
+	public void setRelated(SiblingRelated related) {
+		this.related = related;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingmapping/SiblingEntityA.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingmapping/SiblingEntityA.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingmapping;
+
+public class SiblingEntityA extends SiblingBase {
+	private int id;
+	private SiblingRelated related;
+
+	@Override
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	@Override
+	public SiblingRelated getRelated() {
+		return related;
+	}
+
+	@Override
+	public void setRelated(SiblingRelated related) {
+		this.related = related;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingmapping/SiblingEntityB.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingmapping/SiblingEntityB.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingmapping;
+
+public class SiblingEntityB extends SiblingBase {
+	private int id;
+
+	@Override
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingmapping/SiblingRelated.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingmapping/SiblingRelated.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingmapping;
+
+public class SiblingRelated {
+	private int id;
+	private String data;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getData() {
+		return data;
+	}
+
+	public void setData(String data) {
+		this.data = data;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingoverride/OverrideBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingoverride/OverrideBase.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingoverride;
+
+public abstract class OverrideBase {
+	private int id;
+	private String name;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingoverride/OverrideEntityA.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingoverride/OverrideEntityA.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingoverride;
+
+public class OverrideEntityA extends OverrideBase {
+	private int id;
+
+	@Override
+	public int getId() {
+		return id;
+	}
+
+	@Override
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingoverride/OverrideEntityB.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/siblingoverride/OverrideEntityB.java
@@ -1,0 +1,8 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.siblingoverride;
+
+public class OverrideEntityB extends OverrideBase {
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-column-override/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-column-override/hbm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.siblingcolumnoverride">
+
+	<class name="ColumnOverrideEntityA">
+		<id name="id">
+			<generator class="native"/>
+		</id>
+		<property name="name">
+			<column name="shared_name" length="77"/>
+		</property>
+	</class>
+
+	<class name="ColumnOverrideEntityB">
+		<id name="id">
+			<generator class="native"/>
+		</id>
+		<property name="name" column="shared_name"/>
+	</class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-conflict/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-conflict/hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.siblingconflict">
+
+    <class name="ConflictEntityA">
+        <id name="id">
+            <generator class="sequence"/>
+        </id>
+        <property name="name"/>
+    </class>
+
+    <class name="ConflictEntityB">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-generator-params/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-generator-params/hbm.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.siblinggeneratorparams">
+
+	<class name="GeneratorParamsEntityA">
+		<id name="id">
+			<generator class="sequence">
+				<param name="sequence_name">seq_a</param>
+			</generator>
+		</id>
+		<property name="name"/>
+	</class>
+
+	<class name="GeneratorParamsEntityB">
+		<id name="id">
+			<generator class="sequence">
+				<param name="sequence_name">seq_b</param>
+			</generator>
+		</id>
+		<property name="name"/>
+	</class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-mapping/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-mapping/hbm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.siblingmapping">
+
+    <class name="SiblingEntityA">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+        <many-to-one name="related" class="SiblingRelated" column="related_id"/>
+    </class>
+
+    <class name="SiblingEntityB">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+    </class>
+
+    <class name="SiblingRelated">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="data"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-override/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/sibling-override/hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.siblingoverride">
+
+    <class name="OverrideEntityA">
+        <id name="id" column="entity_a_id">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+    </class>
+
+    <class name="OverrideEntityB">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
Backporto of https://github.com/hibernate/hibernate-orm/pull/13146 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20749 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20749
<!-- Hibernate GitHub Bot issue links end -->