### PR TITLE
HHH-19202 fix array_intersects with parameter

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayIntersectsUnnestFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayIntersectsUnnestFunction.java
@@ -7,7 +7,7 @@ package org.hibernate.dialect.function.array;
 import java.util.List;
 
 import org.hibernate.metamodel.model.domain.ReturnableType;
-import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
+import org.hibernate.sql.ast.spi.translation.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.spi.translation.SqlAstTranslator;
 import org.hibernate.sql.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.SqlAstNode;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayIntersectsUnnestFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayIntersectsUnnestFunction.java
@@ -7,6 +7,7 @@ package org.hibernate.dialect.function.array;
 import java.util.List;
 
 import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.spi.translation.SqlAstTranslator;
 import org.hibernate.sql.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.SqlAstNode;
@@ -32,24 +33,24 @@ public class ArrayIntersectsUnnestFunction extends AbstractArrayIntersectsFuncti
 		final Expression needleExpression = (Expression) sqlAstArguments.get( 1 );
 		sqlAppender.append( '(' );
 		if ( ArrayHelper.isNullable( haystackExpression ) ) {
-			haystackExpression.accept( walker );
+			walker.render( haystackExpression, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 			sqlAppender.append( " is not null and " );
 		}
 		if ( ArrayHelper.isNullable( needleExpression ) ) {
-			needleExpression.accept( walker );
+			walker.render( needleExpression, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 			sqlAppender.append( " is not null and " );
 		}
 		if ( !nullable ) {
 			sqlAppender.append( "not exists(select 1 from unnest(" );
-			needleExpression.accept( walker );
+			walker.render( needleExpression, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 			sqlAppender.append( ") t(i) where t.i is null) and " );
 		}
 		sqlAppender.append( "exists(select * from unnest(" );
-		needleExpression.accept( walker );
+		walker.render( needleExpression, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 		sqlAppender.append( ")" );
 		sqlAppender.append( " intersect " );
 		sqlAppender.append( "select * from unnest(" );
-		haystackExpression.accept( walker );
+		walker.render( haystackExpression, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 		sqlAppender.append( ")))" );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/H2ArrayIntersectsFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/H2ArrayIntersectsFunction.java
@@ -7,7 +7,7 @@ package org.hibernate.dialect.function.array;
 import java.util.List;
 
 import org.hibernate.metamodel.model.domain.ReturnableType;
-import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
+import org.hibernate.sql.ast.spi.translation.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.spi.translation.SqlAstTranslator;
 import org.hibernate.sql.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.SqlAstNode;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/H2ArrayIntersectsFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/H2ArrayIntersectsFunction.java
@@ -7,6 +7,7 @@ package org.hibernate.dialect.function.array;
 import java.util.List;
 
 import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.spi.translation.SqlAstTranslator;
 import org.hibernate.sql.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.SqlAstNode;
@@ -50,7 +51,7 @@ public class H2ArrayIntersectsFunction extends AbstractArrayIntersectsFunction {
 			sqlAppender.append( ",null) and " );
 		}
 		sqlAppender.append( "exists(select " );
-		needleExpression.accept( walker );
+		walker.render( needleExpression, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 		sqlAppender.append( "[t.i] from system_range(1," );
 		sqlAppender.append( Integer.toString( maximumArraySize ) );
 		sqlAppender.append( ") t(i) where array_length(" );
@@ -58,12 +59,11 @@ public class H2ArrayIntersectsFunction extends AbstractArrayIntersectsFunction {
 		sqlAppender.append( ")>=t.i" );
 		sqlAppender.append( " intersect " );
 		sqlAppender.append( "select " );
-		haystackExpression.accept( walker );
+		walker.render( haystackExpression, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 		sqlAppender.append( "[t.i] from system_range(1," );
 		sqlAppender.append( Integer.toString( maximumArraySize ) );
 		sqlAppender.append( ") t(i) where array_length(" );
 		haystackExpression.accept( walker );
 		sqlAppender.append( ")>=t.i))" );
 	}
-
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayIntersectsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayIntersectsTest.java
@@ -174,4 +174,36 @@ public class ArrayIntersectsTest {
 		} );
 	}
 
+	@Test
+	public void testIntersectsArrayParameter(SessionFactoryScope scope) {
+		scope.inSession( em -> {
+			List<EntityWithArrays> results = em.createQuery(
+							"from EntityWithArrays e where array_intersects(e.theArray, :array)", EntityWithArrays.class )
+					.setParameter( "array", new String[] {"abc", "xyz"} ).getResultList();
+			assertEquals( 1, results.size() );
+			assertEquals( 2L, results.get( 0 ).getId() );
+		} );
+	}
+
+	@Test
+	public void testIntersectsArrayParameterNullFully(SessionFactoryScope scope) {
+		scope.inSession( em -> {
+			List<EntityWithArrays> results = em.createQuery(
+					"from EntityWithArrays e where array_intersects_nullable(e.theArray, :array)",
+					EntityWithArrays.class ).setParameter( "array", new String[] {null} ).getResultList();
+			assertEquals( 1, results.size() );
+			assertEquals( 2L, results.get( 0 ).getId() );
+		} );
+	}
+
+	@Test
+	public void testIntersectsArrayParameterNull(SessionFactoryScope scope) {
+		scope.inSession( em -> {
+			List<EntityWithArrays> results = em.createQuery(
+					"from EntityWithArrays e where array_intersects_nullable(e.theArray, :array)",
+					EntityWithArrays.class ).setParameter( "array", new String[] {"abc", null} ).getResultList();
+			assertEquals( 1, results.size() );
+			assertEquals( 2L, results.get( 0 ).getId() );
+		} );
+	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->
### Description:
Hello, I tried fix bug with array_intersects which doesn't work with an array as a parameter for JIRA issue - https://hibernate.atlassian.net/browse/HHH-19202.
Where H2 database throws: `org.hibernate.exception.GenericJDBCException: could not prepare statement [Unknown data type: "?3"; SQL statement`
This contains fix for H2, HSQL and possible PostgreSQL with nullable.

This is new PR against main of origin PR here: https://github.com/hibernate/hibernate-orm/pull/11679

### Changes:
`H2ArrayIntersectsFunction.java` - use walker.render with SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER
`ArrayIntersectsUnnestFunction.java` - use walker.render with SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER
`ArrayIntersectsTest.java` - add tests for testIntersectsArrayParameter, testIntersectsArrayParameterNullFully and testIntersectsArrayParameterNull

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19202 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->