### PR TITLE
HHH-8585 Fix interceptor exception in beforeTransactionCompletion swallowed instead of aborting commit   

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -901,6 +901,7 @@ abstract class AbstractSharedSessionContract
 		}
 		catch (Throwable t) {
 			SESSION_LOGGER.exceptionInBeforeTransactionCompletionInterceptor( t );
+			throw t;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/interceptor/InterceptorBeforeTransactionExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/interceptor/InterceptorBeforeTransactionExceptionTest.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.interceptor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.Interceptor;
+import org.hibernate.Transaction;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that an exception thrown in {@link Interceptor#beforeTransactionCompletion}
+ * aborts the commit rather than being silently swallowed.
+ */
+@DomainModel(annotatedClasses = InterceptorBeforeTransactionExceptionTest.TestEntity.class)
+@SessionFactory
+public class InterceptorBeforeTransactionExceptionTest {
+
+	@Test
+	public void exceptionInBeforeCompletionShouldPreventCommit(SessionFactoryScope factoryScope) {
+		final long entityId;
+
+		// persist an entity so we have something to verify against
+		try (var session = factoryScope.getSessionFactory().openSession()) {
+			session.getTransaction().begin();
+			var entity = new TestEntity( "initial" );
+			session.persist( entity );
+			session.getTransaction().commit();
+			entityId = entity.getId();
+		}
+
+		// now attempt a modification with an interceptor that throws before commit
+		assertThrows( RuntimeException.class, () -> {
+			try (var session = factoryScope.getSessionFactory()
+					.withOptions()
+					.interceptor( new ExceptionThrowingInterceptor() )
+					.openSession()) {
+				session.getTransaction().begin();
+				var entity = session.find( TestEntity.class, entityId );
+				entity.setName( "modified" );
+				session.getTransaction().commit();
+			}
+		} );
+
+		// verify the modification was NOT committed
+		try (var session = factoryScope.getSessionFactory().openSession()) {
+			var entity = session.find( TestEntity.class, entityId );
+			assertNotNull( entity );
+			assertNull( entity.getName().equals( "modified" ) ? "modified" : null,
+					"Transaction should have been rolled back, but the entity was modified" );
+		}
+	}
+
+	private static class ExceptionThrowingInterceptor implements Interceptor {
+		@Override
+		public void beforeTransactionCompletion(Transaction tx) {
+			throw new RuntimeException( "Interceptor vetoes the commit" );
+		}
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+		@Id
+		@GeneratedValue
+		private Long id;
+		private String name;
+
+		TestEntity() {
+		}
+
+		TestEntity(String name) {
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-8585

Exceptions thrown in Interceptor.beforeTransactionCompletion() were being caught and logged but not re-thrown, allowing the transaction to commit despite the interceptor objecting. The exception is now thrown after logging so that it aborts the commit as expected.
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-8585 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->