### PR TITLE
HHH-20800 HbmXmlTransformer emits invalid <transient> for inherited getters when a property-access entity extends an unmapped superclass

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/TransformationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/TransformationHelper.java
@@ -83,7 +83,10 @@ public class TransformationHelper {
 			for ( String name : mappedPropertyNames ) {
 				effectiveMappedNames.add( StringHelper.decapitalize( name ) );
 			}
-			for ( var method : javaClass.getMethods() ) {
+			// only consider getters declared directly on this class (mirroring the field branch's
+			// getDeclaredFields()): a transient must resolve to a member of the class it is placed on,
+			// so inherited getters belong to the ancestor's own mapping, not this one
+			for ( var method : javaClass.getDeclaredMethods() ) {
 				final String propertyName = extractPropertyName( method );
 				if ( propertyName != null
 						&& !effectiveMappedNames.contains( propertyName )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -1525,6 +1525,61 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20800" )
+	public void testMultiLevelUnmappedSuperclassTransientsAreDeclaredOnly(ServiceRegistryScope scope) {
+		// MultiLevelChild extends MultiLevelMiddle (declares id) extends MultiLevelBase (declares name).
+		// With property access the transformer generates a mapped-superclass for both MultiLevelMiddle
+		// and MultiLevelBase. Because getMethods() returns inherited getters, MultiLevelMiddle used to
+		// get a spurious <transient name="name"/> for the getter inherited from MultiLevelBase — which
+		// then fails member resolution at boot (name is not declared on MultiLevelMiddle).
+		// A generated mapped-superclass must only declare transients for properties it actually declares.
+		transformAndVerify( "xml/jaxb/mapping/multilevel-superclass/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getMappedSuperclasses() )
+					.as( "One mapped-superclass per unmapped Java superclass" )
+					.hasSize( 2 );
+
+			final JaxbMappedSuperclassImpl middle = transformed.getMappedSuperclasses().stream()
+					.filter( ms -> ms.getClazz().endsWith( "MultiLevelMiddle" ) )
+					.findFirst()
+					.orElseThrow();
+
+			// id is declared on MultiLevelMiddle → it moves here
+			assertThat( middle.getAttributes().getIdAttributes() )
+					.extracting( JaxbIdImpl::getName )
+					.containsExactly( "id" );
+
+			// name is declared on MultiLevelBase, not MultiLevelMiddle → no transient here
+			assertThat( middle.getAttributes().getTransients() )
+					.extracting( JaxbTransientImpl::getName )
+					.as( "'name' is inherited from MultiLevelBase and must not be transient on MultiLevelMiddle" )
+					.doesNotContain( "name" );
+
+			final JaxbMappedSuperclassImpl base = transformed.getMappedSuperclasses().stream()
+					.filter( ms -> ms.getClazz().endsWith( "MultiLevelBase" ) )
+					.findFirst()
+					.orElseThrow();
+
+			// name is declared on and mapped for MultiLevelBase → it moves here as a basic attribute
+			assertThat( base.getAttributes().getBasicAttributes() )
+					.extracting( JaxbBasicImpl::getName )
+					.containsExactly( "name" );
+
+			// --- MultiLevelChild: keeps only its own 'data' ---
+			final JaxbEntityImpl child = transformed.getEntities().stream()
+					.filter( e -> "MultiLevelChild".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( child.getAttributes().getIdAttributes() )
+					.as( "id is inherited from the mapped-superclass" )
+					.isEmpty();
+			assertThat( child.getAttributes().getBasicAttributes() )
+					.extracting( JaxbBasicImpl::getName )
+					.containsExactly( "data" );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20749" )
 	public void testSiblingEntitiesWithDifferentMappings(ServiceRegistryScope scope) {
 		// SiblingEntityA and SiblingEntityB both extend SiblingBase.

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/multilevelsuperclass/MultiLevelBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/multilevelsuperclass/MultiLevelBase.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.multilevelsuperclass;
+
+/**
+ * Grandparent of the hierarchy. Declares the mapped {@code name} property so that,
+ * with property access, its getter is inherited by both {@link MultiLevelMiddle}
+ * and {@link MultiLevelChild}.
+ */
+public class MultiLevelBase {
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/multilevelsuperclass/MultiLevelChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/multilevelsuperclass/MultiLevelChild.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.multilevelsuperclass;
+
+/**
+ * The mapped entity. Declares its own {@code data} property while inheriting the
+ * mapped {@code id} (from {@link MultiLevelMiddle}) and {@code name}
+ * (from {@link MultiLevelBase}).
+ */
+public class MultiLevelChild extends MultiLevelMiddle {
+	private String data;
+
+	public String getData() {
+		return data;
+	}
+
+	public void setData(String data) {
+		this.data = data;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/multilevelsuperclass/MultiLevelMiddle.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/multilevelsuperclass/MultiLevelMiddle.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.multilevelsuperclass;
+
+/**
+ * Intermediate (unmapped) superclass. Declares only the mapped {@code id} property;
+ * the {@code name} getter is inherited from {@link MultiLevelBase}.
+ */
+public class MultiLevelMiddle extends MultiLevelBase {
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/multilevel-superclass/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/multilevel-superclass/hbm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.multilevelsuperclass">
+
+    <!--
+      MultiLevelChild extends MultiLevelMiddle (declares id) extends MultiLevelBase (declares name).
+      With the default property access, both id and name are mapped via getters that live on
+      different (unmapped) superclasses.
+    -->
+    <class name="MultiLevelChild">
+        <id name="id">
+            <generator class="native"/>
+        </id>
+        <property name="name"/>
+        <property name="data"/>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20800

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20800 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->