### PR TITLE
HHH-20764 Many-to-many order-by should fall back to join-table column names

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ordering/ast/ColumnReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ordering/ast/ColumnReference.java
@@ -6,9 +6,9 @@ package org.hibernate.metamodel.mapping.ordering.ast;
 
 import jakarta.persistence.criteria.Nulls;
 import org.hibernate.metamodel.UnsupportedMappingException;
-import org.hibernate.metamodel.mapping.ModelPartContainer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.ordering.TranslationContext;
+import org.hibernate.persister.collection.AbstractCollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.SortDirection;
 import org.hibernate.sql.ast.spi.SqlAstCreationState;
@@ -20,6 +20,7 @@ import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SortSpecification;
 import org.hibernate.type.NullType;
 
+import static org.hibernate.internal.util.collections.ArrayHelper.contains;
 import static org.hibernate.sql.ast.spi.SqlExpressionResolver.createColumnReferenceKey;
 
 /**
@@ -104,22 +105,31 @@ public class ColumnReference implements OrderingExpression, SequencePart {
 	}
 
 	TableReference getTableReference(TableGroup tableGroup) {
-		ModelPartContainer modelPart = tableGroup.getModelPart();
-		if ( modelPart instanceof PluralAttributeMapping pluralAttribute ) {
-			if ( !pluralAttribute.getCollectionDescriptor().hasManyToManyOrdering() ) {
-				return tableGroup.getPrimaryTableReference();
-			}
-
-			if ( pluralAttribute.getElementDescriptor().getPartMappingType()
-					instanceof EntityPersister entityPersister ) {
-				final String tableName = entityPersister.getTableNameForColumn( columnExpression );
-				return tableGroup.getTableReference( tableGroup.getNavigablePath(), tableName );
+		if ( tableGroup.getModelPart() instanceof PluralAttributeMapping pluralAttribute ) {
+			if ( pluralAttribute.getElementDescriptor().getPartMappingType() instanceof EntityPersister entityPersister
+				&& pluralAttribute.getCollectionDescriptor() instanceof AbstractCollectionPersister persister
+				&& !persister.isOneToMany() ) {
+				if ( containsColumn( persister.getIndexColumnNames(), columnExpression )
+					|| containsColumn( persister.getKeyColumnNames(), columnExpression )
+					|| containsColumn( persister.getElementColumnNames(), columnExpression ) ) {
+					// Join-table columns
+					return tableGroup.getPrimaryTableReference();
+				}
+				return tableGroup.getTableReference( tableGroup.getNavigablePath(),
+						entityPersister.getTableNameForColumn( columnExpression ) );
 			}
 			else {
 				return tableGroup.getPrimaryTableReference();
 			}
 		}
 		return null;
+	}
+
+	public boolean containsColumn(String[] columns, String columnExpression) {
+		if ( columns != null ) {
+			return contains( columns, columnExpression );
+		}
+		return false;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/ordered/ManyToManyOrderByColumnOrmXmlTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/ordered/ManyToManyOrderByColumnOrmXmlTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.manytomany.ordered;
+
+import org.hibernate.Hibernate;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DomainModel(
+		xmlMappings = "org/hibernate/orm/test/manytomany/ordered/UserGroupManyToMany.orm.xml"
+)
+@SessionFactory
+@JiraKey( "HHH-20764" )
+public class ManyToManyOrderByColumnOrmXmlTest {
+
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					OrderedUser grace = new OrderedUser( "grace" );
+					OrderedGroup admins = new OrderedGroup( "admins" );
+					OrderedGroup users = new OrderedGroup( "users" );
+					grace.getGroups().add( users );
+					grace.getGroups().add( admins );
+					session.persist( grace );
+					session.persist( users );
+					session.persist( admins );
+				}
+		);
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testManyToManyOrderByJoinColumnFromOrmXml(SessionFactoryScope scope) {
+
+		scope.inTransaction(
+				session -> {
+					OrderedUser grace = session.createQuery(
+									"from OrderedUser u join fetch u.groups where u.name = :name",
+									OrderedUser.class
+							)
+							.setParameter( "name", "grace" )
+							.uniqueResult();
+
+					assertTrue( Hibernate.isInitialized( grace.getGroups() ) );
+					assertEquals( 2, grace.getGroups().size() );
+					assertEquals( "admins", grace.getGroups().get( 0 ).getName() );
+					assertEquals( "users", grace.getGroups().get( 1 ).getName() );
+				}
+		);
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/ordered/OrderedGroup.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/ordered/OrderedGroup.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.manytomany.ordered;
+
+public class OrderedGroup {
+	private String name;
+
+	private String description;
+
+	public OrderedGroup() {
+	}
+
+	public OrderedGroup(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/ordered/OrderedUser.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/ordered/OrderedUser.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.manytomany.ordered;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OrderedUser {
+	private String name;
+	private List<OrderedGroup> groups = new ArrayList<>();
+
+	public OrderedUser() {
+	}
+
+	public OrderedUser(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public List<OrderedGroup> getGroups() {
+		return groups;
+	}
+
+	public void setGroups(List<OrderedGroup> groups) {
+		this.groups = groups;
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/manytomany/ordered/UserGroupManyToMany.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/manytomany/ordered/UserGroupManyToMany.orm.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+	<package>org.hibernate.orm.test.manytomany.ordered</package>
+	<attribute-accessor>property</attribute-accessor>
+
+	<entity class="OrderedUser" metadata-complete="true">
+		<table name="OrderedUser"/>
+		<attributes>
+			<id name="name">
+				<column name="userName1"/>
+			</id>
+			<many-to-many name="groups" target-entity="OrderedGroup" classification="BAG">
+				<order-by> groupName asc, description asc, userName desc</order-by>
+				<join-table name="UserGroups">
+					<join-column name="userName"/>
+					<inverse-join-column name="groupName"/>
+				</join-table>
+			</many-to-many>
+		</attributes>
+	</entity>
+
+	<entity class="OrderedGroup" metadata-complete="true">
+		<table name="OrderedGroup"/>
+		<attributes>
+			<id name="name"/>
+			<basic name="description">
+				<column name="groupDescription"/>
+			</basic>
+		</attributes>
+	</entity>
+</entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20764

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20764 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->