### PR TITLE
HHH-20785 Adapt for GaussDB version 505.2.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 db=h2
 dbVersion=latest
-
+# dbHost: local.databases.gradle prefers reading the JVM system property -DdbHost; if not set, it falls back to this project property, and finally defaults to localhost.
+# You can set dbHost=<host:port> here, or override it at runtime with -DdbHost=<host:port>.
+dbHost=<host:port>
 # Keep all these properties in sync unless you know what you are doing!
 # We set '-Dlog4j2.disableJmx=true' to prevent classloader leaks triggered by the logger.
 # (Some of these settings need to be repeated in the test.jvmArgs blocks of each module)

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBArrayJdbcType.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBArrayJdbcType.java
@@ -6,17 +6,23 @@ package org.hibernate.community.dialect;
 
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.BasicPluralJavaType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
 import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.BasicBinder;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**
@@ -33,9 +39,74 @@ public class GaussDBArrayJdbcType extends ArrayJdbcType {
 	}
 
 	@Override
+	protected String getElementTypeName(JavaType<?> javaType, SharedSessionContractImplementor session) {
+		// GaussDB M mode stores DATE columns as the non-standard `datea` type, so a date array
+		// column is `datea[]`. The base implementation resolves the element type name through the
+		// DDL type registry, which yields "date" for DATE — `createArrayOf("date", ...)` then
+		// produces a `date[]` array that GaussDB M mode rejects ("column ... is of type datea[] but
+		// expression is of type date[]"). Return "datea" for date elements so the array is built
+		// as `datea[]`, matching the column type.
+		// A mode (openGauss PG kernel) stores DATE as the standard `date` (reported as timestamp by
+		// the JDBC driver), and createArrayOf("date") works — so fall through to the base
+		// implementation, which yields "date". Without this guard A mode passed "datea" to
+		// createArrayOf and failed with "Unable to find server array type for provided name datea".
+		// The array element is the standard LocalDateJdbcType (jdbc code DATE), not
+		// GaussDBLocalDateJdbcType (which is OTHER/1111 and only used to read `datea` columns
+		// directly), so check the jdbc type code rather than the concrete class.
+		if ( getElementJdbcType().getJdbcTypeCode() == Types.DATE ) {
+			final var dialect = session.getJdbcServices().getDialect();
+			if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+				return "datea";
+			}
+		}
+		return super.getElementTypeName( javaType, session );
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaTypeDescriptor) {
 		return new Binder<>( javaTypeDescriptor,
 				(BasicPluralJavaType<?>) javaTypeDescriptor );
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(final JavaType<X> javaTypeDescriptor) {
+		if ( getElementJdbcType().getJdbcTypeCode() == Types.DATE ) {
+			// gsjdbc4 returns PGobject for datea[] array elements (via java.sql.Array.getArray()),
+			// which LocalDateJavaType.wrap can't handle. Read each element through
+			// getResultSet().getDate(2) — reusing the same datea→java.sql.Date conversion that
+			// GaussDBLocalDateJdbcType uses for scalar datea columns — then let ArrayJavaType wrap
+			// the java.sql.Date[] via the standard LocalDateJavaType.wrap(java.sql.Date) path.
+			return new BasicExtractor<>( javaTypeDescriptor, this ) {
+				@Override
+				protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+					return getJavaType().wrap( toDateArray( rs.getArray( paramIndex ) ), options );
+				}
+
+				@Override
+				protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+					return getJavaType().wrap( toDateArray( statement.getArray( index ) ), options );
+				}
+
+				@Override
+				protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+					return getJavaType().wrap( toDateArray( statement.getArray( name ) ), options );
+				}
+			};
+		}
+		return super.getExtractor( javaTypeDescriptor );
+	}
+
+	private static java.sql.Date[] toDateArray(java.sql.Array array) throws SQLException {
+		if ( array == null ) {
+			return null;
+		}
+		try ( ResultSet rs = array.getResultSet() ) {
+			final List<java.sql.Date> dates = new ArrayList<>();
+			while ( rs.next() ) {
+				dates.add( rs.getDate( 2 ) );
+			}
+			return dates.toArray( new java.sql.Date[0] );
+		}
 	}
 
 	private class Binder<X,E> extends BasicBinder<X> {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBBooleanJdbcType.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBBooleanJdbcType.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.BooleanJdbcType;
+
+/**
+ * Boolean JdbcType for GaussDB M mode that reads boolean columns via {@code getString} instead of
+ * {@code getBoolean}, bypassing gsjdbc4's {@code MBooleanTypeUtils.castToBoolean}.
+ *
+ * In M mode (MySQL-compatible) boolean columns are stored as int1/uint8. gsjdbc4's
+ * {@code MResultSet.getBoolean} routes non-BOOLEAN/BIT columns through
+ * {@code MBooleanTypeUtils.castToBoolean}, which only accepts Boolean/Integer/Long/Float/Double/
+ * BigDecimal/String and rejects {@code java.math.BigInteger} &mdash; the value returned for uint8
+ * columns, which CASE expressions such as {@code case when ... then true else false end} produce &mdash;
+ * raising "Cannot cast to boolean". Reading as String and parsing avoids castToBoolean entirely.
+ *
+ * Only registered in M mode (see {@code GaussDBDialect#contributeGaussDBTypes}); A mode keeps the
+ * base {@link BooleanJdbcType} (getBoolean), so A mode is constructively unaffected.
+ *
+ * @author liubao
+ *
+ * Notes: Original code of this class is based on BooleanJdbcType.
+ */
+public class GaussDBBooleanJdbcType extends BooleanJdbcType {
+
+	public static final GaussDBBooleanJdbcType INSTANCE = new GaussDBBooleanJdbcType();
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(final JavaType<X> javaType) {
+		return new BasicExtractor<>( javaType, this ) {
+			@Override
+			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				final String value = rs.getString( paramIndex );
+				if ( rs.wasNull() ) {
+					return javaType.wrap( null, options );
+				}
+				// M mode int1/uint8 columns return "0"/"1"; accept the common boolean spellings.
+				final boolean bool = "1".equals( value )
+						|| "t".equals( value )
+						|| "true".equalsIgnoreCase( value );
+				return javaType.wrap( bool, options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				final boolean bool = statement.getBoolean( index );
+				return javaType.wrap( statement.wasNull() ? null : bool, options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+				final boolean bool = statement.getBoolean( name );
+				return javaType.wrap( statement.wasNull() ? null : bool, options );
+			}
+		};
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBCastingInetJdbcType.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBCastingInetJdbcType.java
@@ -40,9 +40,17 @@ public class GaussDBCastingInetJdbcType implements JdbcType {
 			@Nullable Size size,
 			SqlAppender appender,
 			Dialect dialect) {
-		appender.append( "cast(" );
-		appender.append( writeExpression );
-		appender.append( " as inet)" );
+		if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+			// M mode (MySQL-compatible) has no native `inet` type — the column is `varchar(45)` and the
+			// binder uses setString, so emit the raw write expression without a `cast(... as inet)`.
+			// A mode (openGauss PG kernel) keeps the cast to `inet`.
+			appender.append( writeExpression );
+		}
+		else {
+			appender.append( "cast(" );
+			appender.append( writeExpression );
+			appender.append( " as inet)" );
+		}
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBCastingIntervalSecondJdbcType.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBCastingIntervalSecondJdbcType.java
@@ -64,9 +64,16 @@ public class GaussDBCastingIntervalSecondJdbcType implements AdjustableJdbcType 
 					SqlAppender sqlAppender,
 					SqlAstTranslator<?> walker,
 					SessionFactoryImplementor sessionFactory) {
-				sqlAppender.append( "extract(epoch from " );
-				expression.accept( walker );
-				sqlAppender.append( ')' );
+				final Dialect dialect = sessionFactory.getJdbcServices().getDialect();
+				if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+					// M mode: column is numeric (seconds), read directly — no extract(epoch)
+					expression.accept( walker );
+				}
+				else {
+					sqlAppender.append( "extract(epoch from " );
+					expression.accept( walker );
+					sqlAppender.append( ')' );
+				}
 			}
 
 			@Override
@@ -82,9 +89,15 @@ public class GaussDBCastingIntervalSecondJdbcType implements AdjustableJdbcType 
 			@Nullable Size size,
 			SqlAppender appender,
 			Dialect dialect) {
-		appender.append( '(' );
-		appender.append( writeExpression );
-		appender.append( "*interval'1 second')" );
+		if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+			// M mode: column is numeric (seconds), bind BigDecimal directly — no interval cast
+			appender.append( writeExpression );
+		}
+		else {
+			appender.append( '(' );
+			appender.append( writeExpression );
+			appender.append( "*interval'1 second')" );
+		}
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBDialect.java
@@ -16,7 +16,10 @@ import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.community.dialect.identity.GaussDBIdentityColumnSupport;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.community.dialect.lock.internal.GaussDBLockingSupport;
+import org.hibernate.community.dialect.sequence.GaussDBMModeSequenceInformationExtractor;
+import org.hibernate.community.dialect.sequence.GaussDBMModeSequenceSupport;
 import org.hibernate.community.dialect.sequence.GaussDBSequenceSupport;
 import org.hibernate.dialect.BooleanDecoder;
 import org.hibernate.dialect.Dialect;
@@ -24,18 +27,25 @@ import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.DmlTargetColumnQualifierSupport;
 import org.hibernate.dialect.FunctionalDependencyAnalysisSupport;
 import org.hibernate.dialect.FunctionalDependencyAnalysisSupportImpl;
+import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.NationalizationSupport;
 import org.hibernate.dialect.RowLockStrategy;
 import org.hibernate.dialect.SelectItemReferenceStrategy;
 import org.hibernate.dialect.TimeZoneSupport;
+import org.hibernate.dialect.temptable.StandardLocalTemporaryTableStrategy;
+import org.hibernate.dialect.temptable.TemporaryTableStrategy;
+import org.hibernate.query.sqm.mutation.spi.AfterUseAction;
+import org.hibernate.community.dialect.aggregate.GaussDBAggregateSupport;
 import org.hibernate.dialect.aggregate.AggregateSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
+import org.hibernate.dialect.identity.MySQLIdentityColumnSupport;
 import org.hibernate.dialect.lock.spi.LockingSupport;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.LimitLimitHandler;
 import org.hibernate.dialect.sequence.SequenceSupport;
 import org.hibernate.dialect.unique.CreateTableUniqueDelegate;
 import org.hibernate.dialect.unique.UniqueDelegate;
+import org.hibernate.procedure.internal.PostgreSQLCallableStatementSupport;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.jdbc.env.spi.IdentifierCaseStrategy;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
@@ -62,6 +72,8 @@ import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.mutation.internal.cte.CteInsertStrategy;
 import org.hibernate.query.sqm.mutation.internal.cte.CteMutationStrategy;
+import org.hibernate.query.sqm.mutation.internal.temptable.LocalTemporaryTableInsertStrategy;
+import org.hibernate.query.sqm.mutation.internal.temptable.LocalTemporaryTableMutationStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
 import org.hibernate.service.ServiceRegistry;
@@ -74,11 +86,9 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
-import org.hibernate.sql.model.jdbc.OptionalTableUpdateOperation;
-import org.hibernate.tool.schema.extract.internal.InformationExtractorPostgreSQLImpl;
+import org.hibernate.sql.model.jdbc.OptionalTableUpdateWithUpsertOperation;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
-import org.hibernate.tool.schema.extract.spi.ExtractionContext;
-import org.hibernate.tool.schema.extract.spi.InformationExtractor;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.tool.schema.internal.StandardTableExporter;
 import org.hibernate.tool.schema.spi.Exporter;
 import org.hibernate.type.JavaObjectType;
@@ -88,6 +98,7 @@ import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.ObjectNullAsBinaryTypeJdbcType;
 import org.hibernate.type.descriptor.jdbc.SqlTypedJdbcType;
+import org.hibernate.type.descriptor.jdbc.VarcharUUIDJdbcType;
 import org.hibernate.type.descriptor.jdbc.XmlJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.descriptor.sql.internal.ArrayDdlTypeImpl;
@@ -109,32 +120,48 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
+import java.util.UUID;
 
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
 import static org.hibernate.query.common.TemporalUnit.EPOCH;
 import static org.hibernate.type.SqlTypes.ARRAY;
+import static org.hibernate.type.SqlTypes.BIGINT;
 import static org.hibernate.type.SqlTypes.BINARY;
+import static org.hibernate.type.SqlTypes.BIT;
+import static org.hibernate.type.SqlTypes.BLOB;
+import static org.hibernate.type.SqlTypes.BOOLEAN;
 import static org.hibernate.type.SqlTypes.CHAR;
+import static org.hibernate.type.SqlTypes.DOUBLE;
 import static org.hibernate.type.SqlTypes.FLOAT;
 import static org.hibernate.type.SqlTypes.GEOGRAPHY;
 import static org.hibernate.type.SqlTypes.GEOMETRY;
 import static org.hibernate.type.SqlTypes.INET;
+import static org.hibernate.type.SqlTypes.INTEGER;
+import static org.hibernate.type.SqlTypes.INTERVAL_SECOND;
 import static org.hibernate.type.SqlTypes.JSON;
 import static org.hibernate.type.SqlTypes.LONG32NVARCHAR;
 import static org.hibernate.type.SqlTypes.LONG32VARBINARY;
 import static org.hibernate.type.SqlTypes.LONG32VARCHAR;
 import static org.hibernate.type.SqlTypes.NCHAR;
 import static org.hibernate.type.SqlTypes.NCLOB;
+import static org.hibernate.type.SqlTypes.NUMERIC;
+import static org.hibernate.type.SqlTypes.CLOB;
+import static org.hibernate.type.SqlTypes.DECIMAL;
 import static org.hibernate.type.SqlTypes.NVARCHAR;
 import static org.hibernate.type.SqlTypes.OTHER;
+import static org.hibernate.type.SqlTypes.REAL;
+import static org.hibernate.type.SqlTypes.SMALLINT;
 import static org.hibernate.type.SqlTypes.SQLXML;
 import static org.hibernate.type.SqlTypes.STRUCT;
 import static org.hibernate.type.SqlTypes.TIME;
 import static org.hibernate.type.SqlTypes.TIMESTAMP;
 import static org.hibernate.type.SqlTypes.TIMESTAMP_UTC;
 import static org.hibernate.type.SqlTypes.TIMESTAMP_WITH_TIMEZONE;
+import static org.hibernate.type.SqlTypes.TIME_WITH_TIMEZONE;
 import static org.hibernate.type.SqlTypes.TIME_UTC;
 import static org.hibernate.type.SqlTypes.TINYINT;
 import static org.hibernate.type.SqlTypes.UUID;
@@ -160,6 +187,18 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithM
 public class GaussDBDialect extends Dialect {
 	protected final static DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 2 );
 
+	/**
+	 * Configuration key to explicitly set the GaussDB compatibility mode (e.g. {@code =M}). Used when
+	 * JDBC metadata is unavailable on boot ({@code hibernate.temp.use_jdbc_metadata_defaults=false}),
+	 * where the {@code datcompatibility} probe cannot run; the gaussdb test profile sets it to {@code M}.
+	 */
+	public final static String GAUSSDB_COMPATIBILITY_MODE = "hibernate.dialect.gaussdb.compatibility_mode";
+
+	// GaussDB compatibility mode of the target database (pg_database.datcompatibility):
+	// "A" = Oracle-compatible, "B"/"M" = MySQL-compatible, "pg" = PostgreSQL-compatible.
+	// Defaults to "A"; detection runs from the DialectResolutionInfo constructor.
+	private String compatibilityMode = "A";
+
 	private final UniqueDelegate uniqueDelegate = new CreateTableUniqueDelegate(this);
 	private final StandardTableExporter gaussDBTableExporter = new StandardTableExporter( this ) {
 		@Override
@@ -173,26 +212,100 @@ public class GaussDBDialect extends Dialect {
 		}
 	};
 
-	private final OptionalTableUpdateStrategy optionalTableUpdateStrategy;
-
 	public GaussDBDialect() {
 		this(MINIMUM_VERSION);
 	}
 
 	public GaussDBDialect(DialectResolutionInfo info) {
 		this( info.makeCopyOrDefault( MINIMUM_VERSION ));
+		detectCompatibilityMode( info );
 		registerKeywords( info );
 	}
 
 	public GaussDBDialect(DatabaseVersion version) {
 		super( version );
-		this.optionalTableUpdateStrategy = determineOptionalTableUpdateStrategy( version );
+		// M mode reserves `excluded` as a keyword (PostgreSQL treats it as non-reserved, usable as a column name),
+		// so identifiers named "excluded" must be quoted. GaussDB upserts use ON DUPLICATE KEY (not ON CONFLICT's
+		// EXCLUDED alias), so quoting the identifier is safe.
+		registerKeyword( "excluded" );
 	}
 
-	private static OptionalTableUpdateStrategy determineOptionalTableUpdateStrategy(DatabaseVersion version) {
-		return version.isSameOrAfter( DatabaseVersion.make( 15, 0 ) )
-				? GaussDBDialect::usingMerge
-				: GaussDBDialect::withoutMerge;
+	private void detectCompatibilityMode(DialectResolutionInfo info) {
+		// The compatibility mode (A=Oracle, M/B=MySQL) drives nearly every M-mode override. Prefer an
+		// explicit `hibernate.dialect.gaussdb.compatibility_mode` config value: it works even when JDBC
+		// metadata is disallowed on boot (hibernate.temp.use_jdbc_metadata_defaults=false, e.g. the
+		// SchemaUpdate tests), where metadata is null and the datcompatibility probe below cannot run —
+		// without it the dialect would silently default to "A" and break information_schema.sequences
+		// extraction (M mode has no such view). Fall back to probing datcompatibility when no explicit
+		// mode is configured.
+		final Map<String, Object> configValues = info.getConfigurationValues();
+		if ( configValues != null ) {
+			final Object configured = configValues.get( GAUSSDB_COMPATIBILITY_MODE );
+			if ( configured != null ) {
+				final String mode = configured.toString().trim();
+				if ( !mode.isEmpty() ) {
+					applyCompatibilityMode( mode );
+					return;
+				}
+			}
+		}
+		final DatabaseMetaData metaData = info.getDatabaseMetadata();
+		if ( metaData == null ) {
+			return;
+		}
+		try ( java.sql.Statement statement = metaData.getConnection().createStatement();
+				ResultSet rs = statement.executeQuery(
+						"select datcompatibility from pg_database where datname = current_database()" ) ) {
+			if ( rs.next() ) {
+				final String mode = rs.getString( 1 );
+				if ( mode != null ) {
+					applyCompatibilityMode( mode.trim() );
+				}
+			}
+		}
+		catch (SQLException e) {
+			// keep default ("A") on detection failure
+		}
+	}
+
+	private void applyCompatibilityMode(String mode) {
+		this.compatibilityMode = mode;
+		// initDefaultProperties() ran during super() construction while compatibilityMode was still the
+		// default "A", so re-sync the USE_GET_GENERATED_KEYS default now that the real mode is known.
+		// M mode must disable getGeneratedKeys: gsjdbc4 implements it by rewriting the INSERT with a
+		// RETURNING clause, which single-node M mode rejects ("Unsupported function. only supported in
+		// distributed database").
+		getDefaultProperties().setProperty(
+				AvailableSettings.USE_GET_GENERATED_KEYS,
+				Boolean.toString( !isMMode() )
+		);
+	}
+
+	/**
+	 * Whether the target database runs in MySQL-compatible mode (datcompatibility "B" or "M").
+	 */
+	public boolean isMMode() {
+		return "M".equals( compatibilityMode ) || "B".equals( compatibilityMode );
+	}
+
+	/**
+	 *
+	 * M mode (MySQL-compatible) treats double quotes as string literals, not identifier quoting, so
+	 * {@code create table "User" (...)} raises a syntax error. Identifiers must be quoted with
+	 * backticks (`` ` ``), matching {@link org.hibernate.dialect.MySQLDialect}. A mode keeps the
+	 * PostgreSQL-style double quote. This is the single entry point for all identifier quoting
+	 * (explicit {@code \"name\"} in mappings, auto-quoting of reserved keywords, DDL/SQL generation),
+	 * so overriding it covers every code path (see {@code Dialect#toQuotedIdentifier},
+	 * {@code Column#getQuotedName}, {@code sql.Template}).
+	 */
+	@Override
+	public char openQuote() {
+		return isMMode() ? '`' : '"';
+	}
+
+	@Override
+	public char closeQuote() {
+		return isMMode() ? '`' : '"';
 	}
 
 	@Override
@@ -211,16 +324,57 @@ public class GaussDBDialect extends Dialect {
 			// no tinyint
 			case TINYINT -> "smallint";
 
+			// M mode (MySQL-compatible) CHAR strips trailing spaces on retrieval (MySQL CHAR
+			// semantics), so a single space ' ' stored in char(1) reads back as '' — breaking
+			// CharacterTypeTest which expects the space preserved. Use varchar($l), which retains
+			// trailing spaces. A mode (Oracle-compatible) keeps the native char type.
+			case CHAR -> isMMode() ? "varchar($l)" : super.columnType( CHAR );
+
 			// there are no nchar/nvarchar types
 			case NCHAR -> columnType( CHAR );
 			case NVARCHAR -> columnType( VARCHAR );
 
-			case LONG32VARCHAR, LONG32NVARCHAR -> "text";
-			case NCLOB -> "clob";
+			// M mode (MySQL-compatible) TEXT tops out at 65535 bytes; LONG32/CLOB values (e.g. 240k+
+			// chars) overflow. Use `longtext` (4GB) like MySQLDialect. A mode keeps `text` (unbounded).
+			case LONG32VARCHAR, LONG32NVARCHAR -> isMMode() ? "longtext" : "text";
+			// M mode (MySQL-compatible) has no `clob` type (syntax error at "clob"); use `longtext`.
+			// A mode (Oracle-compatible) keeps `clob`.
+			case NCLOB -> isMMode() ? "longtext" : "clob";
+			case CLOB -> isMMode() ? "longtext" : super.columnType( CLOB );
 
-			case BINARY, VARBINARY, LONG32VARBINARY -> "bytea";
+			// M mode (MySQL-compatible) rejects `bytea`; use binary/varbinary/blob.
+			// `binary` without a length defaults to 1 byte in M mode, so BINARY must carry $l
+			// (e.g. a UUID stored as BINARY is 16 bytes and would otherwise exceed `binary(1)`).
+			// A mode (Oracle-compatible) keeps `bytea`.
+			case BINARY -> isMMode() ? "binary($l)" : "bytea";
+			case VARBINARY -> isMMode() ? "varbinary($l)" : "bytea";
+			case LONG32VARBINARY -> isMMode() ? "longblob" : "bytea"; // longblob (4GB): M mode blob is 65535, LONG32 byte[] (240k+) overflows
+
+			// M mode (MySQL-compatible) has no native `uuid` column type (syntax error on `theuuid uuid`),
+			// so map UUID to `varchar(36)` and pair it with VarcharUUIDJdbcType (read/write UUID as varchar).
+			// A mode (Oracle-compatible) keeps the native `uuid` type via GaussDBUUIDJdbcType.
+			case UUID -> isMMode() ? "varchar(36)" : super.columnType( UUID );
+
+			// M mode has no native `inet` (see registerColumnTypes); keep columnType consistent so
+			// sized casts / fallbacks render `varchar(45)` too. A mode keeps the default `inet`.
+			case INET -> isMMode() ? "varchar(45)" : super.columnType( INET );
 
 			case TIMESTAMP_UTC -> columnType( TIMESTAMP_WITH_TIMEZONE );
+
+			// M mode: the `timestamp` type rejects dates at or before the epoch (1970-01-01),
+			// so map TIMESTAMP to `datetime` (range 1000-9999), matching MySQLDialect. A mode
+			// keeps the default `timestamp` (Oracle-compatible, wide range).
+			case TIMESTAMP -> isMMode() ? "datetime($p)" : super.columnType( TIMESTAMP );
+
+			// M mode (MySQL-compatible) has no timezone-aware timestamp type: both `timestamptz`
+			// and `timestamp with time zone` are syntax errors. Map WITH_TIMEZONE to `datetime`
+			// too, relying on the JDBC layer for timezone conversion (as MySQLDialect does).
+			case TIMESTAMP_WITH_TIMEZONE -> isMMode() ? "datetime($p)" : super.columnType( TIMESTAMP_WITH_TIMEZONE );
+
+			// M mode (MySQL-compatible) has no `time with time zone` type (syntax error on CREATE TABLE);
+			// map TIME_WITH_TIMEZONE to plain `time`, matching MySQLDialect (which also lacks a
+			// timezone-aware time type). A mode keeps the default `time with time zone`.
+			case TIME_WITH_TIMEZONE -> isMMode() ? "time" : super.columnType( TIME_WITH_TIMEZONE );
 
 			default -> super.columnType( sqlTypeCode );
 		};
@@ -236,10 +390,37 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	protected String castType(int sqlTypeCode) {
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible) CAST only accepts MySQL type names (char/signed/unsigned/
+			// binary/decimal/datetime/...); PostgreSQL names (varchar/text/integer/bigint/numeric/
+			// timestamp/...) are syntax errors in CAST. Sized casts (varchar(15)/numeric(38,2)) must
+			// use a $l/$p/$s pattern, otherwise DdlTypeImpl.getCastTypeName falls back to the
+			// columnType (varchar($l)/numeric($p,$s)) which M mode rejects; types without a default
+			// length (char/clob/text) stay static so the no-size path doesn't leave $l unsubstituted.
+			return switch (sqlTypeCode) {
+				case BOOLEAN, BIT -> "unsigned";
+				case TINYINT, SMALLINT, INTEGER, BIGINT -> "signed";
+				case FLOAT, REAL, DOUBLE -> "double";
+				case NUMERIC, DECIMAL -> "decimal($p,$s)";
+				case TIMESTAMP, TIMESTAMP_WITH_TIMEZONE -> "datetime";
+				case VARCHAR, NVARCHAR, CHAR, NCHAR -> "char($l)";
+				// CHAR/NCHAR use "char($l)" (not static "char") so sized casts resolve via
+				// castType to `char(N)`. DdlTypeImpl forces a Character cast to length=1, and a
+				// static castType would fall back to columnType — which is `varchar($l)` in M mode
+				// (to preserve trailing spaces for CharacterTypeTest) — producing `cast(x as varchar(1))`,
+				// a syntax error (M mode CAST only accepts `char`, not `varchar`).
+				case LONG32VARCHAR, LONG32NVARCHAR, CLOB, NCLOB -> "char";
+				case UUID, INET -> "char";
+				case VARBINARY -> "binary($l)";
+				case BINARY, LONG32VARBINARY, BLOB -> "binary";
+				default -> super.castType( sqlTypeCode );
+			};
+		}
 		return switch (sqlTypeCode) {
 			case CHAR, NCHAR, VARCHAR, NVARCHAR -> "varchar";
 			case LONG32VARCHAR, LONG32NVARCHAR -> "text";
 			case NCLOB -> "clob";
+			case CLOB -> super.castType( CLOB );
 			case BINARY, VARBINARY, LONG32VARBINARY -> "bytea";
 			default -> super.castType( sqlTypeCode );
 		};
@@ -263,15 +444,31 @@ public class GaussDBDialect extends Dialect {
 						.build()
 		);
 
-		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( SQLXML, "xml", this ) );
-		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( UUID, "uuid", this ) );
-		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INET, "inet", this ) );
+		// M mode (MySQL-compatible) has no native `xml` type (syntax error on `x xml`); store XML as `text`.
+		// A mode (openGauss PG kernel) keeps `xml`.
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( SQLXML, isMMode() ? "text" : "xml", this ) );
+		// M mode (MySQL-compatible) has no native `uuid` type (syntax error on `theuuid uuid`);
+		// store UUID as `varchar(36)` paired with VarcharUUIDJdbcType. A mode keeps `uuid`.
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( UUID, isMMode() ? "varchar(36)" : "uuid", this ) );
+		// M mode (MySQL-compatible) has no native `inet` type (syntax error on `x inet`); store IPv4/IPv6
+		// addresses as `varchar(45)` (PG inet is text-based, GaussDBCastingInetJdbcType binds/reads strings).
+		// A mode (openGauss PG kernel) keeps `inet`.
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INET, isMMode() ? "varchar(45)" : "inet", this ) );
 		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOMETRY, "geometry", this ) );
 		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOGRAPHY, "geography", this ) );
-		ddlTypeRegistry.addDescriptor( new Scale6IntervalSecondDdlType( this ) );
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible) has no native interval column type (syntax error on
+			// `interval second(6)`); store Duration seconds as numeric($p,$s) instead.
+			// A mode (openGauss PG kernel) keeps the native `interval second($s)` type.
+			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INTERVAL_SECOND, "numeric($p,$s)", this ) );
+		}
+		else {
+			ddlTypeRegistry.addDescriptor( new Scale6IntervalSecondDdlType( this ) );
+		}
 
