### PR TITLE
HHH-20775 Fix hasHandwrittenMetamodel skipping Jakarta Data metamodel on incremental builds

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/async/AsyncRepositoryTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/async/AsyncRepositoryTest.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.processor.test.data.async;
 
-import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -61,8 +60,8 @@ class AsyncRepositoryTest {
 		final var compiler = ToolProvider.getSystemJavaCompiler();
 		try ( var fileManager = compiler.getStandardFileManager( diagnostics, Locale.ROOT, defaultCharset() ) ) {
 			final var sourceFiles = List.of(
-					sourceFile( AsyncBook.class ),
-					sourceFile( InvalidAsyncBookRepository.class )
+					TestUtil.getSourceFile( AsyncBook.class ),
+					TestUtil.getSourceFile( InvalidAsyncBookRepository.class )
 			);
 			final var task = compiler.getTask(
 					null,
@@ -86,12 +85,5 @@ class AsyncRepositoryTest {
 				.collect( Collectors.joining( "\n" ) );
 
 		assertTrue( messages.contains( "method annotated '@Asynchronous' must return 'CompletionStage'" ) );
-	}
-
-	private static File sourceFile(Class<?> type) {
-		return new File(
-				TestUtil.getSourceBaseDir( type ),
-				type.getName().replace( '.', File.separatorChar ) + ".java"
-		);
 	}
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/basic/DataTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/basic/DataTest.java
@@ -14,7 +14,6 @@ import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaFileObject;
 import javax.tools.ToolProvider;
-import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -146,9 +145,9 @@ class DataTest {
 		final var compiler = ToolProvider.getSystemJavaCompiler();
 		try ( var fileManager = compiler.getStandardFileManager( diagnostics, Locale.ROOT, null ) ) {
 			final var sourceFiles = List.of(
-					sourceFile( Author.class ),
-					sourceFile( Book.class ),
-					sourceFile( InvalidPositionalParameterRepository.class )
+					TestUtil.getSourceFile( Author.class ),
+					TestUtil.getSourceFile( Book.class ),
+					TestUtil.getSourceFile( InvalidPositionalParameterRepository.class )
 			);
 			final var task = compiler.getTask(
 					null,
@@ -186,12 +185,5 @@ class DataTest {
 		return messages.stream()
 				.filter( message -> message.contains( text ) )
 				.count();
-	}
-
-	private static File sourceFile(Class<?> type) {
-		return new File(
-				TestUtil.getSourceBaseDir( type ),
-				type.getName().replace( '.', File.separatorChar ) + ".java"
-		);
 	}
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/IncrementalCompilationTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/IncrementalCompilationTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.innerclass;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.TestForIssue;
+import org.hibernate.processor.test.util.TestUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * When an entity is compiled twice (incremental build), the processor must
+ * still generate the Jakarta Data static metamodel ({@code _Entity}).
+ * <p>
+ * Previously, {@code hasHandwrittenMetamodel} would see the {@code _Entity.class}
+ * left over from the first compilation and incorrectly skip generating the
+ * data metamodel on subsequent compilations.
+ */
+@CompilationTest
+@TestForIssue(jiraKey = "HHH-20775")
+class IncrementalCompilationTest {
+
+	@Test
+	void testJakartaDataMetamodelRegeneratedOnIncrementalBuild() throws Exception {
+		final var outDir = new File( TestUtil.getOutBaseDir( IncrementalCompilationTest.class ), "incremental" );
+		outDir.mkdirs();
+
+		final var sourceFile = TestUtil.getSourceFile( IncrementalItemEntity.class );
+		final var dataMetamodelSource = new File( outDir,
+				"org/hibernate/processor/test/data/innerclass/_IncrementalItemEntity.java" );
+
+		// First compilation: generates _IncrementalItemEntity.java
+		TestUtil.compile( outDir, sourceFile );
+		assertTrue( dataMetamodelSource.exists(),
+				"First compilation should generate _IncrementalItemEntity.java" );
+
+		// Delete the generated source to detect whether the second compilation regenerates it
+		assertTrue( dataMetamodelSource.delete() );
+
+		// Second compilation: same source, output dir on classpath (simulates incremental build).
+		// The _IncrementalItemEntity.class from the first compilation is visible as a package sibling.
+		TestUtil.compile( outDir, sourceFile );
+		assertTrue( dataMetamodelSource.exists(),
+				"Second compilation should regenerate _IncrementalItemEntity.java" );
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/IncrementalItemEntity.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/IncrementalItemEntity.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.innerclass;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.processing.Find;
+
+import java.util.List;
+
+@Entity
+public class IncrementalItemEntity {
+	@Id
+	@GeneratedValue
+	public Long id;
+
+	public String name;
+
+	public interface Queries {
+		@Find
+		List<IncrementalItemEntity> findByName(String name);
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/DataRestrictionTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/restriction/DataRestrictionTest.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.processor.test.data.restriction;
 
-import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -101,9 +100,9 @@ class DataRestrictionTest {
 		final var compiler = ToolProvider.getSystemJavaCompiler();
 		try ( var fileManager = compiler.getStandardFileManager( diagnostics, Locale.ROOT, defaultCharset() ) ) {
 			final var sourceFiles = List.of(
-					sourceFile( DataRestrictionPublisher.class ),
-					sourceFile( DataRestrictionBook.class ),
-					sourceFile( InvalidDataRestrictionRepository.class )
+					TestUtil.getSourceFile( DataRestrictionPublisher.class ),
+					TestUtil.getSourceFile( DataRestrictionBook.class ),
+					TestUtil.getSourceFile( InvalidDataRestrictionRepository.class )
 			);
 			final var task = compiler.getTask(
 					null,
@@ -159,9 +158,9 @@ class DataRestrictionTest {
 		final var compiler = ToolProvider.getSystemJavaCompiler();
 		try ( var fileManager = compiler.getStandardFileManager( diagnostics, Locale.ROOT, defaultCharset() ) ) {
 			final var sourceFiles = List.of(
-					sourceFile( DataRestrictionPublisher.class ),
-					sourceFile( DataRestrictionBook.class ),
-					sourceFile( InvalidNativeStaticQuery.class )
+					TestUtil.getSourceFile( DataRestrictionPublisher.class ),
+					TestUtil.getSourceFile( DataRestrictionBook.class ),
+					TestUtil.getSourceFile( InvalidNativeStaticQuery.class )
 			);
 			final var task = compiler.getTask(
 					null,
@@ -192,12 +191,5 @@ class DataRestrictionTest {
 		return messages.stream()
 				.filter( message -> message.contains( text ) )
 				.count();
-	}
-
-	private static File sourceFile(Class<?> type) {
-		return new File(
-				TestUtil.getSourceBaseDir( type ),
-				type.getName().replace( '.', File.separatorChar ) + ".java"
-		);
 	}
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/select/SelectionTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/select/SelectionTest.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.processor.test.data.select;
 
-import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -103,10 +102,10 @@ class SelectionTest {
 		final var compiler = ToolProvider.getSystemJavaCompiler();
 		try ( var fileManager = compiler.getStandardFileManager( diagnostics, Locale.ROOT, defaultCharset() ) ) {
 			final var sourceFiles = List.of(
-					sourceFile( SelectionStatus.class ),
-					sourceFile( SelectionPublisher.class ),
-					sourceFile( SelectionBook.class ),
-					sourceFile( InvalidSelectionRepository.class )
+					TestUtil.getSourceFile( SelectionStatus.class ),
+					TestUtil.getSourceFile( SelectionPublisher.class ),
+					TestUtil.getSourceFile( SelectionBook.class ),
+					TestUtil.getSourceFile( InvalidSelectionRepository.class )
 			);
 			final var task = compiler.getTask(
 					null,
@@ -138,12 +137,5 @@ class SelectionTest {
 		assertTrue( messages.contains( "'@First' may not be combined with a parameter of type 'jakarta.data.Limit'" ) );
 		assertTrue( messages.contains(
 				"Jakarta Data repository method annotations are mutually exclusive: @Find, @Query" ) );
-	}
-
-	private static File sourceFile(Class<?> type) {
-		return new File(
-				TestUtil.getSourceBaseDir( type ),
-				type.getName().replace( '.', File.separatorChar ) + ".java"
-		);
 	}
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/stateful/StatefulRepositoryTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/stateful/StatefulRepositoryTest.java
@@ -119,9 +119,9 @@ class StatefulRepositoryTest {
 		final var compiler = ToolProvider.getSystemJavaCompiler();
 		try ( var fileManager = compiler.getStandardFileManager( diagnostics, Locale.ROOT, defaultCharset() ) ) {
 			final var sourceFiles = List.of(
-					sourceFile( StatefulBook.class ),
-					sourceFile( StatefulBookRepository.class ),
-					sourceFile( StatelessBookRepository.class )
+					TestUtil.getSourceFile( StatefulBook.class ),
+					TestUtil.getSourceFile( StatefulBookRepository.class ),
+					TestUtil.getSourceFile( StatelessBookRepository.class )
 			);
 			final var options = List.of(
 					"-d",
@@ -180,9 +180,9 @@ class StatefulRepositoryTest {
 		final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 		try ( StandardJavaFileManager fileManager = compiler.getStandardFileManager( diagnostics, null, null ) ) {
 			final List<File> sourceFiles = List.of(
-					sourceFile( StatefulBook.class ),
-					sourceFile( InvalidStatefulBookRepository.class ),
-					sourceFile( InvalidStatelessBackedStatefulBookRepository.class )
+					TestUtil.getSourceFile( StatefulBook.class ),
+					TestUtil.getSourceFile( InvalidStatefulBookRepository.class ),
+					TestUtil.getSourceFile( InvalidStatelessBackedStatefulBookRepository.class )
 			);
 			final JavaCompiler.CompilationTask task = compiler.getTask(
 					null,
@@ -224,12 +224,5 @@ class StatefulRepositoryTest {
 				.filter( diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR )
 				.map( diagnostic -> diagnostic.getMessage( Locale.ROOT ) )
 				.collect( Collectors.joining( "\n" ) );
-	}
-
-	private static File sourceFile(Class<?> type) {
-		return new File(
-				TestUtil.getSourceBaseDir( type ),
-				type.getName().replace( '.', File.separatorChar ) + ".java"
-		);
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -849,9 +849,10 @@ public class HibernateProcessor extends AbstractProcessor {
 	}
 
 	private static boolean hasHandwrittenMetamodel(Element element) {
+		final var generatedName = '_' + element.getSimpleName().toString();
 		return element.getEnclosingElement().getEnclosedElements()
-				.stream().anyMatch(e -> e.getSimpleName()
-						.contentEquals('_' + element.getSimpleName().toString()));
+				.stream().anyMatch(e -> e.getSimpleName().contentEquals( generatedName )
+						&& !hasAnnotation( e, Constants.JD_STATIC_METAMODEL ));
 	}
 
 	private void indexEntityName(TypeElement typeElement) {

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/StaticQueryTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/staticquery/StaticQueryTest.java
@@ -15,7 +15,6 @@ import org.hibernate.processor.test.util.TestUtil;
 import org.hibernate.processor.test.util.WithClasses;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
@@ -108,8 +107,8 @@ class StaticQueryTest {
 		final var compiler = ToolProvider.getSystemJavaCompiler();
 		try ( var fileManager = compiler.getStandardFileManager( diagnostics, Locale.ROOT, null ) ) {
 			final var sourceFiles = List.of(
-					sourceFile( Book.class ),
-					sourceFile( InvalidNativeStaticQuery.class )
+					TestUtil.getSourceFile( Book.class ),
+					TestUtil.getSourceFile( InvalidNativeStaticQuery.class )
 			);
 			final var task = compiler.getTask(
 					null,
@@ -126,12 +125,5 @@ class StaticQueryTest {
 			);
 			assertTrue( task.call() );
 		}
-	}
-
-	private static File sourceFile(Class<?> type) {
-		return new File(
-				TestUtil.getSourceBaseDir( type ),
-				type.getName().replace( '.', File.separatorChar ) + ".java"
-		);
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/TestUtil.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/TestUtil.java
@@ -269,6 +269,41 @@ public class TestUtil {
 		return outBaseDir;
 	}
 
+	public static File getSourceFile(Class<?> type) {
+		return new File(
+				getSourceBaseDir( type ),
+				type.getName().replace( '.', File.separatorChar ) + ".java"
+		);
+	}
+
+	/**
+	 * Compile the given source files with {@link org.hibernate.processor.HibernateProcessor},
+	 * writing output to {@code outDir} and placing {@code outDir} on the classpath so that
+	 * previously generated classes are visible (as happens in incremental Maven builds).
+	 */
+	public static void compile(File outDir, File... sourceFiles) throws Exception {
+		var compiler = javax.tools.ToolProvider.getSystemJavaCompiler();
+		var diagnostics = new javax.tools.DiagnosticCollector<javax.tools.JavaFileObject>();
+		try ( var fileManager = compiler.getStandardFileManager( diagnostics, null, null ) ) {
+			fileManager.setLocation( javax.tools.StandardLocation.CLASS_OUTPUT, List.of( outDir ) );
+			fileManager.setLocation( javax.tools.StandardLocation.SOURCE_OUTPUT, List.of( outDir ) );
+			var classpath = new java.util.ArrayList<File>();
+			for ( File f : fileManager.getLocation( javax.tools.StandardLocation.CLASS_PATH ) ) {
+				classpath.add( f );
+			}
+			classpath.add( outDir );
+			fileManager.setLocation( javax.tools.StandardLocation.CLASS_PATH, classpath );
+
+			var task = compiler.getTask(
+					null, fileManager, diagnostics,
+					List.of( "-processor", org.hibernate.processor.HibernateProcessor.class.getName() ),
+					null,
+					fileManager.getJavaFileObjectsFromFiles( List.of( sourceFiles ) )
+			);
+			assertTrue( task.call(), "Compilation failed: " + diagnostics.getDiagnostics() );
+		}
+	}
+
 	public static File getSourceBaseDir(Class<?> testClass) {
 		return getBaseDir( testClass, "java" );
 	}


### PR DESCRIPTION
## Summary
- `hasHandwrittenMetamodel` now excludes siblings annotated with `@jakarta.data.metamodel.StaticMetamodel` (RUNTIME retention) from being considered hand-written, so previously generated `_Entity.class` files don't suppress data metamodel generation on incremental builds.
- Added `TestUtil.getSourceFile()` and `TestUtil.compile()` helpers for programmatic compilation tests.
- Added `IncrementalCompilationTest` that compiles an entity twice with the output directory on the classpath and verifies the data metamodel is regenerated.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20775 (Bug):
- [x] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20775
<!-- Hibernate GitHub Bot issue links end -->