### PR TITLE
HHH-20343 Fix temporary table column names regression

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTable.java
@@ -6,6 +6,8 @@ package org.hibernate.dialect.temptable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -233,11 +235,13 @@ public class TemporaryTable implements Exportable, Contributable {
 				temporaryTable -> {
 					final MetadataImplementor metadata = runtimeModelCreationContext.getMetadata();
 					final List<TemporaryTableColumn> columns = new ArrayList<>();
+					final Set<String> columnNames = new TreeSet<>( String.CASE_INSENSITIVE_ORDER );
 					final List<Column> rootKeyColumns = persistentClass.getRootClass().getKey().getColumns();
 					final boolean identityColumn = rootKeyColumns.size() == 1 && rootKeyColumns.get( 0 ).isIdentity();
 					final boolean isExternallyGenerated;
 					if ( identityColumn ) {
 						isExternallyGenerated = false;
+						columnNames.add( ENTITY_TABLE_IDENTITY_COLUMN );
 						for ( Column column : persistentClass.getKey().getColumns() ) {
 							String sqlTypeName = "";
 							if ( dialect.getIdentityColumnSupport().hasDataTypeInIdentityColumn() ) {
@@ -280,7 +284,7 @@ public class TemporaryTable implements Exportable, Contributable {
 					else {
 						idName = "id";
 					}
-					forEachTemporaryTableColumn( metadata, temporaryTable, idName, persistentClass.getIdentifier(), temporaryTableColumn -> {
+					forEachTemporaryTableColumn( metadata, temporaryTable, idName, persistentClass.getIdentifier(), columnNames, temporaryTableColumn -> {
 						columns.add( new TemporaryTableColumn(
 								temporaryTableColumn.getContainingTable(),
 								temporaryTableColumn.getColumnName(),
@@ -295,7 +299,7 @@ public class TemporaryTable implements Exportable, Contributable {
 
 					final Value discriminator = persistentClass.getDiscriminator();
 					if ( discriminator != null && !discriminator.getSelectables().get( 0 ).isFormula() ) {
-						forEachTemporaryTableColumn( metadata, temporaryTable, "class", discriminator, temporaryTableColumn -> {
+						forEachTemporaryTableColumn( metadata, temporaryTable, "class", discriminator, columnNames, temporaryTableColumn -> {
 							columns.add( new TemporaryTableColumn(
 									temporaryTableColumn.getContainingTable(),
 									temporaryTableColumn.getColumnName(),
@@ -316,6 +320,7 @@ public class TemporaryTable implements Exportable, Contributable {
 									temporaryTable,
 									property.getName(),
 									property.getValue(),
+									columnNames,
 									columns::add
 							);
 						}
@@ -383,13 +388,19 @@ public class TemporaryTable implements Exportable, Contributable {
 		);
 	}
 
-	private static void forEachTemporaryTableColumn(Metadata metadata, TemporaryTable temporaryTable, String prefix, Value value, Consumer<TemporaryTableColumn> consumer) {
+	private static void forEachTemporaryTableColumn(
+			Metadata metadata,
+			TemporaryTable temporaryTable,
+			String prefix,
+			Value value,
+			Set<String> columnNames,
+			Consumer<TemporaryTableColumn> consumer) {
 		final Dialect dialect = metadata.getDatabase().getDialect();
-		SqmMutationStrategyHelper.forEachSelectableMapping( prefix, value, (columnName, selectable) -> {
+		SqmMutationStrategyHelper.forEachSelectableMapping( prefix, value, (attributePath, selectable) -> {
 			consumer.accept(
 					new TemporaryTableColumn(
 							temporaryTable,
-							columnName,
+							determineColumnName( selectable, dialect, columnNames ),
 							selectable.getType(),
 							selectable.getSqlType( metadata ),
 							selectable.getColumnSize( dialect, metadata ),
@@ -398,6 +409,22 @@ public class TemporaryTable implements Exportable, Contributable {
 					)
 			);
 		} );
+	}
+
+	private static String determineColumnName(Column column, Dialect dialect, Set<String> columnNames) {
+		// The temporary table mirrors the physical columns of the entity, so the physical column name is used
+		final String columnName = column.getQuotedName( dialect );
+		if ( columnNames.add( columnName ) ) {
+			return columnName;
+		}
+		// Fallback: the column name is qualified with the name of the table it belongs to
+		// Since even that is not guaranteed to be unique, a counter is appended as a last resort
+		final String qualifiedColumnName = column.getValue().getTable().getName() + "_" + column.getName();
+		String uniqueName = qualifiedColumnName;
+		for ( int i = 1; !columnNames.add( uniqueName ); i++ ) {
+			uniqueName = qualifiedColumnName + "_" + i;
+		}
+		return uniqueName;
 	}
 
 	public List<TemporaryTableColumn> findTemporaryTableColumns(EntityPersister entityDescriptor, ModelPart modelPart) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/SqmMutationStrategyHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/SqmMutationStrategyHelper.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.sqm.mutation.internal;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -350,10 +351,17 @@ public class SqmMutationStrategyHelper {
 				targetAttributeName = toOne.getReferencedPropertyName();
 				targetValue = targetEntity.getReferencedProperty( toOne.getReferencedPropertyName() ).getValue();
 			}
+			// Attribute paths come from the target, but the columns must be this association's foreign key
+			final Iterator<Selectable> keySelectables = toOne.getVirtualSelectables().iterator();
 			forEachSelectableMapping(
 					prefix + "_" + targetAttributeName,
 					targetValue,
-					consumer
+					(attributePath, targetColumn) -> {
+						// Selectable could be either a Column or a Formula, but we only want to pass Columns to the consumer
+						if ( keySelectables.next() instanceof Column keyColumn ) {
+							consumer.accept( attributePath, keyColumn );
+						}
+					}
 			);
 		}
 		else if ( value instanceof Any any ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/persister/entity/TemporaryTableColumnNamingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/persister/entity/TemporaryTableColumnNamingTest.java
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.persister.entity;
+
+import java.util.List;
+
+import org.hibernate.dialect.temptable.TemporaryTable;
+import org.hibernate.dialect.temptable.TemporaryTableColumn;
+import org.hibernate.query.sqm.mutation.internal.temptable.GlobalTemporaryTableInsertStrategy;
+import org.hibernate.query.sqm.mutation.internal.temptable.LocalTemporaryTableInsertStrategy;
+import org.hibernate.query.sqm.mutation.internal.temptable.PersistentTableInsertStrategy;
+import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
+
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * The entity temporary table ({@value TemporaryTable#ENTITY_TABLE_PREFIX}) must mirror the physical
+ * column names of the entity, not the names of the Java fields the columns are mapped to.
+ *
+ * @author Marek Hajdík
+ */
+@JiraKey("HHH-20343")
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsTemporaryTable.class)
+@DomainModel(annotatedClasses = {
+		TemporaryTableColumnNamingTest.Document.class,
+		TemporaryTableColumnNamingTest.Animal.class,
+		TemporaryTableColumnNamingTest.Dog.class
+})
+@SessionFactory
+public class TemporaryTableColumnNamingTest {
+
+	@Test
+	public void testSingleTableEntity(SessionFactoryScope scope) {
+		assertThat( entityTableColumnNames( scope, Document.class ) )
+				.containsExactlyInAnyOrder( "ID_", "DESCRIPTION_", "STREET_", "ZIP_", "PARENT_ID_" );
+	}
+
+	@Test
+	public void testJoinedInheritance(SessionFactoryScope scope) {
+		assertThat( entityTableColumnNames( scope, Animal.class ) )
+				.containsExactlyInAnyOrder( "ANIMAL_ID_", "NAME_" );
+		// ANIMAL.NAME_ and DOG.NAME_ are distinct columns of the same entity,
+		// so the second one is qualified with the name of the table it belongs to
+		assertThat( entityTableColumnNames( scope, Dog.class ) )
+				.containsExactlyInAnyOrder( "ANIMAL_ID_", "NAME_", "BREED_", "DOG_NAME_" );
+	}
+
+	private static List<String> entityTableColumnNames(SessionFactoryScope scope, Class<?> entityType) {
+		final SqmMultiTableInsertStrategy insertStrategy = scope.getSessionFactory().getMappingMetamodel()
+				.getEntityDescriptor( entityType )
+				.getSqmMultiTableInsertStrategy();
+		assertThat( insertStrategy )
+				.as( "No multi-table insert strategy for " + entityType.getSimpleName() )
+				.isNotNull();
+		final TemporaryTable entityTable = entityTable( insertStrategy );
+		assumeTrue( entityTable != null, "Dialect does not use a temporary table based insert strategy" );
+		return entityTable.getColumns().stream()
+				// Skip the synthetic columns, they are not mapped to any entity attribute
+				.filter( column -> column != entityTable.getSessionUidColumn() )
+				.map( TemporaryTableColumn::getColumnName )
+				.filter( columnName -> !TemporaryTable.ENTITY_TABLE_IDENTITY_COLUMN.equals( columnName )
+						&& !TemporaryTable.ENTITY_ROW_NUMBER_COLUMN.equals( columnName ) )
+				.toList();
+	}
+
+	private static TemporaryTable entityTable(SqmMultiTableInsertStrategy insertStrategy) {
+		if ( insertStrategy instanceof LocalTemporaryTableInsertStrategy strategy ) {
+			return strategy.getTemporaryTable();
+		}
+		else if ( insertStrategy instanceof GlobalTemporaryTableInsertStrategy strategy ) {
+			return strategy.getTemporaryTable();
+		}
+		else if ( insertStrategy instanceof PersistentTableInsertStrategy strategy ) {
+			return strategy.getTemporaryTable();
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * A pooled sequence generator forces the use of an entity temporary table,
+	 * even though the entity itself is mapped to a single table.
+	 */
+	@Entity
+	@Table(name = "DOCUMENT_TABLE")
+	public static class Document {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "document_generator")
+		@SequenceGenerator(name = "document_generator", sequenceName = "DOCUMENT_SEQ", allocationSize = 50)
+		@Column(name = "ID_")
+		private Long id;
+
+		@Column(name = "DESCRIPTION_")
+		private String description;
+
+		@Embedded
+		private Address address;
+
+		@ManyToOne
+		@JoinColumn(name = "PARENT_ID_")
+		private Document parent;
+	}
+
+	@Embeddable
+	public static class Address {
+
+		@Column(name = "STREET_")
+		private String street;
+
+		@Column(name = "ZIP_")
+		private String zipCode;
+	}
+
+	@Entity
+	@Table(name = "ANIMAL")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	public static class Animal {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "animal_generator")
+		@SequenceGenerator(name = "animal_generator", sequenceName = "ANIMAL_SEQ", allocationSize = 50)
+		@Column(name = "ANIMAL_ID_")
+		private Long id;
+
+		@Column(name = "NAME_")
+		private String name;
+	}
+
+	@Entity
+	@Table(name = "DOG")
+	public static class Dog extends Animal {
+
+		@Column(name = "BREED_")
+		private String breed;
+
+		@Column(name = "NAME_")
+		private String ownerName;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Fixes [HHH-20343](https://hibernate.atlassian.net/browse/HHH-20343), also reported on the [forum](https://discourse.hibernate.org/t/regression-issue-hibernate-7-x-hte-temporary-tables-use-java-field-name-instead-of-column-name/12380).
### Problem
Since [HHH-19521](https://hibernate.atlassian.net/browse/HHH-19521) the entity temporary table (HTE) names its columns after the Java attribute path instead of the physical column name. A physical name deliberately chosen to avoid a reserved word (e.g. "UID_") collapses back to that reserved word, and creation of the temporary table then fails at runtime. This worked in 6.x, where TemporaryTable used `column.getText( dialect )`.
### Changes
TemporaryTable uses the physical column name. Because an entity may span several tables, which are allowed to contain equally named columns, an ambiguous name is qualified with the name of its table (DOG_NAME). Since even that is not guaranteed to be unique (A_B.C vs A.B_C), a counter is appended as a last resort.
### Tests
TemporaryTableColumnNamingTest asserts the temporary table column names for an entity whose @Column names differ from the field names — id, basic attribute, `@Embedded` and `@ManyToOne` — plus a joined-inheritance case that also covers the duplicate column name fallback.
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-20343]: https://hibernate.atlassian.net/browse/HHH-20343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-19521]: https://hibernate.atlassian.net/browse/HHH-19521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20343 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->