### PR TITLE
HHH-20780: Fix minor error in the documentation

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Tuning.adoc
+++ b/documentation/src/main/asciidoc/introduction/Tuning.adoc
@@ -77,7 +77,7 @@ There are many to choose from, as enumerated by link:{doc-javadoc-url}/org/hiber
 | `hibernate.agroal.acquisitionTimeout` | The maximum amount of time a thread can wait for a connection, after which an exception is thrown instead
 | `hibernate.agroal.reapTimeout` | The duration for eviction of idle connections
 | `hibernate.agroal.leakTimeout` | The duration of time a connection can be held without causing a leak to be reported
-| `hibernate.agroal.idleValidationTimeout` | A foreground validation is executed if a connection has been idle on the pool for longer than this duration
+| `hibernate.agroal.idleValidation` | A foreground validation is executed if a connection has been idle on the pool for longer than this duration
 | `hibernate.agroal.validationTimeout` | The interval between background validation checks
 | `hibernate.agroal.initialSql` | A SQL command to be executed when a connection is created
 |===

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AgroalSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AgroalSettings.java
@@ -102,7 +102,7 @@ public interface AgroalSettings {
 	 *
 	 * @see java.time.Duration#parse(CharSequence)
 	 */
-	String AGROAL_IDLE_VALIDATION_TIMEOUT = AGROAL_CONFIG_PREFIX + ".idleValidation";
+	String AGROAL_IDLE_VALIDATION = AGROAL_CONFIG_PREFIX + ".idleValidation";
 
 	/**
 	 * An SQL command to be executed when a connection is created.
@@ -120,7 +120,7 @@ public interface AgroalSettings {
 
 	/**
 	 * If {@code true}, connections will receive foreground validation on every acquisition
-	 * regardless of {@link AgroalSettings#AGROAL_IDLE_VALIDATION_TIMEOUT}.
+	 * regardless of {@link AgroalSettings#AGROAL_IDLE_VALIDATION}.
 	 * <p>
 	 * The default is {@code false}.
 	 *


### PR DESCRIPTION
The documentation mentioned a property "hibernate.agroal.idleValidationTimeout" whereas it is defined in AgroalSettings.java as "hibernate.agroal.idleValidation". The corresponding constant name was renamed from AGROAL_IDLE_VALIDATION_TIMEOUT to AGROAL_IDLE_VALIDATION to be in sync with the constant's value.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20780 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20780
<!-- Hibernate GitHub Bot issue links end -->