### PR TITLE
[8.0] HHH-20776 CriteriaBuilder.literal() mistypes an enum constant declared with a class body

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
@@ -742,10 +742,19 @@ public class MappingMetamodelImpl
 
 	private static <T> Class<T> unproxiedClass(T bindValue) {
 		final var lazyInitializer = extractLazyInitializer( bindValue );
-		final var result =
-				lazyInitializer != null
-						? lazyInitializer.getPersistentClass()
-						: bindValue.getClass();
+		final Class<?> result;
+		if ( lazyInitializer != null ) {
+			result = lazyInitializer.getPersistentClass();
+		}
+		else if ( bindValue instanceof Enum<?> enumValue ) {
+			// The runtime class of an enum constant declared with a class body is an
+			// anonymous subclass of the enum type, and Class.isEnum() returns false
+			// for it, so we must obtain the enum type from the constant itself.
+			result = enumValue.getDeclaringClass();
+		}
+		else {
+			result = bindValue.getClass();
+		}
 		//noinspection unchecked
 		return (Class<T>) result;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/EnumConstantBodyLiteralTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/EnumConstantBodyLiteralTest.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.criteria;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A literal created for an enum constant which declares a class body must be typed as the
+ * enum itself. The runtime class of such a constant is an anonymous subclass of the enum,
+ * for which {@link Class#isEnum()} returns {@code false}.
+ */
+@JiraKey("HHH-20776")
+@DomainModel(annotatedClasses = EnumConstantBodyLiteralTest.Task.class)
+@SessionFactory
+public class EnumConstantBodyLiteralTest {
+
+	@BeforeAll
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new Task( 1L, Status.OPEN ) );
+			session.persist( new Task( 2L, Status.CLOSED ) );
+			session.persist( new Task( 3L, Status.SUSPENDED ) );
+		} );
+	}
+
+	@AfterAll
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	public void testInListOfEnumLiterals(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var builder = session.getCriteriaBuilder();
+			final var query = builder.createQuery( Long.class );
+			final var task = query.from( Task.class );
+			query.select( task.get( "id" ) )
+					.where( task.get( "status" )
+							.in( builder.literal( Status.OPEN ), builder.literal( Status.SUSPENDED ) ) )
+					.orderBy( builder.asc( task.get( "id" ) ) );
+			assertThat( session.createQuery( query ).getResultList() )
+					.containsExactly( 1L, 3L );
+		} );
+	}
+
+	@Test
+	public void testEqualityWithEnumLiteral(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var builder = session.getCriteriaBuilder();
+			final var query = builder.createQuery( Long.class );
+			final var task = query.from( Task.class );
+			query.select( task.get( "id" ) )
+					.where( builder.equal( task.get( "status" ), builder.literal( Status.CLOSED ) ) );
+			assertThat( session.createQuery( query ).getResultList() )
+					.containsExactly( 2L );
+		} );
+	}
+
+	@Test
+	public void testEnumLiteralAsLeftOperand(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var builder = session.getCriteriaBuilder();
+			final var query = builder.createQuery( Long.class );
+			final var task = query.from( Task.class );
+			query.select( task.get( "id" ) )
+					.where( builder.notEqual( builder.literal( Status.CLOSED ), task.get( "status" ) ) )
+					.orderBy( builder.asc( task.get( "id" ) ) );
+			assertThat( session.createQuery( query ).getResultList() )
+					.containsExactly( 1L, 3L );
+		} );
+	}
+
+	public enum Status {
+		OPEN {
+			@Override
+			public boolean isTerminal() {
+				return false;
+			}
+		},
+		SUSPENDED {
+			@Override
+			public boolean isTerminal() {
+				return false;
+			}
+		},
+		CLOSED {
+			@Override
+			public boolean isTerminal() {
+				return true;
+			}
+		};
+
+		public abstract boolean isTerminal();
+	}
+
+	@Entity(name = "Task")
+	public static class Task {
+		@Id
+		private Long id;
+
+		@Enumerated(EnumType.STRING)
+		private Status status;
+
+		public Task() {
+		}
+
+		public Task(Long id, Status status) {
+			this.id = id;
+			this.status = status;
+		}
+	}
+}


### PR DESCRIPTION
Backport of #13172 to `8.0`.

`CriteriaBuilder.literal(value)` produces a literal typed as `java.io.Serializable` when `value` is an enum constant that declares a class body, so comparing it against an enum-valued path fails:

```
org.hibernate.query.SemanticException: Cannot compare left expression of type
'org.hibernate.bugs.Task$Status' with right expression of type 'java.io.Serializable'
```

The runtime class of such a constant is an anonymous subclass of the enum, and `Class.isEnum()` returns `false` for it. `resolveParameterBindType(T)` therefore falls through to the `Serializable` branch instead of returning `null` and leaving the type to be inferred from the expression the literal is compared against.

Both commits are cherry-picked from `main` without modification: `unproxiedClass` in `MappingMetamodelImpl` is identical on `main` and `8.0`, so the patch applies as-is.

The fix landed on `main`, which is 8.1. Without this backport 8.0.x would ship without it while both `7.4` (#13187) and 8.1 have it.

Verified on this branch (8.0.0-SNAPSHOT, JDK 25, H2): all three cases in `EnumConstantBodyLiteralTest` fail without the production change and pass with it.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20776 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20776
<!-- Hibernate GitHub Bot issue links end -->