### PR TITLE
HHH-20778 Register BIT DDL type for OracleLegacyDialect

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -847,6 +847,7 @@ public class OracleLegacyDialect extends Dialect {
 
 		ddlTypeRegistry.addDescriptor( new ArrayDdlTypeImpl( this, false ) );
 		ddlTypeRegistry.addDescriptor( TABLE, new ArrayDdlTypeImpl( this, false ) );
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( BIT, "number(1,0)", this ) );
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/OracleLegacyDialectTestCase.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/OracleLegacyDialectTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.spi.TypeConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@BaseUnitTest
+public class OracleLegacyDialectTestCase {
+	private StandardServiceRegistry serviceRegistry;
+
+	@BeforeEach
+	public void setUp() {
+		serviceRegistry = ServiceRegistryUtil.serviceRegistryBuilder().build();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		if ( serviceRegistry != null ) {
+			StandardServiceRegistryBuilder.destroy( serviceRegistry );
+		}
+	}
+
+	@Test
+	@JiraKey(value = "HHH-20778")
+	public void testBitDdlTypeRegistration() {
+		final OracleLegacyDialect dialect = new OracleLegacyDialect();
+		final TypeConfiguration typeConfiguration = new TypeConfiguration();
+		dialect.contributeTypes( () -> typeConfiguration, serviceRegistry );
+
+		assertThat( typeConfiguration.getDdlTypeRegistry().getDescriptor( SqlTypes.BIT ) ).isNotNull();
+		assertThat( typeConfiguration.getDdlTypeRegistry().getTypeName( SqlTypes.BIT, dialect ) )
+				.isEqualTo( "number(1,0)" );
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

OracleLegacyDialect does not register a DDL type descriptor for SqlTypes.BIT.

OracleBooleanJdbcType uses BIT as its DDL type code. As a result, Boolean mappings can fail during metadata bootstrap because Hibernate cannot resolve the corresponding DDL type.

OracleLegacyDialect already maps BIT to number(1,0) in columnType(), while OracleDialect also registers the corresponding DdlType descriptor.

This change adds the missing BIT -> number(1,0) DDL type registration to OracleLegacyDialect.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20778
<!-- Hibernate GitHub Bot issue links end -->