### PR TITLE
HHH-20779 Unwrap Envers proxies in collection-change audit work units

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/BaseEnversCollectionEventListener.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/BaseEnversCollectionEventListener.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.CollectionEntry;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.internal.entities.EntityConfiguration;
@@ -23,9 +24,12 @@ import org.hibernate.envers.internal.synchronization.work.AuditWorkUnit;
 import org.hibernate.envers.internal.synchronization.work.CollectionChangeWorkUnit;
 import org.hibernate.envers.internal.synchronization.work.FakeBidirectionalRelationWorkUnit;
 import org.hibernate.envers.internal.synchronization.work.PersistentCollectionChangeWorkUnit;
+import org.hibernate.envers.internal.tools.EntityTools;
 import org.hibernate.event.spi.AbstractCollectionEvent;
 import org.hibernate.persister.collection.AbstractCollectionPersister;
 import org.hibernate.persister.collection.OneToManyPersister;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.LazyInitializer;
 
 /**
  * Base class for Envers' collection event related listeners
@@ -96,7 +100,7 @@ public abstract class BaseEnversCollectionEventListener extends BaseEnversEventL
 									referencingPropertyName,
 									getEnversService(),
 									event.getAffectedOwnerIdOrNull(),
-									event.getAffectedOwnerOrNull()
+									getPossiblyProxyTarget( event.getSession(), event.getAffectedOwnerOrNull() )
 							)
 					);
 
@@ -214,7 +218,7 @@ public abstract class BaseEnversCollectionEventListener extends BaseEnversEventL
 
 		// For each collection change, generating the bidirectional work unit.
 		for ( PersistentCollectionChangeData changeData : collectionChanges ) {
-			final Object relatedObj = changeData.getChangedElement();
+			final Object relatedObj = getPossiblyProxyTarget( event.getSession(), changeData.getChangedElement() );
 			final Serializable relatedId = (Serializable) relatedIdMapper.mapToIdFromEntity( relatedObj );
 			final RevisionType revType = (RevisionType) changeData.getData().get(
 					getEnversService().getConfig().getRevisionTypePropertyName()
@@ -258,7 +262,7 @@ public abstract class BaseEnversCollectionEventListener extends BaseEnversEventL
 						referencingPropertyName,
 						getEnversService(),
 						event.getAffectedOwnerIdOrNull(),
-						event.getAffectedOwnerOrNull()
+						getPossiblyProxyTarget( event.getSession(), event.getAffectedOwnerOrNull() )
 				)
 		);
 	}
@@ -288,7 +292,7 @@ public abstract class BaseEnversCollectionEventListener extends BaseEnversEventL
 			final String toPropertyName = toPropertyNames.iterator().next();
 
 			for ( PersistentCollectionChangeData changeData : workUnit.getCollectionChanges() ) {
-				final Object relatedObj = changeData.getChangedElement();
+				final Object relatedObj = getPossiblyProxyTarget( event.getSession(), changeData.getChangedElement() );
 				final Serializable relatedId = (Serializable) relatedIdMapper.mapToIdFromEntity( relatedObj );
 
 				auditProcess.addWorkUnit(
@@ -303,5 +307,18 @@ public abstract class BaseEnversCollectionEventListener extends BaseEnversEventL
 				);
 			}
 		}
+	}
+
+	/**
+	 * The audit work unit reads the entity's state with reflection getters, which on a proxy
+	 * would return null for every property - the state lives on the proxy's target. Mirrors
+	 * {@code BaseEnversEventListener#addCollectionChangeWorkUnit}.
+	 */
+	private Object getPossiblyProxyTarget(SessionImplementor session, Object entity) {
+		final LazyInitializer lazyInitializer = HibernateProxy.extractLazyInitializer( entity );
+		if ( lazyInitializer != null ) {
+			return EntityTools.getTargetFromProxy( session.getFactory(), lazyInitializer );
+		}
+		return entity;
 	}
 }

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/proxy/ProxiedRelatedEntityCollectionChangeTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/proxy/ProxiedRelatedEntityCollectionChangeTest.java
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.proxy;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.configuration.EnversSettings;
+import org.hibernate.testing.envers.junit.EnversTest;
+import org.hibernate.testing.orm.junit.BeforeClassTemplate;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Version;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The bidirectional collection-change revision of a related entity must be mapped from the
+ * entity's real state even when the session holds the related entity as an uninitialized
+ * proxy. The proxy is seeded here by the child's lazy to-one during {@code em.find}; deleting
+ * the child then fires the collection-remove event whose element resolves to that proxy.
+ * Without unwrapping, the audit row is mapped off the proxy wrapper and every audited
+ * property (including the version, when audited) is written as null.
+ *
+ * <p>Reported at
+ * <a href="https://discourse.hibernate.org/t/12382">discourse.hibernate.org/t/12382</a>.
+ *
+ * @author Apoorva Manjunath
+ */
+@JiraKey("HHH-20779")
+@Jpa(annotatedClasses = {
+		ProxiedRelatedEntityCollectionChangeTest.Parent.class,
+		ProxiedRelatedEntityCollectionChangeTest.Child.class
+}, integrationSettings = {
+		@Setting(name = EnversSettings.DO_NOT_AUDIT_OPTIMISTIC_LOCKING_FIELD, value = "false")
+})
+@EnversTest
+public class ProxiedRelatedEntityCollectionChangeTest {
+
+	private Long parentId;
+	private Long childId;
+
+	@BeforeClassTemplate
+	public void initData(EntityManagerFactoryScope scope) {
+		// Revision 1: the parent is referenced by the child twice - via the lazy
+		// to-one (proxy seeder) and via the owned many-to-many
+		scope.inTransaction( em -> {
+			Parent parent = new Parent( "parent" );
+			Child child = new Child( "child" );
+			child.setMainParent( parent );
+			child.getLinkedParents().add( parent );
+			em.persist( parent );
+			em.persist( child );
+			parentId = parent.getId();
+			childId = child.getId();
+		} );
+
+		// Revision 2: loading the child hydrates mainParent as an uninitialized proxy;
+		// the delete's collection-remove event resolves the linkedParents element to it
+		scope.inTransaction( em -> em.remove( em.find( Child.class, childId ) ) );
+	}
+
+	@Test
+	public void testCollectionChangeRevisionKeepsRelatedEntityData(EntityManagerFactoryScope scope) {
+		scope.inEntityManager( em -> {
+			AuditReader auditReader = AuditReaderFactory.get( em );
+			List<Number> revisions = auditReader.getRevisions( Parent.class, parentId );
+			assertEquals( 2, revisions.size() );
+
+			Parent atModRevision = auditReader.find( Parent.class, parentId, revisions.get( revisions.size() - 1 ) );
+			assertNotNull( atModRevision );
+			assertEquals( "parent", atModRevision.getName() );
+			assertNotNull( atModRevision.getVersion() );
+		} );
+	}
+
+	@Entity(name = "Parent")
+	@Audited
+	public static class Parent {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Version
+		private Integer version;
+
+		private String name;
+
+		@ManyToMany(mappedBy = "linkedParents", fetch = FetchType.LAZY)
+		private Set<Child> children = new HashSet<>();
+
+		public Parent() {
+		}
+
+		public Parent(String name) {
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public Integer getVersion() {
+			return version;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Set<Child> getChildren() {
+			return children;
+		}
+	}
+
+	@Entity(name = "Child")
+	@Audited
+	public static class Child {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Version
+		private Integer version;
+
+		private String name;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Parent mainParent;
+
+		@ManyToMany(fetch = FetchType.LAZY)
+		private Set<Parent> linkedParents = new HashSet<>();
+
+		public Child() {
+		}
+
+		public Child(String name) {
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Parent getMainParent() {
+			return mainParent;
+		}
+
+		public void setMainParent(Parent mainParent) {
+			this.mainParent = mainParent;
+		}
+
+		public Set<Parent> getLinkedParents() {
+			return linkedParents;
+		}
+	}
+}


### PR DESCRIPTION
Reported at https://discourse.hibernate.org/t/envers-collection-change-audit-row-is-mapped-from-an-uninitialized-proxy-writing-null-for-every-audited-property-of-the-related-entity/12382 (per @beikov's
  request there — note I don't have issue-tracker create permissions, so there's no HHH key yet; happy to update the commit message and add `@JiraKey` to the test once one is assigned).

  ### Problem

  `BaseEnversCollectionEventListener` passes the raw collection element / owner reference into `CollectionChangeWorkUnit`, unlike the entity-event path (`BaseEnversEventListener#addCollectionChangeWorkUnit`,
  HHH-7249), which unwraps proxies. When the session already holds the related entity as an uninitialized proxy (e.g. seeded by a lazy to-one on the same child that owns the collection), the audit row is
  mapped off the proxy wrapper by reflection field-reads, and every audited property of the MOD revision is written as null — silent audit corruption by default, and a NOT NULL constraint violation on the
  version column when `org.hibernate.envers.do_not_audit_optimistic_locking_field=false` and the audit schema enforces it.

  ### Fix

  Unwrap via `EntityTools.getTargetFromProxy` at the four `CollectionChangeWorkUnit` construction sites in `BaseEnversCollectionEventListener` (owner unit in `onCollectionAction`, element + owner units in the
  fake-bidirectional path, element units in the bidirectional path), mirroring the existing entity-event path.

  ### Testing

  - New `ProxiedRelatedEntityCollectionChangeTest` (runs under both `DefaultAuditStrategy` and `ValidityAuditStrategy`): fails on current `main` with `expected: <parent> but was: <null>`, passes with the fix.
  - Full `:hibernate-envers:test` suite passes with the change.
  - Test case in the test-case-templates format: https://github.com/apoorvam/hibernate-test-case-templates/tree/envers-collection-change-proxy — also reproduces on 7.4.5.Final and 7.2.19.Final.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20779 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20779
<!-- Hibernate GitHub Bot issue links end -->