### PR TITLE
HHH-20696 Implicit name of list index columns not applied by MetadataBuilder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/IndexColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/IndexColumn.java
@@ -66,8 +66,7 @@ public class IndexColumn extends AnnotatedColumn {
 		return column;
 	}
 
-	private static String getColumnNameFromNamingStrategy(PropertyData inferredData, MetadataBuildingContext context)
-	{
+	private static String getColumnNameFromNamingStrategy(PropertyData inferredData, MetadataBuildingContext context) {
 		final var implicitNamingStrategy = context.getBuildingOptions().getImplicitNamingStrategy();
 		final var identifier = implicitNamingStrategy.determineListIndexColumnName(
 				new ImplicitIndexColumnNameSource() {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/IndexColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/IndexColumn.java
@@ -9,6 +9,8 @@ package org.hibernate.boot.model.internal;
 import java.util.Map;
 
 import org.hibernate.annotations.ListIndexBase;
+import org.hibernate.boot.model.naming.ImplicitIndexColumnNameSource;
+import org.hibernate.boot.model.source.spi.AttributePath;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.PropertyData;
 import org.hibernate.mapping.Join;
@@ -49,7 +51,7 @@ public class IndexColumn extends AnnotatedColumn {
 		}
 		else {
 			column = new IndexColumn();
-			column.setLogicalColumnName( inferredData.getPropertyName() + "_ORDER" ); //JPA default name
+			column.setLogicalColumnName( getColumnNameFromNamingStrategy( inferredData, context ) );
 			column.setImplicit( true );
 //			column.setContext( context );
 //			column.setPropertyHolder( propertyHolder );
@@ -62,6 +64,24 @@ public class IndexColumn extends AnnotatedColumn {
 		}
 
 		return column;
+	}
+
+	private static String getColumnNameFromNamingStrategy(PropertyData inferredData, MetadataBuildingContext context)
+	{
+		final var implicitNamingStrategy = context.getBuildingOptions().getImplicitNamingStrategy();
+		final var identifier = implicitNamingStrategy.determineListIndexColumnName(
+				new ImplicitIndexColumnNameSource() {
+					@Override
+					public AttributePath getPluralAttributePath() {
+						return AttributePath.parse( inferredData.getPropertyName() );
+					}
+
+					@Override
+					public MetadataBuildingContext getBuildingContext() {
+						return context;
+					}
+				} );
+		return identifier.render( context.getMetadataCollector().getDatabase().getDialect() );
 	}
 
 	private static void createParent(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/MetadataBuilderImplicitListIndexColumnNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/MetadataBuilderImplicitListIndexColumnNameTest.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.ImplicitIndexColumnNameSource;
+import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.mapping.BasicValue;
+import org.hibernate.mapping.Column;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.cfg.MappingSettings.DEFAULT_LIST_SEMANTICS;
+import static org.hibernate.cfg.MappingSettings.IMPLICIT_NAMING_STRATEGY;
+
+@JiraKey("HHH-20696")
+public class MetadataBuilderImplicitListIndexColumnNameTest {
+
+	private static final String EXPECTED_INDEX_COLUMN_NAME = "INDEX";
+
+	@Test
+	public void generatesCorrectIndexColumnName() {
+		StandardServiceRegistryBuilder srb = new StandardServiceRegistryBuilder()
+				.applySetting( DEFAULT_LIST_SEMANTICS, "LIST" )
+				.applySetting( IMPLICIT_NAMING_STRATEGY, CustomImplicitNamingStrategy.class.getName() );
+
+		Metadata metadata = new MetadataSources( srb.build() )
+				.addAnnotatedClasses( Entity1.class, Entity2.class )
+				.buildMetadata();
+
+		var collectionBinding = List.copyOf( metadata.getCollectionBindings() ).get(0);
+
+		assertThat( collectionBinding ).isInstanceOf( org.hibernate.mapping.List.class );
+
+		org.hibernate.mapping.List list = (org.hibernate.mapping.List) collectionBinding;
+		assertThat( list.getIndex() ).isInstanceOf( BasicValue.class );
+
+		BasicValue listIndex = (BasicValue) list.getIndex();
+		assertThat( ((Column) listIndex.getColumn()).getName() ).isEqualTo( EXPECTED_INDEX_COLUMN_NAME );
+	}
+
+	public static class CustomImplicitNamingStrategy extends ImplicitNamingStrategyJpaCompliantImpl
+	{
+		@Override
+		public Identifier determineListIndexColumnName(ImplicitIndexColumnNameSource source) {
+			return Identifier.toIdentifier( EXPECTED_INDEX_COLUMN_NAME );
+		}
+	}
+
+	@Entity
+	private static class Entity1 {
+		@Id private long id;
+		@ManyToMany private List<Entity2> other;
+	}
+
+	@Entity
+	private static class Entity2 {
+		@Id private long other_id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/MetadataBuilderImplicitListIndexColumnNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/MetadataBuilderImplicitListIndexColumnNameTest.java
@@ -8,15 +8,19 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
 import org.hibernate.boot.Metadata;
-import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.ImplicitIndexColumnNameSource;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.Column;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.ImplicitListAsListProvider;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -25,22 +29,31 @@ import static org.hibernate.cfg.MappingSettings.DEFAULT_LIST_SEMANTICS;
 import static org.hibernate.cfg.MappingSettings.IMPLICIT_NAMING_STRATEGY;
 
 @JiraKey("HHH-20696")
+@ServiceRegistry(
+		settingProviders = @SettingProvider(
+				settingName = DEFAULT_LIST_SEMANTICS,
+				provider = ImplicitListAsListProvider.class
+		),
+		settings = @Setting(
+				name = IMPLICIT_NAMING_STRATEGY,
+				value = "org.hibernate.orm.test.MetadataBuilderImplicitListIndexColumnNameTest$CustomImplicitNamingStrategy"
+		)
+)
+@DomainModel(
+		annotatedClasses = {
+				MetadataBuilderImplicitListIndexColumnNameTest.Entity1.class,
+				MetadataBuilderImplicitListIndexColumnNameTest.Entity2.class
+		}
+)
 public class MetadataBuilderImplicitListIndexColumnNameTest {
 
 	private static final String EXPECTED_INDEX_COLUMN_NAME = "INDEX";
 
 	@Test
-	public void generatesCorrectIndexColumnName() {
-		StandardServiceRegistryBuilder srb = new StandardServiceRegistryBuilder()
-				.applySetting( DEFAULT_LIST_SEMANTICS, "LIST" )
-				.applySetting( IMPLICIT_NAMING_STRATEGY, CustomImplicitNamingStrategy.class.getName() );
-
-		Metadata metadata = new MetadataSources( srb.build() )
-				.addAnnotatedClasses( Entity1.class, Entity2.class )
-				.buildMetadata();
+	public void generatesCorrectIndexColumnName(final DomainModelScope scope) {
+		Metadata metadata = scope.getDomainModel();
 
 		var collectionBinding = List.copyOf( metadata.getCollectionBindings() ).get(0);
-
 		assertThat( collectionBinding ).isInstanceOf( org.hibernate.mapping.List.class );
 
 		org.hibernate.mapping.List list = (org.hibernate.mapping.List) collectionBinding;
@@ -50,6 +63,7 @@ public class MetadataBuilderImplicitListIndexColumnNameTest {
 		assertThat( ((Column) listIndex.getColumn()).getName() ).isEqualTo( EXPECTED_INDEX_COLUMN_NAME );
 	}
 
+	@SuppressWarnings("unused")
 	public static class CustomImplicitNamingStrategy extends ImplicitNamingStrategyJpaCompliantImpl
 	{
 		@Override
@@ -58,14 +72,16 @@ public class MetadataBuilderImplicitListIndexColumnNameTest {
 		}
 	}
 
+	@SuppressWarnings("unused")
 	@Entity
-	private static class Entity1 {
+	static class Entity1 {
 		@Id private long id;
 		@ManyToMany private List<Entity2> other;
 	}
 
+	@SuppressWarnings("unused")
 	@Entity
-	private static class Entity2 {
+	static class Entity2 {
 		@Id private long other_id;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/namingstrategy/MetadataBuilderImplicitListIndexColumnNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/namingstrategy/MetadataBuilderImplicitListIndexColumnNameTest.java
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.orm.test;
+package org.hibernate.orm.test.namingstrategy;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -36,7 +36,7 @@ import static org.hibernate.cfg.MappingSettings.IMPLICIT_NAMING_STRATEGY;
 		),
 		settings = @Setting(
 				name = IMPLICIT_NAMING_STRATEGY,
-				value = "org.hibernate.orm.test.MetadataBuilderImplicitListIndexColumnNameTest$CustomImplicitNamingStrategy"
+				value = "org.hibernate.orm.test.namingstrategy.MetadataBuilderImplicitListIndexColumnNameTest$CustomImplicitNamingStrategy"
 		)
 )
 @DomainModel(


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20696

Backport to 6.6

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20696 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->