### PR TITLE
HHH-20628 refresh does not load uninitialized lazy collections

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -58,6 +58,9 @@ public class LoadQueryInfluencers implements Serializable {
 	private CascadingFetchProfile enabledCascadingFetchProfile;
 
 	//Lazily initialized!
+	private @Nullable Set<String> refreshCollectionsToFetch;
+
+	//Lazily initialized!
 	@Nullable
 	private HashSet<String> enabledFetchProfileNames;
 
@@ -171,6 +174,25 @@ public class LoadQueryInfluencers implements Serializable {
 	 */
 	public void setEnabledCascadingFetchProfile(@Nullable CascadingFetchProfile enabledCascadingFetchProfile) {
 		this.enabledCascadingFetchProfile = enabledCascadingFetchProfile;
+	}
+
+	/**
+	 * The set of collection roles (full paths) that should be immediately fetched
+	 * while a {@link CascadingFetchProfile#REFRESH} cascade is in progress, or
+	 * {@code null} to indicate no restriction (fetch every cascaded collection).
+	 * <p>
+	 * This is used to avoid eagerly (re)loading collections which were not
+	 * initialized on the entity being refreshed. See HHH-12867.
+	 * <p>
+	 * A {@code null} set (the default) preserves the behavior of fetching
+	 * every cascaded collection.
+	 */
+	public @Nullable Set<String> getRefreshCollectionsToFetch() {
+		return refreshCollectionsToFetch;
+	}
+
+	public void setRefreshCollectionsToFetch(@Nullable Set<String> refreshCollectionsToFetch) {
+		this.refreshCollectionsToFetch = refreshCollectionsToFetch;
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
@@ -9,6 +9,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.UnresolvableObjectException;
+import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.Cascade;
 import org.hibernate.engine.internal.CascadePoint;
 import org.hibernate.engine.spi.CascadingActions;
@@ -24,6 +25,9 @@ import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.ComponentType;
 import org.hibernate.type.Type;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.hibernate.engine.internal.CacheHelper.usingCache;
 import static org.hibernate.engine.internal.CacheHelper.writingToCache;
@@ -154,6 +158,13 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 				refreshedAlready
 		);
 
+		// Capture, before eviction, which collections were already initialized so that the
+		// reload only immediately (re)fetches those. Collections that were left uninitialized
+		// must stay uninitialized rather than being eagerly loaded by the refresh. See HHH-12867.
+		final Set<String> collectionsToFetch = persister.hasCollections()
+				? initializedCollectionRoles( persister, object )
+				: null;
+
 		persistenceContext.removeEntityHolder( entry.getEntityKey() );
 		if ( persister.hasCollections() ) {
 			new EvictVisitor( source, object ).process( object, persister );
@@ -163,7 +174,41 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 		evictEntity( object, persister, id, source );
 		evictCachedCollections( persister, id, source );
 
-		refresh( event, object, source, persister, null, entry, id, persistenceContext );
+		final var influencers = source.getLoadQueryInfluencers();
+		final Set<String> previousCollectionsToFetch = influencers.getRefreshCollectionsToFetch();
+		influencers.setRefreshCollectionsToFetch( collectionsToFetch );
+		try {
+			refresh( event, object, source, persister, null, entry, id, persistenceContext );
+		}
+		finally {
+			influencers.setRefreshCollectionsToFetch( previousCollectionsToFetch );
+		}
+	}
+
+	private static Set<String> initializedCollectionRoles(EntityPersister persister, Object object) {
+		final Set<String> roles = new HashSet<>();
+		collectInitializedCollectionRoles( persister.getPropertyTypes(), persister.getValues( object ), roles );
+		return roles;
+	}
+
+	private static void collectInitializedCollectionRoles(Type[] types, Object[] values, Set<String> roles) {
+		for ( int i = 0; i < types.length; i++ ) {
+			final Type type = types[i];
+			final Object value = values[i];
+			if ( type instanceof CollectionType collectionType ) {
+				if ( value instanceof PersistentCollection<?> collection && collection.wasInitialized() ) {
+					roles.add( collectionType.getRole() );
+				}
+			}
+			else if ( type instanceof ComponentType componentType && value != null ) {
+				// Collections can also be nested inside embeddables (which are never lazy in practice).
+				collectInitializedCollectionRoles(
+						componentType.getSubtypes(),
+						componentType.getPropertyValues( value ),
+						roles
+				);
+			}
+		}
 	}
 
 	private static void refresh(

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
@@ -9,6 +9,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.UnresolvableObjectException;
+import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.cascade.internal.Cascade;
 import org.hibernate.cascade.spi.CascadePoint;
 import org.hibernate.cascade.spi.CascadingActions;
@@ -24,6 +25,9 @@ import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.ComponentType;
 import org.hibernate.type.Type;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.hibernate.engine.internal.CacheHelper.usingCache;
 import static org.hibernate.engine.internal.CacheHelper.writingToCache;
@@ -154,6 +158,13 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 				refreshedAlready
 		);
 
+		// Capture, before eviction, which collections were already initialized so that the
+		// reload only immediately (re)fetches those. Collections that were left uninitialized
+		// must stay uninitialized rather than being eagerly loaded by the refresh. See HHH-12867.
+		final Set<String> collectionsToFetch = persister.hasCollections()
+				? initializedCollectionRoles( persister, object )
+				: null;
+
 		persistenceContext.removeEntityHolder( entry.getEntityKey() );
 		if ( persister.hasCollections() ) {
 			new EvictVisitor( source, object ).process( object, persister );
@@ -163,7 +174,41 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 		evictEntity( object, persister, id, source );
 		evictCachedCollections( persister, id, source );
 
-		refresh( event, object, source, persister, null, entry, id, persistenceContext );
+		final var influencers = source.getLoadQueryInfluencers();
+		final Set<String> previousCollectionsToFetch = influencers.getRefreshCollectionsToFetch();
+		influencers.setRefreshCollectionsToFetch( collectionsToFetch );
+		try {
+			refresh( event, object, source, persister, null, entry, id, persistenceContext );
+		}
+		finally {
+			influencers.setRefreshCollectionsToFetch( previousCollectionsToFetch );
+		}
+	}
+
+	private static Set<String> initializedCollectionRoles(EntityPersister persister, Object object) {
+		final Set<String> roles = new HashSet<>();
+		collectInitializedCollectionRoles( persister.getPropertyTypes(), persister.getValues( object ), roles );
+		return roles;
+	}
+
+	private static void collectInitializedCollectionRoles(Type[] types, Object[] values, Set<String> roles) {
+		for ( int i = 0; i < types.length; i++ ) {
+			final Type type = types[i];
+			final Object value = values[i];
+			if ( type instanceof CollectionType collectionType ) {
+				if ( value instanceof PersistentCollection<?> collection && collection.wasInitialized() ) {
+					roles.add( collectionType.getRole() );
+				}
+			}
+			else if ( type instanceof ComponentType componentType && value != null ) {
+				// Collections can also be nested inside embeddables (which are never lazy in practice).
+				collectInitializedCollectionRoles(
+						componentType.getSubtypes(),
+						componentType.getPropertyValues( value ),
+						roles
+				);
+			}
+		}
 	}
 
 	private static void refresh(

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -7,6 +7,7 @@ package org.hibernate.loader.ast.internal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.hibernate.LockOptions;
@@ -15,6 +16,7 @@ import org.hibernate.engine.FetchTiming;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SubselectFetch;
+import org.hibernate.loader.ast.spi.CascadingFetchProfile;
 import org.hibernate.loader.ast.spi.Loadable;
 import org.hibernate.loader.ast.spi.Loader;
 import org.hibernate.metamodel.CollectionClassification;
@@ -895,9 +897,10 @@ public class LoaderSelectBuilder {
 							attributeMapping != null
 									? attributeMapping.getAttributeMetadata().getCascadeStyle()
 									: null;
-					final var cascadingAction =
-							loadQueryInfluencers.getEnabledCascadingFetchProfile().getCascadingAction();
-					if ( cascadeStyle == null || cascadeStyle.doCascade( cascadingAction ) ) {
+					final var cascadingFetchProfile = loadQueryInfluencers.getEnabledCascadingFetchProfile();
+					final var cascadingAction = cascadingFetchProfile.getCascadingAction();
+					if ( ( cascadeStyle == null || cascadeStyle.doCascade( cascadingAction ) )
+							&& cascadeShouldFetch( cascadingFetchProfile, isFetchablePluralAttributeMapping, fetchable ) ) {
 						fetchTiming = FetchTiming.IMMEDIATE;
 						// In 5.x the CascadeEntityJoinWalker only join fetched the first collection fetch
 						joined = !isFetchablePluralAttributeMapping || rowCardinality == RowCardinality.SINGLE;
@@ -981,6 +984,25 @@ public class LoaderSelectBuilder {
 				}
 			}
 		};
+	}
+
+	/**
+	 * When a {@link CascadingFetchProfile#REFRESH} cascade restricts the set of collections
+	 * to fetch (see {@link LoadQueryInfluencers#getRefreshCollectionsToFetch()}), a plural
+	 * attribute must only be immediately fetched if its role is part of that set, i.e., if
+	 * it was already initialized on the entity being refreshed. This avoids eagerly loading
+	 * collections that were left uninitialized. See HHH-12867.
+	 */
+	private boolean cascadeShouldFetch(
+			CascadingFetchProfile cascadingFetchProfile,
+			boolean isFetchablePluralAttributeMapping,
+			Fetchable fetchable) {
+		if ( cascadingFetchProfile != CascadingFetchProfile.REFRESH || !isFetchablePluralAttributeMapping ) {
+			return true;
+		}
+		final Set<String> collectionsToFetch = loadQueryInfluencers.getRefreshCollectionsToFetch();
+		return collectionsToFetch == null
+			|| collectionsToFetch.contains( fetchable.getNavigableRole().getFullPath() );
 	}
 
 	private static NavigablePath getFetchablePath(FetchParent fetchParent, Fetchable fetchable, boolean isKeyFetchable) {

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
@@ -5,6 +5,9 @@
 package org.hibernate.loader.ast.internal;
 
 import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
 import org.hibernate.Internal;
@@ -16,6 +19,7 @@ import org.hibernate.loader.ast.spi.CascadingFetchProfile;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.sql.ast.spi.SqlAliasBaseManager;
 import org.hibernate.sql.exec.spi.JdbcParametersList;
+import jakarta.annotation.Nullable;
 
 /**
  * Standard implementation of {@link org.hibernate.loader.ast.spi.SingleIdEntityLoader}.
@@ -26,8 +30,20 @@ public class SingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderSup
 
 	private final EnumMap<LockMode, SingleIdLoadPlan<T>> selectByLockMode =
 			new EnumMap<>( LockMode.class );
-	private final EnumMap<CascadingFetchProfile, EnumMap<LockMode,SingleIdLoadPlan<T>>> selectByInternalCascadeProfile =
-			new EnumMap<>( CascadingFetchProfile.class );
+	private final Map<InternalCascadeLoadPlanKey, SingleIdLoadPlan<T>> selectByInternalCascadeProfile =
+			new ConcurrentHashMap<>();
+
+	/**
+	 * Key for a cached "internal cascade" (merge/refresh) load plan. In addition to the
+	 * {@link LockMode} and {@link CascadingFetchProfile}, a REFRESH cascade only immediately
+	 * fetches the collections that were already initialized on the entity being refreshed, so
+	 * the plan also depends on that set of collection roles ({@code null} when unrestricted).
+	 * See HHH-12867.
+	 */
+	private record InternalCascadeLoadPlanKey(
+			CascadingFetchProfile fetchProfile,
+			LockMode lockMode,
+			@Nullable Set<String> collectionsToFetch) {}
 
 	private final BiFunction<LockOptions, LoadQueryInfluencers, SingleIdLoadPlan<T>> loadPlanCreator;
 
@@ -121,40 +137,30 @@ public class SingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderSup
 	}
 
 	private SingleIdLoadPlan<T> getInternalCascadeLoadPlan(LockOptions lockOptions, LoadQueryInfluencers influencers) {
-		// TODO: It might be more efficient to just instantiate a LoadPlanKey
-		//       object here than it is to maintain an EnumMap of EnumMaps
-		final var lockMode = lockOptions.getLockMode();
-		EnumMap<LockMode,SingleIdLoadPlan<T>> map;
+		final var fetchProfile = influencers.getEnabledCascadingFetchProfile();
+		final var collectionsToFetch =
+				fetchProfile == CascadingFetchProfile.REFRESH
+						? influencers.getRefreshCollectionsToFetch()
+						: null;
 		if ( isLoadPlanReusable( lockOptions, influencers ) ) {
-			final var fetchProfile = influencers.getEnabledCascadingFetchProfile();
-			final var existingMap = selectByInternalCascadeProfile.get( fetchProfile );
-			if ( existingMap == null ) {
-				map = new EnumMap<>( LockMode.class );
-				selectByInternalCascadeProfile.put( fetchProfile, map );
-			}
-			else {
-				final var existing = existingMap.get( lockMode );
-				if ( existing != null ) {
-					return existing;
-				}
-				else {
-					map = existingMap;
-				}
-			}
+			final var key = new InternalCascadeLoadPlanKey(
+					fetchProfile,
+					lockOptions.getLockMode(),
+					collectionsToFetch == null ? null : Set.copyOf( collectionsToFetch )
+			);
+			return selectByInternalCascadeProfile.computeIfAbsent(
+					key,
+					k -> loadPlanCreator.apply( lockOptions, influencers )
+			);
 		}
 		else {
-			map = null;
+			return loadPlanCreator.apply( lockOptions, influencers );
 		}
-
-		final var plan = loadPlanCreator.apply( lockOptions, influencers );
-		if ( map != null ) {
-			map.put( lockMode, plan );
-		}
-		return plan;
 	}
 
 	/**
-	 * We key the caches only by {@link LockMode} and {@link CascadingFetchProfile}.
+	 * We key the caches by {@link LockMode} and {@link CascadingFetchProfile} (plus, for a
+	 * REFRESH cascade, the set of collections to immediately fetch).
 	 * If there is a pessimistic lock with non-default options like timeout, a custom
 	 * fetch profile, or an entity graph, we don't cache and reuse the plan.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
@@ -89,9 +89,11 @@ public class SingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderSup
 			// columns (which don't exist in the audit table)
 			return loadPlanCreator.apply( lockOptions, influencers );
 		}
-		else if ( influencers.hasEnabledCascadingFetchProfile()
-				// and if it's a non-exclusive (optimistic) lock
-				&& LockMode.PESSIMISTIC_READ.greaterThan( lockOptions.getLockMode() ) ) {
+		else if ( influencers.hasEnabledCascadingFetchProfile() ) {
+			// A cascading fetch profile changes the fetches baked into the plan, so such a plan
+			// must never be stored in (nor served from) the regular per-lock-mode cache, which
+			// does not account for it. This holds for every lock mode: the cascade cache is
+			// keyed by the lock mode too, and non-default pessimistic options stay uncacheable.
 			return getInternalCascadeLoadPlan( lockOptions, influencers );
 		}
 		else {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cascade/RefreshLazyOneToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cascade/RefreshLazyOneToManyTest.java
@@ -17,8 +17,8 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import org.hibernate.Hibernate;
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.FailureExpected;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.JiraKeyGroup;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,11 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@JiraKey(value = "HHH-12867")
+
+@JiraKeyGroup( {
+		@JiraKey(value = "HHH-12867"),
+		@JiraKey(value = "HHH-20628"),
+} )
 @DomainModel(
 		annotatedClasses = {
 				RefreshLazyOneToManyTest.Invoice.class,
@@ -39,18 +43,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class RefreshLazyOneToManyTest {
 
 	@Test
-	@FailureExpected(jiraKey = "HHH-12867")
 	public void testRefreshCascade(SessionFactoryScope scope) {
-		scope.inTransaction( session -> {
+		Integer id = scope.fromTransaction( session -> {
 			Invoice invoice = new Invoice( "An invoice for John Smith" );
 			session.persist( invoice );
 
-			session.persist( new Line( "1 pen - 5€", invoice ) );
-			session.persist( new Tax( "21%", invoice ) );
+			session.persist( new Line( "1 pen - 5euros", invoice ) );
+			session.persist( new Tax( "21percent", invoice ) );
+			return invoice.id;
 		} );
 
 		scope.inTransaction( session -> {
-			Invoice invoice = session.get( Invoice.class, 1 );
+			Invoice invoice = session.find( Invoice.class, id );
 
 			assertFalse( Hibernate.isInitialized( invoice.getTaxes() ),
 					"Taxes should not be initialized before refresh" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/refresh/CascadeRefreshToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/refresh/CascadeRefreshToManyTest.java
@@ -61,7 +61,9 @@ public class CascadeRefreshToManyTest {
 	}
 
 	@Test
-	public void refreshUninitializedCollectionRefreshesManagedChildren(SessionFactoryScope scope) {
+	@Jira("https://hibernate.atlassian.net/browse/HHH-12867")
+	public void refreshDoesNotFetchUninitializedCollection(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
 		scope.inTransaction( session -> {
 			final Parent parent = session.find( Parent.class, 1L );
 			final Child child = session.find( Child.class, 1L );
@@ -70,9 +72,16 @@ public class CascadeRefreshToManyTest {
 			session.createMutationQuery( "update RefreshChild c set c.name = 'updated child' where c.id = 1" )
 					.executeUpdate();
 
+			statementInspector.clear();
 			session.refresh( parent );
 
-			assertThat( child.getName() ).isEqualTo( "updated child" );
+			// The collection was not initialized before the refresh, so it must remain
+			// uninitialized and must not be eagerly fetched: only the parent row is reloaded.
+			assertThat( Hibernate.isInitialized( parent.getChildren() ) ).isFalse();
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+			// Consequently, the refresh does not cascade to the (unloaded) children, so the
+			// separately-managed child is left untouched.
+			assertThat( child.getName() ).isEqualTo( "child 1" );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/refresh/RefreshMultipleCollectionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/refresh/RefreshMultipleCollectionsTest.java
@@ -1,0 +1,261 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.refresh;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * When an entity has several {@code cascade=REFRESH} collections, a refresh must:
+ * <ul>
+ *     <li>only immediately (re)fetch the collections that were already initialized (HHH-12867);</li>
+ *     <li>join-fetch just the <em>first</em> such collection, loading the rest through
+ *         secondary selects (a single collection can be joined without producing a cartesian product).</li>
+ * </ul>
+ * This exercises the interaction between the two: which collection ends up being the joined one
+ * depends on which collections are actually fetched, not on their declaration order.
+ */
+@DomainModel(
+		annotatedClasses = {
+				RefreshMultipleCollectionsTest.Parent.class,
+				RefreshMultipleCollectionsTest.ChildA.class,
+				RefreshMultipleCollectionsTest.ChildB.class,
+				RefreshMultipleCollectionsTest.ChildC.class
+		}
+)
+@SessionFactory(useCollectingStatementInspector = true)
+@JiraKey("HHH-12867")
+public class RefreshMultipleCollectionsTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Parent parent = new Parent( 1L );
+			parent.addA( new ChildA( 1L ) );
+			parent.addA( new ChildA( 2L ) );
+			parent.addB( new ChildB( 1L ) );
+			parent.addB( new ChildB( 2L ) );
+			parent.addC( new ChildC( 1L ) );
+			parent.addC( new ChildC( 2L ) );
+			session.persist( parent );
+		} );
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	public void allInitializedFetchesEachOnlyFirstJoined(SessionFactoryScope scope) {
+		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
+		scope.inTransaction( session -> {
+			final Parent parent = session.find( Parent.class, 1L );
+			Hibernate.initialize( parent.getaChildren() );
+			Hibernate.initialize( parent.getbChildren() );
+			Hibernate.initialize( parent.getcChildren() );
+
+			inspector.clear();
+			session.refresh( parent );
+
+			// All three stay initialized...
+			assertThat( Hibernate.isInitialized( parent.getaChildren() ) ).isTrue();
+			assertThat( Hibernate.isInitialized( parent.getbChildren() ) ).isTrue();
+			assertThat( Hibernate.isInitialized( parent.getcChildren() ) ).isTrue();
+			// ...but only three statements are issued: entity + first collection joined,
+			// then a secondary select for each of the two remaining collections.
+			assertThat( inspector.getSqlQueries() ).hasSize( 3 );
+			inspector.assertNumberOfJoins( 0, 1 );
+			inspector.assertNumberOfJoins( 1, 0 );
+			inspector.assertNumberOfJoins( 2, 0 );
+		} );
+	}
+
+	@Test
+	public void onlyMiddleCollectionInitializedIsTheOneJoined(SessionFactoryScope scope) {
+		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
+		scope.inTransaction( session -> {
+			final Parent parent = session.find( Parent.class, 1L );
+			// Initialize only the *second* declared collection.
+			Hibernate.initialize( parent.getbChildren() );
+			assertThat( Hibernate.isInitialized( parent.getaChildren() ) ).isFalse();
+			assertThat( Hibernate.isInitialized( parent.getcChildren() ) ).isFalse();
+
+			inspector.clear();
+			session.refresh( parent );
+
+			// Only 'b' was initialized, so only 'b' is fetched - and because it is the only
+			// fetched collection it becomes the one that is join-fetched into the entity query.
+			assertThat( Hibernate.isInitialized( parent.getbChildren() ) ).isTrue();
+			assertThat( Hibernate.isInitialized( parent.getaChildren() ) ).isFalse();
+			assertThat( Hibernate.isInitialized( parent.getcChildren() ) ).isFalse();
+			assertThat( inspector.getSqlQueries() ).hasSize( 1 );
+			inspector.assertNumberOfJoins( 0, 1 );
+		} );
+	}
+
+	@Test
+	public void subsetInitializedFetchesOnlyThoseFirstJoined(SessionFactoryScope scope) {
+		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
+		scope.inTransaction( session -> {
+			final Parent parent = session.find( Parent.class, 1L );
+			// Initialize the first and last declared collections, leaving the middle one lazy.
+			Hibernate.initialize( parent.getaChildren() );
+			Hibernate.initialize( parent.getcChildren() );
+
+			inspector.clear();
+			session.refresh( parent );
+
+			assertThat( Hibernate.isInitialized( parent.getaChildren() ) ).isTrue();
+			assertThat( Hibernate.isInitialized( parent.getcChildren() ) ).isTrue();
+			// The uninitialized one is neither fetched nor initialized.
+			assertThat( Hibernate.isInitialized( parent.getbChildren() ) ).isFalse();
+			// Two fetched collections: first joined, the other via a secondary select.
+			assertThat( inspector.getSqlQueries() ).hasSize( 2 );
+			inspector.assertNumberOfJoins( 0, 1 );
+			inspector.assertNumberOfJoins( 1, 0 );
+		} );
+	}
+
+	@Test
+	public void noneInitializedFetchesNoCollections(SessionFactoryScope scope) {
+		final SQLStatementInspector inspector = scope.getCollectingStatementInspector();
+		scope.inTransaction( session -> {
+			final Parent parent = session.find( Parent.class, 1L );
+
+			inspector.clear();
+			session.refresh( parent );
+
+			assertThat( Hibernate.isInitialized( parent.getaChildren() ) ).isFalse();
+			assertThat( Hibernate.isInitialized( parent.getbChildren() ) ).isFalse();
+			assertThat( Hibernate.isInitialized( parent.getcChildren() ) ).isFalse();
+			// Only the entity row is reloaded, with no collection join.
+			assertThat( inspector.getSqlQueries() ).hasSize( 1 );
+			inspector.assertNumberOfJoins( 0, 0 );
+		} );
+	}
+
+	@Entity(name = "Parent")
+	@Table(name = "mc_parent")
+	public static class Parent {
+		@Id
+		private Long id;
+
+		@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+		private List<ChildA> aChildren = new ArrayList<>();
+
+		@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+		private List<ChildB> bChildren = new ArrayList<>();
+
+		@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+		private List<ChildC> cChildren = new ArrayList<>();
+
+		public Parent() {
+		}
+
+		public Parent(Long id) {
+			this.id = id;
+		}
+
+		public List<ChildA> getaChildren() {
+			return aChildren;
+		}
+
+		public List<ChildB> getbChildren() {
+			return bChildren;
+		}
+
+		public List<ChildC> getcChildren() {
+			return cChildren;
+		}
+
+		public void addA(ChildA child) {
+			aChildren.add( child );
+			child.parent = this;
+		}
+
+		public void addB(ChildB child) {
+			bChildren.add( child );
+			child.parent = this;
+		}
+
+		public void addC(ChildC child) {
+			cChildren.add( child );
+			child.parent = this;
+		}
+	}
+
+	@Entity(name = "ChildA")
+	@Table(name = "mc_child_a")
+	public static class ChildA {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Parent parent;
+
+		public ChildA() {
+		}
+
+		public ChildA(Long id) {
+			this.id = id;
+		}
+	}
+
+	@Entity(name = "ChildB")
+	@Table(name = "mc_child_b")
+	public static class ChildB {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Parent parent;
+
+		public ChildB() {
+		}
+
+		public ChildB(Long id) {
+			this.id = id;
+		}
+	}
+
+	@Entity(name = "ChildC")
+	@Table(name = "mc_child_c")
+	public static class ChildC {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Parent parent;
+
+		public ChildC() {
+		}
+
+		public ChildC(Long id) {
+			this.id = id;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/refresh/RefreshPessimisticLockPlanCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/refresh/RefreshPessimisticLockPlanCacheTest.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.refresh;
+
+import org.hibernate.Hibernate;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A load plan built while a cascading fetch profile is enabled contains extra (cascade-driven)
+ * fetches, so it must never be stored in - or served from - the regular per-lock-mode plan cache,
+ * which is not keyed by the cascading fetch profile.
+ * <p>
+ * This used to happen for exclusive locks: {@code resolveLoadPlan} only routed to the internal
+ * cascade cache for non-exclusive locks, so a {@code refresh} under a pessimistic lock fell through
+ * to the regular cache and poisoned it for subsequent plain loads at the same lock mode.
+ */
+@DomainModel(
+		annotatedClasses = {
+				RefreshPessimisticLockPlanCacheTest.Owner.class,
+				RefreshPessimisticLockPlanCacheTest.Target.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced(runNotEnhancedAsWell = true)
+public class RefreshPessimisticLockPlanCacheTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Target t1 = new Target( 1L, "target 1" );
+			final Target t2 = new Target( 2L, "target 2" );
+			session.persist( t1 );
+			session.persist( t2 );
+			session.persist( new Owner( 1L, t1 ) );
+			session.persist( new Owner( 2L, t2 ) );
+		} );
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	public void cascadePlanUnderPessimisticLockDoesNotPoisonTheRegularCache(SessionFactoryScope scope) {
+		// Refreshing under an exclusive lock builds a plan that immediately fetches the
+		// cascade=REFRESH association.
+		scope.inTransaction( session -> {
+			final Owner owner = session.find( Owner.class, 1L );
+			session.refresh( owner, LockModeType.PESSIMISTIC_WRITE );
+			// just a sanity check to ensure the relation was indeed fetched and is in the plan cache
+			// note that a resfresh currently fetch even unloaded lazy to-one relation
+			//  and this is a bug similar to HHH-20628. There are currently no JIRA ticket for it though.
+			//  Once this is fixed, it will be needed to manually initialize the relation before calling refresh
+			//  to prepare this test.
+			assertThat( Hibernate.isInitialized( owner.getTarget() ) ).isTrue();
+		} );
+
+		// A plain load at the same lock mode must not reuse that cascade plan: the association
+		// is mapped LAZY, so it must still come back uninitialized.
+		scope.inTransaction( session -> {
+			final Owner owner = session.find( Owner.class, 2L, LockModeType.PESSIMISTIC_WRITE );
+			assertThat( Hibernate.isInitialized( owner.getTarget() ) ).isFalse();
+		} );
+	}
+
+	@Entity(name = "PlanCacheOwner")
+	@Table(name = "plan_cache_owner")
+	public static class Owner {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REFRESH)
+		private Target target;
+
+		public Owner() {
+		}
+
+		public Owner(Long id, Target target) {
+			this.id = id;
+			this.target = target;
+		}
+
+		public Target getTarget() {
+			return target;
+		}
+	}
+
+	@Entity(name = "PlanCacheTarget")
+	@Table(name = "plan_cache_target")
+	public static class Target {
+		@Id
+		private Long id;
+
+		private String name;
+
+		public Target() {
+		}
+
+		public Target(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+}


### PR DESCRIPTION
This is first draft to solve [HHH-20628](https://hibernate.atlassian.net/browse/HHH-20628) as well as [HHH-12867](https://hibernate.atlassian.net/browse/HHH-12867) (an old ticket for the same bug, I discovered it while working on this).

Here is a short description of what's in this MR
- I discussed this first with @mbellade
-  I made this with Claude Opus 5 but I heavily participated in it, verified everything and reworked the end result (that's how I found the other bug actually)
- this targets branch main for now but I would like to have it on v7 too
- there are two commits
  - the second one is the actual bug fix and the most complicated
  - the first one is another bug that I fixed at the same time as it became more susceptible to be triggered with my change
- each commit has a detailed description of what they do (written by Claude btw, it's quite clear I think, though there were a few mistakes I corrected :)
- each commit has dedicated tests (and we can add more)
- I ran the full test suite on each commit and also verified that the test fail without the fixes

The fix is basically as follow
- before the change, refreshing an entity with unloaded collections would always trigger an immediate fetch (via a join and optionally extra selects if there are more than one collection)
- now
  - the refresh listener will add extra information in the load query influencers about which lazy-loaded collection should actually be loaded and only those will be considered when building the load plan
  - the load plan cache will take this information into account for its cache keys

I double checked the JPA standard and it a bit implicit but this should be the expected behaviour. It is implicit because nothing much is said about refresh (in https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#refreshing-an-entity-instance), but this new behaviour is consistent with how merge is explicitly said to behave (in https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a1983):
> The persistence provider must not merge fields marked LAZY that have not been fetched: it must ignore such fields when merging.

There are a few relevant points to discuss or at least be aware of :
- this only covers plural relations but actually to-one relation suffers from the same problem: they are loaded on refresh even if there we unloaded before the refresh
  - I didn't tackle that but I would be open to do it as a second step later with a separate ticket
- one of the test introduced in https://github.com/hibernate/hibernate-orm/pull/12265 (for [HHH-18774](https://hibernate.atlassian.net/browse/HHH-18774)) had to be changed because it was only making sense with the old behaviour fixed by this PR.
- in load plan cache, I used a `ConcurrentMap` but the existing code was not using a thread-safe collection, it's possible that it was a bug (as this is called through entity persisters and I believe they can be accessed from multiple threads in parallel)

Cheers!

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20628 (Bug):
- [x] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

[HHH-20628]: https://hibernate.atlassian.net/browse/HHH-20628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-12867]: https://hibernate.atlassian.net/browse/HHH-12867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-18774]: https://hibernate.atlassian.net/browse/HHH-18774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