### PR TITLE
HHH-10326 @NaturalID(mutable=false) is not working when there is another @NaturalId(mutable=true) fix

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
@@ -210,38 +210,37 @@ public class CompoundNaturalIdMapping extends AbstractNaturalIdMapping implement
 
 	@Override
 	public void verifyFlushState(Object id, Object[] currentState, Object[] loadedState, SharedSessionContractImplementor session) {
-		if ( !isMutable() ) {
-			final var persistenceContext = session.getPersistenceContextInternal();
-			final var persister = getDeclaringType().getEntityPersister();
+		final var persistenceContext = session.getPersistenceContextInternal();
+		final var persister = getDeclaringType().getEntityPersister();
 
-			final Object[] naturalId = extractNaturalIdFromEntityState( currentState );
-			final Object snapshot = loadedState == null
-					? persistenceContext.getNaturalIdSnapshot( id, persister )
-					: persister.getNaturalIdMapping().extractNaturalIdFromEntityState( loadedState );
-			final Object[] previousNaturalId = (Object[]) snapshot;
-			assert naturalId.length == getNaturalIdAttributes().size();
-			assert previousNaturalId.length == naturalId.length;
+		final Object[] naturalId = extractNaturalIdFromEntityState( currentState );
+		final Object snapshot = loadedState == null
+				? persistenceContext.getNaturalIdSnapshot( id, persister )
+				: persister.getNaturalIdMapping().extractNaturalIdFromEntityState( loadedState );
+		final Object[] previousNaturalId = (Object[]) snapshot;
+		assert naturalId.length == getNaturalIdAttributes().size();
+		assert previousNaturalId.length == naturalId.length;
 
-			for ( int i = 0; i < getNaturalIdAttributes().size(); i++ ) {
-				final var attributeMapping = getNaturalIdAttributes().get( i );
-				if ( !attributeMapping.getAttributeMetadata().isUpdatable() ) {
-					final Object currentValue = naturalId[i];
-					final Object previousValue = previousNaturalId[i];
-					if ( !attributeMapping.areEqual( currentValue, previousValue, session ) ) {
-						throw new HibernateException(
-								String.format(
-										"An immutable attribute [%s] within compound natural identifier of entity %s was altered from `%s` to `%s`",
-										attributeMapping.getAttributeName(),
-										persister.getEntityName(),
-										previousValue,
-										currentValue
-								)
+		for ( int i = 0; i < getNaturalIdAttributes().size(); i++ ) {
+			final var attributeMapping = getNaturalIdAttributes().get( i );
+			if ( !attributeMapping.getAttributeMetadata().isUpdatable() ) {
+				final Object currentValue = naturalId[i];
+				final Object previousValue = previousNaturalId[i];
+				if ( !attributeMapping.areEqual( currentValue, previousValue, session ) ) {
+					throw new HibernateException(
+							String.format(
+									"An immutable attribute [%s] within compound natural identifier of entity %s was altered from `%s` to `%s`",
+									attributeMapping.getAttributeName(),
+									persister.getEntityName(),
+									previousValue,
+									currentValue
+							)
 						);
 					}
 				}
 				// else property is updatable (mutable), there is nothing to check
 			}
-		}
+
 		// otherwise the natural id is mutable (!immutable), no need to do the checks
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/compound/CompoundMixedNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/compound/CompoundMixedNaturalIdTest.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.naturalid.compound;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import org.hibernate.HibernateException;
+import org.hibernate.annotations.NaturalId;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@JiraKey("HHH-10326")
+@DomainModel(annotatedClasses = {
+		CompoundMixedNaturalIdTest.Owner.class,
+		CompoundMixedNaturalIdTest.Thing.class
+})
+@SessionFactory
+public class CompoundMixedNaturalIdTest {
+
+	@AfterEach
+	void dropTestData(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	void testImmutableAttributeWithinCompoundShouldNotBeChangeable(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Owner first = new Owner();
+			session.persist( first );
+
+			final Thing thing = new Thing();
+			thing.owner = first;
+			thing.name = "name";
+			session.persist( thing );
+		} );
+
+		scope.inTransaction( session -> {
+			final Thing thing = session.createQuery( "from Thing", Thing.class )
+					.uniqueResult();
+
+			final Owner second = new Owner();
+			session.persist( second );
+
+			thing.owner = second;
+
+			try {
+				session.flush();
+				fail( "Changing an immutable natural id attribute should have failed" );
+			}
+			catch (HibernateException expected) {
+				assertThat( expected.getMessage() ).contains( "immutable" );
+			}
+		} );
+	}
+
+	@Test
+	void testMutableAttributeWithinCompoundShouldBeChangeable(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Owner owner = new Owner();
+			session.persist( owner );
+
+			final Thing thing = new Thing();
+			thing.owner = owner;
+			thing.name = "original";
+			session.persist( thing );
+		} );
+
+		scope.inTransaction( session -> {
+			final Thing thing = session.createQuery( "from Thing", Thing.class )
+					.uniqueResult();
+
+			thing.name = "updated";
+			session.flush();
+		} );
+	}
+
+	@Entity(name = "Owner")
+	@Table(name = "owners")
+	public static class Owner {
+		@Id
+		@GeneratedValue
+		Integer id;
+	}
+
+	@Entity(name = "Thing")
+	@Table(name = "things")
+	public static class Thing {
+		@Id
+		@GeneratedValue
+		Integer id;
+
+		@NaturalId
+		@ManyToOne
+		Owner owner;
+
+		@NaturalId(mutable = true)
+		String name;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-10326

When an entity has a compound natural id with mixed mutability (@NaturalId and @NaturalId(mutable=true)), the immutable attributes were not being enforced. CompoundNaturalIdMapping.verifyFlushState() skipped all checks when any attribute was mutable due to the isMutable() method, even though the inner loop already handles per-attribute mutability correctly. 
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-10326 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->