### PR TITLE
HHH-20768 Named queries on nested interfaces inside entities are not registered during bootstrap

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/QueryBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/QueryBinder.java
@@ -236,6 +236,19 @@ public abstract class QueryBinder {
 					new HashSet<>()
 			);
 		}
+		bindNestedStaticQueries( classDetails, context, modelsContext );
+	}
+
+	private static void bindNestedStaticQueries(
+			ClassDetails classDetails,
+			MetadataBuildingContext context,
+			ModelsContext modelsContext) {
+		final var classDetailsRegistry = modelsContext.getClassDetailsRegistry();
+		for ( var nested : classDetails.toJavaClass().getDeclaredClasses() ) {
+			final var nestedDetails = classDetailsRegistry.resolveClassDetails( nested.getName() );
+			final var processedMethods = new HashSet<MethodSignature>();
+			bindDeclaredStaticQueries( nestedDetails, nestedDetails, context, modelsContext, processedMethods );
+		}
 	}
 
 	private static void bindDeclaredStaticQueries(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/named/Book.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/named/Book.java
@@ -173,4 +173,9 @@ public class Book {
 	public int nativeDeleteByTitleWithOptions(String title) {
 		throw new UnsupportedOperationException();
 	}
+
+	public interface NestedEntityQueries {
+		@JakartaQuery( "from Jpa4StaticQueryBook where title = :title" )
+		List<Book> findByTitle(String title);
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/named/Jpa4StaticQueryRegistrationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/named/Jpa4StaticQueryRegistrationTest.java
@@ -78,6 +78,8 @@ class Jpa4StaticQueryRegistrationTest {
 			queryName( CompanionRepository$.class, "findByTitle", String.class );
 	private static final String NESTED_QUERIES_FIND_BY_TITLE =
 			queryName( NestedQueries.class, "findByTitle", String.class );
+	private static final String NESTED_ENTITY_QUERIES_FIND_BY_TITLE =
+			queryName( Book.NestedEntityQueries.class, "findByTitle", String.class );
 
 	@Test
 	void registersMethodLevelQueriesAsNamedQueries(SessionFactoryScope scope) {
@@ -149,6 +151,15 @@ class Jpa4StaticQueryRegistrationTest {
 		assertThat( COMPANION_REPOSITORY_FIND_BY_TITLE )
 				.isEqualTo( CompanionRepository$.class.getName() + "#findByTitle(java.lang.String)" );
 		assertSelectionResultType( namedObjectRepository, COMPANION_REPOSITORY_FIND_BY_TITLE, Book.class );
+	}
+
+	@Test
+	void registersNestedEntityInterfaceQueries(SessionFactoryScope scope) {
+		final var namedObjectRepository = scope.getSessionFactory()
+				.getQueryEngine()
+				.getNamedObjectRepository();
+
+		assertSelectionResultType( namedObjectRepository, NESTED_ENTITY_QUERIES_FIND_BY_TITLE, Book.class );
 	}
 
 	private static void assertSelectionResultType(


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20768


When an entity class contains a nested interface with @JakartaQuery-annotated methods, the queries are not registered as named queries during Hibernate bootstrap. This causes UnknownNamedQueryException at runtime when the generated repository implementation tries to look up the query by name.

For example:

```java
@Entity
public class Book {
    @Id public Long id;
    public String title;

    public interface Queries {
        @JakartaQuery("from Book where title = :title")
        List<Book> findByTitle(String title);
    }
}
```

The annotation processor correctly generates a TypedQueryReference in Book_.Queries_ with the query name "Book.Queries#findByTitle(java.lang.String)", but QueryBinder.bindStaticQueries() only iterates methods directly on the class passed to it. It never recurses into nested types, so the query is never registered in NamedObjectRepositoryImpl.

This works when the nested class is explicitly listed in the domain model (e.g. via `@DomainModel` annotatedClasses), but fails when only the enclosing entity is registered and the nested interface should be discovered automatically.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20768 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->