### PR TITLE
Consistently document incubating hibernate-processor options

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Processor.adoc
+++ b/documentation/src/main/asciidoc/introduction/Processor.adoc
@@ -50,7 +50,7 @@ Now, you still don't have to use the Hibernate Processor with Hibernate—the AP
 [TIP]
 ====
 We've already seen how to set up the annotation processor in the <<hello-hibernate,Gradle build>> we saw earlier.
-For more details on how to integrate the Hibernate Processor, check out the {generator-guide}[Static Metamodel Generator] section in the User Guide.
+For more details on how to integrate the Hibernate Processor, check out the {generator-guide}[Static Metamodel Generator] section in the User Guide, including its link:{doc-user-guide-url}#tooling-modelgen-options[configuration options].
 ====
 
 [[static-metamodel]]

--- a/documentation/src/main/asciidoc/repositories/Configuration.adoc
+++ b/documentation/src/main/asciidoc/repositories/Configuration.adoc
@@ -66,6 +66,8 @@ annotationProcessor 'org.hibernate.orm:hibernate-processor:{fullVersion}'
 include::../userguide/chapters/tooling/extras/maven-example-metamodel.pom[]
 ----
 
+See link:{doc-user-guide-url}#tooling-modelgen-options[Generation Options] in the User Guide for the complete list of annotation processor options.
+
 === Excluding classes from processing
 
 There are three ways to limit the annotation processor to certain classes:

--- a/documentation/src/main/asciidoc/repositories/Configuration.adoc
+++ b/documentation/src/main/asciidoc/repositories/Configuration.adoc
@@ -159,7 +159,7 @@ Methods of a repository interface may be annotated with:
 - Jakarta Interceptors interceptor binding types (per Jakarta Data specification), including,
   in particular, the `@Transactional` interceptor binding defined by Jakarta Transactions , and
 - security annotations from the `jakarta.annotation.security` package: `@DeclareRoles`, `@DenyAll`, `@PermitAll`, `@RolesAllowed`, and `@RunAs`.
-  This is Hibernate ORM specific behavior and can be disabled by passing `-AsuppressJakartaDataSecurityAnnotations=true` to the annotation processor.
+  This is Hibernate ORM specific behavior and can be disabled by passing `-AsuppressJakartaDataSecurityAnnotations=true` _(incubating)_ to the annotation processor.
 
 Note that these annotations are usually applied to a CDI bean implementation class, not to an interface,footnote:[`@Inherited` annotations are inherited from superclass to subclass, but not from interface to implementing class.] but a special exception is made for repository interfaces.
 

--- a/documentation/src/main/asciidoc/userguide/chapters/tooling/modelgen.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/tooling/modelgen.adoc
@@ -123,5 +123,8 @@ part of the `javac` execution using standard link:{ann-proc-options}[-A] options
 `-AsuppressJakartaDataMetamodel=[true|false]`:: Controls whether the processor should suppress Jakarta Data Metamodel even if Jakarta Data is available on the build path. (Default: `false`)
 `-Ainclude=[pattern[,pattern]*]`:: A comma-separated list of type patterns that should be included with `*` as wildcard. (Default: `*`)
 `-Aexclude=[pattern[,pattern]*]`:: A comma-separated list of type patterns that should be excluded with `*` as wildcard. (Default: empty)
-`-Aindex=[true|false]`:: Controls whether the processor should use a filesystem-based index of entity types and enums for use by the query validator to speed up query validation and thus compilation. (Default: `true`)
-`-AjakartaDataSortCompliance=[true|false]`:: Controls whether the processor should allow Jakarta Data repository interfaces that use `jakarta.data.Sort` types with a null type argument, which the Jakarta Data specification allows. (Default: `false`)
+`-Aindex=[true|false]`:: _(Incubating)_ Controls whether the processor should use a filesystem-based index of entity types and enums for use by the query validator to speed up query validation and thus compilation. (Default: `true`)
+`-AjakartaDataSortCompliance=[true|false]`:: _(Incubating)_ Controls whether the processor should allow Jakarta Data repository interfaces that use `jakarta.data.Sort` types with a null type argument, which the Jakarta Data specification allows. (Default: `false`)
+`-AsuppressJakartaDataSecurityAnnotations=[true|false]`:: _(Incubating)_ Controls whether the processor should suppress propagation of `jakarta.annotation.security` annotations from repository interfaces to generated implementations. (Default: `false`)
+`-Adialect=[classname]`:: _(Incubating)_ Specifies the default dialect class to use for HQL validation. When set, the processor validates HQL queries against the given dialect.
+`-AdialectDatabaseVersion=[version]`:: _(Incubating)_ Specifies the database version string to use for the default dialect class.


### PR DESCRIPTION
cedaa489534ef20cbef372f136223371645f68f8 added `@Incubating` annotations, but users of the processor are unlikely to see that.

They're unlikely to look at the docs, too, but that's their problem, not ours.

cc @gavinking 

Backport to 8.0: #13237