### PR TITLE
HHH-20805 Added extra not-null clause to sql in getForeignKeysSql to prevent exception at mysql schema update

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorMySQLImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorMySQLImpl.java
@@ -59,8 +59,9 @@ public class InformationExtractorMySQLImpl extends InformationExtractorJdbcDatab
 					b.unique_constraint_name as PK_NAME
 				from information_schema.key_column_usage a
 				join information_schema.referential_constraints b using (constraint_catalog, constraint_schema, constraint_name)
+				where a.referenced_table_name is not null
 				""";
-		return getForeignKeysSql + (tableSchema == null ? "" : " where a.table_schema = ?")
+		return getForeignKeysSql + (tableSchema == null ? "" : " and a.table_schema = ?")
 				+ " order by a.referenced_table_schema, a.referenced_table_name, a.constraint_name, a.position_in_unique_constraint";
 	}
 


### PR DESCRIPTION
I've added an extra not-null check in the sql that retrieves the forreign key information. This is necessary if unique indices exists and if they named as the related forreign keys.
I've provided a small application to test these behaviour. On the first run, the schema is created as expected; on the second run, the schema update fails.

https://hibernate.atlassian.net/browse/HHH-20805

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20805 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->