### PR TITLE
HHH-20791 HbmXmlTransformer drops the <composite-id> generator

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -48,6 +48,7 @@ import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFetchStyleWithSubselectEnum;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterAliasMappingType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterParameterType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmFilterType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmGeneratorSpecificationType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIdBagCollectionType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmIndexType;
@@ -569,6 +570,26 @@ public class HbmXmlTransformer {
 		}
 		return generatorParameters( a )
 				.equals( generatorParameters( b ) );
+	}
+
+	/**
+	 * Builds a {@link JaxbGenericIdGeneratorImpl} from an hbm {@code <generator>}, copying its
+	 * class and configuration parameters. A {@code null} name leaves the generator anonymous
+	 * (inline usage); a non-null name allows it to be referenced from a {@code <generated-value>}.
+	 */
+	private static JaxbGenericIdGeneratorImpl toGenericIdGenerator(
+			String name,
+			JaxbHbmGeneratorSpecificationType hbmGenerator) {
+		final var generator = new JaxbGenericIdGeneratorImpl();
+		generator.setName( name );
+		generator.setClazz( hbmGenerator.getClazz() );
+		for ( var hbmConfigParameter : hbmGenerator.getConfigParameters() ) {
+			final var jaxbParam = new JaxbConfigurationParameterImpl();
+			jaxbParam.setName( hbmConfigParameter.getName() );
+			jaxbParam.setValue( hbmConfigParameter.getValue() );
+			generator.getParameters().add( jaxbParam );
+		}
+		return generator;
 	}
 
 	private static List<String> generatorParameters(JaxbGenericIdGeneratorImpl generator) {
@@ -2796,26 +2817,15 @@ public class HbmXmlTransformer {
 		final var hbmGenerator = hbmCollectionId.getGenerator();
 		if ( hbmGenerator != null ) {
 			final var generatedValue = new JaxbGeneratedValueImpl();
-			final String generatorClass = hbmGenerator.getClazz();
-			final var hbmParams = hbmGenerator.getConfigParameters();
 
-			if ( !hbmParams.isEmpty() ) {
+			if ( !hbmGenerator.getConfigParameters().isEmpty() ) {
 				final var generatorName = target.getName() + "-collection-id-generator";
 				generatedValue.setGenerator( generatorName );
-
-				final var genDef = new JaxbGenericIdGeneratorImpl();
-				genDef.setName( generatorName );
-				genDef.setClazz( generatorClass );
-				for ( var hbmParam : hbmParams ) {
-					final var param = new JaxbConfigurationParameterImpl();
-					param.setName( hbmParam.getName() );
-					param.setValue( hbmParam.getValue() );
-					genDef.getParameters().add( param );
-				}
-				mappingXmlBinding.getRoot().getGenericGenerators().add( genDef );
+				mappingXmlBinding.getRoot().getGenericGenerators()
+						.add( toGenericIdGenerator( generatorName, hbmGenerator ) );
 			}
 			else {
-				generatedValue.setGenerator( generatorClass );
+				generatedValue.setGenerator( hbmGenerator.getClazz() );
 			}
 
 			collectionId.setGenerator( generatedValue );
@@ -3703,21 +3713,7 @@ public class HbmXmlTransformer {
 			final var jaxbGeneratedValue = new JaxbGeneratedValueImpl();
 			jaxbGeneratedValue.setGenerator( generatorName );
 			target.setGeneratedValue( jaxbGeneratedValue );
-
-			final var generator = new JaxbGenericIdGeneratorImpl();
-			generator.setName( generatorName );
-
-			target.setGenericGenerator( generator );
-			generator.setClazz( hbmGenerator.getClazz() );
-
-			final var hbmConfigParameters = hbmGenerator.getConfigParameters();
-			for ( int i = 0; i < hbmConfigParameters.size(); i++ ) {
-				final var hbmConfigParameter = hbmConfigParameters.get( i );
-				final var jaxbParam = new JaxbConfigurationParameterImpl();
-				generator.getParameters().add( jaxbParam );
-				jaxbParam.setName( hbmConfigParameter.getName() );
-				jaxbParam.setValue( hbmConfigParameter.getValue() );
-			}
+			target.setGenericGenerator( toGenericIdGenerator( generatorName, hbmGenerator ) );
 		}
 
 		target.setUnsavedValue( source.getUnsavedValue() );
@@ -3747,6 +3743,15 @@ public class HbmXmlTransformer {
 				jaxbEmbeddedId::setAttributeAccessor
 		);
 		jaxbEmbeddedId.setTarget( jaxbEmbeddable.getName() );
+
+		final var hbmGenerator = hbmCompositeId.getGenerator();
+		if ( hbmGenerator != null && !"assigned".equals( hbmGenerator.getClazz() ) ) {
+			final var generatorName = jaxbEmbeddedId.getName() + "-composite-id-generator";
+			final var jaxbGeneratedValue = new JaxbGeneratedValueImpl();
+			jaxbGeneratedValue.setGenerator( generatorName );
+			jaxbEmbeddedId.setGeneratedValue( jaxbGeneratedValue );
+			jaxbEmbeddedId.setGenericGenerator( toGenericIdGenerator( generatorName, hbmGenerator ) );
+		}
 	}
 
 	private void transferAccess(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -907,6 +907,27 @@ public class HbmTransformationJaxbTests {
 		} );
 	}
 
+	@Test
+	@JiraKey( "HHH-20791" )
+	public void testEmbeddedIdGeneratorTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/embedded-id-generator/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 1 );
+
+			final JaxbEntityImpl entity = transformed.getEntities().get( 0 );
+			final var embeddedId = entity.getAttributes().getEmbeddedIdAttribute();
+			assertThat( embeddedId )
+					.as( "Aggregated composite-id should be transformed to an embedded-id" )
+					.isNotNull();
+			assertThat( embeddedId.getName() ).isEqualTo( "id" );
+
+			assertThat( embeddedId.getGenericGenerator() )
+					.as( "The <generator> on <composite-id> should be transferred to the embedded-id" )
+					.isNotNull();
+			assertThat( embeddedId.getGenericGenerator().getClazz() )
+					.isEqualTo( "org.hibernate.orm.test.boot.jaxb.mapping.compositeidgenerator.OrderIdGenerator" );
+		} );
+	}
+
 	private void transformAndVerify(
 			String resourceName,
 			ServiceRegistryScope scope,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositeidgenerator/Order.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositeidgenerator/Order.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.compositeidgenerator;
+
+public class Order {
+	private Id id;
+	private String description;
+
+	public Id getId() {
+		return id;
+	}
+
+	public void setId(Id id) {
+		this.id = id;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public static class Id {
+		private int number;
+		private String code;
+
+		public int getNumber() {
+			return number;
+		}
+
+		public void setNumber(int number) {
+			this.number = number;
+		}
+
+		public String getCode() {
+			return code;
+		}
+
+		public void setCode(String code) {
+			this.code = code;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositeidgenerator/OrderIdGenerator.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/compositeidgenerator/OrderIdGenerator.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.compositeidgenerator;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+
+public class OrderIdGenerator implements IdentifierGenerator {
+
+	private static int next = 1;
+
+	@Override
+	public Object generate(SharedSessionContractImplementor session, Object owner) {
+		final Order.Id id = new Order.Id();
+		id.setNumber( next );
+		id.setCode( "ORD-" + next++ );
+		return id;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/embedded-id-generator/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/embedded-id-generator/hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<!-- used to test HbmXmlTransformer -->
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.compositeidgenerator">
+
+	<class name="Order" table="ORDERS">
+		<composite-id name="id" class="Order$Id">
+			<key-property name="number" column="ORDER_NUMBER" type="integer"/>
+			<key-property name="code" column="ORDER_CODE" type="string"/>
+			<generator class="org.hibernate.orm.test.boot.jaxb.mapping.compositeidgenerator.OrderIdGenerator"/>
+		</composite-id>
+		<property name="description" type="string"/>
+	</class>
+
+</hibernate-mapping>


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/13214 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20791 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->