### PR TITLE
HHH-20801 Delegate AnyType.guessEntityPersister to SessionFactoryImplementor#bestGuessEntityName

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
@@ -32,7 +32,6 @@ import static org.hibernate.engine.internal.ForeignKeys.getEntityIdentifierIfNot
 import static org.hibernate.internal.util.collections.ArrayHelper.join;
 import static org.hibernate.metamodel.internal.FullNameImplicitDiscriminatorStrategy.FULL_NAME_STRATEGY;
 import static org.hibernate.pretty.MessageHelper.infoString;
-import static org.hibernate.proxy.HibernateProxy.extractLazyInitializer;
 
 /**
  * Handles "any" mappings
@@ -170,42 +169,11 @@ public class AnyType extends AbstractType implements CompositeType, AssociationT
 	}
 
 	private EntityPersister guessEntityPersister(Object object, SessionFactoryImplementor factory) {
-		if ( typeConfiguration == null ) {
-			return null;
-		}
-
-		String entityName = null;
-
-		// this code is largely copied from Session's bestGuessEntityName
-		Object entity = object;
-		final var lazyInitializer = extractLazyInitializer( entity );
-		if ( lazyInitializer != null ) {
-			if ( lazyInitializer.isUninitialized() ) {
-				entityName = lazyInitializer.getEntityName();
-			}
-			entity = lazyInitializer.getImplementation();
-		}
-
-		if ( entityName == null ) {
-			entityName = entityNameFromResolvers( factory, entity );
-		}
-
-		if ( entityName == null ) {
-			// the old-time stand-by...
-			entityName = object.getClass().getName();
-		}
-
-		return factory.getMappingMetamodel().getEntityDescriptor( entityName );
-	}
-
-	private static String entityNameFromResolvers(SessionFactoryImplementor factory, Object entity) {
-		for ( var resolver : factory.getMappingMetamodel().getEntityNameResolvers() ) {
-			final String entityName = resolver.resolveEntityName( entity );
-			if ( entityName != null ) {
-				return entityName;
-			}
-		}
-		return null;
+		// delegate to bestGuessEntityName: it does not eagerly initialize the proxy
+		// (it reads the entity name from an uninitialized proxy) and, when no resolver
+		// matches, falls back to the name of the unwrapped implementation
+		final String entityName = factory.bestGuessEntityName( object );
+		return entityName == null ? null : factory.getMappingMetamodel().getEntityDescriptor( entityName );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyTypeFlushProxyToLoggableStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyTypeFlushProxyToLoggableStringTest.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.any;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.Any;
+import org.hibernate.annotations.AnyDiscriminatorValue;
+import org.hibernate.annotations.AnyKeyJavaClass;
+import org.hibernate.event.internal.EventListenerLogging;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.testing.logger.LogLevelContext.withLevel;
+
+
+/**
+ * Follow-up to HHH-20229, which rerouted {@link org.hibernate.type.AnyType#toLoggableString}
+ * through {@code AnyType.guessEntityPersister(Object, SessionFactoryImplementor)}.
+ * <p>
+ * That method has a latent bug in its fallback branch: when the {@code @Any} value is an
+ * already-initialized {@link org.hibernate.proxy.HibernateProxy} and no {@code EntityNameResolver}
+ * matches, the entity name is derived from the still-wrapped proxy argument
+ * ({@code object.getClass().getName()}) instead of the unwrapped implementation, producing a name
+ * such as {@code ...Book$HibernateProxy} and making {@code getEntityDescriptor(...)} throw
+ * {@code UnknownEntityTypeException} while logging flush results.
+ * <p>
+ * Reaching {@code EntityPrinter#logEntities} requires DEBUG on {@code org.hibernate.orm.event}
+ * ({@code AbstractFlushingEventListener#logFlushResults} guard) and DEBUG on
+ * {@code org.hibernate.orm.core} ({@code EntityPrinter#logEntities} internal guard).
+ *
+ * @author Vincent Bouthinon
+ */
+@Jpa(annotatedClasses = {AnyTypeFlushProxyToLoggableStringTest.Book.class})
+@JiraKey("HHH-20801")
+class AnyTypeFlushProxyToLoggableStringTest {
+
+	@Test
+	void testLogEntityWithAnyValueAsInitializedProxy(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> entityManager.persist( new Book( 1L ) ) );
+
+		try (
+				var l1 = withLevel( EventListenerLogging.NAME, Logger.Level.DEBUG );
+				var l2 = withLevel( CoreMessageLogger.NAME, Logger.Level.DEBUG )
+		) {
+			scope.inTransaction(
+					entityManager -> {
+						Book origin = entityManager.getReference( Book.class, 1L );
+						// force the proxy to be initialized: guessEntityPersister then skips
+						// lazyInitializer.getEntityName() and relies on the buggy fallback
+						Hibernate.initialize( origin );
+
+						Book book = new Book( 2L );
+						book.setOrigin( origin );
+						entityManager.persist( book );
+						entityManager.flush();
+						entityManager.clear();
+					}
+			);
+		}
+	}
+
+	@Entity(name = "book")
+	public static class Book {
+
+		@Id
+		private Long id;
+
+		@Any
+		@AnyKeyJavaClass(Long.class)
+		@JoinColumn(name = "origin_id")
+		@Column(name = "origin_type")
+		@AnyDiscriminatorValue(discriminator = "BOOK", entity = Book.class)
+		private Object origin;
+
+		public Book() {
+		}
+
+		public Book(Long id) {
+			this.id = id;
+		}
+
+		public Object getOrigin() {
+			return origin;
+		}
+
+		public void setOrigin(Object origin) {
+			this.origin = origin;
+		}
+	}
+}


### PR DESCRIPTION
HHH-20801 AnyType.guessEntityPersister fallback must use the unwrapped implementation, not the proxy argument

When the @Any value is an already-initialized HibernateProxy and no EntityNameResolver matches, guessEntityPersister derived the entity name from the wrapped proxy argument instead of the unwrapped implementation, producing a ...$HibernateProxy name and throwing UnknownEntityTypeException while logging flush results.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20801 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20801
<!-- Hibernate GitHub Bot issue links end -->