-		// Prefer jsonb if possible
-		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "jsonb", this ) );
+		// GaussDB in MySQL-compatibility (M) mode does not support creating `jsonb` tables
+		// (syntax error at "JSONB"), so use the `json` type instead
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "json", this ) );
 
 		ddlTypeRegistry.addDescriptor( new NamedNativeEnumDdlTypeImpl( this ) );
 		ddlTypeRegistry.addDescriptor( new NamedNativeOrdinalEnumDdlTypeImpl( this ) );
@@ -279,7 +476,10 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public int getMaxVarcharLength() {
-		return 10_485_760;
+		// M mode (MySQL-compatible) caps varchar at 16383 bytes; longer strings must
+		// use text (the LONG32VARCHAR fallback maps to "text"). A mode (Oracle-compatible)
+		// supports the larger 10MB varchar. Mirrors MySQLDialect#getMaxVarcharLength.
+		return isMMode() ? 16_383 : 10_485_760;
 	}
 
 	@Override
@@ -290,8 +490,11 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public int getMaxVarbinaryLength() {
-		//has no varbinary-like type
-		return Length.LONG32;
+		// M mode (MySQL-compatible) varbinary tops out at 65535 bytes (like MySQL). Return 65535 so
+		// longer byte[] upgrades to LONG32VARBINARY -> longblob (see columnType); returning LONG32
+		// makes long32/lob columns render varbinary(2147483647) which M mode rejects on CREATE TABLE.
+		// A mode (bytea, unbounded) keeps LONG32.
+		return isMMode() ? 65_535 : Length.LONG32;
 	}
 
 	@Override
@@ -422,18 +625,81 @@ public class GaussDBDialect extends Dialect {
 	}
 
 	@Override
+	public String currentDate() {
+		if ( isMMode() ) {
+			// M mode (MySQL kernel): `current_date` is already a pure `date` type carrying no
+			// time-of-day (e.g. `2026-07-16`), so it needs no truncation. `trunc(current_date)`
+			// is MySQL-incompatible here and returns the zero date `0000-00-00 00:00:00`, which
+			// breaks date comparisons such as HQL `local date > all elements(p.repairTimestamps)`.
+			return "current_date";
+		}
+		// A mode (Oracle-compatible, openGauss PG kernel): current_date may carry time-of-day,
+		// so truncate to the day for date arithmetic (e.g. `date_trunc('day', localtimestamp) - current_date`).
+		return "trunc(current_date)";
+	}
+
+	@Override
 	public String currentTime() {
 		return "localtime";
 	}
 
 	@Override
 	public String currentTimestamp() {
+		if ( isMMode() ) {
+			// M mode (MySQL kernel): bare `localtimestamp` is second-precision, so two timestamps
+			// produced within the same second compare equal. @CurrentTimestamp/@CreationTimestamp/
+			// @UpdateTimestamp tests that update an entity ~10ms apart then fail, even though
+			// getDefaultTimestampPrecision()==6 advertises microsecond precision (via the
+			// CurrentTimestampHasMicrosecondPrecision feature check). Emit `now(6)` to match the
+			// datetime($p) column type and yield microsecond precision. A mode (openGauss PG kernel)
+			// keeps bare `localtimestamp` (microsecond by default) — zero regression.
+			return "now(" + getDefaultTimestampPrecision() + ")";
+		}
 		return "localtimestamp";
 	}
 
 	@Override
 	public String currentTimestampWithTimeZone() {
+		if ( isMMode() ) {
+			// M mode (MySQL kernel): bare `current_timestamp` is second-precision — same issue as
+			// currentTimestamp() above. The `instant` HQL function (= currentTimestampWithTimeZone) fills
+			// @Temporal temporal-table effective_from/effective_to; second-precision makes two writes within
+			// the same second compare equal, breaking asOf(instant) (the strict `effective_to > instant`
+			// filter excludes the historical row, so the current row is returned instead). Emit `now(6)`
+			// for microsecond precision, matching currentTimestamp() and the datetime($p) column type.
+			// A mode (openGauss PG kernel) keeps bare `current_timestamp` (timestamptz, microsecond by
+			// default) — zero regression.
+			return "now(" + getDefaultTimestampPrecision() + ")";
+		}
 		return "current_timestamp";
+	}
+
+	@Override
+	public String getColumnDefaultString(String defaultValue) {
+		if ( isMMode() ) {
+			// M mode requires a datetime(N) column's current-timestamp default to carry matching
+			// precision (N); the bare CURRENT_TIMESTAMP that @ColumnDefault produces is rejected
+			// ("The default value of the ... type is invalid"). now(getDefaultTimestampPrecision())
+			// matches the datetime($p) columnType, whose $p defaults to getDefaultTimestampPrecision()
+			// (6). A mode keeps the super behaviour.
+			final String upper = defaultValue.trim().toUpperCase( Locale.ROOT );
+			if ( upper.equals( "CURRENT_TIMESTAMP" ) || upper.equals( "CURRENT_TIMESTAMP()" )
+					|| upper.equals( "LOCALTIMESTAMP" ) || upper.equals( "LOCALTIMESTAMP()" )
+					|| upper.equals( "NOW" ) || upper.equals( "NOW()" ) ) {
+				return "now(" + getDefaultTimestampPrecision() + ")";
+			}
+		}
+		return super.getColumnDefaultString( defaultValue );
+	}
+
+	@Override
+	public boolean supportsUserDefinedTypes() {
+		// A mode (openGauss PG kernel) supports PostgreSQL-style composite types (`create type ... as (...)`)
+		// for @Struct mapping; GaussDBStructuredJdbcType handles the read/write. The Dialect base default is
+		// false, so override to true for A mode. M mode (MySQL-compatible) rejects CREATE TYPE / DROP TYPE
+		// (syntax error at "type"), so disable @Struct mapping there — the schema generator then skips the
+		// `create type` DDL that would otherwise fail.
+		return !isMMode();
 	}
 
 	/**
@@ -444,6 +710,22 @@ public class GaussDBDialect extends Dialect {
 	 */
 	@Override
 	public String extractPattern(TemporalUnit unit) {
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible) extract() only supports year/month/day/quarter/week/hour/
+			// minute/second; dow/doy/epoch raise "units does not supported" regardless of source type.
+			// Mirror MySQLDialect: use the native MySQL functions (dayofweek/dayofyear/unix_timestamp/
+			// ...) which accept a DATE source directly, so GaussDBExtractFunction need not cast to
+			// timestamp (and `cast(?2 as timestamp)` is itself a syntax error in M mode).
+			return switch (unit) {
+				case SECOND -> "(second(?2)+microsecond(?2)/1e6)";
+				case WEEK -> "weekofyear(?2)";
+				case DAY_OF_WEEK -> "dayofweek(?2)";
+				case DAY_OF_MONTH -> "dayofmonth(?2)";
+				case DAY_OF_YEAR -> "dayofyear(?2)";
+				case EPOCH -> "unix_timestamp(?2)";
+				default -> "?1(?2)";
+			};
+		}
 		return switch (unit) {
 			case DAY_OF_WEEK -> "(" + super.extractPattern( unit ) + "+1)";
 			default -> super.extractPattern(unit);
@@ -453,7 +735,25 @@ public class GaussDBDialect extends Dialect {
 	@Override
 	public String castPattern(CastType from, CastType to) {
 		if ( from == CastType.STRING && to == CastType.BOOLEAN ) {
-			return "cast(?1 as ?2)";
+			// A mode: openGauss PG kernel natively accepts cast('y' as boolean)=true and
+			// raises on cast('bla' as boolean). M mode (MySQL-compatible): cast(?1 as unsigned)
+			// only parses leading digits ('1'->1, 'y'->0), losing the 'y'/'t'/'true'->true
+			// semantics tested by HHH-18447, and cast('bla' as unsigned)=0 instead of raising.
+			// Delegate to the base buildStringToBooleanCast: it maps the recognized spellings
+			// through a values/union-all join, and an unrecognized string like 'bla' matches
+			// nothing -> two result rows -> NonUniqueResultException, which the HHH-18447
+			// invalid-string test expects as a HibernateException.
+			if ( !isMMode() ) {
+				return "cast(?1 as ?2)";
+			}
+			return super.castPattern( from, to );
+		}
+
+		if ( from == CastType.STRING && to == CastType.DATE ) {
+			// M mode's DATE parser rejects `cast('YYYY-MM-DD' as date)` — it truncates the
+			// 4-digit year to 2 digits and fails with "invalid value ... for MON". Parse
+			// with an explicit format instead (matches appendDateTimeLiteral's DATE branch).
+			return "to_date(?1,'YYYY-MM-DD')";
 		}
 
 		if ( to == CastType.STRING ) {
@@ -464,15 +764,23 @@ public class GaussDBDialect extends Dialect {
 				case YN_BOOLEAN:
 					return BooleanDecoder.toString( from );
 				case DATE:
-					return "to_char(?1,'YYYY-MM-DD')";
+					// M mode's to_char() exists but misinterprets Oracle format pictures (returns
+					// garbage); use date_format() with MySQL specifiers instead. to_date() is fine.
+					return isMMode() ? "date_format(?1,'%Y-%m-%d')" : "to_char(?1,'YYYY-MM-DD')";
 				case TIME:
 					return "cast(?1 as ?2)";
 				case TIMESTAMP:
-					return "to_char(?1,'YYYY-MM-DD HH24:MI:SS.FF9')";
+					return isMMode()
+							? "date_format(?1,'%Y-%m-%d %H:%i:%s.%f')"
+							: "to_char(?1,'YYYY-MM-DD HH24:MI:SS.FF9')";
 				case OFFSET_TIMESTAMP:
-					return "to_char(?1,'YYYY-MM-DD HH24:MI:SS.FF9TZH:TZM')";
+					return isMMode()
+							? "date_format(?1,'%Y-%m-%d %H:%i:%s.%f')"
+							: "to_char(?1,'YYYY-MM-DD HH24:MI:SS.FF9TZH:TZM')";
 				case ZONE_TIMESTAMP:
-					return "to_char(?1,'YYYY-MM-DD HH24:MI:SS.FF9 TZR')";
+					return isMMode()
+							? "date_format(?1,'%Y-%m-%d %H:%i:%s.%f')"
+							: "to_char(?1,'YYYY-MM-DD HH24:MI:SS.FF9 TZR')";
 			}
 		}
 
@@ -494,6 +802,16 @@ public class GaussDBDialect extends Dialect {
 
 	@Override @SuppressWarnings("deprecation")
 	public String timestampaddPattern(TemporalUnit unit, TemporalType temporalType, IntervalType intervalType) {
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible) rejects PostgreSQL interval arithmetic `?3 + (?2)*interval '1 unit'`
+			// and `cast(... as timestamp)`; use the native timestampadd(unit, expr, date) function instead.
+			return switch (unit) {
+				case NANOSECOND -> "timestampadd(microsecond,(?2)/1e3,?3)";
+				// NATIVE = second (see timestampdiffPattern); microseconds would scale by 1e6.
+				case NATIVE -> "timestampadd(second,?2,?3)";
+				default -> "timestampadd(?1,?2,?3)";
+			};
+		}
 		return intervalType != null
 				? "(?2+?3)"
 				: "cast(?3+" + intervalPattern( unit ) + " as " + temporalType.name().toLowerCase() + ")";
@@ -511,6 +829,20 @@ public class GaussDBDialect extends Dialect {
 
 	@Override @SuppressWarnings("deprecation")
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible) rejects `extract(unit from ?3-?2)` (interval extract and
+			// epoch are unsupported); use the native timestampdiff(unit, from, to) function instead.
+			if ( unit == null ) {
+				return "timestampdiff(second,?2,?3)";
+			}
+			return switch (unit) {
+				case NANOSECOND -> "timestampdiff(microsecond,?2,?3)*1e3";
+				// NATIVE resolves to second via getFractionalSecondPrecisionInNanos()=1e9;
+				// returning microseconds here scales every Duration result by 1e6.
+				case NATIVE -> "timestampdiff(second,?2,?3)";
+				default -> "timestampdiff(?1,?2,?3)";
+			};
+		}
 		if ( unit == null ) {
 			return "(?3-?2)";
 		}
@@ -538,8 +870,15 @@ public class GaussDBDialect extends Dialect {
 	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
 		super.initializeFunctionRegistry(functionContributions);
 
-		GaussDBFunctionRegistry functionRegistry = new GaussDBFunctionRegistry( functionContributions );
+		GaussDBFunctionRegistry functionRegistry = new GaussDBFunctionRegistry( functionContributions, isMMode() );
 		functionRegistry.register();
+
+		// GaussDB M mode DATE (datea) only recognizes year/month/day in extract(); other units
+		// (week/doy/dow/epoch/quarter/hour/...) need a timestamp source. See GaussDBExtractFunction.
+		functionContributions.getFunctionRegistry().register(
+				"extract",
+				new GaussDBExtractFunction( this, functionContributions.getTypeConfiguration() )
+		);
 	}
 
 	@Override
@@ -581,7 +920,10 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public boolean supportsIfExistsAfterAlterTable() {
-		return true;
+		// M mode rejects `alter table if exists <table> ...` with a syntax error; under PostgreSQL
+		// transaction semantics that aborts the whole schema-generation transaction, so subsequent
+		// DDL (create sequence/table) is silently ignored. A mode accepts the IF EXISTS clause.
+		return !isMMode();
 	}
 
 	@Override
@@ -594,6 +936,12 @@ public class GaussDBDialect extends Dialect {
 	@Override
 	public String getAlterColumnTypeString(String columnName, String columnType, String columnDefinition) {
 		// would need multiple statements to 'set not null'/'drop not null', 'set default'/'drop default', 'set generated', etc
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible) rejects `alter column ... set data type` (DB2/standard syntax)
+			// with "syntax error at or near data". MySQL's `modify column` redefines the whole column,
+			// so pass the full columnDefinition to preserve null/default attributes (same as MySQLDialect).
+			return "modify column " + columnName + " " + columnDefinition.trim();
+		}
 		return "alter column " + columnName + " set data type " + columnType;
 	}
 
@@ -604,7 +952,11 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public boolean supportsValuesList() {
-		return true;
+		// A mode (openGauss PG kernel) supports PostgreSQL `values (..),(..)` derived tables.
+		// M mode (MySQL-compatible) rejects that syntax — `values (true),(false)` raises
+		// "syntax error at or near '('". Return false so buildStringToBooleanCast (cast string
+		// as boolean/YesNo/TrueFalse) and other callers fall back to union all.
+		return !isMMode();
 	}
 
 	@Override
@@ -623,6 +975,12 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public SequenceSupport getSequenceSupport() {
+		// M mode: nextval()/currval()/setval() string args are case-sensitive (not folded like PostgreSQL),
+		// while CREATE SEQUENCE folds the identifier to lowercase. Lower-casing the call-side name makes
+		// nextval('ConcreteOne_SEQ') resolve to the stored concreteone_seq. See GaussDBMModeSequenceSupport.
+		if ( isMMode() ) {
+			return GaussDBMModeSequenceSupport.INSTANCE;
+		}
 		return GaussDBSequenceSupport.INSTANCE;
 	}
 
@@ -633,7 +991,26 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public String getQuerySequencesString() {
+		// M mode has no information_schema.sequences view; query pg_class (relkind='S') for sequence
+		// names and pg_sequence_parameters(oid) for the increment value (its "increment" field), so
+		// the extractor can detect existing sequences (avoiding redundant create-sequence calls that
+		// fail with "Relation already exists" — M mode rejects `create sequence if not exists`) AND
+		// expose the increment value for SequenceInformation.getIncrementValue() and HHH-12973
+		// sequence-mismatch detection. pg_class exposes only relname, hence the function call.
+		if ( isMMode() ) {
+			return "select c.relname as relname, (pg_sequence_parameters(c.oid)).increment as increment from pg_class c where c.relkind='S'";
+		}
 		return "select * from information_schema.sequences";
+	}
+
+	@Override
+	public SequenceInformationExtractor getSequenceInformationExtractor() {
+		// M mode: pg_class exposes only relname (no catalog/schema/start/min/max/increment columns that
+		// information_schema.sequences provides), so use a extractor that reads relname and skips the rest.
+		if ( isMMode() ) {
+			return GaussDBMModeSequenceInformationExtractor.INSTANCE;
+		}
+		return super.getSequenceInformationExtractor();
 	}
 
 	@Override
@@ -673,7 +1050,9 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public String getNoColumnsInsertString() {
-		return "default values";
+		// M mode (MySQL-compatible) rejects `default values`; use `() values ()`. A mode
+		// (Oracle-compatible) supports `default values`.
+		return isMMode() ? "() values ()" : "default values";
 	}
 
 	@Override
@@ -683,7 +1062,10 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public boolean supportsCaseInsensitiveLike() {
-		return true;
+		// A mode (openGauss PG kernel) supports ILIKE natively. M mode (MySQL-compatible) does not,
+		// so fall back to the lower(col) like lower(pattern) emulation rendered by
+		// AbstractSqlAstTranslator#visitLikePredicate.
+		return !isMMode();
 	}
 
 	@Override
@@ -709,6 +1091,13 @@ public class GaussDBDialect extends Dialect {
 	@Override
 	public String getSelectClauseNullString(int sqlType, TypeConfiguration typeConfiguration) {
 		// TODO: adapt this to handle named enum types!
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible) CAST only accepts MySQL type names; getRawTypeName() returns the
+			// PG column type (text/varchar/integer/bigint/numeric/...) which M mode rejects. castType()
+			// returns the MySQL name, but may carry a $l/$p/$s size pattern — irrelevant for a null
+			// literal, so strip the (...) suffix (MySQL accepts char/decimal/binary without a size).
+			return "cast(null as " + castType( sqlType ).replaceAll( "\\(.*\\)", "" ) + ")";
+		}
 		return "cast(null as " + typeConfiguration.getDdlTypeRegistry().getDescriptor( sqlType ).getRawTypeName() + ")";
 	}
 
@@ -757,6 +1146,20 @@ public class GaussDBDialect extends Dialect {
 		appender.appendSql( bool );
 	}
 
+	/**
+	 * Words reserved by GaussDB M mode that PostgreSQL treats as non-reserved, so Hibernate would otherwise
+	 * emit them unquoted as identifiers. Auto-quoting ({@code hibernate.auto_quote_keyword=true}) is scoped to
+	 * this curated set rather than the full ANSI/PostgreSQL keyword set ({@code Dialect#sqlKeywords}), which
+	 * over-reports words M mode actually permits as identifiers (e.g. {@code aggregate}) and would false-quote
+	 * legitimate identifier-named columns. {@code excluded} is also registered via {@link #registerKeyword} so
+	 * it is recognized as a keyword in SQL templates ({@code Template} uses {@code #getKeywords()}).
+	 * {@code match} is a MySQL reserved word (M mode) but non-reserved in PostgreSQL, so an unquoted
+	 * {@code create table Match (...)} raises a syntax error in M mode; it is added here only for M mode
+	 * (A mode keeps {@link #A_MODE_RESERVED_KEYWORDS} so existing A-mode behavior is unchanged).
+	 */
+	private static final Set<String> M_MODE_RESERVED_KEYWORDS = Set.of( "excluded", "match" );
+	private static final Set<String> A_MODE_RESERVED_KEYWORDS = Set.of( "excluded" );
+
 	@Override
 	public IdentifierHelper buildIdentifierHelper(IdentifierHelperBuilder builder, DatabaseMetaData dbMetaData)
 			throws SQLException {
@@ -765,14 +1168,68 @@ public class GaussDBDialect extends Dialect {
 			builder.setUnquotedCaseStrategy( IdentifierCaseStrategy.LOWER );
 			builder.setQuotedCaseStrategy( IdentifierCaseStrategy.MIXED );
 		}
+		// Replicate Dialect#buildIdentifierHelper but apply only the curated M-mode reserved words instead of
+		// the full inherited sqlKeywords (which over-reports ANSI/PG words M mode permits, e.g. `aggregate`).
+		builder.applyIdentifierCasing( dbMetaData );
+		builder.applyReservedWords( isMMode() ? M_MODE_RESERVED_KEYWORDS : A_MODE_RESERVED_KEYWORDS );
+		builder.setNameQualifierSupport( getNameQualifierSupport() );
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible) preserves unquoted identifier case — `create table AbCdEf` stores
+			// "AbCdEf", not lower-cased. But gsjdbc4 reports storesLowerCaseIdentifiers=true (PG behavior),
+			// so applyIdentifierCasing above sets LOWER, which makes schema validation's toMetaDataObjectName
+			// lower-case table names (e.g. "testentity") and fail to match the stored "TestEntity", reporting
+			// "missing table". Override to MIXED to match M mode's actual case preservation. A mode (PG kernel)
+			// genuinely lower-cases unquoted identifiers, so keep the LOWER from applyIdentifierCasing.
+			//
+			// Known limitation: because gsjdbc4 reports storesLowerCaseIdentifiers=true while M mode actually
+			// preserves case, tests that read column metadata through raw JDBC DatabaseMetaData.getColumns
+			// (whose search pattern is lower-cased) cannot match a table stored as "Version" — e.g.
+			// MigrationTest#testSimpleColumnTypeChange expects getColumns("version") to find the "Version"
+			// table. Lowering unquotedCaseStrategy to fix that breaks schema validation (missing table), so
+			// MIXED is the correct trade-off and that single test failure is an inherent M-mode limitation.
+			builder.setUnquotedCaseStrategy( IdentifierCaseStrategy.MIXED );
+		}
+		return builder.build();
+	}
 
-		return super.buildIdentifierHelper( builder, dbMetaData );
+	@Override
+	public TemporaryTableStrategy getLocalTemporaryTableStrategy() {
+		if ( isMMode() ) {
+			// M mode (openGauss PG kernel, MySQL-compatible) supports session-local temporary tables
+			// (`CREATE LOCAL TEMPORARY TABLE`), used by LocalTemporaryTableMutationStrategy as the staging
+			// area for multi-table mutations — M mode has no RETURNING, so CTE DML is unavailable.
+			// StandardLocalTemporaryTableStrategy creates the temp table before each use
+			// (BeforeUseAction.CREATE — directly `create local temporary table`, no drop-if-exists) and by
+			// default does NOT drop after use (AfterUseAction.NONE), relying on the session to auto-drop.
+			// But GaussDB's local temp table is connection-scoped and the connection pool reuses
+			// connections, so NONE leaves HT_* tables behind — the next mutation on a reused connection
+			// hits "Relation HT_X already exists" and aborts the transaction (patient-zero pollution:
+			// JoinedSubclassBulkManipTest passes single-class but fails full-suite with HT_Person already
+			// exists + transaction aborted). Override AfterUseAction to DROP so the temp table is dropped
+			// after each use. A mode keeps the base default (null — CteMutationStrategy, no temp tables).
+			return new StandardLocalTemporaryTableStrategy() {
+				@Override
+				public AfterUseAction getTemporaryTableAfterUseAction() {
+					return AfterUseAction.DROP;
+				}
+			};
+		}
+		return super.getLocalTemporaryTableStrategy();
 	}
 
 	@Override
 	public SqmMultiTableMutationStrategy getFallbackSqmMutationStrategy(
 			EntityMappingType rootEntityDescriptor,
 			RuntimeModelCreationContext runtimeModelCreationContext) {
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible, single-node) has no `INSERT/UPDATE/DELETE ... RETURNING`
+			// (RETURNING is a distributed-db-only feature here), so `CteMutationStrategy` — which
+			// renders `with dml_cte (..) as (dml ... returning ..)` — can't execute. Use a session-local
+			// temporary table as the staging area instead: `CREATE TEMPORARY TABLE` is supported in M
+			// mode and auto-cleaned per session. The base Dialect temporary-table config (afterUse=CLEAN,
+			// beforeUse=NONE) matches the openGauss PG kernel semantics. A mode keeps the CTE strategy.
+			return new LocalTemporaryTableMutationStrategy( rootEntityDescriptor, runtimeModelCreationContext );
+		}
 		return new CteMutationStrategy( rootEntityDescriptor, runtimeModelCreationContext );
 	}
 
@@ -780,6 +1237,10 @@ public class GaussDBDialect extends Dialect {
 	public SqmMultiTableInsertStrategy getFallbackSqmInsertStrategy(
 			EntityMappingType rootEntityDescriptor,
 			RuntimeModelCreationContext runtimeModelCreationContext) {
+		if ( isMMode() ) {
+			// See getFallbackSqmMutationStrategy — M mode has no RETURNING, so avoid CteInsertStrategy.
+			return new LocalTemporaryTableInsertStrategy( rootEntityDescriptor, runtimeModelCreationContext );
+		}
 		return new CteInsertStrategy( rootEntityDescriptor, runtimeModelCreationContext );
 	}
 
@@ -825,12 +1286,11 @@ public class GaussDBDialect extends Dialect {
 						case 23503:
 							return extractUsingTemplate( "violates foreign key constraint \"", "\"", sqle.getMessage() );
 						// NOT NULL VIOLATION
+						// GaussDB M mode message: `The null value in column "<col>" violates the not-null constraint.`
+						// (the leading "The " and the "the " before "not-null" defeat the PG-style end template),
+						// so extract the column name between `column "` and the closing quote.
 						case 23502:
-							return extractUsingTemplate(
-									"null value in column \"",
-									"\" violates not-null constraint",
-									sqle.getMessage()
-							);
+							return extractUsingTemplate( "column \"", "\"", sqle.getMessage() );
 						// TODO: RESTRICT VIOLATION
 						case 23001:
 							return null;
@@ -891,7 +1351,10 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public CallableStatementSupport getCallableStatementSupport() {
-		return GaussDBCallableStatementSupport.INSTANCE;
+		// GaussDB M mode is PostgreSQL-compatible for callable statements; reuse the PG support
+		// so no-arg function calls render as `select func()` instead of `{?=call func(?)}`,
+		// which (via GaussDBCallableStatementSupport, based on Oracle) passes a spurious null parameter.
+		return PostgreSQLCallableStatementSupport.INSTANCE;
 	}
 
 	@Override
@@ -914,7 +1377,20 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public IdentityColumnSupport getIdentityColumnSupport() {
-		return GaussDBIdentityColumnSupport.INSTANCE;
+		// M mode (MySQL-compatible) rejects bigserial/serial; use MySQL-style
+		// `bigint not null auto_increment` + last_insert_id() (verified). A mode keeps
+		// the PG-style bigserial (Oracle-compatible, supports it).
+		return isMMode() ? MySQLIdentityColumnSupport.INSTANCE : GaussDBIdentityColumnSupport.INSTANCE;
+	}
+
+	@Override
+	public boolean getDefaultUseGetGeneratedKeys() {
+		// M mode: the gsjdbc4 (PostgreSQL) driver implements getGeneratedKeys() by
+		// rewriting the INSERT with a RETURNING clause, which single-node GaussDB M mode
+		// rejects. Disable it so IdentityGenerator falls back to BasicSelectingDelegate,
+		// which runs a plain INSERT then `select last_insert_id()` (verified). A mode
+		// keeps the default true (RETURNING works on the openGauss PG kernel).
+		return !isMMode();
 	}
 
 	@Override
@@ -934,7 +1410,11 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public boolean supportsStandardArrays() {
-		return true;
+		// M mode (MySQL-compatible) has no array column type (syntax error on `type[]`);
+		// A mode (Oracle-compatible, openGauss PG kernel) supports arrays. Returning false
+		// for M mode also makes the base Dialect.getPreferredSqlTypeCodeForArray() fall back
+		// to VARBINARY, so @RequiresDialectFeature(SupportsStructuralArrays) skips array tests.
+		return !isMMode();
 	}
 
 	@Override
@@ -951,11 +1431,23 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public boolean supportsTemporalLiteralOffset() {
-		return true;
+		// A mode (openGauss PG kernel) supports `timestamp with time zone '...'` literals; M mode
+		// (MySQL-compatible) rejects them (syntax error at "time"), so report false and let
+		// appendDateTimeLiteral render a plain `timestamp '...'` literal instead.
+		return !isMMode();
 	}
 
 	@Override
 	public void appendDatetimeFormat(SqlAppender appender, String format) {
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible): format() renders as date_format(), which needs MySQL
+			// specifiers. Translate Hibernate/Java format pictures (yyyy-MM-dd HH:mm:ss) to MySQL
+			// (%Y-%m-%d %H:%i:%s). Required by DateTruncEmulation (trunc_truncate's FORMAT emulation
+			// builds a `format(datetime, pattern)` expression) and by the format() function.
+			// Reuse MySQLDialect's well-tested translation.
+			appender.appendSql( MySQLDialect.datetimeFormat( format ).result() );
+			return;
+		}
 		throw new UnsupportedOperationException( "GaussDB not support datetime format yet" );
 	}
 
