### PR TITLE
HHH-20776 CriteriaBuilder.literal() mistypes an enum constant declared with a class body

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
@@ -742,10 +742,19 @@ public class MappingMetamodelImpl
 
 	private static <T> Class<T> unproxiedClass(T bindValue) {
 		final var lazyInitializer = extractLazyInitializer( bindValue );
-		final var result =
-				lazyInitializer != null
-						? lazyInitializer.getPersistentClass()
-						: bindValue.getClass();
+		final Class<?> result;
+		if ( lazyInitializer != null ) {
+			result = lazyInitializer.getPersistentClass();
+		}
+		else if ( bindValue instanceof Enum<?> enumValue ) {
+			// The runtime class of an enum constant declared with a class body is an
+			// anonymous subclass of the enum type, and Class.isEnum() returns false
+			// for it, so we must obtain the enum type from the constant itself.
+			result = enumValue.getDeclaringClass();
+		}
+		else {
+			result = bindValue.getClass();
+		}
 		//noinspection unchecked
 		return (Class<T>) result;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/EnumConstantBodyLiteralTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/EnumConstantBodyLiteralTest.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.criteria;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A literal created for an enum constant which declares a class body must be typed as the
+ * enum itself. The runtime class of such a constant is an anonymous subclass of the enum,
+ * for which {@link Class#isEnum()} returns {@code false}.
+ */
+@JiraKey("HHH-20776")
+@DomainModel(annotatedClasses = EnumConstantBodyLiteralTest.Task.class)
+@SessionFactory
+public class EnumConstantBodyLiteralTest {
+
+	@BeforeAll
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new Task( 1L, Status.OPEN ) );
+			session.persist( new Task( 2L, Status.CLOSED ) );
+			session.persist( new Task( 3L, Status.SUSPENDED ) );
+		} );
+	}
+
+	@AfterAll
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	public void testInListOfEnumLiterals(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var builder = session.getCriteriaBuilder();
+			final var query = builder.createQuery( Long.class );
+			final var task = query.from( Task.class );
+			query.select( task.get( "id" ) )
+					.where( task.get( "status" )
+							.in( builder.literal( Status.OPEN ), builder.literal( Status.SUSPENDED ) ) )
+					.orderBy( builder.asc( task.get( "id" ) ) );
+			assertThat( session.createQuery( query ).getResultList() )
+					.containsExactly( 1L, 3L );
+		} );
+	}
+
+	@Test
+	public void testEqualityWithEnumLiteral(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var builder = session.getCriteriaBuilder();
+			final var query = builder.createQuery( Long.class );
+			final var task = query.from( Task.class );
+			query.select( task.get( "id" ) )
+					.where( builder.equal( task.get( "status" ), builder.literal( Status.CLOSED ) ) );
+			assertThat( session.createQuery( query ).getResultList() )
+					.containsExactly( 2L );
+		} );
+	}
+
+	@Test
+	public void testEnumLiteralAsLeftOperand(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var builder = session.getCriteriaBuilder();
+			final var query = builder.createQuery( Long.class );
+			final var task = query.from( Task.class );
+			query.select( task.get( "id" ) )
+					.where( builder.notEqual( builder.literal( Status.CLOSED ), task.get( "status" ) ) )
+					.orderBy( builder.asc( task.get( "id" ) ) );
+			assertThat( session.createQuery( query ).getResultList() )
+					.containsExactly( 1L, 3L );
+		} );
+	}
+
+	public enum Status {
+		OPEN {
+			@Override
+			public boolean isTerminal() {
+				return false;
+			}
+		},
+		SUSPENDED {
+			@Override
+			public boolean isTerminal() {
+				return false;
+			}
+		},
+		CLOSED {
+			@Override
+			public boolean isTerminal() {
+				return true;
+			}
+		};
+
+		public abstract boolean isTerminal();
+	}
+
+	@Entity(name = "Task")
+	public static class Task {
+		@Id
+		private Long id;
+
+		@Enumerated(EnumType.STRING)
+		private Status status;
+
+		public Task() {
+		}
+
+		public Task(Long id, Status status) {
+			this.id = id;
+			this.status = status;
+		}
+	}
+}


### PR DESCRIPTION
`CriteriaBuilder.literal(value)` produces a literal typed as `java.io.Serializable` when `value` is an enum constant that declares a class body, so comparing it against an enum-valued path fails:

```
org.hibernate.query.SemanticException: Cannot compare left expression of type
'org.hibernate.bugs.Task$Status' with right expression of type 'java.io.Serializable'
```

The runtime class of such a constant is an anonymous subclass of the enum, and `Class.isEnum()` returns `false` for it. `resolveParameterBindType(T)` therefore falls through to the `Serializable` branch instead of returning `null` and leaving the type to be inferred from the expression the literal is compared against. By contrast, `SqmCriteriaNodeBuilder.resolveInferredType(T)` uses `value instanceof Enum<?>` and gets this right, but it sits on the other route.

`unproxiedClass` now resolves the declaring class for enum values. I put it there rather than at the `isEnum()` check because it covers both consumers in one place: the `isEnum()` branch and `searchSupertypesForBindableType`, whose walk would otherwise start at the anonymous subclass. Constant-body enums now behave exactly like bodyless ones.

The number of literals is not the trigger: `in(literal, literal)`, a single-element `in(literal)` and `cb.equal(path, cb.literal(X))` all fail the same way. Passing the value rather than a literal works, because there the type comes from the path. `ValueHandlingMode=INLINE` makes no difference.

Verified broken on 6.6.54.Final, 7.3.2.Final, 7.4.5.Final and current `main`. The patch applies cleanly to `8.0` and `7.4`; `6.6` would need adapting, since the same block lives in `org.hibernate.internal.QueryParameterBindingTypeResolverImpl` there.

The test covers three cases and asserts the returned ids rather than just the absence of an exception: an in-list of literals, equality with a literal, and a literal as the left operand. All three fail without the production change and pass with it. I ran `org.hibernate.orm.test.query.**`, `org.hibernate.orm.test.jpa.**`, `org.hibernate.orm.test.type.**`, `org.hibernate.orm.test.procedure.**` and `**.*Enum*` for regressions (5609 tests, no failures), plus `./gradlew formatChecks`.

Two related observations I deliberately left out of this change:

- `query.select(cb.literal(anyEnum))` fails for plain enums too, with `NullPointerException: ... "nodeType" is null`. That is pre-existing and independent of constant bodies; after this fix, constant-body enums simply behave the same as plain ones there.
- `ReflectHelper.getClass(Enum<T>)` also returns `value.getClass()`, so `SqmCriteriaNodeBuilder.resolveEnumType` builds an `EnumJavaType` over the anonymous subclass. I could not reach that through public API, so it has no test here.

HHH-14851 reports what may be the same symptom against 5.4.24, on a type system that has since been rewritten.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20776 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20776
<!-- Hibernate GitHub Bot issue links end -->