### PR TITLE
HHH-20788 Return null for TablePerSubclass and clarify informational nature of SQL string exposed by RemoveCoordinator

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinator.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.persister.collection.mutation;
 
+import jakarta.annotation.Nullable;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -24,9 +25,10 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
  */
 public interface RemoveCoordinator extends CollectionOperationCoordinator {
 	/**
-	 * The SQL used to perform the removal
+	 * The SQL used to perform the removal, or {@code null} if this is a no-op
+	 * or a more complex operation requiring multiple SQL strings.
 	 */
-	String getSqlString();
+	@Nullable String getSqlString();
 
 	/**
 	 * Delete all rows based on the collection-key

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorAudit.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorAudit.java
@@ -6,6 +6,7 @@ package org.hibernate.persister.collection.mutation;
 
 import java.util.function.UnaryOperator;
 
+import jakarta.annotation.Nullable;
 import org.hibernate.action.queue.spi.decompose.collection.CollectionMutationTarget;
 import org.hibernate.audit.ModificationType;
 import org.hibernate.audit.spi.CollectionAuditWriter;
@@ -58,7 +59,7 @@ public class RemoveCoordinatorAudit implements RemoveCoordinator, CollectionAudi
 	}
 
 	@Override
-	public String getSqlString() {
+	public @Nullable String getSqlString() {
 		return standardCoordinator.getSqlString();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorHistory.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorHistory.java
@@ -6,6 +6,7 @@ package org.hibernate.persister.collection.mutation;
 
 import java.util.function.UnaryOperator;
 
+import jakarta.annotation.Nullable;
 import org.hibernate.action.queue.spi.decompose.collection.CollectionMutationTarget;
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
 import org.hibernate.engine.jdbc.mutation.spi.MutationExecutorService;
@@ -64,7 +65,7 @@ public class RemoveCoordinatorHistory implements RemoveCoordinator {
 	}
 
 	@Override
-	public String getSqlString() {
+	public @Nullable String getSqlString() {
 		if ( operationGroup == null ) {
 			operationGroup = buildOperationGroup( mutationTarget.getCollectionTableMapping() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorNoOp.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorNoOp.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.persister.collection.mutation;
 
+import jakarta.annotation.Nullable;
 import org.hibernate.action.queue.spi.decompose.collection.CollectionMutationTarget;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
@@ -28,7 +29,7 @@ public class RemoveCoordinatorNoOp implements RemoveCoordinator {
 	}
 
 	@Override
-	public String getSqlString() {
+	public @Nullable String getSqlString() {
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorStandard.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.persister.collection.mutation;
 
+import jakarta.annotation.Nullable;
 import org.hibernate.action.queue.spi.decompose.collection.CollectionMutationTarget;
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
 import org.hibernate.engine.jdbc.mutation.ParameterUsage;
@@ -61,7 +62,7 @@ public class RemoveCoordinatorStandard implements RemoveCoordinator {
 	}
 
 	@Override
-	public String getSqlString() {
+	public @Nullable String getSqlString() {
 		if ( operationGroup == null ) {
 			// delayed creation of the operation-group
 			operationGroup = buildOperationGroup();

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorTablePerSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/mutation/RemoveCoordinatorTablePerSubclass.java
@@ -5,6 +5,7 @@
 package org.hibernate.persister.collection.mutation;
 
 
+import jakarta.annotation.Nullable;
 import org.hibernate.action.queue.spi.decompose.collection.CollectionMutationTarget;
 import org.hibernate.engine.jdbc.mutation.spi.MutationExecutorService;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -54,8 +55,8 @@ public class RemoveCoordinatorTablePerSubclass implements RemoveCoordinator {
 	}
 
 	@Override
-	public String getSqlString() {
-		throw new UnsupportedOperationException();
+	public @Nullable String getSqlString() {
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20788 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20788
<!-- Hibernate GitHub Bot issue links end -->