### PR TITLE
HHH-833 Added serialVersionUID to AbstractPersistentCollection.java

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,6 +55,8 @@ import static org.hibernate.resource.transaction.spi.TransactionStatus.ROLLING_B
  */
 public abstract class AbstractPersistentCollection<E> implements Serializable, PersistentCollection<E> {
 
+	@Serial
+	private static final long serialVersionUID = 1L;
 	private transient SharedSessionContractImplementor session;
 	private boolean isTempSession = false;
 

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentArrayHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentArrayHolder.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +42,8 @@ import static java.util.Collections.addAll;
 public class PersistentArrayHolder<E> extends AbstractPersistentCollection<E> {
 
 	protected Object array;
+	@Serial
+	private static final long serialVersionUID = 1L;
 
 	//just to help out during the load (ugly, i know)
 	private transient Class<?> elementClass;

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentBag.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,6 +39,8 @@ import static java.util.Collections.emptyMap;
 @Incubating
 public class PersistentBag<E> extends AbstractPersistentCollection<E> implements List<E> {
 
+	@Serial
+	private static final long serialVersionUID = 1L;
 	/**
 	 * @deprecated Use {@link #bagAsList()} or {@link #collection} instead.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentIdentifierBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentIdentifierBag.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -47,6 +48,8 @@ public class PersistentIdentifierBag<E> extends AbstractPersistentCollection<E> 
 	@Deprecated(forRemoval = true, since = "7")
 	protected List<E> values;
 	protected Map<Integer, Object> identifiers;
+	@Serial
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * The actual bag.

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentList.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentList.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,6 +33,8 @@ import org.hibernate.type.Type;
 @Incubating
 public class PersistentList<E> extends AbstractPersistentCollection<E> implements List<E> {
 	protected List<E> list;
+	@Serial
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * Constructs a PersistentList.  This form needed for SOAP libraries, etc

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentMap.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,6 +39,8 @@ import org.hibernate.type.Type;
 public class PersistentMap<K,E> extends AbstractPersistentCollection<E> implements Map<K,E> {
 
 	protected Map<K,E> map;
+	@Serial
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * Empty constructor.

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentSet.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentSet.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,6 +35,8 @@ import org.hibernate.type.Type;
 @Incubating
 public class PersistentSet<E> extends AbstractPersistentCollection<E> implements Set<E> {
 	protected Set<E> set;
+	@Serial
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * Empty constructor.

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentSortedMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentSortedMap.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Comparator;
@@ -30,6 +31,8 @@ import org.hibernate.persister.collection.BasicCollectionPersister;
 @Incubating
 public class PersistentSortedMap<K,E> extends PersistentMap<K,E> implements SortedMap<K,E> {
 	protected Comparator<? super K> comparator;
+	@Serial
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * Constructs a PersistentSortedMap.  This form needed for SOAP libraries, etc

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentSortedSet.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentSortedSet.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.collection.spi;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.SortedSet;
@@ -27,6 +28,8 @@ import org.hibernate.persister.collection.BasicCollectionPersister;
 @Incubating
 public class PersistentSortedSet<E> extends PersistentSet<E> implements SortedSet<E> {
 	protected Comparator<? super E> comparator;
+	@Serial
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * Constructs a PersistentSortedSet.  This form needed for SOAP libraries, etc

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/PersistentCollectionSerializationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/PersistentCollectionSerializationTest.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.collection;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.collection.spi.PersistentList;
+import org.hibernate.collection.spi.PersistentMap;
+import org.hibernate.collection.spi.PersistentSet;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OrderColumn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(annotatedClasses = PersistentCollectionSerializationTest.Owner.class)
+@SessionFactory
+public class PersistentCollectionSerializationTest {
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Owner owner = new Owner();
+			owner.id = 1L;
+			owner.names = new HashSet<>( Set.of( "a", "b", "c" ) );
+			owner.items = new ArrayList<>( List.of( "first", "second", "third" ) );
+			owner.labels = new HashMap<>( Map.of( "k1", "v1", "k2", "v2" ) );
+			session.persist( owner );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	public void testPersistentSetSerialization(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Owner owner = session.find( Owner.class, 1L );
+			Set<String> set = owner.names;
+			assertThat( set ).isInstanceOf( PersistentSet.class );
+
+			@SuppressWarnings("unchecked")
+			Set<String> cloned = (Set<String>) SerializationHelper.clone( (Serializable) set );
+
+			assertThat( cloned ).containsExactlyInAnyOrderElementsOf( set );
+		} );
+	}
+
+	@Test
+	public void testPersistentListSerialization(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Owner owner = session.find( Owner.class, 1L );
+			List<String> list = owner.items;
+			assertThat( list ).isInstanceOf( PersistentList.class );
+
+			@SuppressWarnings("unchecked")
+			List<String> cloned = (List<String>) SerializationHelper.clone( (Serializable) list );
+
+			assertThat( cloned ).containsExactlyElementsOf( list );
+		} );
+	}
+
+	@Test
+	public void testPersistentMapSerialization(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Owner owner = session.find( Owner.class, 1L );
+			Map<String, String> map = owner.labels;
+			assertThat( map ).isInstanceOf( PersistentMap.class );
+
+			@SuppressWarnings("unchecked")
+			Map<String, String> cloned = (Map<String, String>) SerializationHelper.clone( (Serializable) map );
+
+			assertThat( cloned ).containsExactlyInAnyOrderEntriesOf( map );
+		} );
+	}
+
+	@Entity(name = "SerOwner")
+	public static class Owner implements Serializable {
+		@Id
+		Long id;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		Set<String> names;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		@OrderColumn
+		List<String> items;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		@MapKeyColumn(name = "label_key")
+		Map<String, String> labels;
+	}
+}


### PR DESCRIPTION
HHH-833 Added serialVersionUID to AbstractPersistentCollection.java

(cherry picked from commit 11f794188f47cea5ad7d32b0be3624fff667b609)

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-833 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-833
<!-- Hibernate GitHub Bot issue links end -->