@@ -972,11 +1464,19 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public AggregateSupport getAggregateSupport() {
-		return null;
+		return GaussDBAggregateSupport.valueOf( this );
 	}
 
 	@Override
 	public void appendBinaryLiteral(SqlAppender appender, byte[] bytes) {
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible) uses the x'hex' binary string literal;
+			// PostgreSQL's `bytea '\x..'` is a syntax error in M mode.
+			appender.appendSql( "x'" );
+			PrimitiveByteArrayJavaType.INSTANCE.appendString( appender, bytes );
+			appender.appendSql( '\'' );
+			return;
+		}
 		appender.appendSql( "bytea '\\x" );
 		PrimitiveByteArrayJavaType.INSTANCE.appendString( appender, bytes );
 		appender.appendSql( '\'' );
@@ -991,9 +1491,12 @@ public class GaussDBDialect extends Dialect {
 			TimeZone jdbcTimeZone) {
 		switch ( precision ) {
 			case DATE:
-				appender.appendSql( "date '" );
+				// M mode's DATE parser ignores ISO DateStyle and rejects `date 'YYYY-MM-DD'`
+				// ("invalid value ... for MON", truncates the 4-digit year to 2). to_date with an
+				// explicit format parses correctly and returns the date type.
+				appender.appendSql( "to_date('" );
 				appendAsDate( appender, temporalAccessor );
-				appender.appendSql( '\'' );
+				appender.appendSql( "','YYYY-MM-DD')" );
 				break;
 			case TIME:
 				if ( supportsTemporalLiteralOffset() && temporalAccessor.isSupported( ChronoField.OFFSET_SECONDS ) ) {
@@ -1032,17 +1535,26 @@ public class GaussDBDialect extends Dialect {
 			TimeZone jdbcTimeZone) {
 		switch ( precision ) {
 			case DATE:
-				appender.appendSql( "date '" );
+				appender.appendSql( "to_date('" );
 				appendAsDate( appender, date );
-				appender.appendSql( '\'' );
+				appender.appendSql( "','YYYY-MM-DD')" );
 				break;
 			case TIME:
-				appender.appendSql( "time with time zone '" );
-				appendAsTime( appender, date, jdbcTimeZone );
+				if ( isMMode() ) {
+					// M mode has no timezone-aware time type; appendAsTime(date, tz) renders
+					// `time 'HH:mm:ssXXX'` (with offset) which M mode rejects ("...is incorrect").
+					// Render local time (no offset), matching the TemporalAccessor overload.
+					appender.appendSql( "time '" );
+					appendAsLocalTime( appender, date );
+				}
+				else {
+					appender.appendSql( "time with time zone '" );
+					appendAsTime( appender, date, jdbcTimeZone );
+				}
 				appender.appendSql( '\'' );
 				break;
 			case TIMESTAMP:
-				appender.appendSql( "timestamp with time zone '" );
+				appender.appendSql( isMMode() ? "timestamp '" : "timestamp with time zone '" );
 				appendAsTimestampWithMicros( appender, date, jdbcTimeZone );
 				appender.appendSql( '\'' );
 				break;
@@ -1060,23 +1572,43 @@ public class GaussDBDialect extends Dialect {
 			TimeZone jdbcTimeZone) {
 		switch ( precision ) {
 			case DATE:
-				appender.appendSql( "date '" );
+				appender.appendSql( "to_date('" );
 				appendAsDate( appender, calendar );
-				appender.appendSql( '\'' );
+				appender.appendSql( "','YYYY-MM-DD')" );
 				break;
 			case TIME:
-				appender.appendSql( "time with time zone '" );
-				appendAsTime( appender, calendar, jdbcTimeZone );
+				if ( isMMode() ) {
+					appender.appendSql( "time '" );
+					appendAsLocalTime( appender, calendar );
+				}
+				else {
+					appender.appendSql( "time with time zone '" );
+					appendAsTime( appender, calendar, jdbcTimeZone );
+				}
 				appender.appendSql( '\'' );
 				break;
 			case TIMESTAMP:
-				appender.appendSql( "timestamp with time zone '" );
+				appender.appendSql( isMMode() ? "timestamp '" : "timestamp with time zone '" );
 				appendAsTimestampWithMillis( appender, calendar, jdbcTimeZone );
 				appender.appendSql( '\'' );
 				break;
 			default:
 				throw new IllegalArgumentException();
 		}
+	}
+
+	@Override
+	public void appendUUIDLiteral(SqlAppender appender, UUID literal) {
+		if ( isMMode() ) {
+			// M mode stores UUID as varchar(36) + VarcharUUIDJdbcType (see columnType/registerColumnTypes).
+			// Render the literal as a plain string literal instead of the default `cast('...' as uuid)`,
+			// which M mode rejects (no native uuid type). A mode keeps the default cast.
+			appender.appendSql( "'" );
+			appender.appendSql( literal.toString() );
+			appender.appendSql( "'" );
+			return;
+		}
+		super.appendUUIDLiteral( appender, literal );
 	}
 
 	private String withTimeout(String lockString, Timeout timeout) {
@@ -1185,7 +1717,10 @@ public class GaussDBDialect extends Dialect {
 
 	@Override
 	public boolean supportsInsertReturning() {
-		return true;
+		// M mode (MySQL-compatible) rejects INSERT ... RETURNING ("Unsupported function.
+		// only supported in distributed database" — single-node GaussDB). A mode
+		// (Oracle-compatible, openGauss PG kernel) supports RETURNING.
+		return !isMMode();
 	}
 
 	@Override
@@ -1266,11 +1801,45 @@ public class GaussDBDialect extends Dialect {
 		jdbcTypeRegistry.addDescriptorIfAbsent( GaussDBCastingInetJdbcType.INSTANCE );
 		jdbcTypeRegistry.addDescriptorIfAbsent( GaussDBCastingIntervalSecondJdbcType.INSTANCE );
 		jdbcTypeRegistry.addDescriptorIfAbsent( GaussDBStructuredJdbcType.INSTANCE );
-		jdbcTypeRegistry.addDescriptorIfAbsent( GaussDBCastingJsonJdbcType.JSONB_INSTANCE );
-		jdbcTypeRegistry.addTypeConstructorIfAbsent( GaussDBCastingJsonArrayJdbcTypeConstructor.JSONB_INSTANCE );
+		jdbcTypeRegistry.addDescriptorIfAbsent( GaussDBCastingJsonJdbcType.JSON_INSTANCE );
+		jdbcTypeRegistry.addTypeConstructorIfAbsent( GaussDBCastingJsonArrayJdbcTypeConstructor.JSON_INSTANCE );
 
 		// GaussDB requires a custom binder for binding untyped nulls as VARBINARY
 		typeContributions.contributeJdbcType( ObjectNullAsBinaryTypeJdbcType.INSTANCE );
+
+		// M mode exposes DATE as the non-standard `datea` type (JDBC type code OTHER); the gsjdbc4 driver
+		// can't convert it via getObject(col, LocalDate.class), so read LOCAL_DATE columns through getDate().
+		typeContributions.contributeJdbcType( GaussDBLocalDateJdbcType.INSTANCE );
+
+		// gsjdbc4's getObject(int, Class) cannot convert DATETIME/TIMESTAMP columns to LocalDateTime
+		// ("Cannot convert the column of type DATETIME to requested type timestamp"), Instant
+		// ("conversion to class java.time.Instant from 93 not supported"), or OffsetDateTime
+		// ("conversion to class java.time.OffsetDateTime from datetime not supported"). Read through
+		// getTimestamp(); the temporal JavaType.wrap converts the Timestamp. LocalDate is overridden
+		// separately (non-standard `datea` type); LocalTime reads correctly through getObject, so only
+		// LOCAL_DATE_TIME, INSTANT and OFFSET_DATE_TIME are overridden here. Writing OffsetDateTime through
+		// setObject sends a timestamptz expression that M mode datetime rejects, so the binder uses
+		// setTimestamp(Timestamp) too. A mode (openGauss PG kernel) reads/writes TIMESTAMP via
+		// getTimestamp/setTimestamp correctly too.
+		typeContributions.contributeJdbcType( GaussDBLocalDateTimeJdbcType.INSTANCE );
+		typeContributions.contributeJdbcType( GaussDBInstantJdbcType.INSTANCE );
+		typeContributions.contributeJdbcType( GaussDBOffsetDateTimeJdbcType.INSTANCE );
+		// @JdbcTypeCode(TIMESTAMP_WITH_TIMEZONE) resolves to SqlTypes.TIMESTAMP_WITH_TIMEZONE (2014),
+		// distinct from OFFSET_DATE_TIME (3012) and INSTANT (3008) registered above. The default
+		// TimestampWithTimeZoneJdbcType binds via setObject(.., TIMESTAMP_WITH_TIMEZONE), which gsjdbc4
+		// turns into a `timestamp with time zone` expression that M mode datetime rejects (the call does
+		// not throw, so the built-in setTimestamp fallback never runs). GaussDBTimestampWithTimeZoneJdbcType
+		// binds through setTimestamp directly. A mode (timestamptz columns) round-trips via setTimestamp too.
+		typeContributions.contributeJdbcType( GaussDBTimestampWithTimeZoneJdbcType.INSTANCE );
+
+		// M mode stores boolean as int1/uint8; gsjdbc4 MResultSet.getBoolean routes non-BOOLEAN/BIT columns
+		// through MBooleanTypeUtils.castToBoolean, which rejects java.math.BigInteger (uint8, returned for
+		// CASE expressions like `case when ... then true else false end`) with "Cannot cast to boolean".
+		// Read boolean columns via getString and parse, bypassing castToBoolean. A mode keeps BooleanJdbcType.
+		if ( isMMode() ) {
+			jdbcTypeRegistry.addDescriptor( Types.BOOLEAN, GaussDBBooleanJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptor( Types.BIT, GaussDBBooleanJdbcType.INSTANCE );
+		}
 
 		// Until we remove StandardBasicTypes, we have to keep this
 		typeContributions.contributeType(
@@ -1284,7 +1853,8 @@ public class GaussDBDialect extends Dialect {
 
 		jdbcTypeRegistry.addDescriptor( GaussDBEnumJdbcType.INSTANCE );
 		jdbcTypeRegistry.addDescriptor( GaussDBOrdinalEnumJdbcType.INSTANCE );
-		jdbcTypeRegistry.addDescriptor( GaussDBUUIDJdbcType.INSTANCE );
+		// M mode stores UUID as varchar(36) (no native uuid type); A mode uses the native uuid type.
+		jdbcTypeRegistry.addDescriptor( isMMode() ? VarcharUUIDJdbcType.INSTANCE : GaussDBUUIDJdbcType.INSTANCE );
 
 		// Replace the standard array constructor
 		jdbcTypeRegistry.addTypeConstructor( GaussDBArrayJdbcTypeConstructor.INSTANCE );
@@ -1325,35 +1895,24 @@ public class GaussDBDialect extends Dialect {
 		return sql;
 	}
 
-	@FunctionalInterface
-	private interface OptionalTableUpdateStrategy {
-		MutationOperation buildMutationOperation(
-				EntityMutationTarget mutationTarget,
-				OptionalTableUpdate optionalTableUpdate,
-				SessionFactoryImplementor factory);
-	}
-
 	@Override
 	public MutationOperation createOptionalTableUpdateOperation(
 			EntityMutationTarget mutationTarget,
 			OptionalTableUpdate optionalTableUpdate,
 			SessionFactoryImplementor factory) {
-		return optionalTableUpdateStrategy.buildMutationOperation( mutationTarget, optionalTableUpdate, factory );
-	}
-
-	private static MutationOperation usingMerge(
-			EntityMutationTarget mutationTarget,
-			OptionalTableUpdate optionalTableUpdate,
-			SessionFactoryImplementor factory) {
-		final GaussDBSqlAstTranslator<?> translator = new GaussDBSqlAstTranslator<>( factory, optionalTableUpdate );
-		return translator.createMergeOperation( optionalTableUpdate );
-	}
-
-	private static MutationOperation withoutMerge(
-			EntityMutationTarget mutationTarget,
-			OptionalTableUpdate optionalTableUpdate,
-			SessionFactoryImplementor factory) {
-		return new OptionalTableUpdateOperation( mutationTarget, optionalTableUpdate, factory );
+		if ( isMMode() ) {
+			// M mode (MySQL-compatible): GaussDB MERGE does not support `WHEN MATCHED AND <condition>`,
+			// which the base translator's createMergeOperation emits for the optional-table delete branch.
+			// Follow an upsert-based path instead: an operation whose insert ignores primary key collisions
+			// through GaussDBSqlAstTranslator#visitStandardTableInsert (ON DUPLICATE KEY UPDATE col=col),
+			// without relying on MERGE.
+			return new OptionalTableUpdateWithUpsertOperation( mutationTarget, optionalTableUpdate, factory );
+		}
+		// A mode (openGauss Oracle-compatible): use the default OptionalTableUpdateOperation, which does a
+		// plain insert and catches the unique-violation to fall back to update. A mode does not support
+		// ON CONFLICT, and the M-mode upsert operation above relies on ON DUPLICATE KEY UPDATE, which A
+		// mode rejects when it touches primary/unique key columns.
+		return super.createOptionalTableUpdateOperation( mutationTarget, optionalTableUpdate, factory );
 	}
 
 	private static class NativeParameterMarkers implements ParameterMarkerStrategy {
@@ -1385,12 +1944,17 @@ public class GaussDBDialect extends Dialect {
 	}
 
 	@Override
-	public boolean supportsBindingNullSqlTypeForSetNull() {
-		return true;
+	public boolean supportsJoinsInDelete() {
+		// M mode (MySQL-compatible) natively supports `delete alias from t join ...`,
+		// so the joins are rendered directly in the DELETE clause (see GaussDBSqlAstTranslator)
+		// and the restriction is used as-is. A mode (openGauss PG kernel) keeps the base
+		// behavior, which emulates delete-joins via an `exists(select 1 from (values(0)) d_ ...)`
+		// subquery — that emulation relies on the PG-style `(values(0))` dual expression.
+		return isMMode();
 	}
 
 	@Override
-	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
-		return new InformationExtractorPostgreSQLImpl( extractionContext );
+	public boolean supportsBindingNullSqlTypeForSetNull() {
+		return true;
 	}
 }

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBExtractFunction.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBExtractFunction.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import jakarta.persistence.TemporalType;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.function.ExtractFunction;
+import org.hibernate.metamodel.mapping.JdbcMappingContainer;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.common.TemporalUnit;
+import org.hibernate.query.sqm.produce.function.internal.PatternRenderer;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.ExtractUnit;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import java.util.List;
+
+import static org.hibernate.type.spi.TypeConfiguration.getSqlTemporalType;
+
+/**
+ * GaussDB-specific {@link ExtractFunction} that casts {@code DATE} sources to
+ * {@code timestamp} before extracting temporal units other than
+ * {@code year}/{@code month}/{@code day}.
+ *
+ * <p>GaussDB M mode exposes {@code DATE} as the non-standard {@code datea} type, and its
+ * {@code extract()}/{@code date_part()} only recognizes {@code year}, {@code month}, and
+ * {@code day} units when the argument is a {@code DATE} — every other unit
+ * ({@code week}, {@code doy}, {@code dow}, {@code epoch}, {@code quarter}, {@code hour},
+ * {@code minute}, {@code second}, {@code microsecond}, ...) raises
+ * {@code "Date units ... cannot be recognized"}. {@code TIMESTAMP} sources recognize the
+ * full unit set, so casting a {@code DATE} source to {@code timestamp} makes the remaining
+ * units work.
+ *
+ * <p>The cast is applied only when the source type is {@link TemporalType#DATE}, so
+ * {@code timestamp}/{@code timestamptz}/{@code time} sources are left untouched: casting
+ * {@code timestamptz} to {@code timestamp} would shift {@code epoch} by the zone offset,
+ * and casting {@code time} to {@code timestamp} is unsupported by the database.
+ *
+ * <p>The cast is injected by rewriting the dialect's {@code extractPattern(unit)}, wrapping
+ * the {@code ?2} (source) placeholder in {@code cast(?2 as timestamp)}, so any
+ * dialect-specific pattern logic (e.g. the {@code DAY_OF_WEEK} {@code +1} adjustment in
+ * {@link GaussDBDialect}) is preserved.
+ */
+public class GaussDBExtractFunction extends ExtractFunction {
+	// ExtractFunction.dialect is package-private, so it is inaccessible from this package;
+	// keep our own reference to call the public Dialect#extractPattern(TemporalUnit).
+	private final Dialect gaussDialect;
+
+	public GaussDBExtractFunction(Dialect dialect, TypeConfiguration typeConfiguration) {
+		super( dialect, typeConfiguration );
+		this.gaussDialect = dialect;
+	}
+
+	@Override
+	public void render(
+			SqlAppender sqlAppender,
+			List<? extends SqlAstNode> sqlAstArguments,
+			ReturnableType<?> returnType,
+			SqlAstTranslator<?> walker) {
+		final ExtractUnit field = (ExtractUnit) sqlAstArguments.get( 0 );
+		final TemporalUnit unit = field.getUnit();
+		String pattern = gaussDialect.extractPattern( unit );
+		final Expression expression = (Expression) sqlAstArguments.get( 1 );
+		final JdbcMappingContainer type = expression.getExpressionType();
+		final TemporalType temporalType = type != null ? getSqlTemporalType( type ) : null;
+		// A mode DATE (datea) only recognizes year/month/day in extract(); cast DATE sources to
+		// timestamp for every other unit. M mode (MySQL-compatible) instead uses MySQL functions via
+		// extractPattern (dayofweek/year/...), which accept a DATE source directly — and `cast(?2 as
+		// timestamp)` is itself a syntax error in M mode — so skip the cast there.
+		final boolean mMode = gaussDialect instanceof GaussDBDialect g && g.isMMode();
+		if ( !mMode && temporalType == TemporalType.DATE && needsTimestampSource( unit ) ) {
+			pattern = pattern.replace( "?2", "cast(?2 as timestamp)" );
+		}
+		new PatternRenderer( pattern ).render( sqlAppender, sqlAstArguments, walker );
+	}
+
+	/**
+	 * Whether a {@code DATE} source must be cast to {@code timestamp} for the given unit.
+	 * GaussDB M mode {@code DATE} ({@code datea}) only supports {@code year}/{@code month}/
+	 * {@code day} in {@code extract()}; all other units need a {@code timestamp} source.
+	 */
+	private static boolean needsTimestampSource(TemporalUnit unit) {
+		return switch ( unit ) {
+			case YEAR, MONTH, DAY -> false;
+			default -> true;
+		};
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBFunctionRegistry.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBFunctionRegistry.java
@@ -19,6 +19,7 @@ import org.hibernate.community.dialect.function.array.GaussDBArrayReplaceFunctio
 import org.hibernate.community.dialect.function.array.GaussDBArraySetFunction;
 import org.hibernate.community.dialect.function.json.GaussDBJsonObjectFunction;
 import org.hibernate.dialect.function.CommonFunctionFactory;
+import org.hibernate.dialect.function.RegexpLikeOperatorFunction;
 import org.hibernate.dialect.function.array.ArrayIncludesOperatorFunction;
 import org.hibernate.dialect.function.array.ArrayIntersectsOperatorFunction;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
@@ -37,10 +38,13 @@ public class GaussDBFunctionRegistry {
 
 	private final TypeConfiguration typeConfiguration;
 
-	public GaussDBFunctionRegistry(FunctionContributions functionContributions) {
+	private final boolean mMode;
+
+	public GaussDBFunctionRegistry(FunctionContributions functionContributions, boolean mMode) {
 		this.functionContributions = functionContributions;
 		this.functionRegistry = functionContributions.getFunctionRegistry();
 		this.typeConfiguration = functionContributions.getTypeConfiguration();
+		this.mMode = mMode;
 	}
 
 	public void register() {
@@ -73,32 +77,70 @@ public class GaussDBFunctionRegistry {
 		functionFactory.everyAny_boolAndOr();
 		functionFactory.median_percentileCont( false );
 		functionFactory.stddev();
-		functionFactory.stddevPopSamp();
-		functionFactory.variance();
-		functionFactory.varPopSamp();
 		functionFactory.covarPopSamp();
 		functionFactory.corr();
 		functionFactory.regrLinearRegressionAggregates();
-		functionFactory.insert_overlay();
-		functionFactory.overlay();
+		// GaussDB M mode (MySQL-compatible) rejects the PG-style statistical aggregates
+		// stddev_pop/stddev_samp, variance and var_pop/var_samp with
+		// "function() is not supported in M-format database", while it does support
+		// stddev, covar_pop/covar_samp, corr and regr_*. A mode (openGauss PG kernel)
+		// supports all of them, so register the unsupported ones only in A mode.
+		if ( !mMode ) {
+			functionFactory.stddevPopSamp();
+			functionFactory.variance();
+			functionFactory.varPopSamp();
+		}
+		// A mode (openGauss PG kernel) supports ANSI overlay() natively, so register insert via
+		// overlay and overlay directly. M mode (MySQL-compatible) rejects ANSI overlay syntax; use
+		// the real MySQL insert(str,start,len,repl) and let the base InsertSubstringOverlayEmulation
+		// emulate overlay() through it.
+		if ( mMode ) {
+			functionFactory.insert();
+		}
+		else {
+			functionFactory.insert_overlay();
+			functionFactory.overlay();
+		}
 		functionFactory.soundex(); //was introduced apparently
 		functionFactory.locate_positionSubstring();
 		functionFactory.windowFunctions();
+		// A mode (openGauss PG kernel) supports hypothetical-set aggregates (rank / dense_rank /
+		// percent_rank / cume_dist) as both WITHIN GROUP ordered-set and window (OVER) functions.
+		// M mode (MySQL-compatible) rejects the WITHIN GROUP syntax ("Function rank(...) does not
+		// exist"), so register them only in A mode.
+		if ( !mMode ) {
+			functionFactory.hypotheticalOrderedSetAggregates();
+		}
 		functionFactory.listagg_stringAgg( "varchar" );
 		functionFactory.arrayAggregate();
 		functionFactory.arraySlice_operator();
 		functionFactory.makeDateTimeTimestamp();
-		// Note that GaussDB doesn't support the OVER clause for ordered set-aggregate functions
-		functionFactory.inverseDistributionOrderedSetAggregates();
-		functionFactory.hypotheticalOrderedSetAggregates();
-		functionFactory.dateTrunc();
-		functionFactory.hex( "encode(?1, 'hex')" );
-		functionFactory.sha( "sha256(?1)" );
-		functionFactory.md5( "decode(md5(?1), 'hex')" );
-		functionFactory.format_toChar();
+		// M mode (MySQL-compatible) does not support ordered-set aggregate functions with WITHIN
+		// GROUP — it reports "Function rank(integer,integer) does not exist", treating the
+		// within-group ORDER BY expression as a second argument; window-emulation (OVER) is also
+		// unsupported. A mode supports the hypothetical-set variants (registered above). The
+		// inverse-distribution variants (percentile_cont / percentile_disc / mode) are not
+		// registered for either mode, so SupportsInverseDistributionFunctions returns false and
+		// those tests are skipped instead of failing against unsupported syntax.
+		if ( mMode ) {
+			// M mode (MySQL-compatible) lacks PostgreSQL's encode/date_trunc/to_char(datetime);
+			// use MySQL equivalents. format=date_format is also required by trunc's FORMAT
+			// emulation (DateTruncEmulation renders str_to_date(date_format(...),...)).
+			functionFactory.hex( "hex(?1)" );
+			functionFactory.format_dateFormat();
+			functionFactory.pad_space();
+			functionFactory.trunc_truncate();
+		}
+		else {
+			functionFactory.dateTrunc();
+			functionFactory.hex( "encode(?1, 'hex')" );
+			functionFactory.sha( "sha256(?1)" );
+			functionFactory.md5( "decode(md5(?1), 'hex')" );
+			functionFactory.format_toChar();
+		}
 
-		functionContributions.getFunctionRegistry().register( "min", new GaussDBMinMaxFunction( "min" ) );
-		functionContributions.getFunctionRegistry().register( "max", new GaussDBMinMaxFunction( "max" ) );
+		functionContributions.getFunctionRegistry().register( "min", new GaussDBMinMaxFunction( "min", mMode ) );
+		functionContributions.getFunctionRegistry().register( "max", new GaussDBMinMaxFunction( "max", mMode ) );
 
 		// uses # instead of ^ for XOR
 		functionContributions.getFunctionRegistry().patternDescriptorBuilder( "bitxor", "(?1 # ?2)" )
@@ -109,10 +151,14 @@ public class GaussDBFunctionRegistry {
 		functionContributions.getFunctionRegistry().register(
 				"round", new GaussDBTruncRoundFunction( "round", true )
 		);
-		functionContributions.getFunctionRegistry().register(
-				"trunc",
-				new GaussDBTruncFunction( true, functionContributions.getTypeConfiguration() )
-		);
+		if ( !mMode ) {
+			// A mode: GaussDB-specific trunc (date_trunc + GaussDBTruncRoundFunction for numbers).
+			// M mode: trunc_truncate() above already registered trunc (FORMAT emulation + truncate()).
+			functionContributions.getFunctionRegistry().register(
+					"trunc",
+					new GaussDBTruncFunction( true, functionContributions.getTypeConfiguration() )
+			);
+		}
 		functionContributions.getFunctionRegistry().registerAlternateKey( "truncate", "trunc" );
 
 		array_gaussdb();
@@ -127,7 +173,19 @@ public class GaussDBFunctionRegistry {
 		arraySet_gaussdb();
 		arrayFill_gaussdb();
 		jsonObject_gaussdb();
-		functionFactory.regexpLike();
+		if ( mMode ) {
+			// M mode ships a builtin `regexp_like(text,text,text)` PL/pgSQL function whose 3-arg
+			// form raises "CASE statement is missing ELSE part" — its body uses a PL/pgSQL CASE
+			// statement without ELSE, which M mode's engine rejects even when a WHEN branch matches.
+			// The 2-arg builtin (`$1 ~ $2`) works, but CommonFunctionFactory.regexpLike() routes both
+			// arities through the named (builtin) function. Render with the `~`/`~*` operators
+			// instead (2-arg case-sensitive, 3-arg with literal 'i' case-insensitive), which M mode
+			// supports natively. A mode keeps the builtin function via the common factory.
+			functionRegistry.register( "regexp_like", new RegexpLikeOperatorFunction( typeConfiguration, false ) );
+		}
+		else {
+			functionFactory.regexpLike();
+		}
 	}
 
 	public void array_gaussdb() {
@@ -182,6 +240,6 @@ public class GaussDBFunctionRegistry {
 	}
 
 	public void jsonObject_gaussdb() {
-		functionRegistry.register( "json_object", new GaussDBJsonObjectFunction( typeConfiguration ) );
+		functionRegistry.register( "json_object", new GaussDBJsonObjectFunction( functionContributions.getDialect(), typeConfiguration ) );
 	}
 }

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBInstantJdbcType.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBInstantJdbcType.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.InstantJdbcType;
+
+/**
+ * GaussDB-specific {@link InstantJdbcType} that reads {@code DATETIME}/{@code TIMESTAMP}
+ * columns via {@link ResultSet#getTimestamp(int)} instead of {@code getObject(int, Instant.class)}.
+ *
+ * <p>gsjdbc4's {@code ResultSet.getObject(int, Class)} cannot convert a {@code DATETIME} column to
+ * {@code java.time.Instant} &mdash; it throws "conversion to class java.time.Instant from 93 not
+ * supported" (93 is the JDBC {@code TIMESTAMP}/{@code DATETIME} type code). {@code getTimestamp(int)}
+ * reads the value fine, and {@link org.hibernate.type.descriptor.java.InstantJavaType#wrap} converts
+ * the resulting {@link Timestamp} to an {@code java.time.Instant}. Only the {@code INSTANT} descriptor
+ * is overridden.
+ *
+ * <p>Registered globally (both A and M mode): {@code getTimestamp} reads {@code TIMESTAMP} columns
+ * correctly under the openGauss PG kernel (A mode) as well, so A mode is constructively unaffected.
+ *
+ * @author liubao
+ *
+ * Notes: Original code of this class is based on GaussDBLocalDateJdbcType.
+ */
+public class GaussDBInstantJdbcType extends InstantJdbcType {
+	public static final GaussDBInstantJdbcType INSTANCE = new GaussDBInstantJdbcType();
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+		return new GaussDBInstantExtractor<>( javaType, this );
+	}
+
+	private static class GaussDBInstantExtractor<X> extends BasicExtractor<X> {
+		private GaussDBInstantExtractor(JavaType<X> javaType, GaussDBInstantJdbcType jdbcType) {
+			super( javaType, jdbcType );
+		}
+
+		@Override
+		protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( rs.getTimestamp( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, int paramIndex, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( statement.getTimestamp( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( statement.getTimestamp( name ), options );
+		}
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBLocalDateJdbcType.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBLocalDateJdbcType.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.LocalDateJdbcType;
+
+/**
+ * GaussDB-specific {@link LocalDateJdbcType} that reads {@code DATE} columns via
+ * {@link ResultSet#getDate(int)} instead of {@code getObject(int, LocalDate.class)}.
+ *
+ * <p>GaussDB M mode exposes its {@code DATE} type as the non-standard {@code datea} SQL type
+ * (JDBC type code {@link java.sql.Types#OTHER}), which the gsjdbc4 driver cannot convert to
+ * {@code java.time.LocalDate} through {@code getObject(int, Class)} (it throws
+ * "conversion to class java.time.LocalDate from datea not supported"). {@code getDate(int)}
+ * reads the value fine, and {@link org.hibernate.type.descriptor.java.LocalDateJavaType#wrap}
+ * converts the resulting {@link java.sql.Date} to a {@link java.time.LocalDate}. {@code TIME}
+ * and {@code TIMESTAMP} columns report the standard JDBC type codes and are unaffected, so only
+ * the {@code LOCAL_DATE} descriptor is overridden.
+ */
+public class GaussDBLocalDateJdbcType extends LocalDateJdbcType {
+	public static final GaussDBLocalDateJdbcType INSTANCE = new GaussDBLocalDateJdbcType();
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+		return new GaussDBLocalDateExtractor<>( javaType, this );
+	}
+
+	private static class GaussDBLocalDateExtractor<X> extends BasicExtractor<X> {
+		private GaussDBLocalDateExtractor(JavaType<X> javaType, GaussDBLocalDateJdbcType jdbcType) {
+			super( javaType, jdbcType );
+		}
+
+		@Override
+		protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( rs.getDate( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, int paramIndex, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( statement.getDate( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( statement.getDate( name ), options );
+		}
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBLocalDateTimeJdbcType.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBLocalDateTimeJdbcType.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.BasicBinder;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.LocalDateTimeJdbcType;
+
+/**
+ * GaussDB-specific {@link LocalDateTimeJdbcType} that reads {@code DATETIME}/{@code TIMESTAMP}
+ * columns via {@link ResultSet#getTimestamp(int)} and writes via {@link PreparedStatement#setTimestamp(int, Timestamp)}
+ * instead of {@code getObject}/{@code setObject(int, LocalDateTime, int)}.
+ *
+ * <h3>Read path</h3>
+ * gsjdbc4's {@code ResultSet.getObject(int, Class)} cannot convert a {@code DATETIME} column to
+ * {@code java.time.LocalDateTime} &mdash; it throws "Cannot convert the column of type DATETIME to
+ * requested type timestamp." {@code getTimestamp(int)} reads the value fine, and
+ * {@link org.hibernate.type.descriptor.java.LocalDateTimeJavaType#wrap} converts the resulting
+ * {@link Timestamp} to a {@code java.time.LocalDateTime}.
+ *
+ * <h3>Write path</h3>
+ * gsjdbc4's {@code setObject(int, LocalDateTime, TIMESTAMP)} routes to {@code setTimestamp(LocalDateTime)},
+ * whose {@code TimestampUtils.toString(LocalDateTime)} <em>attaches the default time zone</em> (converting
+ * through {@code OffsetDateTime}) and emits a string like {@code 2026-07-10 09:31:09.29287+00}. GaussDB M
+ * mode {@code datetime(6)} rejects values carrying a time-zone offset ("Incorrect datetime value"), so
+ * inserting a {@code LocalDateTime} with fractional seconds fails. {@code setTimestamp(int, Timestamp)}
+ * instead routes through {@code TimestampUtils.toString(Calendar, Timestamp)} which emits
+ * {@code 2026-07-10 09:31:09.292870} (no offset) and is accepted. {@code OffsetDateTime}, {@code LocalDate}
+ * and {@code LocalTime} columns are not affected (OffsetDateTime goes through a separate accepted path;
+ * LocalDate/LocalTime have no offset), so only the {@code LOCAL_DATE_TIME} descriptor is overridden.
+ *
+ * <p>Registered globally (both A and M mode): {@code getTimestamp}/{@code setTimestamp(Timestamp)} read
+ * {@code TIMESTAMP} columns correctly under the openGauss PG kernel (A mode) as well, so A mode is
+ * constructively unaffected.
+ *
+ * @author liubao
+ *
+ * Notes: Original code of this class is based on GaussDBLocalDateJdbcType.
+ */
+public class GaussDBLocalDateTimeJdbcType extends LocalDateTimeJdbcType {
+	public static final GaussDBLocalDateTimeJdbcType INSTANCE = new GaussDBLocalDateTimeJdbcType();
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+		return new GaussDBLocalDateTimeExtractor<>( javaType, this );
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
+		return new GaussDBLocalDateTimeBinder<>( javaType, this );
+	}
+
+	private static class GaussDBLocalDateTimeExtractor<X> extends BasicExtractor<X> {
+		private GaussDBLocalDateTimeExtractor(JavaType<X> javaType, GaussDBLocalDateTimeJdbcType jdbcType) {
+			super( javaType, jdbcType );
+		}
+
+		@Override
+		protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( rs.getTimestamp( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, int paramIndex, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( statement.getTimestamp( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( statement.getTimestamp( name ), options );
+		}
+	}
+
+	private static class GaussDBLocalDateTimeBinder<X> extends BasicBinder<X> {
+		private GaussDBLocalDateTimeBinder(JavaType<X> javaType, GaussDBLocalDateTimeJdbcType jdbcType) {
+			super( javaType, jdbcType );
+		}
+
+		@Override
+		protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+			final LocalDateTime localDateTime = getJavaType().unwrap( value, LocalDateTime.class, options );
+			st.setTimestamp( index, Timestamp.valueOf( localDateTime ) );
+		}
+
+		@Override
+		protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
+			final LocalDateTime localDateTime = getJavaType().unwrap( value, LocalDateTime.class, options );
+			st.setTimestamp( name, Timestamp.valueOf( localDateTime ) );
+		}
+
+		@Override
+		protected void doBindNull(PreparedStatement st, int index, WrapperOptions options) throws SQLException {
+			st.setNull( index, Types.TIMESTAMP );
+		}
+
+		@Override
+		protected void doBindNull(CallableStatement st, String name, WrapperOptions options) throws SQLException {
+			st.setNull( name, Types.TIMESTAMP );
+		}
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBOffsetDateTimeJdbcType.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBOffsetDateTimeJdbcType.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.BasicBinder;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.OffsetDateTimeJdbcType;
+
+/**
+ * GaussDB-specific {@link OffsetDateTimeJdbcType} that reads {@code DATETIME}/{@code TIMESTAMP}
+ * columns via {@link ResultSet#getTimestamp(int)} and writes via {@link PreparedStatement#setTimestamp(int, Timestamp)}
+ * instead of {@code getObject}/{@code setObject(int, OffsetDateTime, int)}.
+ *
+ * <h3>Read path</h3>
+ * gsjdbc4's {@code ResultSet.getObject(int, Class)} raises "conversion to class java.time.OffsetDateTime
+ * from datetime not supported" for a {@code DATETIME} column under M mode (the failure surfaces when
+ * Hibernate loads an entity whose {@code OffsetDateTime} attribute is read through the default
+ * {@code GetObjectExtractor}). {@code getTimestamp(int)} reads the value fine, and
+ * {@link org.hibernate.type.descriptor.java.OffsetDateTimeJavaType#wrap} converts the resulting
+ * {@link Timestamp} to a {@code java.time.OffsetDateTime} (using the JVM default time zone).
+ *
+ * <h3>Write path</h3>
+ * gsjdbc4's {@code setObject(int, OffsetDateTime, TIMESTAMP_WITH_TIMEZONE)} sends a
+ * {@code timestamp with time zone} expression that M mode {@code datetime(6)} rejects with
+ * "column ... is of type datetime but expression is of type timestamp with time zone".
+ * {@code setTimestamp(int, Timestamp)} instead routes through {@code TimestampUtils.toString(Calendar, Timestamp)}
+ * which emits a plain {@code datetime} literal and is accepted. {@code LocalDate}, {@code LocalTime},
+ * {@code LocalDateTime} and {@code Instant} are handled by their own GaussDB-specific descriptors,
+ * so only the {@code OFFSET_DATE_TIME} descriptor is overridden here.
+ *
+ * <p>Registered globally (both A and M mode): {@code getTimestamp}/{@code setTimestamp(Timestamp)} read/write
+ * {@code TIMESTAMP}/{@code timestamptz} columns correctly under the openGauss PG kernel (A mode) as well,
+ * so A mode is constructively unaffected.
+ *
+ * @author liubao
+ *
+ * Notes: Original code of this class is based on GaussDBLocalDateTimeJdbcType.
+ */
+public class GaussDBOffsetDateTimeJdbcType extends OffsetDateTimeJdbcType {
+	public static final GaussDBOffsetDateTimeJdbcType INSTANCE = new GaussDBOffsetDateTimeJdbcType();
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+		return new GaussDBOffsetDateTimeExtractor<>( javaType, this );
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
+		return new GaussDBOffsetDateTimeBinder<>( javaType, this );
+	}
+
+	private static class GaussDBOffsetDateTimeExtractor<X> extends BasicExtractor<X> {
+		private GaussDBOffsetDateTimeExtractor(JavaType<X> javaType, GaussDBOffsetDateTimeJdbcType jdbcType) {
+			super( javaType, jdbcType );
+		}
+
+		@Override
+		protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( rs.getTimestamp( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, int paramIndex, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( statement.getTimestamp( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+			return getJavaType().wrap( statement.getTimestamp( name ), options );
+		}
+	}
+
+	private static class GaussDBOffsetDateTimeBinder<X> extends BasicBinder<X> {
+		private GaussDBOffsetDateTimeBinder(JavaType<X> javaType, GaussDBOffsetDateTimeJdbcType jdbcType) {
+			super( javaType, jdbcType );
+		}
+
+		@Override
+		protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+			final Timestamp timestamp = getJavaType().unwrap( value, Timestamp.class, options );
+			st.setTimestamp( index, timestamp );
+		}
+
+		@Override
+		protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
+			final Timestamp timestamp = getJavaType().unwrap( value, Timestamp.class, options );
+			st.setTimestamp( name, timestamp );
+		}
+
+		@Override
+		protected void doBindNull(PreparedStatement st, int index, WrapperOptions options) throws SQLException {
+			st.setNull( index, Types.TIMESTAMP );
+		}
+
+		@Override
+		protected void doBindNull(CallableStatement st, String name, WrapperOptions options) throws SQLException {
+			st.setNull( name, Types.TIMESTAMP );
+		}
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBSqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBSqlAstTranslator.java
@@ -10,13 +10,18 @@ import org.hibernate.query.sqm.ComparisonOperator;
 import org.hibernate.query.common.FetchClauseType;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.spi.SqlAstTranslatorWithMerge;
+import org.hibernate.dialect.DmlTargetColumnQualifierSupport;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteMaterialization;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.delete.DeleteStatement;
 import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
+import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.Star;
 import org.hibernate.sql.ast.tree.expression.Summarization;
+import org.hibernate.sql.ast.tree.expression.UnparsedNumericLiteral;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.insert.ConflictClause;
@@ -32,6 +37,7 @@ import org.hibernate.sql.ast.tree.update.UpdateStatement;
 import org.hibernate.sql.exec.internal.JdbcOperationQueryInsertImpl;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.sql.exec.spi.JdbcOperationQueryInsert;
+import org.hibernate.sql.model.internal.OptionalTableInsert;
 import org.hibernate.sql.model.internal.TableInsertStandard;
 import org.hibernate.type.SqlTypes;
 
@@ -57,6 +63,35 @@ public class GaussDBSqlAstTranslator<T extends JdbcOperation> extends SqlAstTran
 	}
 
 	@Override
+	public void visitStar(Star star) {
+		// GaussDB M mode (MySQL-compatible) optimizer bug: a correlated scalar subquery using
+		// count(*) in a comparison — e.g. HQL `size(collection) = N` renders as
+		// `where (select count(*) from child where child.fk = parent.id) = ?` — raises a FATAL
+		// "Failed on assertion in nlist.cpp function list_nth_cell line 671. list is NIL" and kills
+		// the connection. Rendering count(1) instead of count(*) avoids the bug and is semantically
+		// equivalent (counts all rows). A mode (openGauss PG kernel) keeps count(*).
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+			appendSql( '1' );
+			return;
+		}
+		super.visitStar( star );
+	}
+
+	@Override
+	public <N extends Number> void visitUnparsedNumericLiteral(UnparsedNumericLiteral<N> literal) {
+		// GaussDB M mode rejects a numeric literal that starts with '.' (e.g. HQL `.001f` renders the
+		// raw ".001" -> "syntax error at or near \".\""). Prepend "0" -> "0.001". A mode (PG kernel)
+		// accepts it, so keep super.
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+			final String literalValue = literal.getUnparsedLiteralValue();
+			if ( literalValue.charAt( 0 ) == '.' ) {
+				appendSql( "0" );
+			}
+		}
+		super.visitUnparsedNumericLiteral( literal );
+	}
+
+	@Override
 	protected String getArrayContainsFunction() {
 		return super.getArrayContainsFunction();
 	}
@@ -64,7 +99,9 @@ public class GaussDBSqlAstTranslator<T extends JdbcOperation> extends SqlAstTran
 	@Override
 	protected void renderInsertIntoNoColumns(TableInsertStandard tableInsert) {
 		renderIntoIntoAndTable( tableInsert );
-		appendSql( "default values" );
+		// Delegate to the dialect so M mode (MySQL-compatible) renders `() values ()`
+		// instead of `default values`, which M mode rejects. A mode keeps `default values`.
+		appendSql( getDialect().getNoColumnsInsertString() );
 	}
 
 	@Override
@@ -85,7 +122,13 @@ public class GaussDBSqlAstTranslator<T extends JdbcOperation> extends SqlAstTran
 		if ( identificationVariable != null ) {
 			final Clause currentClause = getClauseStack().getCurrent();
 			if ( currentClause == Clause.INSERT ) {
-				// GaussDB requires the "as" keyword for inserts
+				if ( getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+					// M mode (MySQL-compatible) rejects INSERT table aliases entirely
+					// (both `insert into t as a` and `insert into t a` are syntax errors),
+					// so emit nothing. A mode (Oracle-compatible) requires the "as" keyword.
+					return;
+				}
+				// GaussDB A mode requires the "as" keyword for inserts
 				appendSql( " as " );
 			}
 			else {
@@ -108,13 +151,146 @@ public class GaussDBSqlAstTranslator<T extends JdbcOperation> extends SqlAstTran
 	}
 
 	@Override
+	protected void renderDeleteClause(DeleteStatement statement) {
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+			// M mode (MySQL-compatible) rejects `delete from t alias` (PostgreSQL style);
+			// render MySQL-style `delete alias from t alias` instead. A mode keeps PG style.
+			appendSql( "delete" );
+			final var clauseStack = getClauseStack();
+			try {
+				clauseStack.push( Clause.DELETE );
+				renderTableReferenceIdentificationVariable( statement.getTargetTable() );
+				if ( statement.getFromClause().getRoots().isEmpty() ) {
+					appendSql( " from " );
+					renderDmlTargetTableExpression( statement.getTargetTable() );
+				}
+				else {
+					visitFromClause( statement.getFromClause() );
+				}
+			}
+			finally {
+				clauseStack.pop();
+			}
+		}
+		else {
+			super.renderDeleteClause( statement );
+		}
+	}
+
+	@Override
+	protected void renderUpdateClause(UpdateStatement updateStatement) {
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode()
+				&& !updateStatement.getFromClause().getRoots().isEmpty() ) {
+			// M mode (MySQL-compatible) rejects PG-style `update t set ... from t1 join t2 ...`.
+			// Render MySQL-style `update t1 join t2 on ...` up front; renderFromClauseAfterUpdateSet
+			// is then a no-op. A mode (openGauss PG kernel) keeps the base `update t set ... from`.
+			appendSql( "update " );
+			renderFromClauseSpaces( updateStatement.getFromClause() );
+		}
+		else {
+			super.renderUpdateClause( updateStatement );
+		}
+	}
+
+	@Override
 	protected void renderFromClauseAfterUpdateSet(UpdateStatement statement) {
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+			// M mode renders the FROM clause up front in renderUpdateClause (MySQL style),
+			// so there is nothing to append after SET. A mode keeps PG-style `... from t1 join t2`
+			// plus the row-matching predicate via renderFromClauseJoiningDmlTargetReference.
+			return;
+		}
 		renderFromClauseJoiningDmlTargetReference( statement );
 	}
 
 	@Override
 	protected void visitConflictClause(ConflictClause conflictClause) {
-		visitOnDuplicateKeyConflictClauseWithDoNothing( conflictClause );
+		// GaussDB uses MySQL-style `ON DUPLICATE KEY UPDATE` for both M mode (MySQL-compatible) and A mode
+		// (openGauss Oracle-compatible), because A mode does not support PostgreSQL's `ON CONFLICT` syntax.
+		// Emulate DO NOTHING via `ON DUPLICATE KEY UPDATE col=col` (MySQL-standard) &mdash; `UPDATE NOTHING`
+		// is not valid GaussDB/MySQL syntax and raises "syntax error at end of input".
+		visitOnDuplicateKeyConflictClause( conflictClause );
+	}
+
+	@Override
+	public void visitColumnReference(ColumnReference columnReference) {
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode()
+				&& "excluded".equals( columnReference.getQualifier() )
+				&& getStatementStack().getCurrent() instanceof InsertSelectStatement insertSelectStatement
+				&& insertSelectStatement.getSourceSelectStatement() == null ) {
+			// M mode (MySQL-compatible) has no `excluded` row alias for insert-values ON DUPLICATE KEY
+			// UPDATE; reference the proposed value via `values(col)` (MySQL-standard). A mode (ON CONFLICT)
+			// uses `excluded.col` and keeps the base behavior.
+			appendSql( "values(" );
+			columnReference.appendReadExpression( this, null );
+			append( ')' );
+		}
+		else {
+			super.visitColumnReference( columnReference );
+		}
+	}
+
+	@Override
+	protected String determineColumnReferenceQualifier(ColumnReference columnReference) {
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+			// M mode (MySQL-compatible) does not alias the INSERT target table, so a column reference
+			// qualified with the target table's identification variable (e.g. be1_0) in the ON DUPLICATE
+			// KEY UPDATE SET clause has no resolvable table &mdash; GaussDB raises "Missing FROM-clause
+			// entry for table be1_0". Re-qualify such references with the table expression (table name),
+			// mirroring MySQLSqlAstTranslator. A mode (ON CONFLICT) keeps the base behavior.
+			final DmlTargetColumnQualifierSupport qualifierSupport = getDialect().getDmlTargetColumnQualifierSupport();
+			final String dmlAlias;
+			if ( getClauseStack().getCurrent() != Clause.SET
+					|| !( getCurrentDmlStatement() instanceof InsertSelectStatement insertSelectStatement )
+					|| ( dmlAlias = insertSelectStatement.getTargetTable().getIdentificationVariable() ) == null
+					|| !dmlAlias.equals( columnReference.getQualifier() ) ) {
+				return columnReference.getQualifier();
+			}
+			else if ( qualifierSupport != DmlTargetColumnQualifierSupport.NONE || !getQueryPartStack().isEmpty() ) {
+				return getCurrentDmlStatement().getTargetTable().getTableExpression();
+			}
+			else {
+				return null;
+			}
+		}
+		return super.determineColumnReferenceQualifier( columnReference );
+	}
+
+	@Override
+	public void visitStandardTableInsert(TableInsertStandard tableInsert) {
+		if ( tableInsert instanceof OptionalTableInsert
+				&& getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+			// M mode (MySQL-compatible): emulate DO NOTHING for optional (collection/secondary) tables via
+			// `ON DUPLICATE KEY UPDATE col=col` (MySQL-standard). `UPDATE NOTHING` is not valid GaussDB/MySQL
+			// syntax and raises "syntax error at end of input". The base visitStandardTableInsert rejects
+			// OptionalTableInsert, so M mode overrides here. A mode does not build OptionalTableInsert — see
+			// GaussDBDialect#createOptionalTableUpdateOperation (A mode falls back to the default
+			// OptionalTableUpdateOperation, which uses a plain insert + catch unique-violation) — and thus
+			// uses the base translator, which is correct because A mode does not support ON CONFLICT either.
+			getCurrentClauseStack().push( Clause.INSERT );
+			try {
+				renderInsertInto( tableInsert );
+				appendSql( " on duplicate key update " );
+				final ColumnReference[] firstCol = new ColumnReference[1];
+				tableInsert.forEachValueBinding( (columnPosition, columnValueBinding) -> {
+					if ( columnPosition == 0 ) {
+						firstCol[0] = columnValueBinding.getColumnReference();
+					}
+				} );
+				appendSql( firstCol[0].getColumnExpression() );
+				appendSql( '=' );
+				visitColumnReference( firstCol[0] );
+				if ( tableInsert.getNumberOfReturningColumns() > 0 ) {
+					visitReturningColumns( tableInsert::getReturningColumns );
+				}
+			}
+			finally {
+				getCurrentClauseStack().pop();
+			}
+		}
+		else {
+			super.visitStandardTableInsert( tableInsert );
+		}
 	}
 
 	@Override
@@ -183,6 +359,12 @@ public class GaussDBSqlAstTranslator<T extends JdbcOperation> extends SqlAstTran
 
 	@Override
 	protected void renderMaterializationHint(CteMaterialization materialization) {
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+			// M mode (MySQL-compatible) rejects the `materialized`/`not materialized` CTE hint
+			// (syntax error); emit nothing so CTEs render as plain `as (select ...)`. A mode
+			// (Oracle-compatible, openGauss PG kernel) keeps the PostgreSQL-style hint.
+			return;
+		}
 		if ( materialization == CteMaterialization.NOT_MATERIALIZED ) {
 			appendSql( "not " );
 		}
@@ -258,8 +440,33 @@ public class GaussDBSqlAstTranslator<T extends JdbcOperation> extends SqlAstTran
 
 	@Override
 	public void visitLikePredicate(LikePredicate likePredicate) {
-		// We need a custom implementation here because GaussDB
-		// uses the backslash character as default escape character
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+			if ( likePredicate.isCaseSensitive() ) {
+				// M mode's default collation is case-insensitive, so a case-sensitive LIKE would
+				// match 'Prod%' against "product"/"PROD" as well. Force a case-sensitive comparison
+				// with `collate "C"` so Hibernate's case-sensitive LIKE keeps its semantics.
+				// renderEscapeCharacter forces `escape ''` when no explicit escape is given, to
+				// disable backslash escaping (MySQL treats `\` as the escape; PG/Hibernate treat
+				// it as a literal).
+				likePredicate.getMatchExpression().accept( this );
+				appendSql( " collate \"C\"" );
+				if ( likePredicate.isNegated() ) {
+					appendSql( " not" );
+				}
+				appendSql( " like " );
+				likePredicate.getPattern().accept( this );
+				renderEscapeCharacter( likePredicate.getEscapeCharacter() );
+			}
+			else {
+				// Case-insensitive LIKE: M mode has no native ILIKE (supportsCaseInsensitiveLike()
+				// returns false), so let the base translator emulate it via lower(col) like lower(pattern).
+				// The lower()-folded operands are already case-insensitive, so no collate is needed.
+				super.visitLikePredicate( likePredicate );
+			}
+			return;
+		}
+		// A mode (openGauss PG kernel): we need a custom implementation here because GaussDB
+		// uses the backslash character as default escape character.
 		// According to the documentation, we can overcome this by specifying an empty escape character
 		// See https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
 		likePredicate.getMatchExpression().accept( this );
@@ -281,6 +488,25 @@ public class GaussDBSqlAstTranslator<T extends JdbcOperation> extends SqlAstTran
 		}
 		else {
 			appendSql( " escape ''''" );
+		}
+	}
+
+	@Override
+	protected void renderEscapeCharacter(Expression escapeCharacter) {
+		if ( getDialect() instanceof GaussDBDialect g && g.isMMode() ) {
+			// M mode: force an empty escape character to disable backslash escaping (MySQL default),
+			// making the backslash a literal — matching Hibernate/PG semantics. An explicit escape
+			// character is honored as-is.
+			if ( escapeCharacter != null ) {
+				appendSql( " escape " );
+				escapeCharacter.accept( this );
+			}
+			else {
+				appendSql( " escape ''''" );
+			}
+		}
+		else {
+			super.renderEscapeCharacter( escapeCharacter );
 		}
 	}
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBTimestampWithTimeZoneJdbcType.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBTimestampWithTimeZoneJdbcType.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Calendar;
+
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.BasicBinder;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.TimestampWithTimeZoneJdbcType;
+
+/**
+ * GaussDB-specific {@link TimestampWithTimeZoneJdbcType} for {@code @JdbcTypeCode(TIMESTAMP_WITH_TIMEZONE)}
+ * (JDBC type code {@link Types#TIMESTAMP_WITH_TIMEZONE}). Reads {@code DATETIME}/{@code TIMESTAMP}
+ * columns via {@link ResultSet#getTimestamp(int, Calendar)} and writes via
+ * {@link PreparedStatement#setTimestamp(int, Timestamp, Calendar)} instead of
+ * {@code getObject}/{@code setObject(int, OffsetDateTime, TIMESTAMP_WITH_TIMEZONE)}.
+ *
+ * <h3>Why a separate descriptor</h3>
+ * The default {@code TimestampWithTimeZoneJdbcType} binds through
+ * {@code setObject(int, OffsetDateTime, Types.TIMESTAMP_WITH_TIMEZONE)}, which gsjdbc4 turns into a
+ * {@code timestamp with time zone} expression. M mode {@code datetime(6)} columns reject that with
+ * "column ... is of type datetime but expression is of type timestamp with time zone". Crucially the
+ * {@code setObject} call itself does <em>not</em> throw &mdash; the error surfaces only when the
+ * statement executes &mdash; so the built-in {@code setTimestamp} fallback in
+ * {@code TimestampWithTimeZoneJdbcType} never runs. This descriptor skips {@code setObject} and binds
+ * through {@code setTimestamp} directly, honoring {@link WrapperOptions#getJdbcTimeZone()} (and
+ * {@link Calendar} values) exactly like the built-in fallback.
+ *
+ * <p>{@code OFFSET_DATE_TIME} ({@link GaussDBOffsetDateTimeJdbcType}) and {@code INSTANT}
+ * ({@link GaussDBInstantJdbcType}) have their own descriptors; this one covers the remaining
+ * {@code TIMESTAMP_WITH_TIMEZONE} code (2014) used by {@code @JdbcTypeCode(TIMESTAMP_WITH_TIMEZONE)}.
+ *
+ * <p>Registered globally (both A and M mode): {@code getTimestamp}/{@code setTimestamp} read/write
+ * {@code timestamptz} columns correctly under the openGauss PG kernel (A mode) as well, so A mode
+ * is constructively unaffected.
+ *
+ * @author liubao
+ *
+ * Notes: Original code of this class is based on TimestampWithTimeZoneJdbcType and GaussDBOffsetDateTimeJdbcType.
+ */
+public class GaussDBTimestampWithTimeZoneJdbcType extends TimestampWithTimeZoneJdbcType {
+	public static final GaussDBTimestampWithTimeZoneJdbcType INSTANCE = new GaussDBTimestampWithTimeZoneJdbcType();
+
+	@Override
+	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
+		return new GaussDBTimestampWithTimeZoneBinder<>( javaType, this );
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+		return new GaussDBTimestampWithTimeZoneExtractor<>( javaType, this );
+	}
+
+	private static Calendar jdbcCalendar(WrapperOptions options) {
+		return options.getJdbcTimeZone() != null ? Calendar.getInstance( options.getJdbcTimeZone() ) : null;
+	}
+
+	private static class GaussDBTimestampWithTimeZoneBinder<X> extends BasicBinder<X> {
+		private GaussDBTimestampWithTimeZoneBinder(JavaType<X> javaType, GaussDBTimestampWithTimeZoneJdbcType jdbcType) {
+			super( javaType, jdbcType );
+		}
+
+		@Override
+		protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+			final Timestamp timestamp = getJavaType().unwrap( value, Timestamp.class, options );
+			if ( value instanceof Calendar calendar ) {
+				st.setTimestamp( index, timestamp, calendar );
+			}
+			else {
+				final Calendar cal = jdbcCalendar( options );
+				if ( cal != null ) {
+					st.setTimestamp( index, timestamp, cal );
+				}
+				else {
+					st.setTimestamp( index, timestamp );
+				}
+			}
+		}
+
+		@Override
+		protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
+			final Timestamp timestamp = getJavaType().unwrap( value, Timestamp.class, options );
+			if ( value instanceof Calendar calendar ) {
+				st.setTimestamp( name, timestamp, calendar );
+			}
+			else {
+				final Calendar cal = jdbcCalendar( options );
+				if ( cal != null ) {
+					st.setTimestamp( name, timestamp, cal );
+				}
+				else {
+					st.setTimestamp( name, timestamp );
+				}
+			}
+		}
+
+		@Override
+		protected void doBindNull(PreparedStatement st, int index, WrapperOptions options) throws SQLException {
+			st.setNull( index, Types.TIMESTAMP );
+		}
+
+		@Override
+		protected void doBindNull(CallableStatement st, String name, WrapperOptions options) throws SQLException {
+			st.setNull( name, Types.TIMESTAMP );
+		}
+	}
+
+	private static class GaussDBTimestampWithTimeZoneExtractor<X> extends BasicExtractor<X> {
+		private GaussDBTimestampWithTimeZoneExtractor(JavaType<X> javaType, GaussDBTimestampWithTimeZoneJdbcType jdbcType) {
+			super( javaType, jdbcType );
+		}
+
+		@Override
+		protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+			final Calendar cal = jdbcCalendar( options );
+			return getJavaType().wrap( cal != null ? rs.getTimestamp( paramIndex, cal ) : rs.getTimestamp( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, int paramIndex, WrapperOptions options) throws SQLException {
+			final Calendar cal = jdbcCalendar( options );
+			return getJavaType().wrap( cal != null ? statement.getTimestamp( paramIndex, cal ) : statement.getTimestamp( paramIndex ), options );
+		}
+
+		@Override
+		protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+			final Calendar cal = jdbcCalendar( options );
+			return getJavaType().wrap( cal != null ? statement.getTimestamp( name, cal ) : statement.getTimestamp( name ), options );
+		}
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/aggregate/GaussDBAggregateSupport.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/aggregate/GaussDBAggregateSupport.java
@@ -1,0 +1,666 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect.aggregate;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.aggregate.AggregateSupport;
+import org.hibernate.dialect.aggregate.AggregateSupport.AggregateColumnWriteExpression;
+import org.hibernate.dialect.aggregate.AggregateSupport.WriteExpressionRenderer;
+import org.hibernate.dialect.aggregate.PostgreSQLAggregateSupport;
+import org.hibernate.internal.util.StringHelper;
+import org.hibernate.metamodel.mapping.EmbeddableMappingType;
+import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.metamodel.mapping.SelectableMapping;
+import org.hibernate.metamodel.mapping.SelectablePath;
+import org.hibernate.metamodel.mapping.SqlTypedMapping;
+import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.type.BasicPluralType;
+import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.XmlHelper;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import static org.hibernate.dialect.function.array.DdlTypeHelper.getCastTypeName;
+import static org.hibernate.type.SqlTypes.ARRAY;
+import static org.hibernate.type.SqlTypes.BINARY;
+import static org.hibernate.type.SqlTypes.BIGINT;
+import static org.hibernate.type.SqlTypes.BOOLEAN;
+import static org.hibernate.type.SqlTypes.DATE;
+import static org.hibernate.type.SqlTypes.DOUBLE;
+import static org.hibernate.type.SqlTypes.FLOAT;
+import static org.hibernate.type.SqlTypes.INSTANT;
+import static org.hibernate.type.SqlTypes.INTEGER;
+import static org.hibernate.type.SqlTypes.JSON;
+import static org.hibernate.type.SqlTypes.JSON_ARRAY;
+import static org.hibernate.type.SqlTypes.LOCAL_DATE;
+import static org.hibernate.type.SqlTypes.LOCAL_DATE_TIME;
+import static org.hibernate.type.SqlTypes.LONG32VARBINARY;
+import static org.hibernate.type.SqlTypes.OFFSET_DATE_TIME;
+import static org.hibernate.type.SqlTypes.TIMESTAMP;
+import static org.hibernate.type.SqlTypes.TIMESTAMP_UTC;
+import static org.hibernate.type.SqlTypes.TIMESTAMP_WITH_TIMEZONE;
+import static org.hibernate.type.SqlTypes.ZONED_DATE_TIME;
+import static org.hibernate.type.SqlTypes.SMALLINT;
+import static org.hibernate.type.SqlTypes.TINYINT;
+import static org.hibernate.type.SqlTypes.SQLXML;
+import static org.hibernate.type.SqlTypes.VARBINARY;
+import static org.hibernate.type.SqlTypes.XML_ARRAY;
+
+/**
+ * Aggregate support for {@link org.hibernate.community.dialect.GaussDBDialect}.
+ * <p>
+ * GaussDB in MySQL-compatibility (M) mode does not support the {@code jsonb} type at all
+ * (creating a {@code jsonb} table fails with a syntax error), so the dialect uses the
+ * {@code json} type instead. The PostgreSQL {@code ->}/{@code ->>} operators <em>do</em>
+ * work on {@code json} in M mode and behave like PostgreSQL's (they return SQL NULL for a
+ * JSON null value, whereas {@code JSON_UNQUOTE(JSON_EXTRACT(...))} returns the literal
+ * string {@code "null"}), so the scalar/JSON read expressions reuse them unchanged. What
+ * M mode lacks is the {@code jsonb || jsonb} concatenation operator ({@code ||} is logical
+ * OR in M mode), so only the write side needs rewriting:
+ * <ul>
+ *   <li>write: {@code json_set(json, '$.path', value, ...)} instead of
+ *       {@code jsonb || jsonb_build_object(...)}. {@code json_set} has the same overwrite
+ *       semantics as the PostgreSQL {@code ||} operator (right side wins, other keys
+ *       preserved). Values are passed raw (not wrapped in {@code to_jsonb}), because
+ *       {@code json_set} converts them to JSON itself and would double-quote a
+ *       {@code jsonb} argument.</li>
+ * </ul>
+ *
+ * @author liubao
+ *
+ * Notes: Original code of this class is based on PostgreSQLAggregateSupport.
+ */
+public class GaussDBAggregateSupport extends PostgreSQLAggregateSupport {
+
+	private static final AggregateSupport INSTANCE = new GaussDBAggregateSupport();
+
+	// XML aggregate rendering. GaussDB M mode's XMLTABLE requires the PASSING argument to be
+	// `xmltype`, but the aggregate column is `xml` and `cast(xml as xmltype)` is rejected, so the
+	// passing column is routed through text: `cast(cast(<col> as text) as xmltype)` (see
+	// xmlExtractArguments and GaussDBRootXmlWriteExpression). The COLUMNS type declarations
+	// (v xml / v text / scalars) are accepted unchanged in M mode.
+	private static final String XML_EXTRACT_START = "xmlelement(name \"" + XmlHelper.ROOT_TAG + "\",(select xmlagg(t.v) from xmltable(";
+	private static final String XML_EXTRACT_SEPARATOR = "/*' passing ";
+	private static final String XML_EXTRACT_END = " columns v xml path '.')t))";
+	private static final String XML_QUERY_START = "(select xmlagg(t.v) from xmltable(";
+	private static final String XML_QUERY_SEPARATOR = "' passing ";
+	private static final String XML_QUERY_END = " columns v xml path '.')t)";
+
+	public static AggregateSupport valueOf(Dialect dialect) {
+		return GaussDBAggregateSupport.INSTANCE;
+	}
+
+	@Override
+	public String aggregateComponentCustomReadExpression(
+			String template,
+			String placeholder,
+			String aggregateParentReadExpression,
+			String columnExpression,
+			int aggregateColumnTypeCode,
+			SqlTypedMapping column,
+			TypeConfiguration typeConfiguration) {
+		switch ( aggregateColumnTypeCode ) {
+			case JSON_ARRAY:
+			case JSON:
+				switch ( column.getJdbcMapping().getJdbcType().getDefaultSqlTypeCode() ) {
+					case JSON:
+					case JSON_ARRAY:
+						// `->` works on json in M mode and returns SQL NULL for a JSON null,
+						// unlike JSON_EXTRACT which returns a json null value. Parenthesize the
+						// extraction: M mode binds `is null` tighter than `->`, so without parens
+						// a sub-aggregate null check `parent->'col' is null` parses as
+						// `parent->('col' is null)` (type json) and is rejected in CHECK constraints.
+						return template.replace(
+								placeholder,
+								"(" + aggregateParentReadExpression + "->'" + columnExpression + "')"
+						);
+					case BINARY:
+					case VARBINARY:
+					case LONG32VARBINARY:
+						// We encode binary data as hex, so we have to decode here
+						return template.replace(
+								placeholder,
+								"decode(" + aggregateParentReadExpression + "->>'" + columnExpression + "','hex')"
+						);
+					case ARRAY:
+						final BasicPluralType<?, ?> pluralType = (BasicPluralType<?, ?>) column.getJdbcMapping();
+						switch ( pluralType.getElementType().getJdbcType().getDefaultSqlTypeCode() ) {
+							case BOOLEAN:
+							case TINYINT:
+							case SMALLINT:
+							case INTEGER:
+							case BIGINT:
+							case FLOAT:
+							case DOUBLE:
+								return template.replace(
+										placeholder,
+										"cast(array(select jsonb_array_elements(JSON_EXTRACT(" + aggregateParentReadExpression + ",'$." + columnExpression + "'))) as " + getCastTypeName( column, typeConfiguration ) + ')'
+								);
+							case BINARY:
+							case VARBINARY:
+							case LONG32VARBINARY:
+								// We encode binary data as hex, so we have to decode here
+								return template.replace(
+										placeholder,
+										"array(select decode(jsonb_array_elements_text(JSON_EXTRACT(" + aggregateParentReadExpression + ",'$." + columnExpression + "')),'hex'))"
+								);
+							default:
+								return template.replace(
+										placeholder,
+										"cast(array(select jsonb_array_elements_text(JSON_EXTRACT(" + aggregateParentReadExpression + ",'$." + columnExpression + "'))) as " + getCastTypeName( column, typeConfiguration ) + ')'
+								);
+						}
+					default:
+						// `->>` returns SQL NULL for a JSON null value, matching PostgreSQL.
+						// JSON_UNQUOTE(JSON_EXTRACT(...)) instead returns the literal string
+						// "null", which breaks CHECK constraints (cast to integer errors out)
+						// and reads (a null field read back as the string "null").
+						if ( column.getJdbcMapping().getJdbcType().getDefaultSqlTypeCode() == DATE ) {
+							// M mode `cast(text as date)` rejects ISO dates ("invalid value ... for MON"),
+							// but `cast(text as timestamp)` accepts them; cast via timestamp, then date.
+							// Still SQL-NULL-safe: cast(null as timestamp) -> null -> cast(null as date) -> null.
+							return template.replace(
+									placeholder,
+									"cast(cast(" + aggregateParentReadExpression + "->>'" + columnExpression + "' as timestamp) as " + getCastTypeName( column, typeConfiguration ) + ')'
+							);
+						}
+						return template.replace(
+								placeholder,
+								"cast(" + aggregateParentReadExpression + "->>'" + columnExpression + "' as " + getCastTypeName( column, typeConfiguration ) + ')'
+						);
+				}
+			case XML_ARRAY:
+			case SQLXML:
+				switch ( column.getJdbcMapping().getJdbcType().getDefaultSqlTypeCode() ) {
+					case SQLXML:
+						return template.replace(
+								placeholder,
+								XML_EXTRACT_START + xmlExtractArguments( aggregateParentReadExpression, columnExpression + "/*" ) + XML_EXTRACT_END
+						);
+					case XML_ARRAY:
+						if ( typeConfiguration.getCurrentBaseSqlTypeIndicators().isXmlFormatMapperLegacyFormatEnabled() ) {
+							throw new IllegalArgumentException( "XML array '" + columnExpression + "' in '" + aggregateParentReadExpression + "' is not supported with legacy format enabled." );
+						}
+						else {
+							return template.replace(
+									placeholder,
+									"xmlelement(name \"Collection\",(select xmlagg(t.v order by t.i) from xmltable(" + xmlExtractArguments( aggregateParentReadExpression, columnExpression + "/*" ) + " columns v xml path '.', i for ordinality)t))"
+							);
+						}
+					case BINARY:
+					case VARBINARY:
+					case LONG32VARBINARY:
+						// We encode binary data as hex, so we have to decode here
+						return template.replace(
+								placeholder,
+								"decode((select t.v from xmltable(" + xmlExtractArguments( aggregateParentReadExpression, columnExpression )+ " columns v text path '.') t),'hex')"
+						);
+					case ARRAY:
+						throw new UnsupportedOperationException( "Transforming XML_ARRAY to native arrays is not supported!" );
+					default:
+						return template.replace(
+								placeholder,
+								"(select t.v from xmltable(" + xmlExtractArguments( aggregateParentReadExpression, columnExpression ) + " columns v " + getCastTypeName( column, typeConfiguration ) + " path '.') t)"
+						);
+				}
+		}
+		// XML_ARRAY, SQLXML and STRUCT reuse the PostgreSQL implementation unchanged
+		return super.aggregateComponentCustomReadExpression(
+				template,
+				placeholder,
+				aggregateParentReadExpression,
+				columnExpression,
+				aggregateColumnTypeCode,
+				column,
+				typeConfiguration
+		);
+	}
+
+	@Override
+	public WriteExpressionRenderer aggregateCustomWriteExpressionRenderer(
+			SelectableMapping aggregateColumn,
+			SelectableMapping[] columnsToUpdate,
+			TypeConfiguration typeConfiguration) {
+		final int aggregateSqlTypeCode = aggregateColumn.getJdbcMapping().getJdbcType().getDefaultSqlTypeCode();
+		if ( aggregateSqlTypeCode == JSON ) {
+			return new GaussDBRootJsonWriteExpression( aggregateColumn, columnsToUpdate );
+		}
+		if ( aggregateSqlTypeCode == SQLXML ) {
+			return new GaussDBRootXmlWriteExpression( aggregateColumn, columnsToUpdate );
+		}
+		// XML and other aggregate types reuse the PostgreSQL implementation unchanged
+		return super.aggregateCustomWriteExpressionRenderer( aggregateColumn, columnsToUpdate, typeConfiguration );
+	}
+
+	private static String xmlExtractArguments(String aggregateParentReadExpression, String xpathFragment) {
+		final String extractArguments;
+		int separatorIndex;
+		if ( aggregateParentReadExpression.startsWith( XML_EXTRACT_START )
+			&& aggregateParentReadExpression.endsWith( XML_EXTRACT_END )
+			&& (separatorIndex = aggregateParentReadExpression.indexOf( XML_EXTRACT_SEPARATOR )) != -1 ) {
+			final var sb = new StringBuilder( aggregateParentReadExpression.length() - XML_EXTRACT_START.length() + xpathFragment.length() );
+			sb.append( aggregateParentReadExpression, XML_EXTRACT_START.length(), separatorIndex );
+			sb.append( '/' );
+			sb.append( xpathFragment );
+			sb.append( aggregateParentReadExpression, separatorIndex + 2, aggregateParentReadExpression.length() - XML_EXTRACT_END.length() );
+			extractArguments = sb.toString();
+		}
+		else if ( aggregateParentReadExpression.startsWith( XML_QUERY_START )
+				&& aggregateParentReadExpression.endsWith( XML_QUERY_END )
+				&& (separatorIndex = aggregateParentReadExpression.indexOf( XML_QUERY_SEPARATOR )) != -1 ) {
+			final var sb = new StringBuilder( aggregateParentReadExpression.length() - XML_QUERY_START.length() + xpathFragment.length() );
+			sb.append( aggregateParentReadExpression, XML_QUERY_START.length(), separatorIndex );
+			sb.append( '/' );
+			sb.append( xpathFragment );
+			sb.append( aggregateParentReadExpression, separatorIndex, aggregateParentReadExpression.length() - XML_QUERY_END.length() );
+			extractArguments = sb.toString();
+		}
+		else {
+			// Top-level: the parent is the bare `xml` aggregate column. M mode XMLTABLE requires
+			// `xmltype`; cast(xml as xmltype) is rejected, so route through text.
+			extractArguments = "'/" + XmlHelper.ROOT_TAG + "/" + xpathFragment + "' passing cast(cast(" + aggregateParentReadExpression + " as text) as xmltype)";
+		}
+		return extractArguments;
+	}
+
+	private static String xmlCustomWriteExpression(String customWriteExpression, JdbcMapping jdbcMapping) {
+		final int sqlTypeCode = jdbcMapping.getJdbcType().getDefaultSqlTypeCode();
+		switch ( sqlTypeCode ) {
+			case BINARY:
+			case VARBINARY:
+			case LONG32VARBINARY:
+				// We encode binary data as hex
+				return "encode(" + customWriteExpression + ",'hex')";
+			default:
+				return customWriteExpression;
+		}
+	}
+
+	private static String jsonCustomWriteExpression(String customWriteExpression, JdbcMapping jdbcMapping) {
+		final int sqlTypeCode = jdbcMapping.getJdbcType().getDefaultSqlTypeCode();
+		switch ( sqlTypeCode ) {
+			case BINARY:
+			case VARBINARY:
+			case LONG32VARBINARY:
+				// We encode binary data as hex; json_set embeds the hex string as a JSON string
+				return "encode(" + customWriteExpression + ",'hex')";
+			case DATE:
+			case LOCAL_DATE:
+				// M mode serializes a date as "2000-01-01 00:00:00 AD" (with a time component and era),
+				// which JdbcDateJavaType.fromEncodedString can't parse when the whole JSON document is
+				// read back (e.g. after an UPDATE via json_set). Emit a clean ISO date string instead,
+				// matching what the persist path (JsonGeneratingVisitor) writes. NULL-safe: to_char(null,..)=null.
+				return "to_char(" + customWriteExpression + ",'YYYY-MM-DD')";
+			case TIMESTAMP:
+			case LOCAL_DATE_TIME:
+				// M mode separates date and time with a space; ISO_LOCAL_DATE_TIME (used by
+				// JdbcTimestampJavaType / LocalDateTimeJavaType on read-back) requires a 'T'.
+				// .MS preserves fractional seconds. NULL-safe.
+				return "to_char(" + customWriteExpression + ",'YYYY-MM-DD\"T\"HH24:MI:SS.MS')";
+			case TIMESTAMP_WITH_TIMEZONE:
+			case TIMESTAMP_UTC:
+			case INSTANT:
+			case OFFSET_DATE_TIME:
+			case ZONED_DATE_TIME:
+				// M mode serializes a timestamptz as "2000-01-01 00:00:00+00" (space separator,
+				// colon-less offset, expressed in the session timezone), which the ISO formatters used
+				// on read-back (OffsetDateTime/Instant/ZonedDateTime) can't parse. Normalize to UTC and
+				// emit a trailing "Z". The "Z" is embedded in the to_char format rather than concatenated
+				// with ||, because || is logical-OR (not string concat) in M mode. NULL-safe.
+				return "to_char(" + customWriteExpression + " at time zone 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')";
+			default:
+				// Raw value: json_set converts it to JSON itself. Do not wrap in to_jsonb,
+				// because json_set would double-quote a jsonb argument.
+				return customWriteExpression;
+		}
+	}
+
+	interface GaussDBJsonWriteExpression {
+		void append(
+				SqlAppender sb,
+				String path,
+				SqlAstTranslator<?> translator,
+				AggregateColumnWriteExpression expression);
+	}
+
+	private static class GaussDBAggregateJsonWriteExpression implements GaussDBJsonWriteExpression {
+		private final LinkedHashMap<String, GaussDBJsonWriteExpression> subExpressions = new LinkedHashMap<>();
+
+		protected void initializeSubExpressions(SelectableMapping[] columns) {
+			for ( SelectableMapping column : columns ) {
+				final SelectablePath selectablePath = column.getSelectablePath();
+				final SelectablePath[] parts = selectablePath.getParts();
+				GaussDBAggregateJsonWriteExpression currentAggregate = this;
+				for ( int i = 1; i < parts.length - 1; i++ ) {
+					currentAggregate = (GaussDBAggregateJsonWriteExpression) currentAggregate.subExpressions.computeIfAbsent(
+							parts[i].getSelectableName(),
+							k -> new GaussDBAggregateJsonWriteExpression()
+					);
+				}
+				final String customWriteExpression = column.getWriteExpression();
+				currentAggregate.subExpressions.put(
+						parts[parts.length - 1].getSelectableName(),
+						new GaussDBBasicJsonWriteExpression(
+								column,
+								jsonCustomWriteExpression( customWriteExpression, column.getJdbcMapping() )
+						)
+				);
+			}
+		}
+
+		@Override
+		public void append(
+				SqlAppender sb,
+				String path,
+				SqlAstTranslator<?> translator,
+				AggregateColumnWriteExpression expression) {
+			// Emit `json_set` path-value pairs: `, '$.column', value`.
+			// The caller (`render` or a parent aggregate) opens the `json_set(...)`
+			// and supplies the target expression; we only append the path-value pairs.
+			for ( Map.Entry<String, GaussDBJsonWriteExpression> entry : subExpressions.entrySet() ) {
+				final String column = entry.getKey();
+				final GaussDBJsonWriteExpression value = entry.getValue();
+				sb.append( ", '$." );
+				sb.append( column );
+				sb.append( "'," );
+				if ( value instanceof GaussDBAggregateJsonWriteExpression ) {
+					// Nested aggregate: merge the existing sub-object with the new fields.
+					// `jsonb1 || jsonb_build_object(col, ...)` becomes
+					// `json_set(jsonb1, '$.col', json_set(jsonb1->'col', ...))`
+					final String subPath = "JSON_EXTRACT(" + path + ",'$." + column + "')";
+					sb.append( "json_set(coalesce(" );
+					sb.append( subPath );
+					sb.append( ",'{}')" );
+					value.append( sb, subPath, translator, expression );
+					sb.append( ")" );
+				}
+				else {
+					value.append( sb, path, translator, expression );
+				}
+			}
+		}
+	}
+
+	private static class GaussDBRootJsonWriteExpression extends GaussDBAggregateJsonWriteExpression
+			implements WriteExpressionRenderer {
+		private final boolean nullable;
+		private final String path;
+
+		GaussDBRootJsonWriteExpression(SelectableMapping aggregateColumn, SelectableMapping[] columns) {
+			this.nullable = aggregateColumn.isNullable();
+			this.path = aggregateColumn.getSelectionExpression();
+			initializeSubExpressions( columns );
+		}
+
+		@Override
+		public void render(
+				SqlAppender sqlAppender,
+				SqlAstTranslator<?> translator,
+				AggregateColumnWriteExpression aggregateColumnWriteExpression,
+				String qualifier) {
+			final String basePath;
+			if ( qualifier == null || qualifier.isBlank() ) {
+				basePath = path;
+			}
+			else {
+				basePath = qualifier + "." + path;
+			}
+			// `coalesce(base,'{}') || jsonb_build_object(...)` becomes
+			// `json_set(coalesce(base,'{}'), '$.field', value, ...)`
+			sqlAppender.append( "json_set(" );
+			if ( nullable ) {
+				sqlAppender.append( "coalesce(" );
+				sqlAppender.append( basePath );
+				sqlAppender.append( ",'{}')" );
+			}
+			else {
+				sqlAppender.append( basePath );
+			}
+			append( sqlAppender, basePath, translator, aggregateColumnWriteExpression );
+			sqlAppender.append( ")" );
+		}
+	}
+
+	private static class GaussDBBasicJsonWriteExpression implements GaussDBJsonWriteExpression {
+
+		private final SelectableMapping selectableMapping;
+		private final String customWriteExpressionStart;
+		private final String customWriteExpressionEnd;
+
+		GaussDBBasicJsonWriteExpression(SelectableMapping selectableMapping, String customWriteExpression) {
+			this.selectableMapping = selectableMapping;
+			if ( customWriteExpression.equals( "?" ) ) {
+				this.customWriteExpressionStart = "";
+				this.customWriteExpressionEnd = "";
+			}
+			else {
+				final String[] parts = StringHelper.split( "?", customWriteExpression );
+				assert parts.length == 2;
+				this.customWriteExpressionStart = parts[0];
+				this.customWriteExpressionEnd = parts[1];
+			}
+		}
+
+		@Override
+		public void append(
+				SqlAppender sb,
+				String path,
+				SqlAstTranslator<?> translator,
+				AggregateColumnWriteExpression expression) {
+			// Only the value; the `$.field` path is emitted by the parent aggregate.
+			sb.append( customWriteExpressionStart );
+			// We use NO_UNTYPED here so that expressions which require type inference are casted explicitly,
+			// since we don't know how the custom write expression looks like where this is embedded,
+			// so we have to be pessimistic and avoid ambiguities
+			translator.render( expression.getValueExpression( selectableMapping ), SqlAstNodeRenderingMode.NO_UNTYPED );
+			sb.append( customWriteExpressionEnd );
+		}
+	}
+
+	interface GaussDBXmlWriteExpression {
+		void append(
+				SqlAppender sb,
+				String path,
+				SqlAstTranslator<?> translator,
+				AggregateColumnWriteExpression expression);
+	}
+
+	private static class GaussDBAggregateXmlWriteExpression implements GaussDBXmlWriteExpression {
+
+		private final SelectableMapping selectableMapping;
+		private final LinkedHashMap<String, GaussDBXmlWriteExpression> subExpressions = new LinkedHashMap<>();
+
+		private GaussDBAggregateXmlWriteExpression(SelectableMapping selectableMapping) {
+			this.selectableMapping = selectableMapping;
+		}
+
+		protected void initializeSubExpressions(SelectableMapping aggregateColumn, SelectableMapping[] columns) {
+			for ( SelectableMapping column : columns ) {
+				final SelectablePath selectablePath = column.getSelectablePath();
+				final SelectablePath[] parts = selectablePath.getParts();
+				GaussDBAggregateXmlWriteExpression currentAggregate = this;
+				for ( int i = 1; i < parts.length - 1; i++ ) {
+					final AggregateJdbcType aggregateJdbcType = (AggregateJdbcType) currentAggregate.selectableMapping.getJdbcMapping().getJdbcType();
+					final EmbeddableMappingType embeddableMappingType = aggregateJdbcType.getEmbeddableMappingType();
+					final int selectableIndex = embeddableMappingType.getSelectableIndex( parts[i].getSelectableName() );
+					currentAggregate = (GaussDBAggregateXmlWriteExpression) currentAggregate.subExpressions.computeIfAbsent(
+							parts[i].getSelectableName(),
+							k -> new GaussDBAggregateXmlWriteExpression( embeddableMappingType.getJdbcValueSelectable( selectableIndex ) )
+					);
+				}
+				final String customWriteExpression = column.getWriteExpression();
+				currentAggregate.subExpressions.put(
+						parts[parts.length - 1].getSelectableName(),
+						new GaussDBBasicXmlWriteExpression(
+								column,
+								xmlCustomWriteExpression( customWriteExpression, column.getJdbcMapping() )
+						)
+				);
+			}
+			passThroughUnsetSubExpressions( aggregateColumn );
+		}
+
+		protected void passThroughUnsetSubExpressions(SelectableMapping aggregateColumn) {
+			final AggregateJdbcType aggregateJdbcType = (AggregateJdbcType) aggregateColumn.getJdbcMapping().getJdbcType();
+			final EmbeddableMappingType embeddableMappingType = aggregateJdbcType.getEmbeddableMappingType();
+			final int jdbcValueCount = embeddableMappingType.getJdbcValueCount();
+			for ( int i = 0; i < jdbcValueCount; i++ ) {
+				final SelectableMapping selectableMapping = embeddableMappingType.getJdbcValueSelectable( i );
+
+				final GaussDBXmlWriteExpression xmlWriteExpression = subExpressions.get( selectableMapping.getSelectableName() );
+				if ( xmlWriteExpression == null ) {
+					subExpressions.put(
+							selectableMapping.getSelectableName(),
+							new GaussDBPassThroughXmlWriteExpression( selectableMapping )
+					);
+				}
+				else if ( xmlWriteExpression instanceof GaussDBAggregateXmlWriteExpression writeExpression ) {
+					writeExpression.passThroughUnsetSubExpressions( selectableMapping );
+				}
+			}
+		}
+
+		protected String getTagName() {
+			return selectableMapping.getSelectableName();
+		}
+
+		@Override
+		public void append(
+				SqlAppender sb,
+				String path,
+				SqlAstTranslator<?> translator,
+				AggregateColumnWriteExpression expression) {
+			sb.append( "xmlelement(name " );
+			sb.appendDoubleQuoteEscapedString( getTagName() );
+			sb.append( ",xmlconcat" );
+			char separator = '(';
+			for ( Map.Entry<String, GaussDBXmlWriteExpression> entry : subExpressions.entrySet() ) {
+				sb.append( separator );
+
+				final GaussDBXmlWriteExpression value = entry.getValue();
+				if ( value instanceof GaussDBAggregateXmlWriteExpression ) {
+					final String subPath = XML_QUERY_START + xmlExtractArguments( path, entry.getKey() ) + XML_QUERY_END;
+					value.append( sb, subPath, translator, expression );
+				}
+				else {
+					value.append( sb, path, translator, expression );
+				}
+				separator = ',';
+			}
+			sb.append( "))" );
+		}
+	}
+
+	private static class GaussDBRootXmlWriteExpression extends GaussDBAggregateXmlWriteExpression
+			implements WriteExpressionRenderer {
+		private final String path;
+
+		GaussDBRootXmlWriteExpression(SelectableMapping aggregateColumn, SelectableMapping[] columns) {
+			super( aggregateColumn );
+			path = aggregateColumn.getSelectionExpression();
+			initializeSubExpressions( aggregateColumn, columns );
+		}
+
+		@Override
+		protected String getTagName() {
+			return XmlHelper.ROOT_TAG;
+		}
+
+		@Override
+		public void render(
+				SqlAppender sqlAppender,
+				SqlAstTranslator<?> translator,
+				AggregateColumnWriteExpression aggregateColumnWriteExpression,
+				String qualifier) {
+			final String basePath;
+			if ( qualifier == null || qualifier.isBlank() ) {
+				basePath = path;
+			}
+			else {
+				basePath = qualifier + "." + path;
+			}
+			// M mode XMLTABLE requires the PASSING argument to be `xmltype`; the `xml` aggregate
+			// column can't be cast directly to xmltype, so route through text. Sub-aggregates and
+			// pass-through fields reuse this passing via xmlExtractArguments unchanged.
+			append( sqlAppender, XML_QUERY_START + "'/" + getTagName() + "' passing cast(cast(" + basePath + " as text) as xmltype)" + XML_QUERY_END, translator, aggregateColumnWriteExpression );
+		}
+	}
+
+	private static class GaussDBBasicXmlWriteExpression implements GaussDBXmlWriteExpression {
+
+		private final SelectableMapping selectableMapping;
+		private final String[] customWriteExpressionParts;
+
+		GaussDBBasicXmlWriteExpression(SelectableMapping selectableMapping, String customWriteExpression) {
+			this.selectableMapping = selectableMapping;
+			if ( customWriteExpression.equals( "?" ) ) {
+				this.customWriteExpressionParts = new String[]{ "", "" };
+			}
+			else {
+				assert !customWriteExpression.startsWith( "?" );
+				final String[] parts = StringHelper.split( "?", customWriteExpression );
+				assert parts.length == 2 || (parts.length & 1) == 1;
+				this.customWriteExpressionParts = parts;
+			}
+		}
+
+		@Override
+		public void append(
+				SqlAppender sb,
+				String path,
+				SqlAstTranslator<?> translator,
+				AggregateColumnWriteExpression expression) {
+			final JdbcType jdbcType = selectableMapping.getJdbcMapping().getJdbcType();
+			final boolean isArray = jdbcType.getDefaultSqlTypeCode() == XML_ARRAY;
+			sb.append( "xmlelement(name " );
+			sb.appendDoubleQuoteEscapedString( selectableMapping.getSelectableName() );
+			sb.append( ',' );
+			if ( isArray ) {
+				// Remove the <Collection> tag to wrap the value into the selectable specific tag.
+				// M mode XMLTABLE requires `xmltype`; the xml value is routed through text. A NULL array
+				// value would pass NULL to XMLTABLE, which M mode rejects ("NULL is passed when the
+				// detoast operation is executed"); coalesce to an empty <Collection/> (0 rows) instead.
+				sb.append( "(select xmlagg(t.v order by t.i) from xmltable('/Collection/*' passing coalesce(cast(cast(" );
+			}
+			sb.append( customWriteExpressionParts[0] );
+			for ( int i = 1; i < customWriteExpressionParts.length; i++ ) {
+				// We use NO_UNTYPED here so that expressions which require type inference are casted explicitly,
+				// since we don't know how the custom write expression looks like where this is embedded,
+				// so we have to be pessimistic and avoid ambiguities
+				translator.render( expression.getValueExpression( selectableMapping ), SqlAstNodeRenderingMode.NO_UNTYPED );
+				sb.append( customWriteExpressionParts[i] );
+			}
+			if ( isArray ) {
+				sb.append( " as text) as xmltype),cast('<Collection/>' as xmltype)) columns v xml path '.', i for ordinality)t)" );
+			}
+			sb.append( ')' );
+		}
+	}
+
+	private static class GaussDBPassThroughXmlWriteExpression implements GaussDBXmlWriteExpression {
+
+		private final SelectableMapping selectableMapping;
+
+		GaussDBPassThroughXmlWriteExpression(SelectableMapping selectableMapping) {
+			this.selectableMapping = selectableMapping;
+		}
+
+		@Override
+		public void append(
+				SqlAppender sb,
+				String path,
+				SqlAstTranslator<?> translator,
+				AggregateColumnWriteExpression expression) {
+			sb.append( XML_QUERY_START );
+			sb.append( xmlExtractArguments( path, selectableMapping.getSelectableName() ) );
+			sb.append( XML_QUERY_END );
+		}
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/function/GaussDBMinMaxFunction.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/function/GaussDBMinMaxFunction.java
@@ -36,7 +36,9 @@ import static org.hibernate.query.sqm.produce.function.FunctionParameterType.COM
  */
 public class GaussDBMinMaxFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 
-	public GaussDBMinMaxFunction(String name) {
+	private final boolean mMode;
+
+	public GaussDBMinMaxFunction(String name, boolean mMode) {
 		super(
 				name,
 				FunctionKind.AGGREGATE,
@@ -44,6 +46,7 @@ public class GaussDBMinMaxFunction extends AbstractSqmSelfRenderingFunctionDescr
 				StandardFunctionReturnTypeResolvers.useFirstNonNull(),
 				StandardFunctionArgumentTypeResolvers.IMPLIED_RESULT_TYPE
 		);
+		this.mMode = mMode;
 	}
 
 	@Override
@@ -97,6 +100,15 @@ public class GaussDBMinMaxFunction extends AbstractSqmSelfRenderingFunctionDescr
 		final JdbcMapping sourceMapping = arg.getExpressionType().getSingleJdbcMapping();
 		// Cast uuid expressions to "text" first, aggregate that, and finally cast to uuid again
 		if ( sourceMapping.getJdbcType().getDefaultSqlTypeCode() == SqlTypes.UUID ) {
+			if ( mMode ) {
+				// M mode (MySQL-compatible) has no native uuid type: UUID is stored as varchar(36)
+				// (see GaussDBDialect.columnType/registerColumnTypes), so the column is already a
+				// plain varchar and can be aggregated directly. M mode rejects `cast(... as text)`
+				// (only char is allowed in CAST) and has no uuid type for the `::uuid` re-cast, so
+				// emit the argument as-is. A mode keeps the text-cast workaround for native uuid.
+				arg.accept( translator );
+				return null;
+			}
 			sqlAppender.appendSql( "cast(" );
 			arg.accept( translator );
 			sqlAppender.appendSql( " as text)" );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/function/json/GaussDBJsonObjectFunction.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/function/json/GaussDBJsonObjectFunction.java
@@ -4,13 +4,17 @@
  */
 package org.hibernate.community.dialect.function.json;
 
+import org.hibernate.community.dialect.GaussDBDialect;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.function.json.JsonObjectFunction;
+import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.metamodel.model.domain.ReturnableType;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.JsonNullBehavior;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.List;
@@ -23,8 +27,14 @@ import java.util.List;
  */
 public class GaussDBJsonObjectFunction extends JsonObjectFunction {
 
-	public GaussDBJsonObjectFunction(TypeConfiguration typeConfiguration) {
+	// Hold the Dialect reference to query isMMode() at render time (mode is detected by GaussDBDialect
+	// from datcompatibility). Keeping the reference rather than a boolean preserves a single source of
+	// truth for the mode — same pattern as GaussDBExtractFunction.
+	private final Dialect dialect;
+
+	public GaussDBJsonObjectFunction(Dialect dialect, TypeConfiguration typeConfiguration) {
 		super( typeConfiguration, false );
+		this.dialect = dialect;
 	}
 
 	@Override
@@ -66,10 +76,50 @@ public class GaussDBJsonObjectFunction extends JsonObjectFunction {
 				}
 				key.accept( walker );
 				sqlAppender.appendSql( ',' );
-				valueNode.accept( walker );
+				renderValue( sqlAppender, valueNode, walker );
 			}
 		}
 		sqlAppender.appendSql( ')' );
+	}
+
+	@Override
+	protected void renderValue(SqlAppender sqlAppender, SqlAstNode value, SqlAstTranslator<?> walker) {
+		final JdbcMappingContainer expressionType = ((Expression) value).getExpressionType();
+		if ( expressionType.getSingleJdbcMapping().getJdbcType().isBinary() ) {
+			// GaussDB json_build_object renders bytea/varbinary as the PG bytea text "\x01020304", but the
+			// test (HHH-20522) expects the plain hex string "01020304". A mode stores binary as bytea and
+			// uses PG encode(bytea,'hex'); M mode stores binary as varbinary (encode rejects varbinary)
+			// and uses MySQL hex(varbinary) instead.
+			if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+				sqlAppender.appendSql( "hex(" );
+				value.accept( walker );
+				sqlAppender.appendSql( ")" );
+			}
+			else {
+				sqlAppender.appendSql( "encode(" );
+				value.accept( walker );
+				sqlAppender.appendSql( ",'hex')" );
+			}
+		}
+		else if ( expressionType.getSingleJdbcMapping().getJdbcType().getDdlTypeCode() == SqlTypes.TIMESTAMP ) {
+			// GaussDB json_build_object renders timestamp with a space separator and (in M mode)
+			// truncates to seconds, but the test expects ISO "2024-01-15T10:30:45.123" (T separator).
+			// A mode (Oracle-compatible) has PG to_char(datetime); M mode (MySQL-compatible) lacks it
+			// and uses MySQL date_format instead.
+			if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+				sqlAppender.appendSql( "date_format(" );
+				value.accept( walker );
+				sqlAppender.appendSql( ", '%Y-%m-%dT%H:%i:%s.%f')" );
+			}
+			else {
+				sqlAppender.appendSql( "to_char(" );
+				value.accept( walker );
+				sqlAppender.appendSql( ", 'YYYY-MM-DD\"T\"HH24:MI:SS.US')" );
+			}
+		}
+		else {
+			value.accept( walker );
+		}
 	}
 
 }

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/lock/internal/GaussDBLockingSupport.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/lock/internal/GaussDBLockingSupport.java
@@ -83,41 +83,42 @@ public class GaussDBLockingSupport implements LockingSupport, LockingSupport.Met
 		return Helper.getLockTimeout(
 				"select current_setting('lockwait_timeout')",
 				(resultSet) -> {
-					// even though lock_timeout is "in milliseconds", `current_setting`
-					// returns a String form which unfortunately varies depending on
-					// the actual value:
-					//		* for zero (no timeout), "0" is returned
-					//		* for non-zero, `{timeout-in-seconds}s` is returned (e.g. "4s")
-					// so we need to "parse" that form here
+					// Although lockwait_timeout is stored internally in milliseconds, `current_setting`
+					// returns a String in a canonical, human-readable form whose suffix varies by value:
+					//   * "0" for no timeout (WAIT_FOREVER)
+					//   * non-zero values carry a unit suffix, e.g. "500ms", "3s", "1min", "1h", "1d"
+					// Locate the boundary between the digits and the unit, then dispatch on the full
+					// unit string. The previous endsWith("s") branch matched "ms" first, leaving "1m"
+					// for parseInt and throwing NumberFormatException.
 					final String value = resultSet.getString( 1 );
 					if ( "0".equals( value ) ) {
 						return Timeouts.WAIT_FOREVER;
 					}
-					if ( value.endsWith( "min" ) ) {
-						final int minute = getTimeout( value, 3 );
-						return Timeout.milliseconds( minute * 60 * 1000);
-					}
-					else if ( value.endsWith( "s" ) ) {
-						final int seconds  = getTimeout( value, 1 );
-						return Timeout.seconds(seconds);
-					}
-					final int milliseconds  = getTimeout( value, 2 );
-					return Timeout.milliseconds(milliseconds);
+					final int unitStartIndex = findUnitStartIndex( value );
+					final int amount = Integer.parseInt( value, 0, unitStartIndex, 10 );
+					final String unit = unitStartIndex >= value.length() ? "ms" : value.substring( unitStartIndex );
+					return switch ( unit ) {
+						case "ms" -> Timeout.milliseconds( amount );
+						case "s" -> Timeout.seconds( amount );
+						case "min" -> Timeout.seconds( amount * 60 );
+						case "h" -> Timeout.seconds( amount * 3600 );
+						case "d" -> Timeout.seconds( amount * 3600 * 24 );
+						default -> throw new IllegalArgumentException(
+								"Unexpected GaussDB lockwait_timeout format: " + value );
+					};
 				},
 				connection,
 				factory
 		);
 	}
 
-	private static int getTimeout(String value, int unitLength) {
-		final int number;
-		try {
-			number = Integer.parseInt( value.substring( 0, value.length() - unitLength ) );
+	private static int findUnitStartIndex(String value) {
+		for ( int i = value.length() - 1; i >= 0; i-- ) {
+			if ( Character.isDigit( value.charAt( i ) ) ) {
+				return i + 1;
+			}
 		}
-		catch (NumberFormatException e) {
-			throw new RuntimeException( e );
-		}
-		return number;
+		return -1;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/sequence/GaussDBMModeSequenceInformationExtractor.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/sequence/GaussDBMModeSequenceInformationExtractor.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect.sequence;
+
+import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorLegacyImpl;
+
+/**
+ * Sequence metadata extractor for GaussDB M mode (MySQL-compatible).
+ *
+ * M mode has no {@code information_schema.sequences} view (MySQL has no sequences concept), so the legacy
+ * extractor's {@code sequence_name}/catalog/schema/start/min/max/increment columns are unavailable. Sequences
+ * are still queryable via {@code pg_class} ({@code relkind='S'}) joined with {@code pg_sequence_parameters(oid)},
+ * which exposes {@code relname} and the {@code increment} value (see {@code getQuerySequencesString}).
+ *
+ * Returning {@code relname} plus {@code increment} lets {@link org.hibernate.tool.schema.internal.AbstractSchemaMigrator}
+ * detect existing sequences (avoiding redundant {@code create sequence} calls that fail with "Relation already
+ * exists" — M mode rejects {@code create sequence if not exists}) AND exposes the increment value for
+ * {@code SequenceInformation.getIncrementValue()} and HHH-12973 sequence-mismatch detection. The other columns
+ * stay null because {@code pg_class} does not carry them in M mode.
+ *
+ * A mode keeps the default extractor backed by {@code information_schema.sequences}.
+ */
+public class GaussDBMModeSequenceInformationExtractor extends SequenceInformationExtractorLegacyImpl {
+
+	public static final GaussDBMModeSequenceInformationExtractor INSTANCE = new GaussDBMModeSequenceInformationExtractor();
+
+	@Override
+	protected String sequenceNameColumn() {
+		return "relname";
+	}
+
+	@Override
+	protected String sequenceCatalogColumn() {
+		return null;
+	}
+
+	@Override
+	protected String sequenceSchemaColumn() {
+		return null;
+	}
+
+	@Override
+	protected String sequenceStartValueColumn() {
+		return null;
+	}
+
+	@Override
+	protected String sequenceMinValueColumn() {
+		return null;
+	}
+
+	@Override
+	protected String sequenceMaxValueColumn() {
+		return null;
+	}
+
+	@Override
+	protected String sequenceIncrementColumn() {
+		// pg_sequence_parameters(oid) exposes the increment as its "increment" field; aliased to "increment"
+		// in getQuerySequencesString. Non-null so SequenceInformation.getIncrementValue() works (HHH-12973).
+		return "increment";
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/sequence/GaussDBMModeSequenceSupport.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/sequence/GaussDBMModeSequenceSupport.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect.sequence;
+
+import java.util.Locale;
+
+import org.hibernate.MappingException;
+
+/**
+ * Sequence support for {@link org.hibernate.community.dialect.GaussDBDialect}
+ * when the target database runs in MySQL-compatible mode (datcompatibility "B"/"M").
+ * <p>
+ * In M mode, {@code nextval()}/{@code currval()}/{@code setval()} treat their string
+ * argument as case-sensitive (unlike PostgreSQL, which folds it to lowercase via regclass
+ * resolution). How the sequence name must be rendered on the call side therefore depends on
+ * whether the identifier was quoted at {@code CREATE SEQUENCE} time:
+ * <ul>
+ *   <li>Unquoted: {@code CREATE SEQUENCE ConcreteOne_SEQ} folds the identifier to lowercase
+ *       ({@code concreteone_seq}), so the call must also use the lowercase name.</li>
+ *   <li>Quoted (e.g. globally-quoted identifiers wrapped in backticks/double-quotes):
+ *       {@code CREATE SEQUENCE `Person_SEQ`} preserves the original case, so the call must
+ *       keep it — lower-casing would make {@code nextval('person_seq')} miss the stored
+ *       {@code Person_SEQ}. The quote characters themselves are stripped, since the
+ *       {@code nextval} argument is a name string, not a SQL identifier.</li>
+ * </ul>
+ * {@code CREATE}/{@code DROP SEQUENCE} are not overridden because their identifiers are
+ * folded (or preserved) by the DDL parser itself.
+ */
+public class GaussDBMModeSequenceSupport extends GaussDBSequenceSupport {
+
+	public static final GaussDBMModeSequenceSupport INSTANCE = new GaussDBMModeSequenceSupport();
+
+	@Override
+	public String getSelectSequenceNextValString(String sequenceName) {
+		return "nextval('" + normalize( sequenceName ) + "')";
+	}
+
+	@Override
+	public String getSelectSequencePreviousValString(String sequenceName) throws MappingException {
+		return "currval('" + normalize( sequenceName ) + "')";
+	}
+
+	@Override
+	public String getRestartSequenceString(String sequenceName, long startWith) {
+		return "select setval('" + normalize( sequenceName ) + "', " + startWith + ", false)";
+	}
+
+	private static String normalize(String sequenceName) {
+		if ( sequenceName.indexOf( '`' ) >= 0 || sequenceName.indexOf( '"' ) >= 0 ) {
+			// Quoted identifier: CREATE SEQUENCE preserved the original case and nextval's
+			// string argument is case-sensitive, so keep the case and strip the quote chars.
+			return sequenceName.replace( "`", "" ).replace( "\"", "" );
+		}
+		// Unquoted: CREATE SEQUENCE folded the identifier to lowercase, so match that.
+		return sequenceName.toLowerCase( Locale.ROOT );
+	}
+}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/sequence/GaussDBSequenceSupport.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/sequence/GaussDBSequenceSupport.java
@@ -39,4 +39,21 @@ public class GaussDBSequenceSupport implements SequenceSupport {
 		return "drop sequence if exists " + sequenceName;
 	}
 
+	/**
+	 * GaussDB's {@code ALTER SEQUENCE} only supports {@code MAXVALUE}, {@code CACHE} and {@code OWNER},
+	 * so the {@code RESTART WITH} syntax is not supported.
+	 * Use {@code setval()} function instead to reset the sequence value.
+	 * <p>
+	 * The three-argument form with {@code is_called=false} is used so that the next {@code nextval()}
+	 * returns {@code startWith} itself, matching PostgreSQL's {@code ALTER SEQUENCE ... RESTART WITH}
+	 * semantics. The two-argument form defaults to {@code is_called=true}, which makes the next
+	 * {@code nextval()} return {@code startWith + increment} (off by one), breaking tests that reset
+	 * a sequence and then expect {@code nextval} to yield the restart value (e.g. truncate/resync).
+	 */
+	@Override
+	public String getRestartSequenceString(String sequenceName, long startWith) {
+		return "select setval('" + sequenceName + "', " + startWith + ", false)";
+	}
+
+
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/query/Dictionary.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/query/Dictionary.java
@@ -12,11 +12,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.NamedNativeQuery;
 import jakarta.persistence.SqlResultSetMapping;
+import jakarta.persistence.Table;
 
 /**
  * @author Emmanuel Bernard
  */
 @Entity
+@Table(name = "DictionaryTbl")
 @DiscriminatorColumn(name = "disc")
 @DiscriminatorValue("Dic")
 @SqlResultSetMapping(
@@ -33,7 +35,7 @@ import jakarta.persistence.SqlResultSetMapping;
 		}
 )
 @NamedNativeQuery(name = "all.dictionaries",
-		query = "select id, name, editor, disc as type from Dictionary",
+		query = "select id, name, editor, disc as type from DictionaryTbl",
 		resultSetMapping = "dictionary")
 public class Dictionary {
 	private Integer id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/array/StructArrayWithNullElementTestDemoTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/array/StructArrayWithNullElementTestDemoTest.java
@@ -9,12 +9,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import org.hibernate.annotations.Struct;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks.SupportsStructAggregate;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks.SupportsTypedArrays;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -33,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class StructArrayWithNullElementTestDemoTest {
 
 	@Test
+	@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "gsjdbc4 can't bind struct arrays via createArrayOf (Unable to find server array type)")
 	void test(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			var book = new Book();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
@@ -542,6 +542,7 @@ public class DefaultCatalogAndSchemaTest
 	}
 
 	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.NotGaussDBMMode.class)
 	public void sequenceGenerator() {
 		org.hibernate.id.enhanced.SequenceStyleGenerator generator = idGenerator(
 				org.hibernate.id.enhanced.SequenceStyleGenerator.class,
@@ -556,6 +557,7 @@ public class DefaultCatalogAndSchemaTest
 	}
 
 	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.NotGaussDBMMode.class)
 	public void enhancedSequenceGenerator() {
 		org.hibernate.id.enhanced.SequenceStyleGenerator generator = idGenerator(
 				org.hibernate.id.enhanced.SequenceStyleGenerator.class,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bulkid/AbstractMutationStrategyGeneratedIdentityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bulkid/AbstractMutationStrategyGeneratedIdentityTest.java
@@ -56,6 +56,12 @@ public abstract class AbstractMutationStrategyGeneratedIdentityTest {
 			reason = "T-SQL complains IDENTITY_INSERT is off when a value for an identity column is provided")
 	@SkipForDialect(dialectClass = InformixDialect.class, reason = "Informix counts from 1 like a normal person")
 	public void testInsertStatic(SessionFactoryScope scope) {
+		// GaussDB M mode (MySQL kernel) ignores the explicitly-provided id=0 for an IDENTITY (auto_increment)
+		// column and generates its own value, so the joined-subclass INSERT into Person(id=0) and Engineer(id=0)
+		// end up with mismatched ids -> FK violation "insert or update on table Engineer". Same root cause as the
+		// @SkipForDialect(MySQLDialect matchSubTypes) above (GaussDBDialect is not a MySQLDialect subtype, so it
+		// does not apply). A mode (PG kernel) accepts an explicit id for IDENTITY/SERIAL, so M-only skip.
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		scope.inTransaction( session -> {
 			session.createMutationQuery(
 							"insert into Engineer(id, name, employed, fellow) values (0, :name, :employed, false)" )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/refresh/RefreshEntityWithLazyPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/refresh/RefreshEntityWithLazyPropertyTest.java
@@ -100,6 +100,10 @@ public class RefreshEntityWithLazyPropertyTest {
 
 	@Test
 	public void testRefreshOfLazyFormula(SessionFactoryScope scope) {
+		// GaussDB M mode (MySQL kernel) treats || as logical OR, not String concat; @Formula("firstName || ' ' || lastName")
+		// is user SQL the dialect does not rewrite (same root cause as the class-level MySQLDialect skip). A mode (PG
+		// kernel) supports || as concat, so M-only skip keeps A coverage for this and the other 5 @Test methods.
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		scope.inTransaction( session -> {
 			Person p = session.find( Person.class, PERSON_ID );
 			assertThat( p.getFullName() ).isEqualTo( "John Doe" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/ColumnDiscrimnatorWithSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/ColumnDiscrimnatorWithSchemaTest.java
@@ -33,6 +33,11 @@ class ColumnDiscrimnatorWithSchemaTest {
 
 	@Test
 	void testIt(SessionFactoryScope scope) {
+		// GaussDB M mode folds the unquoted DEFAULT_SCHEMA "GREET" to lowercase when resolving the sequence name
+		// (nextval('greet.author_seq')), but the schema and sequence were created as "GREET" — so nextval fails with
+		// "schema greet does not exist". Same M-mode unquoted-sequence case-folding limitation as
+		// DefaultCatalogAndSchemaTest. A mode (PG kernel) preserves the case, so M-only skip.
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		scope.inTransaction( entityManager -> {
 			var book = new Book( "The Art of Computer Programming",
 					new SpecialBookDetails( "Hardcover", "Computer Science" ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columntransformer/ColumnTransformerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columntransformer/ColumnTransformerTest.java
@@ -14,7 +14,9 @@ import org.hibernate.dialect.MySQLDialect;
 
 import org.hibernate.community.dialect.TiDBDialect;
 import org.hibernate.dialect.SpannerDialect;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
@@ -39,6 +41,7 @@ import static org.junit.Assert.assertThat;
 @SkipForDialect(dialectClass = MySQLDialect.class, reason = "MySQL doesn't support casting to a VARCHAR(255)")
 @SkipForDialect(dialectClass = TiDBDialect.class, reason = "TiDB doesn't support casting to a VARCHAR(255)")
 @SkipForDialect(dialectClass = SpannerDialect.class, reason = "Spanner doesn't support casting to a VARCHAR(255)")
+@RequiresDialectFeature(feature = DialectFeatureChecks.NotGaussDBMMode.class, comment = "GaussDB M mode (MySQL-compatible) doesn't support casting to a VARCHAR(255), same as MySQLDialect; the Staff entity hardcodes `cast(kooky as VARCHAR(255))`. A mode (PG kernel) supports it.")
 public class ColumnTransformerTest {
 	public static final double ERROR = 0.01d;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/FilterParameterTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/FilterParameterTests.java
@@ -21,6 +21,7 @@ import org.hibernate.boot.registry.BootstrapServiceRegistry;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.community.dialect.TiDBDialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.MariaDBDialect;
@@ -36,6 +37,7 @@ import org.hibernate.testing.util.ServiceRegistryUtil;
 import org.hibernate.type.NumericBooleanConverter;
 import org.hibernate.type.YesNoConverter;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -153,6 +155,11 @@ public class FilterParameterTests extends AbstractStatefulStatelessFilterTest {
 	@SkipForDialect(dialectClass = TiDBDialect.class, reason = "TiDB silently converts strings to integral types")
 	@SkipForDialect(dialectClass = PostgresPlusDialect.class, reason = "PostgresPlus silently converts strings to integral types")
 	public void testMismatch(BiConsumer<SessionFactoryScope, Consumer<? extends SharedSessionContract>> inTransaction) {
+		// GaussDB M mode (MySQL-compatible) silently converts the YesNoConverter string 'N' to integral 0
+		// (like MySQL/MariaDB/TiDB/PostgresPlus skipped above), so `mismatch = :mismatch` (smallint = 'N')
+		// raises no exception; the test expects one. A mode (openGauss PG kernel) is type-strict and raises
+		// "operator does not exist: smallint = text", so it is not skipped (preserves A-mode zero regression).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		scope.inTransaction( (session) -> {
 			session.disableFilter( "subDepartmentFilter" );
 			final EntityThree loaded = session.find( EntityThree.class, 1 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/ManyToManyWithDynamicFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/ManyToManyWithDynamicFilterTest.java
@@ -13,11 +13,13 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,6 +67,10 @@ public class ManyToManyWithDynamicFilterTest {
 	@Test
 	@JiraKey(value = "HHH-11410")
 	void testManyToManyCollectionWithActiveFilterOnJoin(SessionFactoryScope scope) {
+		// GaussDB M mode (PG kernel) is strict about ambiguous columns: the @Filter defaultCondition
+		// "active = true" applies to both User and Role, so unqualified "active" is ambiguous in the
+		// many-to-many join SQL. A mode is unaffected, so it is not skipped (zero regression).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		scope.inTransaction( session -> {
 			session.enableFilter( "activeUserFilter" );
 			session.enableFilter( "activeRoleFilter" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/uuid/sqlrep/sqlbinary/UUIDBinaryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/uuid/sqlrep/sqlbinary/UUIDBinaryTest.java
@@ -53,6 +53,15 @@ public class UUIDBinaryTest {
 
 	@Test
 	public void testUsage(SessionFactoryScope scope) {
+		// GaussDB M mode maps BINARY to MySQL `binary($l)` (dolphin extension; M mode rejects PG `bytea`).
+		// gsjdbc4 setBytes() sends a bytea oid that the M-mode binary column accepts for `insert ... values(?)`
+		// (the SharedDriverManagerConnectionProvider patches TypeInfoCache to infer the param type from the
+		// column) but REJECTS for a `where id=?` comparison param — "invalid byte sequence for encoding UTF8"
+		// (bytea->binary has no implicit cast), and `cast(? as binary)`/`?::binary` cannot work around it
+		// (any-typed / length-doubled "exceeds 16"). This is a deep gsjdbc4 + M-mode-binary driver limitation,
+		// not dialect-fixable (BINARY sqlType must map to a binary column; see tasks/lessons.md "P6 遗留").
+		// A mode (PG kernel) uses bytea and setBytes/getBytes work, so M-only skip.
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		final MappingMetamodel domainModel = scope.getSessionFactory().getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = domainModel.findEntityDescriptor( Node.class );
 		final JdbcMapping jdbcMapping = entityDescriptor.getIdentifierMapping().getSingleJdbcMapping();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/embeddable/StructAggregateEmbeddableInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/embeddable/StructAggregateEmbeddableInheritanceTest.java
@@ -15,6 +15,7 @@ import org.hibernate.boot.spi.AdditionalMappingContributions;
 import org.hibernate.boot.spi.AdditionalMappingContributor;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.OracleDialect;
@@ -162,6 +163,7 @@ public class StructAggregateEmbeddableInheritanceTest implements AdditionalMappi
 	@SkipForDialect( dialectClass = PostgreSQLDialect.class, majorVersion = 10, reason = "Procedures were only introduced in version 11" )
 	@SkipForDialect( dialectClass = PostgresPlusDialect.class, majorVersion = 10, reason = "Procedures were only introduced in version 11" )
 	@SkipForDialect( dialectClass = DB2Dialect.class, reason = "DB2 does not support struct types in procedures" )
+	@SkipForDialect( dialectClass = GaussDBDialect.class, reason = "GaussDB does not support struct types in procedures: gsjdbc4 rejects OUT parameter registration (This statement does not declare an OUT parameter)" )
 	public void testProcedure(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			final Dialect dialect = session.getJdbcServices().getDialect();
@@ -225,7 +227,7 @@ public class StructAggregateEmbeddableInheritanceTest implements AdditionalMappi
 						namespace,
 						"create function structFunction() returns inheritance_embeddable as $$ declare result inheritance_embeddable; begin result.parentProp = 'function_embeddable'; result.childOneProp = 1; result.subChildOneProp = 1.0; result.childTwoProp = null; result.embeddable_type = 'sub_child_one'; return result; end $$ language plpgsql",
 						"drop function structFunction",
-						Set.of( PostgreSQLDialect.class.getName() )
+						Set.of( PostgreSQLDialect.class.getName(), GaussDBDialect.class.getName() )
 				)
 		);
 		contributions.contributeAuxiliaryDatabaseObject(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/env/KeywordRecognitionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/env/KeywordRecognitionTests.java
@@ -5,11 +5,13 @@
 package org.hibernate.orm.test.jdbc.env;
 
 import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.ServiceRegistryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import static org.hibernate.cfg.MappingSettings.KEYWORD_AUTO_QUOTING_ENABLED;
@@ -22,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class KeywordRecognitionTests {
 	@Test
 	@JiraKey("HHH-9768")
+	@SkipForDialect(dialectClass = GaussDBDialect.class,
+			reason = "GaussDB uses a curated M-mode reserved-word set that excludes the ANSI keyword 'end'")
 	@ServiceRegistry(settings = @Setting(name = KEYWORD_AUTO_QUOTING_ENABLED, value = "true"))
 	public void testAnsiSqlKeyword(ServiceRegistryScope registryScope) {
 		// END is ANSI SQL keyword

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/CriteriaUpdateAndDeleteWithJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/CriteriaUpdateAndDeleteWithJoinTest.java
@@ -17,10 +17,13 @@ import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
+import org.hibernate.community.dialect.GaussDBDialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +57,10 @@ public class CriteriaUpdateAndDeleteWithJoinTest {
 
 	@Test
 	public void testUpdate(EntityManagerFactoryScope scope) {
+		// GaussDB M mode (PG kernel) is strict about ambiguous columns: the UPDATE SET "code" (Parent) and
+		// the joined WHERE "code" (Child) render ambiguously. A mode is unaffected (zero regression).
+		Assumptions.assumeFalse( scope.getEntityManagerFactory().unwrap( SessionFactoryImplementor.class )
+				.getJdbcServices().getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		scope.inTransaction(
 				entityManager -> {
 					CriteriaBuilder cb = entityManager.getCriteriaBuilder();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/ParameterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/ParameterTest.java
@@ -46,7 +46,7 @@ public class ParameterTest {
 	@Test
 	@SkipForDialect(dialectClass = InformixDialect.class,
 			reason = "Blobs are not allowed in this expression")
-	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsArrayComparison.class)
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsStructuralArrays.class)
 	public void testPrimitiveArrayParameterBinding(SessionFactoryScope scope) {
 		scope.inTransaction( em -> {
 			CriteriaQuery<MultiTypedBasicAttributesEntity> criteria = em.getCriteriaBuilder()
@@ -65,7 +65,7 @@ public class ParameterTest {
 	@Test
 	@SkipForDialect(dialectClass = InformixDialect.class,
 			reason = "Blobs are not allowed in this expression")
-	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsArrayComparison.class)
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsStructuralArrays.class)
 	public void testNonPrimitiveArrayParameterBinding(SessionFactoryScope scope) {
 		scope.inTransaction( em -> {
 			CriteriaQuery<MultiTypedBasicAttributesEntity> criteria = em.getCriteriaBuilder()
@@ -148,7 +148,7 @@ public class ParameterTest {
 	@JiraKey("HHH-17912")
 	@SkipForDialect(dialectClass = InformixDialect.class,
 			reason = "Blobs are not allowed in this expression")
-	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsArrayComparison.class)
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsStructuralArrays.class)
 	public void testAttributeEqualListParameter(SessionFactoryScope scope) {
 		scope.inTransaction( em -> {
 			final CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ql/NamedNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ql/NamedNativeQueryTest.java
@@ -138,6 +138,12 @@ public class NamedNativeQueryTest {
 	@SkipForDialect( dialectClass = SQLServerDialect.class, reason = "SQL Server does not support the || operator.")
 	// TODO: Re-form DestinationEntity.insertSelect to something more supported?
 	public void testInsertMultipleValues(SessionFactoryScope scope) {
+		// The DestinationEntity.insertSelect native query uses `fe.name||fe.lastName` (|| as concat).
+		// GaussDB M mode treats `||` as logical OR (MySQL kernel), coercing 'Name0' to double and failing
+		// ("The double value 'Name0' is incorrect"). The @SkipForDialect(SQLServerDialect, "|| operator")
+		// above does not apply (GaussDBDialect is not a SQLServer subtype) and native SQL is not rewritten.
+		// A mode (PG kernel) supports `||` as concat, so M-only skip (same `||` inherent class as FormulaTests).
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		final String name = "Name";
 		final String lastName = "LastName";
 		final List<Integer> ids = new ArrayList<>();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryResultTypeAutoDiscoveryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryResultTypeAutoDiscoveryTest.java
@@ -50,6 +50,7 @@ import org.hibernate.type.descriptor.jdbc.CharJdbcType;
 import org.hibernate.type.descriptor.jdbc.NumericJdbcType;
 import org.hibernate.type.descriptor.jdbc.RealJdbcType;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -146,6 +147,8 @@ public class NativeQueryResultTypeAutoDiscoveryTest {
 	@SkipForDialect(dialectClass = DB2Dialect.class, majorVersion = 10, reason = "No support for the bit datatype so we use smallint")
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "No support for the bit datatype so we use char(1)")
 	public void booleanType(EntityManagerFactoryScope scope) {
+		// GaussDB M mode maps boolean to tinyint(1); gsjdbc4 reports TINYINT -> Byte, not Boolean
+		Assumptions.assumeFalse( scope.getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		doTest( scope, BooleanEntity.class, true );
 	}
 
@@ -155,6 +158,8 @@ public class NativeQueryResultTypeAutoDiscoveryTest {
 	@SkipForDialect(dialectClass = DB2Dialect.class, majorVersion = 10, reason = "No support for the bit datatype so we use smallint")
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "No support for the bit datatype so we use char(1)")
 	public void bitType(EntityManagerFactoryScope scope) {
+		// GaussDB M mode maps bit to tinyint(1); gsjdbc4 reports TINYINT -> Byte, not Boolean
+		Assumptions.assumeFalse( scope.getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		doTest( scope, BitEntity.class, false );
 	}
 
@@ -192,6 +197,8 @@ public class NativeQueryResultTypeAutoDiscoveryTest {
 	@SkipForDialect(dialectClass = TiDBDialect.class, reason = "Turns reals into doubles in result sets and advertises the type as double in the metadata")
 	@SkipForDialect(dialectClass = HSQLDialect.class, reason = "Turns reals into doubles in result sets and advertises the type as double in the metadata")
 	public void realType(EntityManagerFactoryScope scope) {
+		// GaussDB M mode maps real to double; gsjdbc4 reports DOUBLE, not Float (like MySQL)
+		Assumptions.assumeFalse( scope.getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		doTest( scope, RealEntity.class, 15516.125f );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/ConnectionLockTimeoutTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/ConnectionLockTimeoutTests.java
@@ -223,6 +223,8 @@ public class ConnectionLockTimeoutTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.IsJtds.class, reverse = true, comment = "Seems jTDS has a bug?")
+	@SkipForDialect(dialectClass = GaussDBDialect.class,
+			reason = "GaussDB `lockwait_timeout` governs object-lock waits, not DML row locks, so the connection lock timeout does not time out the concurrent row update")
 	@DomainModel(annotatedClasses = Names.class)
 	@SessionFactory
 	void testLockWaitTimeout(SessionFactoryScope factoryScope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/JsonMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/JsonMappingTests.java
@@ -16,6 +16,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.DerbyDialect;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.SpannerDialect;
 import org.hibernate.dialect.SpannerPostgreSQLDialect;
@@ -294,6 +295,7 @@ public abstract class JsonMappingTests {
 			reason = "Blobs are not allowed in this expression")
 	@SkipForDialect( dialectClass = SpannerPostgreSQLDialect.class, reason = "Spanner doesn't support comparing JSONB type")
 	@SkipForDialect( dialectClass = SpannerDialect.class, reason = "Spanner doesn't support comparing JSON type")
+	@SkipForDialect( dialectClass = GaussDBDialect.class, reason = "GaussDB M mode json type has no = operator")
 	public void verifyComparisonWorks(SessionFactoryScope scope) {
 		scope.inTransaction(
 				(session) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaFromHbmTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaFromHbmTests.java
@@ -74,6 +74,11 @@ public class FormulaFromHbmTests {
 	@SkipForDialect(dialectClass = InformixDialect.class,
 			reason = "The Informix JDBC driver doesn't support the JDBC escape for the concat function which is used in the mapping")
 	public void testBasicHqlUse(SessionFactoryScope scope) {
+		// The mapping's @Formula uses cast(... as varchar(255)) (PG cast syntax). GaussDB M mode CAST only accepts
+		// MySQL type names (char/signed/decimal/datetime/binary) and rejects varchar; @Formula is user SQL the
+		// dialect does not rewrite (same family as the existing MySQLDialect skip). A mode (PG kernel) supports
+		// the cast, so M-only skip.
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		scope.inTransaction(
 				(session) -> session.createQuery( "from EntityOfFormulas" ).list()
 		);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaTests.java
@@ -75,6 +75,13 @@ public class FormulaTests {
 
 	@Test
 	void testCriteria(SessionFactoryScope scope) {
+		// GaussDB M mode treats `||` as logical OR (MySQL kernel), so the default @Formula
+		// "(rate * 100) || '%'" evaluates (1.25) || '%' = true -> "t" instead of "1.25%". The
+		// @DialectOverride.Formula(dialect=MySQLDialect, concat(...)) would fix it, but
+		// GaussDBDialect is not a MySQLDialect subtype so the override does not apply, and @Formula
+		// is user SQL the dialect does not rewrite (same inherent class as RefreshEntityWithLazyProperty
+		// / FormulaFromHbm `||`). A mode (PG kernel) supports `||` as concat, so M-only skip.
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		scope.inTransaction( session -> {
 			final CriteriaBuilder criteriaBuilder = scope.getSessionFactory().getCriteriaBuilder();
 			final CriteriaQuery<Account> criteria = criteriaBuilder.createQuery( Account.class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/MultipleGeneratedValuesTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/MultipleGeneratedValuesTests.java
@@ -39,6 +39,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MultipleGeneratedValuesTests {
 	@Test
 	public void test(SessionFactoryScope scope) {
+		// GaussDB M mode: bare `current_timestamp` literal is second-precision (MySQL compat — same reason
+		// CurrentTimestampHasMicrosecondPrecision excludes MySQLDialect). The @ProposedGenerated
+		// sqlDefaultValue="current_timestamp" createdAt2/updatedAt2 use this bare literal (not the dialect's
+		// currentTimestampWithTimeZone()=now(6)), so waitALittle(10ms) doesn't cross a second -> updatedAt2
+		// unchanged -> isNotEqualTo fails. The feature passes for GaussDB (precision 6 via now(6), and it is not
+		// MySQLDialect so the MySQL exclusion misses it) but checks the dialect function, not the bare literal.
+		// Not dialect-fixable (user sqlDefaultValue literal; getDefaultTimestampPrecision() must stay 6 for
+		// datetime(6)/now(6) used by TemporalEntity etc.). A mode timestamptz is microsecond by default. M-only skip.
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		final GeneratedInstantEntity created = scope.fromTransaction( (session) -> {
 			final GeneratedInstantEntity entity = new GeneratedInstantEntity( 1, "tsifr" );
 			session.persist( entity );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/ProposedGeneratedTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/ProposedGeneratedTests.java
@@ -34,6 +34,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ProposedGeneratedTests {
 	@Test
 	public void test(SessionFactoryScope scope) throws InterruptedException {
+		// GaussDB M mode: bare `current_timestamp` literal is second-precision (MySQL compat — same reason
+		// CurrentTimestampHasMicrosecondPrecision excludes MySQLDialect). Both createdAt and updatedAt use
+		// @ProposedGenerated sqlDefaultValue="current_timestamp" (this bare literal, not the dialect's
+		// currentTimestampWithTimeZone()=now(6)), so waitALittle(10ms) doesn't cross a second -> updatedAt
+		// unchanged -> isNotEqualTo fails. The feature passes for GaussDB (precision 6 via now(6), and it is not
+		// MySQLDialect so the MySQL exclusion misses it) but checks the dialect function, not the bare literal.
+		// Not dialect-fixable (user sqlDefaultValue literal; getDefaultTimestampPrecision() must stay 6 for
+		// datetime(6)/now(6) used by TemporalEntity etc.). A mode timestamptz is microsecond by default. M-only skip.
+		// Same root cause as MultipleGeneratedValuesTests.
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		final GeneratedInstantEntity created = scope.fromTransaction( (session) -> {
 			final GeneratedInstantEntity entity = new GeneratedInstantEntity( 1, "tsifr" );
 			session.persist( entity );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/SchemaBasedMultitenancyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/SchemaBasedMultitenancyTest.java
@@ -7,12 +7,14 @@ package org.hibernate.orm.test.multitenancy;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.SpannerPostgreSQLDialect;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.context.spi.TenantSchemaMapper;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseASEDialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.relational.SchemaManager;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
@@ -21,6 +23,7 @@ import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.Setting;
 import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import static org.hibernate.cfg.MultiTenancySettings.MULTI_TENANT_IDENTIFIER_RESOLVER;
@@ -44,6 +47,11 @@ public class SchemaBasedMultitenancyTest {
 	private static String currentTenantIdentifier;
 
 	@Test void test(EntityManagerFactoryScope scope) {
+		// GaussDB M mode is case-sensitive for schema identifiers (MySQL behavior): the test creates schema
+		// "HELLO" but the tenant resolver yields "hello", which don't match. A mode (PG kernel) folds to lowercase.
+		// A mode is unaffected, so it is not skipped (zero regression).
+		Assumptions.assumeFalse( scope.getEntityManagerFactory().unwrap( SessionFactoryImplementor.class )
+				.getJdbcServices().getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		var schemaManager = (SchemaManager) scope.getEntityManagerFactory().getSchemaManager();
 		createSchema( schemaManager, "HELLO" );
 		createSchema( schemaManager, "GOODBYE" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/QuerySqlExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/QuerySqlExceptionTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.community.dialect.AltibaseDialect;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 
@@ -25,6 +26,7 @@ import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +53,12 @@ public class QuerySqlExceptionTest {
 
 	@Test
 	public void sqlExceptionOnExecutionWillCloseStatement(EntityManagerFactoryScope scope) {
+		// The test triggers an execution-time SQLException via `select (:param / 2)`, relying on `"foo" / 2`
+		// raising a type error. GaussDB M mode is MySQL-compatible and evaluates `"foo" / 2` to 0.0 without
+		// error, so the trigger never fires. A mode (openGauss PG kernel) is type-strict and raises the error,
+		// so it is not skipped (preserves A-mode zero regression).
+		Assumptions.assumeFalse( scope.getEntityManagerFactory().unwrap( SessionFactoryImplementor.class )
+				.getJdbcServices().getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		// We need at least one row in the "contacts" table,
 		// otherwise the SELECT below might not even get executed completely
 		// (the DB somehow detects the result will be 0 rows anyway and doesn't bother evaluating parameters).

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaOrderedSetAggregateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaOrderedSetAggregateTest.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.List;
 
 import jakarta.persistence.criteria.Nulls;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MySQLDialect;
@@ -283,6 +284,7 @@ public class CriteriaOrderedSetAggregateTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsHypotheticalSetFunctions.class)
+	@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "GaussDB does not support hypothetical-set WITHIN GROUP (treats the within-group ORDER BY as a second argument, e.g. 'Function rank(integer,integer) does not exist'); only window (OVER) usage works")
 	public void testHypotheticalSetPercentRank(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			HibernateCriteriaBuilder cb = session.getCriteriaBuilder();
@@ -299,6 +301,7 @@ public class CriteriaOrderedSetAggregateTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsHypotheticalSetFunctions.class)
+	@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "GaussDB does not support hypothetical-set WITHIN GROUP (treats the within-group ORDER BY as a second argument, e.g. 'Function rank(integer,integer) does not exist'); only window (OVER) usage works")
 	public void testHypotheticalSetRank(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			HibernateCriteriaBuilder cb = session.getCriteriaBuilder();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaWindowFunctionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaWindowFunctionTest.java
@@ -202,6 +202,11 @@ public class CriteriaWindowFunctionTest {
 	@SkipForDialect(dialectClass = DB2Dialect.class, majorVersion = 10, reason = "No support for nth_value function")
 	@SkipForDialect(dialectClass = InformixDialect.class, reason = "No support for nth_value function")
 	public void testNthValue(SessionFactoryScope scope) {
+		// GaussDB M mode (MySQL kernel) reports "syntax error at or near nth_value" for nth_value() over(...);
+		// the function is registered, but the M-mode DB rejects the syntax. A mode (openGauss PG kernel) supports
+		// nth_value as a standard window function, so M-only skip (unlike testRank, where the function is unregistered
+		// and A mode also fails).
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		scope.inTransaction(
 				session -> {
 					HibernateCriteriaBuilder cb = session.getCriteriaBuilder();
@@ -230,6 +235,8 @@ public class CriteriaWindowFunctionTest {
 	}
 
 	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.NotGaussDBMMode.class,
+			comment = "GaussDB M mode does not register the rank window function (GaussDBFunctionRegistry registers hypothetical-set functions only in A mode), so cb.rank(window) throws NPE in M mode. A mode supports rank() over().")
 	public void testRank(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -257,6 +264,8 @@ public class CriteriaWindowFunctionTest {
 	@Test
 	@SkipForDialect(dialectClass = DB2Dialect.class, majorVersion = 10, reason = "No support for percent_rank and cume_dist functions before DB2 11")
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "No support for percent_rank and cume_dist functions with over clause")
+	@RequiresDialectFeature(feature = DialectFeatureChecks.NotGaussDBMMode.class,
+			comment = "GaussDB M mode does not register the percent_rank/cume_dist window functions (GaussDBFunctionRegistry registers hypothetical-set functions only in A mode), so cb.percentRank/cumeDist(window) throw NPE in M mode. A mode supports them over().")
 	public void testReusableWindow(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/CountExpressionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/CountExpressionTest.java
@@ -11,11 +11,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.OneToMany;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -94,6 +96,11 @@ public class CountExpressionTest {
 //	@SkipForDialect(dialectClass = InformixDialect.class,
 //			reason = "Informix allows only one column in count(distinct)")
 	public void testCountDistinctTuple(SessionFactoryScope scope) {
+		// GaussDB M mode (MySQL-compatible kernel) rejects `count(distinct (a,b))` with "Unsupport type",
+		// and Hibernate's concat+chr emulation can't apply because M mode treats `||` as logical OR (not
+		// string concat) and rejects `cast(... as text)`. A mode (openGauss PG kernel) supports tuple
+		// distinct counts natively, so it is not skipped (preserves A-mode zero regression).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		scope.inTransaction( session -> {
 			List results = session.createQuery(
 							"SELECT " +
@@ -118,6 +125,10 @@ public class CountExpressionTest {
 //	@SkipForDialect(dialectClass = InformixDialect.class,
 //			reason = "Informix allows only one column in count(distinct)")
 	public void testCountDistinctTupleSanity(SessionFactoryScope scope) {
+		// GaussDB M mode: see testCountDistinctTuple — tuple distinct counts are unsupported and the
+		// concat+chr emulation is unusable (`||` is OR, `cast as text` rejected). A mode supports it
+		// natively; not skipped (preserves A-mode zero regression).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		scope.inTransaction( session -> {
 			// A simple concatenation of tuple arguments would produce a distinct count of 1 in this case
 			// This test checks if the chr(0) count tuple distinct emulation works correctly

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -646,6 +646,7 @@ public class FunctionTests {
 	@SkipForDialect(dialectClass = SpannerDialect.class, reason = "date and timestamp are not compatible")
 	@SkipForDialect(dialectClass = InformixDialect.class, reason = "Datetime truncation is not supported")
 	@SkipForDialect(dialectClass = CockroachDialect.class, reason = "unsupported binary operator: <timestamptz> - <date>")
+	@RequiresDialectFeature(feature = DialectFeatureChecks.NotGaussDBMMode.class, comment = "GaussDB M mode current_date returns a datea carrying the current time (not midnight), so trunc(local datetime, day) - local date is non-zero. A mode current_date is a pure date (midnight).")
 	public void testDateTruncWithLocalDatetimeMinusLocalDate(SessionFactoryScope scope) {
 		scope.inTransaction( session ->
 				assertThat( session.createQuery( "select trunc(local datetime, day) - local date", Duration.class )
@@ -1147,6 +1148,7 @@ public class FunctionTests {
 	@SkipForDialect(dialectClass = HSQLDialect.class, reason = "HSQL treats the cast value as a hexadecimal literal")
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase doesn't support casting varchar to binary")
 	@SkipForDialect(dialectClass = InformixDialect.class, reason = "Informix doesn't support casting varchar to byte")
+	@RequiresDialectFeature(feature = DialectFeatureChecks.NotGaussDBMMode.class, comment = "GaussDB M mode cast(varchar as binary) raises 'parameter is out of range'. A mode (PG kernel) supports cast as bytea.")
 	public void testCastFunctionBinary(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -1350,6 +1352,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsVarSampFunction.class)
 	public void testSampleStatisticalFunctions(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> session.createQuery( "select var_samp(e.theDouble), stddev_samp(e.theDouble) from EntityOfBasics e", Object[].class)
@@ -1358,6 +1361,7 @@ public class FunctionTests {
 	}
 
 	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsVarSampFunction.class)
 	public void testPopulationStatisticalFunctions(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> session.createQuery( "select var_pop(abs(e.theDouble)), stddev_pop(e.theDouble) from EntityOfBasics e", Object[].class)
@@ -2021,6 +2025,8 @@ public class FunctionTests {
 	@Test
 	@SkipForDialect(dialectClass = MySQLDialect.class,
 			reason = "MySQL has a really weird TIME type")
+	@RequiresDialectFeature(feature = DialectFeatureChecks.NotGaussDBMMode.class,
+			comment = "GaussDB M mode (MySQL-compatible) timestampadd on TIME with negative wrap returns an invalid value (22007), same as MySQLDialect weird TIME type. A mode (PG kernel) supports time - interval wraparound.")
 	@SkipForDialect(dialectClass = InformixDialect.class,
 			reason = "The result of a datetime computation is out of range")
 	public void testTimeDurationArithmeticWrapAroundWithLiterals(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertConflictTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertConflictTests.java
@@ -29,6 +29,7 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,6 +66,10 @@ public class InsertConflictTests {
 			reason = "ON CONFLICT clause with empty conflict target in INSERT statement is not supported")
 	@SkipForDialect( dialectClass = SpannerDialect.class, reason = "UNIMPLEMENTED: ON CONFLICT clause with empty conflict target in INSERT statement is not supported in Emulator")
 	public void testOnConflictDoNothing(SessionFactoryScope scope) {
+		// GaussDB A mode (openGauss Oracle-compatible) does not support ON CONFLICT, and its
+		// ON DUPLICATE KEY UPDATE rejects updating primary/unique key columns, so DO NOTHING cannot
+		// be emulated (it returns 1, not 0; MERGE lacks RETURNING for data-modifying CTEs).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && !g.isMMode() );
 		scope.inTransaction(
 				session -> {
 					int updated = session.createMutationQuery(
@@ -72,9 +77,13 @@ public class InsertConflictTests {
 							"values (1, 'John') " +
 							"on conflict do nothing"
 					).executeUpdate();
-					if ( scope.getSessionFactory().getJdbcServices().getDialect() instanceof MySQLDialect ) {
+					final var dialect = scope.getSessionFactory().getJdbcServices().getDialect();
+					if ( dialect instanceof MySQLDialect
+							|| (dialect instanceof GaussDBDialect g && g.isMMode()) ) {
 						// Since JDBC set the MySQL CLIENT_FOUND_ROWS flag, the updated count is 1 even if values didn't change
 						// Also see https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
+						// GaussDB M mode (MySQL-compatible) emulates `on conflict do nothing` via
+						// `on duplicate key update col=col`, which also returns 1 on a conflicting row.
 						assertEquals( 1, updated );
 					}
 					else {
@@ -199,6 +208,10 @@ public class InsertConflictTests {
 	@SkipForDialect( dialectClass = SpannerPostgreSQLDialect.class,
 			reason = "ON CONFLICT clause with empty conflict target in INSERT statement is not supported")
 	public void testOnConflictDoNothingMultiTable(SessionFactoryScope scope) {
+		// GaussDB A mode does not support ON CONFLICT and ON DUPLICATE KEY UPDATE rejects updating
+		// primary/unique key columns; the contact_supp secondary table's only insert column is the PK,
+		// so DO NOTHING cannot be emulated (MERGE also lacks RETURNING for data-modifying CTEs).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && !g.isMMode() );
 		scope.inTransaction(
 				session -> {
 					int updated = session.createMutationQuery(
@@ -206,9 +219,13 @@ public class InsertConflictTests {
 									"values (1, ('John', 'Doe')) " +
 									"on conflict do nothing"
 					).executeUpdate();
-					if ( scope.getSessionFactory().getJdbcServices().getDialect() instanceof MySQLDialect ) {
+					final var dialect = scope.getSessionFactory().getJdbcServices().getDialect();
+					if ( dialect instanceof MySQLDialect
+							|| (dialect instanceof GaussDBDialect g && g.isMMode()) ) {
 						// Since JDBC set the MySQL CLIENT_FOUND_ROWS flag, the updated count is 1 even if values didn't change
 						// Also see https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
+						// GaussDB M mode (MySQL-compatible) emulates `on conflict do nothing` via
+						// `on duplicate key update col=col`, which also returns 1 on a conflicting row.
 						assertEquals( 1, updated );
 					}
 					else {
@@ -228,6 +245,10 @@ public class InsertConflictTests {
 			reason = "Cloud Spanner does not support ON CONFLICT clauses for INSERT ... SELECT statements")
 	@SkipForDialect(dialectClass = SybaseASEDialect.class, reason = "MERGE into a table that has a self-referential FK does not work")
 	public void testOnConflictDoUpdateMultiTable(SessionFactoryScope scope) {
+		// GaussDB A mode does not support ON CONFLICT and ON DUPLICATE KEY UPDATE rejects updating
+		// primary/unique key columns; the contact_supp secondary table's only insert column is the PK,
+		// so its DO NOTHING part cannot be emulated (MERGE also lacks RETURNING for CTEs).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && !g.isMMode() );
 		scope.inTransaction(
 				session -> {
 					int updated = session.createMutationQuery(
@@ -261,6 +282,10 @@ public class InsertConflictTests {
 	@SkipForDialect(dialectClass = SpannerPostgreSQLDialect.class,
 			reason = "Spanner does not support predicates (WHERE clause) in conflict clauses")
 	public void testOnConflictDoUpdateWithWhereMultiTable(SessionFactoryScope scope) {
+		// GaussDB A mode does not support ON CONFLICT and ON DUPLICATE KEY UPDATE rejects updating
+		// primary/unique key columns; the contact_supp secondary table's only insert column is the PK,
+		// so its DO NOTHING part cannot be emulated (MERGE also lacks RETURNING for CTEs).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && !g.isMMode() );
 		scope.inTransaction(
 				session -> {
 					int updated = session.createMutationQuery(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertConflictWithCriteriaCopyTreeEnabledTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertConflictWithCriteriaCopyTreeEnabledTests.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Tuple;
 import org.hibernate.cfg.QuerySettings;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.SpannerDialect;
 import org.hibernate.dialect.SpannerPostgreSQLDialect;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
@@ -21,6 +22,7 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
 import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 
@@ -42,6 +44,9 @@ public class InsertConflictWithCriteriaCopyTreeEnabledTests {
 
 	@Test
 	void createCriteriaInsertValuesTest(SessionFactoryScope scope) {
+		// GaussDB A mode does not support ON CONFLICT and ON DUPLICATE KEY UPDATE rejects updating
+		// primary/unique key columns; the insert targets only the PK (id), so DO NOTHING cannot be emulated.
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && !g.isMMode() );
 		scope.inTransaction(
 				session -> {
 					HibernateCriteriaBuilder cb = session.getCriteriaBuilder();
@@ -59,6 +64,9 @@ public class InsertConflictWithCriteriaCopyTreeEnabledTests {
 
 	@Test
 	void createCriteriaInsertSelectTest(SessionFactoryScope scope) {
+		// GaussDB A mode does not support ON CONFLICT and ON DUPLICATE KEY UPDATE rejects updating
+		// primary/unique key columns; the insert targets only the PK (id), so DO NOTHING cannot be emulated.
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && !g.isMMode() );
 		scope.inTransaction(
 				session -> {
 					HibernateCriteriaBuilder cb = session.getCriteriaBuilder();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/OrderedSetAggregateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/OrderedSetAggregateTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.domain.StandardDomainModel;
@@ -167,6 +168,7 @@ public class OrderedSetAggregateTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsHypotheticalSetFunctions.class)
+	@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "GaussDB does not support hypothetical-set WITHIN GROUP (treats the within-group ORDER BY as a second argument, e.g. 'Function rank(integer,integer) does not exist'); only window (OVER) usage works")
 	public void testHypotheticalSetPercentRank(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -178,6 +180,7 @@ public class OrderedSetAggregateTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsHypotheticalSetFunctions.class)
+	@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "GaussDB does not support hypothetical-set WITHIN GROUP (treats the within-group ORDER BY as a second argument, e.g. 'Function rank(integer,integer) does not exist'); only window (OVER) usage works")
 	public void testHypotheticalSetRank(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -189,6 +192,7 @@ public class OrderedSetAggregateTest {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsHypotheticalSetFunctions.class)
+	@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "GaussDB does not support hypothetical-set WITHIN GROUP (treats the within-group ORDER BY as a second argument, e.g. 'Function rank(integer,integer) does not exist'); only window (OVER) usage works")
 	public void testHypotheticalSetRankWithGroupByHavingOrderByLimit(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/MigrationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/MigrationTest.java
@@ -80,6 +80,11 @@ public class MigrationTest {
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportAlterColumnType.class)
 	public void testSimpleColumnTypeChange(ServiceRegistryScope registryScope) {
+		// GaussDB M mode gsjdbc4 metadata inconsistency: storesLowerCaseIdentifiers=true but the DB stores the
+		// mixed-case table "Version", so assertColumnLength's raw metaData.getColumns("version") returns 0 rows and
+		// the length reads as -1. The test uses raw DatabaseMetaData (not the IdentifierHelper the dialect controls),
+		// so this cannot be fixed at the dialect layer. M-only skip; A mode (PG kernel) is unaffected.
+		org.junit.jupiter.api.Assumptions.assumeFalse( registryScope.getRegistry().requireService( org.hibernate.engine.jdbc.spi.JdbcServices.class ).getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		String resource1 = "org/hibernate/orm/test/schemaupdate/1_Version.hbm.xml";
 		String resource4 = "org/hibernate/orm/test/schemaupdate/4_Version.hbm.xml";
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/query/NativeSQLQueriesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/query/NativeSQLQueriesTest.java
@@ -835,6 +835,12 @@ public class NativeSQLQueriesTest {
 	@Test @JiraKey( "HHH-15102" )
 	@SkipForDialect(dialectClass = MySQLDialect.class, matchSubTypes = true)
 	public void testCommentInSQLQuery(SessionFactoryScope scope) {
+		// The native SQL uses "--count(*), effectively" as a line comment, but MySQL (and GaussDB M mode, MySQL kernel)
+		// requires whitespace after "--" to start a comment; without it "effectively" is parsed as a column reference
+		// ("Column effectively does not exist"). Same root cause as the existing MySQLDialect skip (GaussDBDialect is
+		// not a MySQLDialect subtype, so that skip does not apply). A mode (PG kernel) treats "--" as a comment
+		// unconditionally, so M-only skip.
+		org.junit.jupiter.api.Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		scope.inTransaction( s -> s.createNativeQuery( "select sum(1) --count(*), effectively\nfrom ORGANIZATION" ).getSingleResult() );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertTest.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
@@ -16,6 +17,7 @@ import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.junit.RequiresDialects;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -122,6 +124,12 @@ public class UpsertTest {
 	}
 
 	@Test void testIdOnlySubtype(SessionFactoryScope scope) {
+		// GaussDB A mode: IdOnly/IdOnlyIntermediate have only the PK column. The default
+		// OptionalTableUpdateOperation misjudges them as "no previous non-null values" and falls back to a
+		// plain INSERT, which aborts the transaction on the 2nd upsert (duplicate key). The upsert-based
+		// emulation can't help either, because ON DUPLICATE KEY UPDATE rejects updating the PK. M mode
+		// allows updating the PK in ON DUPLICATE KEY, so it works there.
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && !g.isMMode() );
 		scope.getSessionFactory().getSchemaManager().truncate();
 
 		scope.inStatelessTransaction(s-> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
 import org.hibernate.StaleStateException;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -15,6 +16,7 @@ import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.junit.RequiresDialects;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -53,6 +55,11 @@ public class UpsertVersionedTest {
 	}
 
 	@Test void testStaleUpsert(SessionFactoryScope scope) {
+		// GaussDB M-mode ON DUPLICATE KEY UPDATE always returns affected=1 (no MySQL 0/1/2 distinction),
+		// so the INSERT...ON DUPLICATE KEY DO-NOTHING fallback returns 1 (read as "new row inserted")
+		// instead of 0 (stale), defeating versioned upsert stale detection.
+		// A mode (PG ON CONFLICT semantics) is unaffected, so it is not skipped (zero regression).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		scope.getSessionFactory().getSchemaManager().truncate();
 		scope.inStatelessTransaction( s -> {
 			s.insert(new Record(789L, 1L, "hello world"));

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertWithDiscriminatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertWithDiscriminatorTest.java
@@ -7,10 +7,12 @@ package org.hibernate.orm.test.stateless;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 
@@ -25,6 +27,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @JiraKey( "HHH-20155" )
 class UpsertWithDiscriminatorTest {
 	@Test void test(SessionFactoryScope scope) {
+		// GaussDB A mode (openGauss) does not support ON CONFLICT, and ON DUPLICATE KEY UPDATE
+		// rejects touching primary/unique key columns (probe-confirmed). For this discriminator
+		// single-table inheritance the subtypes add no business columns (X/Y/Z expose only id +
+		// DTYPE), so OptionalTableUpdateOperation falls back to a plain INSERT, which aborts the
+		// transaction on the 2nd upsert (duplicate key). M mode allows ON DUPLICATE KEY UPDATE
+		// id=id, so it works. Same limitation as UpsertTest#testIdOnlySubtype.
+		Assumptions.assumeFalse(
+				scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g
+						&& !g.isMMode()
+		);
 		scope.getSessionFactory().inStatelessTransaction( s -> {
 			s.upsert( new X() );
 			s.upsert( new Y() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/view/ViewTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/view/ViewTest.java
@@ -7,11 +7,13 @@ package org.hibernate.orm.test.view;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.SpannerDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -25,6 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class ViewTest {
 
 	@Test void test(SessionFactoryScope scope) {
+		// GaussDB M mode CREATE VIEW rejects expression types text (upper(name)) and float8 (sum(quantity));
+		// the @View query is user SQL the dialect cannot rewrite. A mode (PG kernel) allows these types (zero regression).
+		Assumptions.assumeFalse( scope.getSessionFactory().getJdbcServices().getDialect() instanceof GaussDBDialect g && g.isMMode() );
 		UUID id = scope.fromTransaction( s -> {
 			Table t = new Table();
 			t.quantity = 69.0;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereTest.java
@@ -49,6 +49,13 @@ public class EagerToManyWhereTest {
 	@Test
 	@JiraKey( value = "HHH-13011" )
 	public void testAssociatedWhereClause(SessionFactoryScope factoryScope) {
+		// GaussDB (openGauss kernel, A and M compat) reports "inactive is ambiguous" for @SQLRestriction("inactive = 0")
+		// on Category EAGER-fetched across joins. Root cause (jshell M-vs-A probe): openGauss flags a bare column in a
+		// `left join (subquery) on <cond>` ON-clause as ambiguous even when only one joined table has it (standard PG does
+		// not; the qualified `c1.inactive=0` passes on both A and M). @SQLRestriction is user SQL rendered bare for all
+		// dialects (runtime-generated alias cannot be qualified), dialect does not rewrite user fragments — not
+		// dialect-fixable, no sql_mode switch (SQLSTATE 42702). M-only skip; A also fails but is not run in the suite.
+		org.junit.jupiter.api.Assumptions.assumeFalse( factoryScope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		var product = new Product();
 		var flowers = new Category();
 		flowers.id = 1;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereUseClassWhereTest.java
@@ -50,6 +50,9 @@ public class EagerToManyWhereUseClassWhereTest {
 	@Test
 	@JiraKey("HHH-13011")
 	public void testAssociatedWhereClause(SessionFactoryScope factoryScope) {
+		// GaussDB M mode reports "inactive is ambiguous" for the @SQLRestriction on Category when EAGER-fetched
+		// across multiple joins; user-supplied SQL is not table-qualified and the dialect does not rewrite it.
+		org.junit.jupiter.api.Assumptions.assumeFalse( factoryScope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		var product = new Product();
 		var flowers = new Category();
 		flowers.id = 1;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereUseClassWhereViaAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereUseClassWhereViaAnnotationTest.java
@@ -51,6 +51,9 @@ public class EagerToManyWhereUseClassWhereViaAnnotationTest {
 	@Test
 	@JiraKey( value = "HHH-15936" )
 	public void testAssociatedWhereClause(SessionFactoryScope factoryScope) {
+		// GaussDB M mode reports "inactive is ambiguous" for the @SQLRestriction on Category when EAGER-fetched
+		// across multiple joins; user-supplied SQL is not table-qualified and the dialect does not rewrite it.
+		org.junit.jupiter.api.Assumptions.assumeFalse( factoryScope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		var product = new Product();
 		var flowers = new Category();
 		flowers.id = 1;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerToManyWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerToManyWhereTest.java
@@ -38,6 +38,9 @@ public class EagerToManyWhereTest {
 	@Test
 	@JiraKey( value = "HHH-13011" )
 	public void testAssociatedWhereClause(SessionFactoryScope factoryScope) {
+		// GaussDB M mode reports "inactive is ambiguous" for the where fragment on Category when EAGER-fetched
+		// across multiple joins; user-supplied SQL is not table-qualified and the dialect does not rewrite it.
+		org.junit.jupiter.api.Assumptions.assumeFalse( factoryScope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		var product = new Product();
 		var flowers = new Category();
 		flowers.setId( 1 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerToManyWhereUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerToManyWhereUseClassWhereTest.java
@@ -35,6 +35,9 @@ public class EagerToManyWhereUseClassWhereTest {
 	@Test
 	@JiraKey( "HHH-13011" )
 	public void testAssociatedWhereClause(SessionFactoryScope factoryScope) {
+		// GaussDB M mode reports "inactive is ambiguous" for the where fragment on Category when EAGER-fetched
+		// across multiple joins; user-supplied SQL is not table-qualified and the dialect does not rewrite it.
+		org.junit.jupiter.api.Assumptions.assumeFalse( factoryScope.getSessionFactory().getJdbcServices().getDialect() instanceof org.hibernate.community.dialect.GaussDBDialect g && g.isMMode() );
 		var product = new Product();
 		var flowers = new Category();
 		flowers.setId( 1 );

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/filter/Category.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/filter/Category.hbm.xml
@@ -23,7 +23,7 @@
             <many-to-many column="PROD_ID" class="Product"/>
         </set>
 
-        <filter name="effectiveDate" condition=":asOfDate BETWEEN eff_start_dt and eff_end_dt"/>
+        <filter name="effectiveDate" condition="eff_start_dt &lt;= :asOfDate and eff_end_dt &gt;= :asOfDate"/>
         <filter name="unioned">
             'abc' in ( select d.REG from DEPARTMENT d where (d.DEPT_ID=123) union select p.NAME from SALES_PERSON p )
         </filter>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/filter/Product.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/filter/Product.hbm.xml
@@ -34,12 +34,12 @@
 	    <set cascade="all" inverse="false" name="categories" fetch="join" lazy="false" table="PROD_CAT" >
 		    <key column="PROD_ID"/>
 		    <many-to-many class="Category" column="CAT_ID" fetch="join" >
-	            <filter name="effectiveDate" condition=":asOfDate BETWEEN eff_start_dt and eff_end_dt"/>
+	            <filter name="effectiveDate" condition="eff_start_dt &lt;= :asOfDate and eff_end_dt &gt;= :asOfDate"/>
 			    <filter name="cat" condition="CAT_ID = :catId"/> 
             </many-to-many>
 	    </set>
 
-	    <filter name="effectiveDate" condition=":asOfDate BETWEEN eff_start_dt and eff_end_dt"/>
+	    <filter name="effectiveDate" condition="eff_start_dt &lt;= :asOfDate and eff_end_dt &gt;= :asOfDate"/>
 	    <filter name="heavyProducts" condition=":weightKilograms &lt; weight_kg"/>
 
 	</class>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/hql/Animal.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/hql/Animal.hbm.xml
@@ -54,8 +54,8 @@
 				<property name="heightInches">
 					<column name="height_centimeters" 
 						not-null="true" 
-						read="height_centimeters / 2.54E0"
-						write="? * 2.54E0"/>
+						read="height_centimeters / 2.54"
+						write="? * 2.54"/>
 				</property>   
 				<property name="intValue"/>
 				<property name="floatValue"/>

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cleaner/PostgreSQLDatabaseCleaner.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cleaner/PostgreSQLDatabaseCleaner.java
@@ -187,7 +187,7 @@ public class PostgreSQLDatabaseCleaner implements DatabaseCleaner {
 					}
 				}
 				sb.setCharAt( sb.length() - 1, ' ' );
-				sb.append( "RESTART IDENTITY CASCADE" );
+				sb.append( useRestartIdentity( connection ) ? "RESTART IDENTITY CASCADE" : "CASCADE" );
 				truncateSql = sb.toString();
 				truncateSqlPerSchema.put( schemaName, truncateSql );
 			}
@@ -223,6 +223,27 @@ public class PostgreSQLDatabaseCleaner implements DatabaseCleaner {
 			throw new RuntimeException( e );
 		}
 		return false;
+	}
+
+	/**
+	 * Whether {@code TRUNCATE ... RESTART IDENTITY} can be appended. GaussDB in MySQL-compatible mode
+	 * (datcompatibility "B"/"M") rejects {@code RESTART IDENTITY} with a syntax error, so only
+	 * {@code CASCADE} is used there. Real PostgreSQL has no {@code pg_database.datcompatibility} column,
+	 * so the query fails and {@code RESTART IDENTITY} is kept (A mode / true PostgreSQL support it).
+	 */
+	private static boolean useRestartIdentity(Connection connection) {
+		try (Statement stmt = connection.createStatement();
+				ResultSet rs = stmt.executeQuery(
+						"select datcompatibility from pg_database where datname = current_database()" )) {
+			if ( rs.next() ) {
+				final String mode = rs.getString( 1 );
+				return !"M".equals( mode ) && !"B".equals( mode );
+			}
+		}
+		catch (SQLException e) {
+			// not GaussDB — assume real PostgreSQL, which supports RESTART IDENTITY
+		}
+		return true;
 	}
 
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SharedDriverManagerConnectionProvider.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SharedDriverManagerConnectionProvider.java
@@ -139,30 +139,46 @@ public class SharedDriverManagerConnectionProvider extends DriverManagerConnecti
 					final Object connection = c.unwrap( pgConnection );
 					final Object typeInfo = pgConnection.getMethod( "getTypeInfo" ).invoke( connection );
 					final Class<?> typeInfoCacheClass = Class.forName( "org.postgresql.jdbc.TypeInfoCache" );
-					final Field oidToPgNameField = typeInfoCacheClass.getDeclaredField( "oidToPgName" );
-					final Field pgNameToOidField = typeInfoCacheClass.getDeclaredField( "pgNameToOid" );
-					final Field pgNameToSQLTypeField = typeInfoCacheClass.getDeclaredField( "pgNameToSQLType" );
-					final Field oidToSQLTypeField = typeInfoCacheClass.getDeclaredField( "oidToSQLType" );
-					oidToPgNameField.setAccessible( true );
-					pgNameToOidField.setAccessible( true );
-					pgNameToSQLTypeField.setAccessible( true );
-					oidToSQLTypeField.setAccessible( true );
+					// GaussDB's gsjdbc4 driver (based on an older pgjdbc) prefixes the type cache
+					// fields with an underscore and does not expose oidToSQLType, so fall back to
+					// the underscore-prefixed names and treat oidToSQLType as optional.
+					final Field oidToPgNameField = findField( typeInfoCacheClass, "oidToPgName", "_oidToPgName" );
+					final Field pgNameToOidField = findField( typeInfoCacheClass, "pgNameToOid", "_pgNameToOid" );
+					final Field pgNameToSQLTypeField = findField( typeInfoCacheClass, "pgNameToSQLType", "_pgNameToSQLType" );
+					final Field oidToSQLTypeField = findField( typeInfoCacheClass, "oidToSQLType", "_oidToSQLType" );
 					//noinspection unchecked
-					final Map<Integer, String> oidToPgName = (Map<Integer, String>) oidToPgNameField.get( typeInfo );
+					final Map<Integer, String> oidToPgName = oidToPgNameField == null
+							? null
+							: (Map<Integer, String>) getAccessible( oidToPgNameField ).get( typeInfo );
 					//noinspection unchecked
-					final Map<String, Integer> pgNameToOid = (Map<String, Integer>) pgNameToOidField.get( typeInfo );
+					final Map<String, Integer> pgNameToOid = pgNameToOidField == null
+							? null
+							: (Map<String, Integer>) getAccessible( pgNameToOidField ).get( typeInfo );
 					//noinspection unchecked
-					final Map<String, Integer> pgNameToSQLType = (Map<String, Integer>) pgNameToSQLTypeField.get( typeInfo );
+					final Map<String, Integer> pgNameToSQLType = pgNameToSQLTypeField == null
+							? null
+							: (Map<String, Integer>) getAccessible( pgNameToSQLTypeField ).get( typeInfo );
 					//noinspection unchecked
-					final Map<Integer, Integer> oidToSQLType = (Map<Integer, Integer>) oidToSQLTypeField.get( typeInfo );
+					final Map<Integer, Integer> oidToSQLType = oidToSQLTypeField == null
+							? null
+							: (Map<Integer, Integer>) getAccessible( oidToSQLTypeField ).get( typeInfo );
+					if ( pgNameToOid == null ) {
+						return true;
+					}
 					for ( Iterator<Map.Entry<String, Integer>> iter = pgNameToOid.entrySet().iterator(); iter.hasNext(); ) {
 						Map.Entry<String, Integer> entry = iter.next();
 						final String typeName = entry.getKey();
 						if ( !PGJDBC_STANDARD_TYPE_NAMES.contains( typeName ) ) {
 							final Integer oid = entry.getValue();
-							oidToPgName.remove( oid );
-							oidToSQLType.remove( oid );
-							pgNameToSQLType.remove( typeName );
+							if ( oidToPgName != null ) {
+								oidToPgName.remove( oid );
+							}
+							if ( oidToSQLType != null ) {
+								oidToSQLType.remove( oid );
+							}
+							if ( pgNameToSQLType != null ) {
+								pgNameToSQLType.remove( typeName );
+							}
 							iter.remove();
 						}
 					}
@@ -220,6 +236,29 @@ public class SharedDriverManagerConnectionProvider extends DriverManagerConnecti
 
 	private static final Set<String> DRIVER_REQUIRES_NEW_CONNECTION_ON_TIMEZONE_CHANGE = Set.of(
 			"org.h2.Driver", "org.hsqldb.jdbc.JDBCDriver", "org.firebirdsql.jdbc.FBDriver" );
+
+	/**
+	 * Finds a declared field by trying each of the given names in turn.
+	 * Used to stay compatible with pgjdbc variants (e.g. GaussDB's gsjdbc4)
+	 * that rename or omit internal type-cache fields. Returns {@code null}
+	 * when none of the names match.
+	 */
+	private static Field findField(Class<?> type, String... fieldNames) {
+		for ( String fieldName : fieldNames ) {
+			try {
+				return type.getDeclaredField( fieldName );
+			}
+			catch (NoSuchFieldException ignored) {
+				// try the next name
+			}
+		}
+		return null;
+	}
+
+	private static Field getAccessible(Field field) {
+		field.setAccessible( true );
+		return field;
+	}
 
 	public void onDefaultTimeZoneChange() {
 		if ( DRIVER_REQUIRES_NEW_CONNECTION_ON_TIMEZONE_CHANGE.contains( config.driverClassName ) ) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -591,9 +591,28 @@ abstract public class DialectFeatureChecks {
 
 	public static class SupportsCteInsertStrategy implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
+			if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+				// M mode lacks RETURNING (single-node only), so the CTE-based insert
+				// strategy (with t as (insert ... returning) select) is unavailable; the
+				// dialect falls back to LocalTemporaryTableInsertStrategy, whose ID-allocation
+				// semantics differ (it consumes reserved HiLo/Pooled IDs rather than opening a
+				// new segment), so the CTE-insert tests don't apply. A mode keeps CTE insert.
+				return false;
+			}
 			return (dialect instanceof PostgreSQLDialect && !(dialect instanceof SpannerPostgreSQLDialect))
 				|| dialect instanceof DB2Dialect
 				|| dialect instanceof GaussDBDialect;
+		}
+	}
+
+	public static class NotGaussDBMMode implements DialectFeatureCheck {
+		public boolean apply(Dialect dialect) {
+			// GaussDB M mode (MySQL-compatible) folds unquoted identifiers to lowercase on
+			// CREATE SEQUENCE, yet treats nextval()'s string argument as case-sensitive, so the
+			// dialect must render unquoted sequence names in lowercase to match. Tests that assert
+			// mixed-case sequence names (e.g. catalog/schema qualifier-substitution checks) cannot
+			// hold in M mode. A mode (Oracle-compatible) and every other dialect are unaffected.
+			return !( dialect instanceof GaussDBDialect g && g.isMMode() );
 		}
 	}
 
@@ -750,7 +769,11 @@ abstract public class DialectFeatureChecks {
 
 	public static class SupportsFullJoin implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
-			return !( dialect instanceof DerbyDialect );
+			// GaussDB M mode (MySQL-compatible) does not support FULL JOIN; skip the test rather
+			// than fail on the rendered `full join` syntax error. A mode (openGauss PG kernel)
+			// supports it.
+			return !( dialect instanceof DerbyDialect )
+					&& !( dialect instanceof GaussDBDialect g && g.isMMode() );
 		}
 	}
 
@@ -795,18 +818,41 @@ abstract public class DialectFeatureChecks {
 
 	public static class SupportsStructAggregate implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
+			// GaussDB M mode (MySQL-compatible) does not support PG-style composite types
+			// (CREATE TYPE ... AS (...) is a syntax error), so @Struct aggregate tests are skipped.
+			// A mode (openGauss PG kernel) supports them.
+			if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+				return false;
+			}
 			return supportsAggregate( dialect, SqlTypes.STRUCT );
 		}
 	}
 
 	public static class SupportsJsonAggregate implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
+			// GaussDB M mode (MySQL-compatible) JSON aggregate read/write expressions are not yet
+			// adapted. The read side uses PostgreSQL `->'col'`/`->>'col'`, but M mode needs the
+			// `$.col` path form (else "Invalid JSON path expression"). The write side serializes
+			// date/timestamp/timestamptz via `to_char`, which M mode rejects: `to_char(timestamp,...)`
+			// does not exist, `to_char(date,...)` returns wrong values, and `at time zone 'UTC'`
+			// is unavailable. Skip until the M-mode JSON aggregate renderer is rewritten (read path
+			// `$.` prefix + write `date_format` + tz handling). A mode (openGauss PG kernel) supports
+			// the PostgreSQL JSON function family unchanged.
+			if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+				return false;
+			}
 			return supportsAggregate( dialect, SqlTypes.JSON );
 		}
 	}
 
 	public static class SupportsXmlAggregate implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
+			// GaussDB M mode (MySQL-compatible) lacks the PG XML function family
+			// (XMLTABLE/xmlexists/xmlquery/xmlagg/xmlelement/xmlparse/extractvalue all fail; only
+			// xmltype() exists), so XML aggregate embeddable tests are skipped. A mode supports them.
+			if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+				return false;
+			}
 			return supportsAggregate( dialect, SqlTypes.SQLXML );
 		}
 	}
@@ -841,6 +887,10 @@ abstract public class DialectFeatureChecks {
 
 	public static class SupportsJsonComponentUpdate implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
+			if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+				// M mode JSON aggregate write renderer is not yet adapted; see SupportsJsonAggregate.
+				return false;
+			}
 			try {
 				dialect.getAggregateSupport().requiresAggregateCustomWriteExpressionRenderer( SqlTypes.JSON );
 				return true;
@@ -853,6 +903,10 @@ abstract public class DialectFeatureChecks {
 
 	public static class SupportsXmlComponentUpdate implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
+			if ( dialect instanceof GaussDBDialect g && g.isMMode() ) {
+				// M mode lacks the PG XML function family; see SupportsXmlAggregate.
+				return false;
+			}
 			try {
 				dialect.getAggregateSupport().requiresAggregateCustomWriteExpressionRenderer( SqlTypes.SQLXML );
 				return true;

--- a/local-build-plugins/src/main/groovy/local.databases.gradle
+++ b/local-build-plugins/src/main/groovy/local.databases.gradle
@@ -8,7 +8,8 @@ ext {
     assert project.hasProperty('db')
     db = project.getProperty('db')
     dbVersion = project.getProperty('dbVersion')
-    dbHost = System.getProperty( 'dbHost', 'localhost' )
+    // dbHost first takes the JVM system property -DdbHost, then takes the project property in gradle.properties, and finally defaults to localhost
+    dbHost = System.getProperty( 'dbHost' ) ?: project.findProperty( 'dbHost' ) ?: 'localhost'
     dbService = System.getProperty( 'dbService', '' )
     dbPassword = System.getProperty( 'dbPassword', '' ).replace('"', '')
     dbConnectionStringSuffix = System.getProperty( 'dbConnectionStringSuffix', '' ).replace('"', '')

--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -75,7 +75,9 @@ dependencies {
     testRuntimeOnly libs.jdbc.derby
     testRuntimeOnly libs.jdbc.derbyTools
     testRuntimeOnly libs.jdbc.hsqldb
-    testRuntimeOnly libs.jdbc.postgresql
+    if ( !db.startsWith( 'gaussdb' ) ) {
+        testRuntimeOnly libs.jdbc.postgresql
+    }
     testRuntimeOnly libs.jdbc.edb
     testRuntimeOnly libs.jdbc.mssql
     testRuntimeOnly libs.jdbc.informix
@@ -225,6 +227,18 @@ tasks.withType( Test.class ).configureEach { test ->
     test.systemProperties['hibernate.test.validatefailureexpected'] = true
     test.systemProperties['hibernate.highlight_sql'] = false
     test.systemProperties += providers.systemPropertiesPrefixedBy("hibernate.").get()
+
+    // GaussDB M mode reserves extra keywords (e.g. `excluded`) that PostgreSQL treats as non-reserved
+    // and thus Hibernate allows as column names. Enable keyword auto-quoting (together with
+    // registerKeyword in GaussDBDialect) so such identifiers are quoted automatically.
+    if ( db == 'gaussdb' ) {
+        test.systemProperties['hibernate.auto_quote_keyword'] = 'true'
+        // GaussDBDialect detects M mode (MySQL-compatible) from `datcompatibility` via JDBC metadata,
+        // but tests that set hibernate.temp.use_jdbc_metadata_defaults=false disable metadata on boot,
+        // leaving the dialect defaulting to A mode (breaks information_schema.sequences extraction,
+        // which M mode lacks). Pass the mode explicitly so detection works regardless of metadata.
+        test.systemProperties['hibernate.dialect.gaussdb.compatibility_mode'] = 'A'
+    }
 
     test.enableAssertions = true
 


### PR DESCRIPTION
[](https://hibernate.atlassian.net/browse/HHH-20785)
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->
This modification aims to provide support for both A-mode and M-mode in GaussDB. Certain test cases are proactively skipped for A-mode or M-mode due to unsupported features, but this does not affect the use of these test cases with other databases.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20785 (New Feature):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->