### PR TITLE
HHH-20783 Add a dedicated failed-transactions counter to Statistics

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/statistics/Statistics.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/statistics/Statistics.adoc
@@ -68,6 +68,7 @@ https://docs.hibernate.org/orm/{majorMinorVersion}/javadocs/org/hibernate/stat/S
 ==== Transaction statistics methods
 
 `getSuccessfulTransactionCount`:: The number of transactions that completed successfully.
+`getFailedTransactionCount`:: The number of transactions that did not complete successfully, that is, which were rolled back.
 `getTransactionCount`:: The number of transactions we know to have completed.
 
 [[statistics-concurrency-control]]

--- a/hibernate-core/src/main/java/org/hibernate/stat/Statistics.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/Statistics.java
@@ -376,6 +376,15 @@ public interface Statistics {
 	long getTransactionCount();
 
 	/**
+	 * The number of transactions we know to have failed.
+	 *
+	 * @since 8.1
+	 */
+	default long getFailedTransactionCount() {
+		return getTransactionCount() - getSuccessfulTransactionCount();
+	}
+
+	/**
 	 * The number of prepared statements that were acquired.
 	 */
 	long getPrepareStatementCount();

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/StatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/StatisticsImpl.java
@@ -98,6 +98,7 @@ public class StatisticsImpl implements StatisticsImplementor, Service {
 
 	private final LongAdder committedTransactionCount = new LongAdder();
 	private final LongAdder transactionCount = new LongAdder();
+	private final LongAdder failedTransactionCount = new LongAdder();
 
 	private final LongAdder optimisticFailureCount = new LongAdder();
 
@@ -192,6 +193,7 @@ public class StatisticsImpl implements StatisticsImplementor, Service {
 
 		transactionCount.reset();
 		committedTransactionCount.reset();
+		failedTransactionCount.reset();
 
 		optimisticFailureCount.reset();
 
@@ -846,6 +848,11 @@ public class StatisticsImpl implements StatisticsImplementor, Service {
 	}
 
 	@Override
+	public long getFailedTransactionCount() {
+		return failedTransactionCount.sum();
+	}
+
+	@Override
 	public long getCloseStatementCount() {
 		return closeStatementCount.sum();
 	}
@@ -890,6 +897,9 @@ public class StatisticsImpl implements StatisticsImplementor, Service {
 		transactionCount.increment();
 		if ( success ) {
 			committedTransactionCount.increment();
+		}
+		else {
+			failedTransactionCount.increment();
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/StatelessSessionStatisticsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/StatelessSessionStatisticsTest.java
@@ -96,6 +96,8 @@ public class StatelessSessionStatisticsTest {
 		assertEquals(1, statistics.getEntityDeleteCount());
 		assertEquals(1, statistics.getCollectionRemoveCount());
 		assertEquals(4, statistics.getTransactionCount());
+		assertEquals(4, statistics.getSuccessfulTransactionCount());
+		assertEquals(0, statistics.getFailedTransactionCount());
 		assertEquals(stmtCount+=2, statistics.getPrepareStatementCount());
 		assertEquals(stmtCount, statistics.getCloseStatementCount());
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tm/CMTTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tm/CMTTest.java
@@ -436,6 +436,7 @@ public class CMTTest {
 
 			assertEquals( sessionFactory.getStatistics().getTransactionCount(), 4 );
 			assertEquals( sessionFactory.getStatistics().getSuccessfulTransactionCount(), 3 );
+			assertEquals( sessionFactory.getStatistics().getFailedTransactionCount(), 1 );
 			assertEquals( sessionFactory.getStatistics().getEntityDeleteCount(), 1 );
 			assertEquals( sessionFactory.getStatistics().getEntityInsertCount(), 1 );
 			assertEquals( sessionFactory.getStatistics().getSessionOpenCount(), 4 );

--- a/hibernate-micrometer/src/main/java/org/hibernate/orm/micrometer/HibernateMetrics.java
+++ b/hibernate-micrometer/src/main/java/org/hibernate/orm/micrometer/HibernateMetrics.java
@@ -113,7 +113,7 @@ public class HibernateMetrics implements MeterBinder {
 				Statistics::getSuccessfulTransactionCount, "result", "success"
 		);
 		counter(registry, "hibernate.transactions", "The number of transactions we know to have failed",
-				s -> s.getTransactionCount() - s.getSuccessfulTransactionCount(), "result", "failure"
+				Statistics::getFailedTransactionCount, "result", "failure"
 		);
 		counter(registry,
 				"hibernate.optimistic.failures",


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20783

The failed-transactions value exposed by hibernate-micrometer as hibernate.transactions{result="failure"} was derived as
getTransactionCount() - getSuccessfulTransactionCount(). Since endTransaction() increments the two counters non-atomically, a concurrent reader (e.g. a Prometheus scrape) could transiently observe a negative value - and Micrometer 1.14+ (Prometheus Java client 1.x) rejects negative counters, failing the entire /actuator/prometheus scrape with HTTP 500.

As suggested by Christian Beikov on the forum (https://discourse.hibernate.org/t/12391), this introduces a dedicated counter:

- Statistics#getFailedTransactionCount() - new default method (derived fallback for custom implementations)
- StatisticsImpl - a dedicated LongAdder, incremented in endTransaction(false), reset in clear()
- HibernateMetrics now reads the dedicated counter, so the exposed value is exact, monotonic, and can never go negative (no transient overcount either, which could otherwise trip alerts on the failure counter)

Includes a regression test (deterministic success/rollback/clear cases plus a short concurrency guard). A standalone reproducer against the old derivation is attached to the Jira ticket (observes ~31k negative reads within 10 seconds on 6.6.55.Final).

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20783 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------