### PR TITLE
HHH-20774 <dynamic-update> and <dynamic-insert> elements in XML mappings are silently ignored

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
@@ -231,6 +231,18 @@ public class XmlAnnotationHelper {
 					xmlDocumentContext.getModelBuildingContext()
 			);
 		}
+		if ( jaxbEntity.isDynamicInsert() != null && jaxbEntity.isDynamicInsert() ) {
+			classDetails.applyAnnotationUsage(
+					HibernateAnnotations.DYNAMIC_INSERT,
+					xmlDocumentContext.getModelBuildingContext()
+			);
+		}
+		if ( jaxbEntity.isDynamicUpdate() != null && jaxbEntity.isDynamicUpdate() ) {
+			classDetails.applyAnnotationUsage(
+					HibernateAnnotations.DYNAMIC_UPDATE,
+					xmlDocumentContext.getModelBuildingContext()
+			);
+		}
 	}
 
 	public static void applyColumn(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/dynamicupdate/DynamicEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/dynamicupdate/DynamicEntity.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.dynamicupdate;
+
+public class DynamicEntity {
+	private Long id;
+	private String name;
+	private String description;
+	private String notes;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getNotes() {
+		return notes;
+	}
+
+	public void setNotes(String notes) {
+		this.notes = notes;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/dynamicupdate/XmlDynamicUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/dynamicupdate/XmlDynamicUpdateTest.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.dynamicupdate;
+
+import java.util.Locale;
+
+import org.hibernate.testing.jdbc.CollectingStatementObserver;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JiraKey("HHH-20774")
+@DomainModel(xmlMappings = "org/hibernate/orm/test/boot/models/xml/dynamicupdate/DynamicEntity.orm.xml")
+@SessionFactory(useCollectingStatementObserver = true)
+public class XmlDynamicUpdateTest {
+
+	@AfterEach
+	public void cleanup(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testDynamicInsertFromXmlMapping(SessionFactoryScope scope) {
+		final CollectingStatementObserver observer = scope.getCollectingStatementObserver();
+		observer.clear();
+
+		scope.inTransaction( session -> {
+			final DynamicEntity entity = new DynamicEntity();
+			entity.setName( "initial" );
+			session.persist( entity );
+			session.flush();
+
+			final String insertSql = observer.getSqlQueries().stream()
+					.filter( sql -> sql.toLowerCase( Locale.ROOT ).startsWith( "insert" ) )
+					.findFirst()
+					.orElseThrow( () -> new AssertionError( "No insert statement found" ) );
+
+			assertThat( insertSql ).contains( "name" );
+			assertThat( insertSql ).doesNotContain( "description" );
+			assertThat( insertSql ).doesNotContain( "notes" );
+		} );
+	}
+
+	@Test
+	public void testDynamicUpdateFromXmlMapping(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final DynamicEntity entity = new DynamicEntity();
+			entity.setName( "initial" );
+			entity.setDescription( "desc" );
+			entity.setNotes( "notes" );
+			session.persist( entity );
+		} );
+
+		final CollectingStatementObserver observer = scope.getCollectingStatementObserver();
+		observer.clear();
+
+		scope.inTransaction( session -> {
+			final DynamicEntity entity = session
+					.createQuery( "from DynamicEntity", DynamicEntity.class )
+					.uniqueResult();
+			entity.setName( "updated" );
+			session.flush();
+
+			final String updateSql = observer.getSqlQueries().stream()
+					.filter( sql -> sql.toLowerCase( Locale.ROOT ).startsWith( "update" ) )
+					.findFirst()
+					.orElseThrow( () -> new AssertionError( "No update statement found" ) );
+
+			assertThat( updateSql ).contains( "name" );
+			assertThat( updateSql ).doesNotContain( "description" );
+			assertThat( updateSql ).doesNotContain( "notes" );
+		} );
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/models/xml/dynamicupdate/DynamicEntity.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/models/xml/dynamicupdate/DynamicEntity.orm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="8.0">
+    <package>org.hibernate.orm.test.boot.models.xml.dynamicupdate</package>
+    <entity class="DynamicEntity" metadata-complete="true">
+        <table name="dynamic_entity"/>
+        <dynamic-insert>true</dynamic-insert>
+        <dynamic-update>true</dynamic-update>
+        <attributes>
+            <id name="id">
+                <generated-value strategy="IDENTITY"/>
+            </id>
+            <basic name="name"/>
+            <basic name="description"/>
+            <basic name="notes"/>
+        </attributes>
+    </entity>
+</entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20774

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20774 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->