### PR TITLE
HHH-20772 add @Incubating to new Processor options

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -5,6 +5,7 @@
 package org.hibernate.processor;
 
 import jakarta.annotation.Nullable;
+import org.hibernate.Incubating;
 import org.hibernate.processor.annotation.AnnotationMetaEntity;
 import org.hibernate.processor.annotation.AnnotationMetaPackage;
 import org.hibernate.processor.annotation.NonManagedMetamodel;
@@ -180,11 +181,13 @@ public class HibernateProcessor extends AbstractProcessor {
 	/**
 	 * The default dialect class to use for any HQL validation.
 	 */
+	@Incubating
 	public static final String DIALECT_OPTION = "dialect";
 
 	/**
 	 * The database version string to use for the default dialect class.
 	 */
+	@Incubating
 	public static final String DIALECT_DATABASE_VERSION_OPTION = "dialectDatabaseVersion";
 
 	/**
@@ -222,6 +225,7 @@ public class HibernateProcessor extends AbstractProcessor {
 	 * {@code jakarta.data.Sort} types with a null type argument, which
 	 * the Jakarta Data specification allows.
 	 */
+	@Incubating
 	public static final String JAKARTA_DATA_SORT_COMPLIANCE = "jakartaDataSortCompliance";
 
 	/**
@@ -229,6 +233,7 @@ public class HibernateProcessor extends AbstractProcessor {
 	 * annotations from repository interfaces to generated implementations.
 	 * By default, security annotations are propagated.
 	 */
+	@Incubating
 	public static final String SUPPRESS_JAKARTA_DATA_SECURITY_ANNOTATIONS = "suppressJakartaDataSecurityAnnotations";
 
 
@@ -254,6 +259,7 @@ public class HibernateProcessor extends AbstractProcessor {
 	 * index is created. The index is used to speed up query validation
 	 * for faster compilation times.
 	 */
+	@Incubating
 	public static final String INDEX = "index";
 
 	private static final boolean ALLOW_OTHER_PROCESSORS_TO_CLAIM_ANNOTATIONS = false;


### PR DESCRIPTION
Everyone has been going crazy adding new switches of late. This is bad for the same reasons that millions of config settings are bad in Hibernate ORM, with the additional badness that setting annotation processor config options really lacks ergonomics in some environments.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
