### PR TITLE
HHH-18911 Fix usage of ConcreteProxy in lazy loaded ManyToOne reference

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -1864,6 +1864,10 @@ public class ToOneAttributeMapping
 				SqlAstJoinType.LEFT
 		);
 		if ( compatibleTableGroup != null ) {
+			creationState.getSqlAstCreationState().getFromClauseAccess().registerTableGroup(
+					fetchablePath,
+					compatibleTableGroup
+			);
 			return compatibleTableGroup;
 		}
 		// We have to create the table group that points to the target so that table reference resolving works

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/concrete/ConcreteProxyLazyManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/concrete/ConcreteProxyLazyManyToOneTest.java
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.proxy.concrete;
+
+import jakarta.persistence.*;
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.ConcreteProxy;
+import org.hibernate.sql.ast.SqlAstJoinType;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests lazy many-to-one association to a {@link ConcreteProxy} entity.
+ */
+@DomainModel(annotatedClasses = {
+		ConcreteProxyLazyManyToOneTest.Vehicle.class,
+		ConcreteProxyLazyManyToOneTest.Owner.class,
+		ConcreteProxyLazyManyToOneTest.Person.class,
+		ConcreteProxyLazyManyToOneTest.Company.class,
+})
+@SessionFactory(statementInspectorClass = SQLStatementInspector.class)
+@JiraKey("HHH-18911")
+public class ConcreteProxyLazyManyToOneTest {
+
+	@Test
+	public void testManyToOneWithInnerJoin(SessionFactoryScope scope) {
+		final SQLStatementInspector inspector = scope.getStatementInspector( SQLStatementInspector.class );
+		inspector.clear();
+		scope.inSession( session -> {
+			final List<Vehicle> vehicles =
+					session.createQuery( "select v from Vehicle v join v.owner o", Vehicle.class ).getResultList();
+			assertOwnerProxy( vehicles );
+			inspector.assertExecutedCount( 1 );
+		} );
+	}
+
+	@Test
+	public void testManyToOneWithLeftJoin(SessionFactoryScope scope) {
+		final SQLStatementInspector inspector = scope.getStatementInspector( SQLStatementInspector.class );
+		inspector.clear();
+		scope.inSession( session -> {
+			final List<Vehicle> vehicles =
+					session.createQuery( "select v from Vehicle v left join v.owner o", Vehicle.class ).getResultList();
+			assertOwnerProxy( vehicles );
+			inspector.assertExecutedCount( 1 );
+		} );
+	}
+
+	private static void assertOwnerProxy(List<Vehicle> vehicles) {
+		assertThat( vehicles.size(), is( 1 ) );
+		final Owner owner = vehicles.getFirst().getOwner();
+		assertThat( Hibernate.isInitialized( owner ), is( false ) );
+		assertThat( owner, instanceOf( Person.class ) );
+	}
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Vehicle vehicle = new Vehicle( 1L, new Person( 1L, "John" ) );
+			session.persist( vehicle );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Entity(name = "Vehicle")
+	public static class Vehicle {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		private Owner owner;
+
+		public Vehicle() {
+		}
+
+		public Vehicle(Long id, Owner owner) {
+			this.id = id;
+			this.owner = owner;
+			owner.getVehicles().add( this );
+		}
+
+		public Owner getOwner() {
+			return owner;
+		}
+	}
+
+	@Entity(name = "Owner")
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "type")
+	@ConcreteProxy
+	public static abstract class Owner {
+		@Id
+		private Long id;
+
+		@OneToMany(mappedBy = "owner")
+		private List<Vehicle> vehicles = new ArrayList<>();
+
+		public Owner() {
+		}
+
+		public Owner(Long id) {
+			this.id = id;
+		}
+
+		public List<Vehicle> getVehicles() {
+			return vehicles;
+		}
+	}
+
+	@Entity(name = "Person")
+	public static class Person extends Owner {
+		private String name;
+
+		public Person() {
+		}
+
+		public Person(Long id, String name) {
+			super( id );
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "Company")
+	public static class Company extends Owner {
+		private String companyName;
+
+		public Company() {
+		}
+
+		public Company(Long id, String companyName) {
+			super( id );
+			this.companyName = companyName;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Adding missing registration of compatible table group for lazy ManyToOne relationship. This is specifically needed when the lazy loaded reference is annotated with @ConcreteProxy, since it fails on `org.hibernate.sql.ast.SqlTreeCreationException: Could not locate TableGroup`

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-18911 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18911
<!-- Hibernate GitHub Bot issue links end -->