### PR TITLE
[HHH-20806] Honor SQL restrictions for optimized to-one association paths

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -876,6 +876,7 @@ public class ToOneAttributeMapping
 		// Otherwise we need to join to the associated entity table(s)
 		final boolean forceJoin = hasNotFoundAction()
 				|| entityMappingType.getSoftDeleteMapping() != null
+				|| entityMappingType.hasWhereRestrictions()
 				|| cardinality == ONE_TO_ONE && isNullable();
 		canUseParentTableGroup = ! forceJoin
 				&& sideNature == ForeignKeyDescriptor.Nature.KEY

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/where/ToOneSQLRestrictionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/where/ToOneSQLRestrictionTests.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.where;
+
+import java.util.List;
+
+import org.hibernate.Session;
+import org.hibernate.annotations.SQLRestriction;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(annotatedClasses = { ToOneSQLRestrictionTests.Parent.class, ToOneSQLRestrictionTests.Child.class })
+@SessionFactory
+public class ToOneSQLRestrictionTests {
+
+	@Test
+	public void testAssociationIdQueryAppliesRestriction(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Parent deletedParent = new Parent( 1L, true );
+			final Parent activeParent = new Parent( 2L, false );
+			session.persist( deletedParent );
+			session.persist( activeParent );
+			session.persist( new Child( 1L, deletedParent ) );
+			session.persist( new Child( 2L, activeParent ) );
+		} );
+
+		scope.inTransaction( session -> {
+			// This query dereferences the to-one association id without an explicit join.
+			// Hibernate may optimize that path to the child table foreign key column, but
+			// the target entity still has an @SQLRestriction that must be applied.
+			final List<Child> deletedParentChildren = findChildrenByParentId( session, 1L );
+			final List<Child> activeParentChildren = findChildrenByParentId( session, 2L );
+
+			assertThat( deletedParentChildren ).isEmpty();
+			assertThat( activeParentChildren ).extracting( Child::getId ).containsExactly( 2L );
+		} );
+	}
+
+	private List<Child> findChildrenByParentId(Session session, Long parentId) {
+		return session.createQuery(
+						"select child " +
+								"from Child child " +
+								"where child.parent.id = :parentId",
+						Child.class
+				)
+				.setParameter( "parentId", parentId )
+				.getResultList();
+	}
+
+	@Entity(name = "Parent")
+	@SQLRestriction("deleted = false")
+	public static class Parent {
+		@Id
+		private Long id;
+
+		@Column(nullable = false)
+		private boolean deleted;
+
+		protected Parent() {
+		}
+
+		private Parent(Long id, boolean deleted) {
+			this.id = id;
+			this.deleted = deleted;
+		}
+	}
+
+	@Entity(name = "Child")
+	public static class Child {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Parent parent;
+
+		protected Child() {
+		}
+
+		private Child(Long id, Parent parent) {
+			this.id = id;
+			this.parent = parent;
+		}
+
+		public Long getId() {
+			return id;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

## Description

Fixes a to-one FK optimization case where Hibernate could resolve child.parent.id through the local FK column and skip joining the target entity table. If the target entity had @SQLRestriction, that restriction was skipped.

Bug reference : https://discourse.hibernate.org/t/join-elimination-in-7-x-skips-sqlrestriction-when-querying-by-to-one-association-id/12398

## Changes Made

- Disabled FK shortcut optimization for to-one associations whose target entity has SQL restrictions.
- Ensured Hibernate keeps the target table join so @SQLRestriction predicates are applied.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20806 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20806
<!-- Hibernate GitHub Bot issue links end -->