### PR TITLE
HHH-20716 Process hql-import elements from orm xml mappings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -235,6 +235,7 @@ public class MetadataBuildingProcess {
 
 		managedResourcesBinder.prepare();
 		managedResourcesBinder.bindTypeDefinitions();
+		managedResourcesBinder.bindQueryRenames();
 		managedResourcesBinder.bindFilterDefinitions();
 		managedResourcesBinder.bindFetchProfiles();
 		managedResourcesBinder.bindEntityHierarchies( new HashSet<>() );

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/ManagedResourcesBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/ManagedResourcesBinder.java
@@ -129,6 +129,13 @@ public class ManagedResourcesBinder {
 		}
 	}
 
+	public void bindQueryRenames() {
+		final var importedRenames = domainModelSource.getGlobalRegistrations().getImportedRenames();
+		for ( var entry : importedRenames.entrySet() ) {
+			rootMetadataBuildingContext.getMetadataCollector().addImport( entry.getKey(), entry.getValue() );
+		}
+	}
+
 	public void bindFilterDefinitions() {
 		final var collector = rootMetadataBuildingContext.getMetadataCollector();
 		for ( var registration : domainModelSource.getGlobalRegistrations().getFilterDefRegistrations().values() ) {


### PR DESCRIPTION
This PR fixes the failure in `org.hibernate.orm.test.hqlimport.HqlImportTest`.

The HHH-20716 rebase missed a few changes related to `AnnotationMetadataSourceProcessorImpl`, which was removed in 9.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20716 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20716
<!-- Hibernate GitHub Bot issue links end -->