### PR TITLE
HHH-20762 HbmXmlTransformer does not transfer order-by for <idbag> and <bag> collections

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -2743,9 +2743,11 @@ public class HbmXmlTransformer {
 			// the target will cause CollectionBinder to classify it as ID_BAG.
 			// Setting BAG explicitly would bypass the CollectionId annotation check.
 			transferCollectionId( idBag, target );
+			target.setOrderBy( idBag.getOrderBy() );
 		}
-		else if ( source instanceof JaxbHbmBagCollectionType ) {
+		else if ( source instanceof JaxbHbmBagCollectionType bag ) {
 			target.setClassification( LimitedCollectionClassification.BAG );
+			target.setOrderBy( bag.getOrderBy() );
 		}
 		else if ( source instanceof JaxbHbmListType listType ) {
 			transferListIndex(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1669,6 +1669,27 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20762" )
+	public void testIdBagOrderByTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/idbag-order-by/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl ownerEntity = transformed.getEntities().stream()
+					.filter( e -> "IdBagOwner".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( ownerEntity.getAttributes().getManyToManyAttributes() ).hasSize( 1 );
+
+			final JaxbManyToManyImpl items = ownerEntity.getAttributes().getManyToManyAttributes().get( 0 );
+			assertThat( items.getName() ).isEqualTo( "items" );
+			assertThat( items.getOrderBy() )
+					.as( "idbag order-by should be transferred to the many-to-many" )
+					.isEqualTo( "itemName asc" );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20697" )
 	public void testNonAggregatedCompositeIdColumnsNotUnique(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/inverse-composite-key/hbm.xml", scope, transformed -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/idbagorderby/IdBagItem.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/idbagorderby/IdBagItem.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.idbagorderby;
+
+public class IdBagItem {
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/idbagorderby/IdBagOwner.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/idbagorderby/IdBagOwner.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.idbagorderby;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IdBagOwner {
+	private String name;
+	private List<IdBagItem> items = new ArrayList<>();
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public List<IdBagItem> getItems() {
+		return items;
+	}
+
+	public void setItems(List<IdBagItem> items) {
+		this.items = items;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/idbag-order-by/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/idbag-order-by/hbm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.idbagorderby">
+
+    <class name="IdBagOwner" table="idbag_owner">
+        <id name="name"/>
+
+        <idbag name="items" order-by="itemName asc" table="owner_items">
+            <collection-id type="long" column="bag_id">
+                <generator class="increment"/>
+            </collection-id>
+            <key column="ownerName"/>
+            <many-to-many column="itemName" class="IdBagItem"/>
+        </idbag>
+    </class>
+
+    <class name="IdBagItem" table="idbag_item">
+        <id name="name"/>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
http://hibernate.atlassian.net/browse/HHH-20762

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20762 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20762
<!-- Hibernate GitHub Bot issue links end -->