### PR TITLE
HHH-20750 Fix addInnerClass overwriting implementation with query metamodel for nested interfaces

### DIFF
--- a/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/test/InnerQueryInterfaceTest.java
+++ b/tooling/metamodel-generator/src/integrationTest/java/org/hibernate/processor/test/integ/test/InnerQueryInterfaceTest.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.integ.test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.query.JakartaQuery;
+import org.hibernate.annotations.processing.HQL;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DomainModel(annotatedClasses = {
+		InnerQueryInterfaceTest.MyEntity.class,
+		InnerQueryInterfaceTest.MyEntity.Queries.class
+})
+@SessionFactory
+class InnerQueryInterfaceTest {
+
+	@Entity(name = "InnerQueryEntity")
+	@Table(name = "integ_inner_query_entity")
+	public static class MyEntity {
+		@Id
+		@GeneratedValue
+		public Long id;
+		public String name;
+
+		public MyEntity() {
+		}
+
+		public MyEntity(String name) {
+			this.name = name;
+		}
+
+		public interface Queries {
+			EntityManager entityManager();
+
+			@HQL("from InnerQueryEntity where name = :name")
+			List<MyEntity> findByHql(String name);
+
+			@JakartaQuery("from InnerQueryEntity where name = :name")
+			List<MyEntity> findByJakarta(String name);
+		}
+	}
+
+	@AfterEach
+	void cleanup(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	void testNestedQueriesWithHqlAndJakartaQuery(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new MyEntity( "Hibernate" ) );
+			session.persist( new MyEntity( "Hibernate" ) );
+			session.persist( new MyEntity( "Other" ) );
+		} );
+		scope.inTransaction( session -> {
+			var queries = new InnerQueryInterfaceTest_.MyEntity_._Queries( session );
+			List<MyEntity> hqlResults = queries.findByHql( "Hibernate" );
+			assertEquals( 2, hqlResults.size() );
+			List<MyEntity> jakartaResults = queries.findByJakarta( "Hibernate" );
+			assertEquals( 2, jakartaResults.size() );
+		} );
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -376,7 +376,11 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	}
 
 	public void addInnerClass(AnnotationMetaEntity metaEntity) {
-		putMember( "INNER_" + metaEntity.getQualifiedName(),
+		final var simpleName = metaEntity.getSimpleName();
+		final var key = metaEntity.repositoryQueryMetamodel
+				? "INNER-" + simpleName + "_"
+				: "INNER-_" + simpleName;
+		putMember( key,
 				new InnerClassMetaAttribute( metaEntity ) );
 	}
 

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerQueryInterfaceTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerQueryInterfaceTest.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.innerclass;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.query.JakartaQuery;
+import org.hibernate.annotations.processing.HQL;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * When a nested interface triggers both {@code createRepository} (via {@code @HQL})
+ * and {@code createQueryMetamodel} (via {@code @JakartaQuery}), both inner classes
+ * must be present in the generated metamodel.
+ */
+@CompilationTest
+@WithClasses(InnerQueryInterfaceTest.MyEntity.class)
+class InnerQueryInterfaceTest {
+
+	@Entity
+	public static class MyEntity {
+		@Id
+		@GeneratedValue
+		public Long id;
+		public String name;
+
+		public interface Queries {
+			EntityManager entityManager();
+
+			@HQL("where name = :name")
+			List<MyEntity> findByHql(String name);
+
+			@JakartaQuery("from MyEntity where name = :name")
+			List<MyEntity> findByJakarta(String name);
+		}
+	}
+
+	@Test
+	void testBothInnerClassesGenerated() {
+		assertMetamodelClassGeneratedFor( MyEntity.class );
+		final String source = getMetaModelSourceAsString( MyEntity.class );
+		assertTrue( source.contains( "class _Queries implements Queries" ),
+				"Implementation inner class '_Queries' was not generated" );
+		assertTrue( source.contains( "class Queries_" ),
+				"Query metamodel inner class 'Queries_' was not generated" );
+	}
+}


### PR DESCRIPTION
## Summary
- Backport of #13137 to `main`
- When a nested repository interface has methods triggering both `createRepository` (e.g. `@HQL`) and `createQueryMetamodel` (e.g. `@JakartaQuery`/`@Query`), `addInnerClass` used the same map key for both, causing the query metamodel to overwrite the implementation class
- Fix: disambiguate the map key using the `repositoryQueryMetamodel` flag
- Added reproducer test `InnerQueryInterfaceTest`

https://hibernate.atlassian.net/browse/HHH-20750

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------