### PR TITLE
HHH-20802 CI test: module-level annotations fixes

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Advanced.adoc
+++ b/documentation/src/main/asciidoc/introduction/Advanced.adoc
@@ -19,7 +19,7 @@ Examples of well-defined filters might include:
 - a filter that restricts to data associated with a certain geographical region.
 
 A filter must be declared somewhere.
-A package descriptor is as good a place as any for a link:{doc-javadoc-url}org/hibernate/annotations/FilterDef.html[`@FilterDef`]:
+A package descriptor or a module descriptor is as good a place as any for a link:{doc-javadoc-url}org/hibernate/annotations/FilterDef.html[`@FilterDef`]:
 
 [source,java]
 ----
@@ -33,7 +33,12 @@ Fancier filters might in principle have multiple parameters, though we admit thi
 
 [IMPORTANT]
 ====
-If you add annotations to a package descriptor, and you're using `Configuration` to configure Hibernate, make sure you call `Configuration.addPackage()` to let Hibernate know that the package descriptor is annotated.
+In container environments with <<entity-discovery,scanning>>, annotated packages/modules are auto-discovered.
+
+In other environments, to let Hibernate know about the annotated packages/modules:
+
+* If you're using `Configuration` to configure Hibernate, use `Configuration.addPackage()`/`Configuration.addModule()`.
+* If you're using `MetadataSources` directly, use `MetadataSources.addPackage()`/`MetadataSources.addModule()`.
 ====
 
 _Typically_, but not necessarily, a `@FilterDef` specifies a default restriction:

--- a/documentation/src/main/asciidoc/userguide/chapters/bootstrap/Bootstrap.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/bootstrap/Bootstrap.adoc
@@ -183,6 +183,9 @@ Configuration cfg = new Configuration()
     // reads package-level (package-info.class) annotations in the named package
     .addPackage( "org.hibernate.auction" )
 
+    // reads module-level (module-info.class) annotations of the given module
+    .addModule( MyModule.class.getModule() )
+
     .setProperty( "hibernate.dialect", "org.hibernate.dialect.H2Dialect" )
     .setProperty( "hibernate.connection.datasource", "java:comp/env/jdbc/test" )
     .setProperty( "hibernate.order_updates", "true" );

--- a/documentation/src/main/asciidoc/userguide/chapters/events/Events.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/events/Events.adoc
@@ -151,6 +151,7 @@ It is possible that multiple callback methods are defined for a particular lifec
 When that is the case, the defined order of execution is well defined by the Jakarta Persistence spec (specifically section 3.5.4):
 
 * Any default listeners associated with the entity are invoked first, in the order they were specified in the XML. See the `jakarta.persistence.ExcludeDefaultListeners` annotation.
+* Next, module-level listeners declared via `@EntityListeners` on `module-info.java` are invoked, followed by package-level listeners declared on `package-info.java`. These are _not_ affected by `@ExcludeDefaultListeners`.
 * Next, entity listener class callbacks associated with the entity hierarchy are invoked, in the order they are defined in the `EntityListeners`.
 If multiple classes in the entity hierarchy define entity listeners, the listeners defined for a superclass are invoked before the listeners defined for its subclasses.
 See the ``jakarta.persistence.ExcludeSuperclassListener``'s annotation.

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -294,6 +294,8 @@ tasks.register('generateEnversStaticMetamodel', JavaCompile) {
 }
 
 tasks.withType( Test.class ).configureEach { test ->
+    test.dependsOn tasks.jar
+    test.systemProperty 'hibernate.core.jar.path', tasks.jar.archiveFile.get().asFile.absolutePath
     test.systemProperty 'file.encoding', 'utf-8'
     // Allow creating a function in HSQLDB for this Java method
     test.systemProperty 'hsqldb.method_class_names', 'org.hibernate.orm.test.jpa.transaction.TransactionTimeoutTest.sleep'

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CollectionTypeRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CollectionTypeRegistration.java
@@ -12,6 +12,7 @@ import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.usertype.UserCollectionType;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -26,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author Steve Ebersole
  */
-@Target({TYPE, PACKAGE, ANNOTATION_TYPE})
+@Target({TYPE, PACKAGE, MODULE, ANNOTATION_TYPE})
 @Retention(RUNTIME)
 @Repeatable( CollectionTypeRegistrations.class )
 public @interface CollectionTypeRegistration {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CollectionTypeRegistrations.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CollectionTypeRegistrations.java
@@ -8,6 +8,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
+import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -18,7 +20,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author Steve Ebersole
  */
-@Target({TYPE, ANNOTATION_TYPE})
+@Target({TYPE, PACKAGE, MODULE, ANNOTATION_TYPE})
 @Retention(RUNTIME)
 public @interface CollectionTypeRegistrations {
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CompositeTypeRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CompositeTypeRegistration.java
@@ -12,6 +12,7 @@ import jakarta.persistence.spi.Discoverable;
 import org.hibernate.usertype.CompositeUserType;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -28,7 +29,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see CompositeType
  * @see TypeRegistration
  */
-@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE, MODULE} )
 @Retention( RUNTIME )
 @Repeatable( CompositeTypeRegistrations.class )
 @Discoverable

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CompositeTypeRegistrations.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CompositeTypeRegistrations.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -19,7 +20,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author Steve Ebersole
  */
-@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE, MODULE} )
 @Retention( RUNTIME )
 @Discoverable
 public @interface CompositeTypeRegistrations {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/ConverterRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/ConverterRegistration.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Converter;
 import jakarta.persistence.spi.Discoverable;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -25,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author Steve Ebersole
  */
-@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE, MODULE} )
 @Retention( RUNTIME )
 @Repeatable( ConverterRegistrations.class )
 @Discoverable

--- a/hibernate-core/src/main/java/org/hibernate/annotations/ConverterRegistrations.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/ConverterRegistrations.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -17,7 +18,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * @author Steve Ebersole
  */
-@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE, MODULE} )
 @Retention( RUNTIME )
 @Discoverable
 public @interface ConverterRegistrations {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/EmbeddableInstantiatorRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/EmbeddableInstantiatorRegistration.java
@@ -12,6 +12,7 @@ import jakarta.persistence.spi.Discoverable;
 import org.hibernate.metamodel.spi.EmbeddableInstantiator;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -22,7 +23,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>
  * May be overridden for a specific embedded using {@link org.hibernate.annotations.EmbeddableInstantiator}
  */
-@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE, MODULE} )
 @Retention( RUNTIME )
 @Repeatable( EmbeddableInstantiatorRegistrations.class )
 @Discoverable

--- a/hibernate-core/src/main/java/org/hibernate/annotations/EmbeddableInstantiatorRegistrations.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/EmbeddableInstantiatorRegistrations.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -19,7 +20,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author Steve Ebersole
  */
-@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE, MODULE} )
 @Retention( RUNTIME )
 @Discoverable
 public @interface EmbeddableInstantiatorRegistrations {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FetchProfile.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FetchProfile.java
@@ -11,6 +11,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static jakarta.persistence.FetchType.EAGER;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -75,7 +76,7 @@ import static org.hibernate.annotations.FetchMode.JOIN;
  *
  * @author Hardy Ferentschik
  */
-@Target({TYPE, PACKAGE})
+@Target({TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 @Repeatable(FetchProfiles.class)
 public @interface FetchProfile {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FetchProfiles.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FetchProfiles.java
@@ -7,6 +7,7 @@ package org.hibernate.annotations;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -16,7 +17,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author Hardy Ferentschik
  */
-@Target({ TYPE, PACKAGE })
+@Target({ TYPE, PACKAGE, MODULE })
 @Retention(RUNTIME)
 public @interface FetchProfiles {
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FilterDef.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FilterDef.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Target;
 
 import org.hibernate.Incubating;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -65,7 +66,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see org.hibernate.Filter
  * @see DialectOverride.FilterDefs
  */
-@Target({TYPE, PACKAGE})
+@Target({TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 @Repeatable(FilterDefs.class)
 public @interface FilterDef {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FilterDefs.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FilterDefs.java
@@ -6,6 +6,7 @@ package org.hibernate.annotations;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -16,7 +17,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @author Matthew Inger
  * @author Emmanuel Bernard
  */
-@Target({PACKAGE, TYPE})
+@Target({PACKAGE, TYPE, MODULE})
 @Retention(RUNTIME)
 public @interface FilterDefs {
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/GenericGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/GenericGenerator.java
@@ -18,6 +18,7 @@ import jakarta.persistence.GenerationType;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -63,7 +64,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author Emmanuel Bernard
  */
-@Target({METHOD, FIELD, TYPE, PACKAGE})
+@Target({METHOD, FIELD, TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 @Incubating
 @IdGeneratorType(GenericGeneratorGeneration.class)

--- a/hibernate-core/src/main/java/org/hibernate/annotations/JavaTypeRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/JavaTypeRegistration.java
@@ -13,6 +13,7 @@ import jakarta.persistence.spi.Discoverable;
 import org.hibernate.type.descriptor.java.BasicJavaType;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -35,7 +36,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @since 6.0
  */
-@Target({PACKAGE, TYPE, ANNOTATION_TYPE})
+@Target({PACKAGE, TYPE, ANNOTATION_TYPE, MODULE})
 @Inherited
 @Retention(RUNTIME)
 @Repeatable( JavaTypeRegistrations.class )

--- a/hibernate-core/src/main/java/org/hibernate/annotations/JavaTypeRegistrations.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/JavaTypeRegistrations.java
@@ -11,6 +11,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -23,7 +24,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @since 6.0
  */
-@Target({PACKAGE, TYPE, ANNOTATION_TYPE})
+@Target({PACKAGE, TYPE, ANNOTATION_TYPE, MODULE})
 @Inherited
 @Retention(RUNTIME)
 @Discoverable

--- a/hibernate-core/src/main/java/org/hibernate/annotations/JdbcTypeRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/JdbcTypeRegistration.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Target;
 import jakarta.persistence.spi.Discoverable;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -40,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @since 6.0
  */
-@Target({PACKAGE, TYPE})
+@Target({PACKAGE, TYPE, MODULE})
 @Inherited
 @Retention(RUNTIME)
 @Repeatable( JdbcTypeRegistrations.class )

--- a/hibernate-core/src/main/java/org/hibernate/annotations/JdbcTypeRegistrations.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/JdbcTypeRegistrations.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -22,7 +23,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @since 6.0
  */
-@Target({PACKAGE, TYPE})
+@Target({PACKAGE, TYPE, MODULE})
 @Inherited
 @Retention(RUNTIME)
 @Discoverable

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedEntityGraph.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedEntityGraph.java
@@ -14,6 +14,7 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 import java.lang.annotation.Retention;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -36,7 +37,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @since 7.0
  * @author Steve Ebersole
  */
-@Target({TYPE, PACKAGE})
+@Target({TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 @Repeatable(NamedEntityGraphs.class)
 @Discoverable

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedEntityGraphs.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedEntityGraphs.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Target;
 import java.lang.annotation.Retention;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -20,7 +21,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @since 7.0
  * @author Steve Ebersole
  */
-@Target({TYPE, PACKAGE, ANNOTATION_TYPE})
+@Target({TYPE, PACKAGE, ANNOTATION_TYPE, MODULE})
 @Retention(RUNTIME)
 @Discoverable
 public @interface NamedEntityGraphs {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQueries.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQueries.java
@@ -8,6 +8,7 @@ import jakarta.persistence.spi.Discoverable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -18,7 +19,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author Emmanuel Bernard
  */
-@Target({TYPE, PACKAGE})
+@Target({TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 @Discoverable
 public @interface NamedNativeQueries {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQuery.java
@@ -14,6 +14,7 @@ import jakarta.persistence.spi.Discoverable;
 import org.hibernate.CacheMode;
 import jakarta.persistence.QueryFlushMode;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -35,7 +36,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see org.hibernate.annotations.NamedQuery
  * @see jakarta.persistence.NamedNativeQuery
  */
-@Target({TYPE, PACKAGE})
+@Target({TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 @Repeatable(NamedNativeQueries.class)
 @Discoverable

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedQueries.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedQueries.java
@@ -8,6 +8,7 @@ import jakarta.persistence.spi.Discoverable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -19,7 +20,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @author Emmanuel Bernard
  * @author Carlos Gonzalez-Cadenas
  */
-@Target({TYPE, PACKAGE})
+@Target({TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 @Discoverable
 public @interface NamedQueries {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedQuery.java
@@ -16,6 +16,7 @@ import jakarta.persistence.spi.Discoverable;
 import org.hibernate.CacheMode;
 import jakarta.persistence.QueryFlushMode;
 
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -37,7 +38,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see org.hibernate.annotations.NamedNativeQuery
  * @see jakarta.persistence.NamedQuery
  */
-@Target({TYPE, PACKAGE})
+@Target({TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 @Repeatable(NamedQueries.class)
 @Discoverable

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NativeGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NativeGenerator.java
@@ -15,6 +15,7 @@ import jakarta.persistence.TableGenerator;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -25,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @since 7.0
  * @author Steve Ebersole
  */
-@Target({METHOD, FIELD, TYPE, PACKAGE})
+@Target({METHOD, FIELD, TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 @IdGeneratorType(org.hibernate.id.NativeGenerator.class)
 @Incubating

--- a/hibernate-core/src/main/java/org/hibernate/annotations/TypeRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/TypeRegistration.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -32,7 +33,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @since 6.2
  */
-@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE, MODULE} )
 @Retention( RUNTIME )
 @Repeatable( TypeRegistrations.class )
 @Discoverable

--- a/hibernate-core/src/main/java/org/hibernate/annotations/TypeRegistrations.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/TypeRegistrations.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -21,7 +22,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @since 6.2
  */
-@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE, MODULE} )
 @Retention( RUNTIME )
 @Discoverable
 public @interface TypeRegistrations {

--- a/hibernate-core/src/main/java/org/hibernate/boot/MetadataSources.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/MetadataSources.java
@@ -79,6 +79,7 @@ public class MetadataSources implements Serializable {
 	private LinkedHashSet<Class<?>> annotatedClasses;
 	private LinkedHashSet<String> annotatedClassNames;
 	private LinkedHashSet<String> annotatedPackages;
+	private LinkedHashSet<String> annotatedModuleNames;
 
 	private Map<String,Class<?>> extraQueryImports;
 
@@ -133,6 +134,10 @@ public class MetadataSources implements Serializable {
 
 	public List<Binding<JaxbHbmHibernateMapping>> getHbmXmlBindings() {
 		return hbmXmlBindings == null ? emptyList() : hbmXmlBindings;
+	}
+
+	public Collection<String> getAnnotatedModuleNames() {
+		return annotatedModuleNames == null ? emptySet() : annotatedModuleNames;
 	}
 
 	public Collection<String> getAnnotatedPackages() {
@@ -325,6 +330,46 @@ public class MetadataSources implements Serializable {
 	public MetadataSources addPackage(Package packageRef) {
 		addPackageInternal( packageRef.getName() );
 		return this;
+	}
+
+	/**
+	 * Read module-level metadata.
+	 *
+	 * @param module The module to process for annotations
+	 *
+	 * @return this (for method chaining)
+	 */
+	public MetadataSources addModule(Module module) {
+		if ( module == null ) {
+			throw new IllegalArgumentException( "The specified module cannot be null" );
+		}
+		if ( !module.isNamed() ) {
+			throw new IllegalArgumentException( "The specified module is not a named module" );
+		}
+		addModuleInternal( module.getName() );
+		return this;
+	}
+
+	/**
+	 * Read module-level metadata.
+	 *
+	 * @param moduleName The name of the module to process for annotations
+	 *
+	 * @return this (for method chaining)
+	 */
+	public MetadataSources addModule(String moduleName) {
+		if ( moduleName == null ) {
+			throw new IllegalArgumentException( "The specified module name cannot be null" );
+		}
+		addModuleInternal( moduleName );
+		return this;
+	}
+
+	private void addModuleInternal(String moduleName) {
+		if ( annotatedModuleNames == null ) {
+			annotatedModuleNames = new LinkedHashSet<>();
+		}
+		annotatedModuleNames.add( moduleName );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -464,6 +464,9 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 				if ( sources.getAnnotatedPackages() != null ) {
 					sources.getAnnotatedPackages().forEach( newSources::addPackage );
 				}
+				if ( sources.getAnnotatedModuleNames() != null ) {
+					sources.getAnnotatedModuleNames().forEach( newSources::addModule );
+				}
 				if ( sources.getExtraQueryImports() != null ) {
 					sources.getExtraQueryImports().forEach( newSources::addQueryImport );
 				}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AbstractEntityIdGeneratorResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AbstractEntityIdGeneratorResolver.java
@@ -155,6 +155,21 @@ public abstract class AbstractEntityIdGeneratorResolver implements IdGeneratorRe
 			}
 		}
 
+		final var declaringModule = declaringType.toJavaClass().getModule();
+		if ( declaringModule != null && declaringModule.isNamed() ) {
+			final var moduleDetails =
+					buildingContext.getBootstrapContext().getModelsContext()
+							.getModuleDetailsRegistry()
+							.findModuleDetails( declaringModule.getName() );
+			if ( moduleDetails != null ) {
+				final var fromModule = findGeneratorAnnotation( moduleDetails );
+				if ( fromModule != null ) {
+					handleIdGeneratorType( fromModule, idValue, idMember, buildingContext );
+					return true;
+				}
+			}
+		}
+
 		return false;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationBinder.java
@@ -164,9 +164,27 @@ public final class AnnotationBinder {
 		}
 	}
 
-	private static void bindNamedEntityGraphs(ClassDetails packageInfoClassDetails, MetadataBuildingContext context) {
+	public static void bindModule(String moduleName, MetadataBuildingContext context) {
+		final var moduleDetails = modelsContext( context ).getModuleDetailsRegistry()
+				.resolveModuleDetails( moduleName );
+
+		registerGlobalGenerators( moduleDetails, context );
+
+		bindTypeDescriptorRegistrations( moduleDetails, context );
+		bindEmbeddableInstantiatorRegistrations( moduleDetails, context );
+		bindUserTypeRegistrations( moduleDetails, context );
+		bindCompositeUserTypeRegistrations( moduleDetails, context );
+		bindConverterRegistrations( moduleDetails, context );
+
+		bindQueries( moduleDetails, context );
+		bindFilterDefs( moduleDetails, context );
+
+		bindNamedEntityGraphs( moduleDetails, context );
+	}
+
+	private static void bindNamedEntityGraphs(AnnotationTarget annotationTarget, MetadataBuildingContext context) {
 		final var collector = context.getMetadataCollector();
-		packageInfoClassDetails.forEachRepeatedAnnotationUsages(
+		annotationTarget.forEachRepeatedAnnotationUsages(
 				HibernateAnnotations.NAMED_ENTITY_GRAPH,
 				modelsContext( context ),
 				annotation -> collector.addNamedEntityGraph( new NamedEntityGraphDefinition(
@@ -468,6 +486,12 @@ public final class AnnotationBinder {
 		if ( packageInfoClassDetails != null ) {
 			bindFetchProfiles( packageInfoClassDetails, context );
 		}
+	}
+
+	public static void bindFetchProfilesForModule(String moduleName, MetadataBuildingContext context) {
+		final var moduleDetails = modelsContext( context ).getModuleDetailsRegistry()
+				.resolveModuleDetails( moduleName );
+		bindFetchProfiles( moduleDetails, context );
 	}
 
 	private static void bindFetchProfiles(AnnotationTarget annotatedElement, MetadataBuildingContext context) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ManagedResourcesImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ManagedResourcesImpl.java
@@ -37,6 +37,7 @@ public class ManagedResourcesImpl implements ManagedResources {
 	private final Set<Class<?>> annotatedClassReferences = new LinkedHashSet<>();
 	private final Set<String> annotatedClassNames = new LinkedHashSet<>();
 	private final Set<String> annotatedPackageNames = new LinkedHashSet<>();
+	private final Set<String> annotatedModuleNames = new LinkedHashSet<>();
 	private final List<Binding<? extends JaxbBindableMappingDescriptor>> mappingFileBindings = new ArrayList<>();
 	private Map<String, Class<?>> extraQueryImports;
 
@@ -46,6 +47,7 @@ public class ManagedResourcesImpl implements ManagedResources {
 		managedResources.annotatedClassReferences.addAll( sources.getAnnotatedClasses() );
 		managedResources.annotatedClassNames.addAll( sources.getAnnotatedClassNames() );
 		managedResources.annotatedPackageNames.addAll( sources.getAnnotatedPackages() );
+		managedResources.annotatedModuleNames.addAll( sources.getAnnotatedModuleNames() );
 		handleXmlMappings( sources, managedResources, bootstrapContext );
 		managedResources.extraQueryImports = sources.getExtraQueryImports();
 		return managedResources;
@@ -91,6 +93,11 @@ public class ManagedResourcesImpl implements ManagedResources {
 	}
 
 	@Override
+	public Collection<String> getAnnotatedModuleNames() {
+		return unmodifiableSet( annotatedModuleNames );
+	}
+
+	@Override
 	public Collection<Binding<? extends JaxbBindableMappingDescriptor>> getXmlMappingBindings() {
 		return unmodifiableList( mappingFileBindings );
 	}
@@ -122,6 +129,11 @@ public class ManagedResourcesImpl implements ManagedResources {
 	@Internal
 	public void addAnnotatedPackageName(String annotatedPackageName) {
 		annotatedPackageNames.add( annotatedPackageName );
+	}
+
+	@Internal
+	public void addAnnotatedModuleName(String moduleName) {
+		annotatedModuleNames.add( moduleName );
 	}
 
 	@Internal

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/ManagedResources.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/ManagedResources.java
@@ -58,6 +58,14 @@ public interface ManagedResources {
 	Collection<String> getAnnotatedPackageNames();
 
 	/**
+	 * Informational access to any known annotated module names (modules with a {@code module-info.class}
+	 * file that Hibernate has been told about).  Changes to made to the returned list have no effect.
+	 *
+	 * @return The list of known annotated module names.
+	 */
+	Collection<String> getAnnotatedModuleNames();
+
+	/**
 	 * Informational access to binding for all known XML mapping files.  Changes to made to the returned
 	 * list have no effect.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AdditionalManagedResourcesImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AdditionalManagedResourcesImpl.java
@@ -72,6 +72,11 @@ public class AdditionalManagedResourcesImpl implements ManagedResources {
 	}
 
 	@Override
+	public Collection<String> getAnnotatedModuleNames() {
+		return emptyList();
+	}
+
+	@Override
 	public Collection<Binding<? extends JaxbBindableMappingDescriptor>> getXmlMappingBindings() {
 		if ( xmlMappings == null ) {
 			return emptyList();

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
@@ -27,7 +27,9 @@ import org.hibernate.models.spi.ClassDetails;
 import static org.hibernate.boot.model.internal.AnnotationBinder.bindClass;
 import static org.hibernate.boot.model.internal.AnnotationBinder.bindDefaults;
 import static org.hibernate.boot.model.internal.AnnotationBinder.bindFetchProfilesForClass;
+import static org.hibernate.boot.model.internal.AnnotationBinder.bindFetchProfilesForModule;
 import static org.hibernate.boot.model.internal.AnnotationBinder.bindFetchProfilesForPackage;
+import static org.hibernate.boot.model.internal.AnnotationBinder.bindModule;
 import static org.hibernate.boot.model.internal.AnnotationBinder.bindPackage;
 import static org.hibernate.boot.model.internal.AnnotationBinder.buildInheritanceStates;
 import static org.hibernate.boot.model.internal.EntityBinder.isEntity;
@@ -49,6 +51,7 @@ public class AnnotationMetadataSourceProcessorImpl implements MetadataSourceProc
 	private final MetadataBuildingContextRootImpl rootMetadataBuildingContext;
 	private final ClassLoaderService classLoaderService;
 
+	private final LinkedHashSet<String> annotatedModuleNames = new LinkedHashSet<>();
 	private final LinkedHashSet<String> annotatedPackages = new LinkedHashSet<>();
 	private final LinkedHashSet<ClassDetails> knownClasses = new LinkedHashSet<>();
 
@@ -77,6 +80,7 @@ public class AnnotationMetadataSourceProcessorImpl implements MetadataSourceProc
 			knownClasses.add( classDetailsRegistry.resolveClassDetails( annotatedClass.getName() ) );
 		}
 
+		annotatedModuleNames.addAll( managedResources.getAnnotatedModuleNames() );
 		annotatedPackages.addAll( managedResources.getAnnotatedPackageNames() );
 	}
 
@@ -117,6 +121,9 @@ public class AnnotationMetadataSourceProcessorImpl implements MetadataSourceProc
 				.adjustDefaultNamespace( defaults.getImplicitCatalogName(), defaults.getImplicitSchemaName() );
 
 		bindDefaults( rootMetadataBuildingContext );
+		for ( String annotatedModuleName : annotatedModuleNames ) {
+			bindModule( annotatedModuleName, rootMetadataBuildingContext );
+		}
 		for ( String annotatedPackage : annotatedPackages ) {
 			bindPackage( classLoaderService, annotatedPackage, rootMetadataBuildingContext );
 		}
@@ -278,6 +285,9 @@ public class AnnotationMetadataSourceProcessorImpl implements MetadataSourceProc
 
 	@Override
 	public void postProcessEntityHierarchies() {
+		for ( String annotatedModuleName : annotatedModuleNames ) {
+			bindFetchProfilesForModule( annotatedModuleName, rootMetadataBuildingContext );
+		}
 		for ( String annotatedPackage : annotatedPackages ) {
 			bindFetchProfilesForPackage( annotatedPackage, rootMetadataBuildingContext );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/HibernateAnnotations.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/HibernateAnnotations.java
@@ -204,13 +204,13 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<CollectionTypeRegistrations, CollectionTypeRegistrationsAnnotation> COLLECTION_TYPE_REGISTRATIONS = new OrmAnnotationDescriptor<>(
 			CollectionTypeRegistrations.class,
 			CollectionTypeRegistrationsAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<CollectionTypeRegistration, CollectionTypeRegistrationAnnotation> COLLECTION_TYPE_REGISTRATION = new OrmAnnotationDescriptor<>(
 			CollectionTypeRegistration.class,
 			CollectionTypeRegistrationAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			COLLECTION_TYPE_REGISTRATIONS
 	);
@@ -242,13 +242,13 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<CompositeTypeRegistrations, CompositeTypeRegistrationsAnnotation> COMPOSITE_TYPE_REGISTRATIONS = new OrmAnnotationDescriptor<>(
 			CompositeTypeRegistrations.class,
 			CompositeTypeRegistrationsAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<CompositeTypeRegistration, CompositeTypeRegistrationAnnotation> COMPOSITE_TYPE_REGISTRATION = new OrmAnnotationDescriptor<>(
 			CompositeTypeRegistration.class,
 			CompositeTypeRegistrationAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			COMPOSITE_TYPE_REGISTRATIONS
 	);
@@ -261,13 +261,13 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<ConverterRegistrations, ConverterRegistrationsAnnotation> CONVERTER_REGISTRATIONS = new OrmAnnotationDescriptor<>(
 			ConverterRegistrations.class,
 			ConverterRegistrationsAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<ConverterRegistration, ConverterRegistrationAnnotation> CONVERTER_REGISTRATION = new OrmAnnotationDescriptor<>(
 			ConverterRegistration.class,
 			ConverterRegistrationAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			CONVERTER_REGISTRATIONS
 	);
@@ -316,13 +316,13 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<EmbeddableInstantiatorRegistrations, EmbeddableInstantiatorRegistrationsAnnotation> EMBEDDABLE_INSTANTIATOR_REGISTRATIONS = new OrmAnnotationDescriptor<>(
 			EmbeddableInstantiatorRegistrations.class,
 			EmbeddableInstantiatorRegistrationsAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<EmbeddableInstantiatorRegistration, EmbeddableInstantiatorRegistrationAnnotation> EMBEDDABLE_INSTANTIATOR_REGISTRATION = new OrmAnnotationDescriptor<>(
 			EmbeddableInstantiatorRegistration.class,
 			EmbeddableInstantiatorRegistrationAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			EMBEDDABLE_INSTANTIATOR_REGISTRATIONS
 	);
@@ -347,13 +347,13 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<FetchProfiles, FetchProfilesAnnotation> FETCH_PROFILES = new OrmAnnotationDescriptor<>(
 			FetchProfiles.class,
 			FetchProfilesAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<FetchProfile, FetchProfileAnnotation> FETCH_PROFILE = new OrmAnnotationDescriptor<>(
 			FetchProfile.class,
 			FetchProfileAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			FETCH_PROFILES
 	);
@@ -373,13 +373,13 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<FilterDefs, FilterDefsAnnotation> FILTER_DEFS = new OrmAnnotationDescriptor<>(
 			FilterDefs.class,
 			FilterDefsAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<FilterDef, FilterDefAnnotation> FILTER_DEF = new OrmAnnotationDescriptor<>(
 			FilterDef.class,
 			FilterDefAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			FILTER_DEFS
 	);
@@ -423,7 +423,7 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<GenericGenerator, GenericGeneratorAnnotation> GENERIC_GENERATOR = new OrmAnnotationDescriptor<>(
 			GenericGenerator.class,
 			GenericGeneratorAnnotation.class,
-			EnumSet.of( Kind.METHOD, Kind.FIELD, Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.METHOD, Kind.FIELD, Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<HQLSelect, HQLSelectAnnotation> HQL_SELECT = new OrmAnnotationDescriptor<>(
@@ -465,13 +465,13 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<JavaTypeRegistrations, JavaTypeRegistrationsAnnotation> JAVA_TYPE_REGISTRATIONS = new OrmAnnotationDescriptor<>(
 			JavaTypeRegistrations.class,
 			JavaTypeRegistrationsAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			true
 	);
 	OrmAnnotationDescriptor<JavaTypeRegistration, JavaTypeRegistrationAnnotation> JAVA_TYPE_REGISTRATION = new OrmAnnotationDescriptor<>(
 			JavaTypeRegistration.class,
 			JavaTypeRegistrationAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			true,
 			JAVA_TYPE_REGISTRATIONS
 	);
@@ -490,13 +490,13 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<JdbcTypeRegistrations, JdbcTypeRegistrationsAnnotation> JDBC_TYPE_REGISTRATIONS = new OrmAnnotationDescriptor<>(
 			JdbcTypeRegistrations.class,
 			JdbcTypeRegistrationsAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			true
 	);
 	OrmAnnotationDescriptor<JdbcTypeRegistration, JdbcTypeRegistrationAnnotation> JDBC_TYPE_REGISTRATION = new OrmAnnotationDescriptor<>(
 			JdbcTypeRegistration.class,
 			JdbcTypeRegistrationAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			true,
 			JDBC_TYPE_REGISTRATIONS
 	);
@@ -600,39 +600,39 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<NamedEntityGraphs, NamedEntityGraphsAnnotation> NAMED_ENTITY_GRAPHS = new OrmAnnotationDescriptor<>(
 			NamedEntityGraphs.class,
 			NamedEntityGraphsAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<NamedEntityGraph, NamedEntityGraphAnnotation> NAMED_ENTITY_GRAPH = new OrmAnnotationDescriptor<>(
 			NamedEntityGraph.class,
 			NamedEntityGraphAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			NAMED_ENTITY_GRAPHS
 	);
 	OrmAnnotationDescriptor<NamedNativeQueries, NamedNativeQueriesAnnotation> NAMED_NATIVE_QUERIES = new OrmAnnotationDescriptor<>(
 			NamedNativeQueries.class,
 			NamedNativeQueriesAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<NamedNativeQuery, NamedNativeQueryAnnotation> NAMED_NATIVE_QUERY = new OrmAnnotationDescriptor<>(
 			NamedNativeQuery.class,
 			NamedNativeQueryAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			NAMED_NATIVE_QUERIES
 	);
 	OrmAnnotationDescriptor<NamedQueries, NamedQueriesAnnotation> NAMED_QUERIES = new OrmAnnotationDescriptor<>(
 			NamedQueries.class,
 			NamedQueriesAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<NamedQuery, NamedQueryAnnotation> NAMED_QUERY = new OrmAnnotationDescriptor<>(
 			NamedQuery.class,
 			NamedQueryAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			NAMED_QUERIES
 	);
@@ -645,7 +645,7 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<NativeGenerator, NativeGeneratorAnnotation> NATIVE_GENERATOR = new OrmAnnotationDescriptor<>(
 			NativeGenerator.class,
 			NativeGeneratorAnnotation.class,
-			EnumSet.of( Kind.METHOD, Kind.FIELD, Kind.CLASS, Kind.PACKAGE ),
+			EnumSet.of( Kind.METHOD, Kind.FIELD, Kind.CLASS, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<NaturalId, NaturalIdAnnotation> NATURAL_ID = new OrmAnnotationDescriptor<>(
@@ -925,13 +925,13 @@ public interface HibernateAnnotations {
 	OrmAnnotationDescriptor<TypeRegistrations, TypeRegistrationsAnnotation> TYPE_REGISTRATIONS = new OrmAnnotationDescriptor<>(
 			TypeRegistrations.class,
 			TypeRegistrationsAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false
 	);
 	OrmAnnotationDescriptor<TypeRegistration, TypeRegistrationAnnotation> TYPE_REGISTRATION = new OrmAnnotationDescriptor<>(
 			TypeRegistration.class,
 			TypeRegistrationAnnotation.class,
-			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE ),
+			EnumSet.of( Kind.CLASS, Kind.ANNOTATION, Kind.PACKAGE, Kind.MODULE ),
 			false,
 			TYPE_REGISTRATIONS
 	);

--- a/hibernate-core/src/main/java/org/hibernate/boot/scan/internal/ResultCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/scan/internal/ResultCollector.java
@@ -16,9 +16,14 @@ import java.util.Set;
 ///
 /// @author Steve Ebersole
 public class ResultCollector {
+	private final Set<String> discoveredModules = new HashSet<>();
 	private final Set<String> discoveredPackages = new HashSet<>();
 	private final Set<String> discoveredClasses = new HashSet<>();
 	private final Set<URI> discoveredMappings = new HashSet<>();
+
+	public void addModule(String moduleName) {
+		discoveredModules.add( moduleName );
+	}
 
 	public void addPackage(String packageName) {
 		discoveredPackages.add( packageName );
@@ -27,6 +32,10 @@ public class ResultCollector {
 	public void addClass(String className) {
 		if ( className.endsWith( "package-info" ) ) {
 			addPackage( StringHelper.qualifier( className ) );
+		}
+		else if ( className.equals( "module-info" ) ) {
+			// module-info is indexed by Jandex as a ClassInfo but represents a module;
+			// module discovery is handled separately via addModule
 		}
 		else {
 			discoveredClasses.add( className );
@@ -40,6 +49,7 @@ public class ResultCollector {
 
 	public ScanningResult toResult() {
 		return new ScanningResultImpl(
+				Collections.unmodifiableSet( discoveredModules ),
 				Collections.unmodifiableSet( discoveredPackages ),
 				Collections.unmodifiableSet( discoveredClasses ),
 				Collections.unmodifiableSet( discoveredMappings )

--- a/hibernate-core/src/main/java/org/hibernate/boot/scan/internal/ScanningResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/scan/internal/ScanningResultImpl.java
@@ -14,12 +14,13 @@ import java.util.Set;
 ///
 /// @author Steve Ebersole
 public record ScanningResultImpl(
+		Set<String> discoveredModules,
 		Set<String> discoveredPackages,
 		Set<String> discoveredClasses,
 		Set<URI> mappingFiles) implements ScanningResult {
 
 	public ScanningResultImpl() {
-		this( Collections.emptySet(), Collections.emptySet(), Collections.emptySet() );
+		this( Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet() );
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/scan/spi/ScanningResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/scan/spi/ScanningResult.java
@@ -22,6 +22,9 @@ public interface ScanningResult {
 	/// Singleton access for "no results".
 	ScanningResult NONE = new ScanningResultImpl();
 
+	/// All discovered module names (from `module-info.class` entries).
+	Set<String> discoveredModules();
+
 	/// All discovered package names (without `package-info`).
 	Set<String> discoveredPackages();
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
@@ -103,6 +103,8 @@ import static org.hibernate.internal.CoreMessageLogger.CORE_LOGGER;
  *     .addAnnotatedClass(User.class)
  *     // read package-level annotations of the named package
  *     .addPackage("org.hibernate.auction")
+ *     // read module-level annotations of the given module
+ *     .addModule(MyModule.class.getModule())
  *     // set a configuration property
  *     .setProperty(AvailableSettings.DATASOURCE,
  *                  "java:comp/env/jdbc/test")
@@ -820,6 +822,46 @@ public class Configuration {
 		for ( String packageName : packageNames ) {
 			addPackage( packageName );
 		}
+		return this;
+	}
+
+	/**
+	 * Read module-level metadata from the given {@linkplain Module module}.
+	 * <p>
+	 * Annotations placed on {@code module-info.java} (such as
+	 * {@link org.hibernate.annotations.FilterDef @FilterDef},
+	 * {@link org.hibernate.annotations.TypeRegistration @TypeRegistration},
+	 * {@link jakarta.persistence.NamedQuery @NamedQuery}, etc.)
+	 * will be processed during bootstrap.
+	 *
+	 * @param module the module whose annotations should be processed
+	 *
+	 * @return {@code this} for method chaining
+	 *
+	 * @since 7.0
+	 *
+	 * @see org.hibernate.boot.MetadataSources#addModule(Module)
+	 */
+	@Incubating
+	public Configuration addModule(Module module) {
+		metadataSources.addModule( module );
+		return this;
+	}
+
+	/**
+	 * Read module-level metadata for the named module.
+	 *
+	 * @param moduleName the name of the module whose annotations should be processed
+	 *
+	 * @return {@code this} for method chaining
+	 *
+	 * @since 7.0
+	 *
+	 * @see org.hibernate.boot.MetadataSources#addModule(String)
+	 */
+	@Incubating
+	public Configuration addModule(String moduleName) {
+		metadataSources.addModule( moduleName );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/CallbackDefinitionResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/CallbackDefinitionResolver.java
@@ -19,6 +19,7 @@ import org.hibernate.jpa.boot.spi.EntityCallbackDefinition;
 import org.hibernate.jpa.boot.spi.ListenerCallbackDefinition;
 import org.hibernate.jpa.event.spi.CallbackType;
 import org.hibernate.mapping.PersistentClass;
+import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.MethodDetails;
 import org.hibernate.models.spi.ModelsContext;
@@ -46,6 +47,7 @@ public final class CallbackDefinitionResolver {
 		final List<CallbackDefinition> callbackDefinitions = new ArrayList<>();
 		final List<String> callbacksMethodNames = new ArrayList<>();
 		final List<LifecycleEventHandler> orderedPackageListeners = new ArrayList<>();
+		final List<LifecycleEventHandler> orderedModuleListeners = new ArrayList<>();
 		final List<LifecycleEventHandler> orderedListeners = new ArrayList<>();
 		final List<LifecycleEventHandler> orderedDefaultListeners = new ArrayList<>();
 
@@ -81,6 +83,7 @@ public final class CallbackDefinitionResolver {
 		while ( currentClazz != null );
 
 		applyPackageListeners( entityClass, orderedPackageListeners, modelsContext );
+		applyModuleListeners( entityClass, orderedModuleListeners, modelsContext );
 
 		//handle default listeners
 		if ( !stopDefaultListeners ) {
@@ -104,6 +107,13 @@ public final class CallbackDefinitionResolver {
 			}
 		}
 		for ( var listenerRegistration : orderedPackageListeners ) {
+			final var callbackDefinition =
+					resolveListenerCallback( listenerRegistration, entityClass, callbackType );
+			if ( callbackDefinition != null ) {
+				callbackDefinitions.add( 0, callbackDefinition );
+			}
+		}
+		for ( var listenerRegistration : orderedModuleListeners ) {
 			final var callbackDefinition =
 					resolveListenerCallback( listenerRegistration, entityClass, callbackType );
 			if ( callbackDefinition != null ) {
@@ -180,13 +190,13 @@ public final class CallbackDefinitionResolver {
 	}
 
 	private static void applyListeners(
-			ClassDetails currentClazz,
+			AnnotationTarget annotationTarget,
 			ClassDetails entityClass,
 			List<LifecycleEventHandler> listOfListeners,
 			ModelsContext sourceModelContext) {
 		final var classDetailsRegistry = sourceModelContext.getClassDetailsRegistry();
 
-		final var entityListeners = currentClazz.getDirectAnnotationUsage( EntityListeners.class );
+		final var entityListeners = annotationTarget.getDirectAnnotationUsage( EntityListeners.class );
 		if ( entityListeners != null ) {
 			final var listenerClasses = entityListeners.value();
 			int size = listenerClasses.length;
@@ -200,7 +210,7 @@ public final class CallbackDefinitionResolver {
 		}
 
 		if ( useAnnotationAnnotatedByListener ) {
-			for ( var metaAnnotatedUsage : currentClazz.getMetaAnnotated( EntityListeners.class, sourceModelContext ) ) {
+			for ( var metaAnnotatedUsage : annotationTarget.getMetaAnnotated( EntityListeners.class, sourceModelContext ) ) {
 				final var descriptor =
 						sourceModelContext.getAnnotationDescriptorRegistry()
 								.getDescriptor( metaAnnotatedUsage.getClass() );
@@ -233,6 +243,18 @@ public final class CallbackDefinitionResolver {
 			}
 			catch (ClassLoadingException ignore) {
 			}
+		}
+	}
+
+	private static void applyModuleListeners(
+			ClassDetails entityClass,
+			List<LifecycleEventHandler> listOfListeners,
+			ModelsContext sourceModelContext) {
+		final var module = entityClass.toJavaClass().getModule();
+		if ( module.isNamed() ) {
+			final var moduleDetails = sourceModelContext.getModuleDetailsRegistry()
+					.resolveModuleDetails( module );
+			applyListeners( moduleDetails, entityClass, listOfListeners, sourceModelContext );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -210,6 +210,8 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 	private void applyScanning(HibernatePersistenceConfiguration cfg, MetadataSources metadataSources, StandardServiceRegistry standardServiceRegistry) {
 		var scanningResult = performScanning( cfg, standardServiceRegistry );
 
+		scanningResult.discoveredModules().forEach( metadataSources::addModule );
+
 		scanningResult.discoveredPackages().forEach( metadataSources::addPackage );
 
 		scanningResult.discoveredClasses().forEach( metadataSources::addAnnotatedClassName );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/ModuleLevelAnnotationsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/ModuleLevelAnnotationsTest.java
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataBuilderImplementor;
+import org.hibernate.testing.orm.junit.Jira;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Jira("https://hibernate.atlassian.net/browse/HHH-20802")
+public class ModuleLevelAnnotationsTest {
+
+	private static final String MODULE_NAME = "test.module.subject";
+
+	private static final String SUBJECT_PACKAGE = "org.hibernate.orm.test.boot.models.bind.module.subject";
+
+	@Entity(name = "ModuleEntity")
+	public static class ModuleEntity {
+		@Id
+		public Long id;
+	}
+
+	@Test
+	void testJpaNamedQueryOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@jakarta.persistence.NamedQuery(name = \"moduleQuery\", query = \"select e from ModuleEntity e\")",
+				metadata -> assertNotNull(
+						metadata.getNamedHqlQueryMapping( "moduleQuery" ),
+						"Named query 'moduleQuery' defined on module-info.java should be available"
+				)
+		);
+	}
+
+	@Test
+	void testJpaNamedNativeQueryOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@jakarta.persistence.NamedNativeQuery(name = \"moduleNativeQuery\", query = \"SELECT 1\")",
+				metadata -> assertNotNull(
+						metadata.getNamedNativeQueryMapping( "moduleNativeQuery" ),
+						"Named native query 'moduleNativeQuery' defined on module-info.java should be available"
+				)
+		);
+	}
+
+	@Test
+	void testJpaNamedStoredProcedureQueryOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@jakarta.persistence.NamedStoredProcedureQuery(name = \"moduleProc\", procedureName = \"my_procedure\")",
+				metadata -> assertNotNull(
+						metadata.getNamedProcedureCallMapping( "moduleProc" ),
+						"Named stored procedure query 'moduleProc' defined on module-info.java should be available"
+				)
+		);
+	}
+
+	private void assertModuleAnnotation(
+			Path tempDir,
+			String annotation,
+			MetadataAssertion assertion) throws Exception {
+		assertModuleAnnotation( tempDir, annotation, List.of(), (metadata, loaded) -> assertion.verify( metadata ) );
+	}
+
+	private void assertModuleAnnotation(
+			Path tempDir,
+			String annotation,
+			List<String> classPackages,
+			ModuleMetadataAssertion assertion) throws Exception {
+		assertModuleAnnotation( tempDir, annotation, classPackages, List.of(), assertion );
+	}
+
+	private void assertModuleAnnotation(
+			Path tempDir,
+			String annotation,
+			List<String> classPackages,
+			List<String> moduleEntitySimpleNames,
+			ModuleMetadataAssertion assertion) throws Exception {
+		final var opens = classPackages.stream()
+				.map( pkg -> "\topens " + pkg + ";\n" )
+				.reduce( "", String::concat );
+		final var moduleInfoSource = """
+				%s
+				module %s {
+					requires static jakarta.persistence;
+					requires static org.hibernate.orm.core;
+				%s}
+				""".formatted( annotation, MODULE_NAME, opens );
+
+		final var loaded = TestModuleUtil.compileAndLoadModule(
+				tempDir, MODULE_NAME, moduleInfoSource, classPackages
+		);
+
+		final var bootstrapRegistry = new BootstrapServiceRegistryBuilder()
+				.applyClassLoader( loaded.classLoader() )
+				.build();
+		final var serviceRegistry = new StandardServiceRegistryBuilder( bootstrapRegistry ).build();
+		try {
+			final var metadataSources = new MetadataSources( serviceRegistry );
+			metadataSources.addAnnotatedClass( ModuleEntity.class );
+			for ( String simpleClassName : moduleEntitySimpleNames ) {
+				metadataSources.addAnnotatedClass(
+						loaded.classLoader().loadClass( SUBJECT_PACKAGE + "." + simpleClassName )
+				);
+			}
+			metadataSources.addModule( loaded.module() );
+
+			// Pre-register the module in the ModuleDetailsRegistry, because
+			// resolveModuleDetails(String) only searches ModuleLayer.boot()
+			// and cannot find modules from custom module layers.
+			final var builder = (MetadataBuilderImplementor) metadataSources.getMetadataBuilder();
+			builder.getBootstrapContext().getModelsContext()
+					.getModuleDetailsRegistry().resolveModuleDetails( loaded.module() );
+
+			assertion.verify( builder.build(), loaded );
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( serviceRegistry );
+		}
+	}
+
+	@FunctionalInterface
+	interface MetadataAssertion {
+		void verify(Metadata metadata);
+	}
+
+	@FunctionalInterface
+	interface ModuleMetadataAssertion {
+		void verify(Metadata metadata, TestModuleUtil.LoadedModule loaded) throws Exception;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/ModuleLevelAnnotationsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/ModuleLevelAnnotationsTest.java
@@ -4,21 +4,28 @@
  */
 package org.hibernate.orm.test.boot.models.bind.module;
 
-import java.nio.file.Path;
-import java.util.List;
-
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataBuilderImplementor;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.collection.internal.CustomCollectionTypeSemantics;
+import org.hibernate.mapping.BasicValue;
+import org.hibernate.mapping.Component;
+import org.hibernate.mapping.SimpleValue;
 import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.type.CustomCollectionType;
+import org.hibernate.type.CustomType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import java.nio.file.Path;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Jira("https://hibernate.atlassian.net/browse/HHH-20802")
@@ -59,6 +66,30 @@ public class ModuleLevelAnnotationsTest {
 	}
 
 	@Test
+	void testHibernateNamedQueryOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.NamedQuery(name = \"hqlModuleQuery\", query = \"select e from ModuleEntity e\")",
+				metadata -> assertNotNull(
+						metadata.getNamedHqlQueryMapping( "hqlModuleQuery" ),
+						"Hibernate @NamedQuery 'hqlModuleQuery' defined on module-info.java should be available"
+				)
+		);
+	}
+
+	@Test
+	void testFilterDefOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.FilterDef(name = \"moduleFilter\")",
+				metadata -> assertNotNull(
+						metadata.getFilterDefinition( "moduleFilter" ),
+						"Filter definition 'moduleFilter' from module-info.java should be available"
+				)
+		);
+	}
+
+	@Test
 	void testJpaNamedStoredProcedureQueryOnModuleInfo(@TempDir Path tempDir) throws Exception {
 		assertModuleAnnotation(
 				tempDir,
@@ -67,6 +98,216 @@ public class ModuleLevelAnnotationsTest {
 						metadata.getNamedProcedureCallMapping( "moduleProc" ),
 						"Named stored procedure query 'moduleProc' defined on module-info.java should be available"
 				)
+		);
+	}
+
+	@Test
+	void testHibernateNamedNativeQueryOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.NamedNativeQuery(name = \"hqlModuleNativeQuery\", query = \"SELECT 1\")",
+				metadata -> assertNotNull(
+						metadata.getNamedNativeQueryMapping( "hqlModuleNativeQuery" ),
+						"Hibernate @NamedNativeQuery 'hqlModuleNativeQuery' defined on module-info.java should be available"
+				)
+		);
+	}
+
+	@Test
+	void testNamedEntityGraphOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.NamedEntityGraph(name = \"moduleGraph\", graph = \"ModuleEntity: id\")",
+				metadata -> assertNotNull(
+						metadata.getNamedEntityGraph( "moduleGraph" ),
+						"Named entity graph 'moduleGraph' defined on module-info.java should be available"
+				)
+		);
+	}
+
+	@Test
+	void testFetchProfileOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.FetchProfile(name = \"moduleFetchProfile\")",
+				metadata -> assertNotNull(
+						metadata.getFetchProfile( "moduleFetchProfile" ),
+						"Fetch profile 'moduleFetchProfile' from module-info.java should be available"
+				)
+		);
+	}
+
+	@Test
+	void testJavaTypeRegistrationOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.JavaTypeRegistration(javaType = " + SUBJECT_PACKAGE + ".StubDomainType.class,"
+				+ " descriptorClass = " + SUBJECT_PACKAGE + ".StubJavaType.class)",
+				List.of( SUBJECT_PACKAGE ),
+				(metadata, loaded) -> {
+					var stubDomainType = loaded.classLoader()
+							.loadClass( SUBJECT_PACKAGE + ".StubDomainType" );
+					var typeConfig = ((MetadataImplementor) metadata).getTypeConfiguration();
+					var descriptor = typeConfig.getJavaTypeRegistry().findDescriptor( stubDomainType );
+					assertNotNull( descriptor,
+							"JavaType for StubDomainType from module-info.java should be available" );
+					assertThat( descriptor.getClass().getName() )
+							.isEqualTo( SUBJECT_PACKAGE + ".StubJavaType" );
+				}
+		);
+	}
+
+	@Test
+	void testJdbcTypeRegistrationOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.JdbcTypeRegistration(value = org.hibernate.type.descriptor.jdbc.VarcharJdbcType.class,"
+				+ " registrationCode = 9999)",
+				metadata -> assertNotNull(
+						((MetadataImplementor) metadata).getTypeConfiguration()
+								.getJdbcTypeRegistry().findDescriptor( 9999 ),
+						"JdbcType registered with code 9999 from module-info.java should be available"
+				)
+		);
+	}
+
+	@Test
+	void testConverterRegistrationOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.ConverterRegistration(converter = " + SUBJECT_PACKAGE + ".StubConverter.class)",
+				List.of( SUBJECT_PACKAGE ),
+				List.of( "SubjectEntity" ),
+				(metadata, loaded) -> {
+					var entityBinding = metadata.getEntityBinding( SUBJECT_PACKAGE + ".SubjectEntity" );
+					assertNotNull( entityBinding, "SubjectEntity should be bound" );
+					var property = entityBinding.getProperty( "domainType" );
+					var basicValue = (BasicValue) property.getValue();
+					var converterDescriptor = basicValue.getJpaAttributeConverterDescriptor();
+					assertNotNull( converterDescriptor,
+							"Converter from module-info.java should be auto-applied to StubDomainType property" );
+					assertThat( converterDescriptor.getAttributeConverterClass().getName() )
+							.isEqualTo( SUBJECT_PACKAGE + ".StubConverter" );
+				}
+		);
+	}
+
+	@Test
+	void testTypeRegistrationOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.TypeRegistration(basicClass = " + SUBJECT_PACKAGE + ".StubDomainType.class,"
+				+ " userType = " + SUBJECT_PACKAGE + ".StubUserType.class)",
+				List.of( SUBJECT_PACKAGE ),
+				List.of( "SubjectEntity" ),
+				(metadata, loaded) -> {
+					var entityBinding = metadata.getEntityBinding( SUBJECT_PACKAGE + ".SubjectEntity" );
+					assertNotNull( entityBinding, "SubjectEntity should be bound" );
+					var property = entityBinding.getProperty( "domainType" );
+					var basicValue = (BasicValue) property.getValue();
+					assertThat( basicValue.getType() ).isInstanceOf( CustomType.class );
+					assertThat( ((CustomType<?>) basicValue.getType()).getUserType().getClass().getName() )
+							.isEqualTo( SUBJECT_PACKAGE + ".StubUserType" );
+				}
+		);
+	}
+
+	@Test
+	void testCollectionTypeRegistrationOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.CollectionTypeRegistration("
+				+ "classification = org.hibernate.metamodel.CollectionClassification.BAG,"
+				+ " type = " + SUBJECT_PACKAGE + ".StubUserCollectionType.class)",
+				List.of( SUBJECT_PACKAGE ),
+				List.of( "CollectionSubjectEntity" ),
+				(metadata, loaded) -> {
+					var entityBinding = metadata.getEntityBinding( SUBJECT_PACKAGE + ".CollectionSubjectEntity" );
+					assertNotNull( entityBinding, "CollectionSubjectEntity should be bound" );
+					var property = entityBinding.getProperty( "elements" );
+					var collection = (org.hibernate.mapping.Collection) property.getValue();
+					assertThat( collection.getCollectionSemantics() )
+							.isInstanceOf( CustomCollectionTypeSemantics.class );
+					var semantics = (CustomCollectionTypeSemantics<?, ?>) collection.getCollectionSemantics();
+					assertThat( semantics.getCollectionType() ).isInstanceOf( CustomCollectionType.class );
+					assertThat( ((CustomCollectionType) semantics.getCollectionType())
+							.getUserType().getClass().getName() )
+							.isEqualTo( SUBJECT_PACKAGE + ".StubUserCollectionType" );
+				}
+		);
+	}
+
+	@Test
+	void testCompositeTypeRegistrationOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.CompositeTypeRegistration(embeddableClass = " + SUBJECT_PACKAGE + ".StubDomainType.class,"
+				+ " userType = " + SUBJECT_PACKAGE + ".StubCompositeUserType.class)",
+				List.of( SUBJECT_PACKAGE ),
+				List.of( "SubjectEntity" ),
+				(metadata, loaded) -> {
+					var entityBinding = metadata.getEntityBinding( SUBJECT_PACKAGE + ".SubjectEntity" );
+					assertNotNull( entityBinding, "SubjectEntity should be bound" );
+					var property = entityBinding.getProperty( "domainType" );
+					assertThat( property.getValue() ).isInstanceOf( Component.class );
+				}
+		);
+	}
+
+	@Test
+	void testEmbeddableInstantiatorRegistrationOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.EmbeddableInstantiatorRegistration(embeddableClass = " + SUBJECT_PACKAGE + ".StubEmbeddable.class,"
+				+ " instantiator = " + SUBJECT_PACKAGE + ".StubEmbeddableInstantiator.class)",
+				List.of( SUBJECT_PACKAGE ),
+				List.of( "EmbeddableSubjectEntity" ),
+				(metadata, loaded) -> {
+					var entityBinding = metadata.getEntityBinding( SUBJECT_PACKAGE + ".EmbeddableSubjectEntity" );
+					assertNotNull( entityBinding, "EmbeddableSubjectEntity should be bound" );
+					var property = entityBinding.getProperty( "embeddable" );
+					var component = (Component) property.getValue();
+					assertNotNull( component.getCustomInstantiator(),
+							"Custom instantiator from module-info.java should be registered for StubEmbeddable" );
+					assertThat( component.getCustomInstantiator().getName() )
+							.isEqualTo( SUBJECT_PACKAGE + ".StubEmbeddableInstantiator" );
+				}
+		);
+	}
+
+	@Test
+	void testGenericGeneratorOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.GenericGenerator(type = org.hibernate.id.IncrementGenerator.class)",
+				List.of( SUBJECT_PACKAGE ),
+				List.of( "GeneratorSubjectEntity" ),
+				(metadata, loaded) -> {
+					var entityBinding = metadata.getEntityBinding(
+							SUBJECT_PACKAGE + ".GeneratorSubjectEntity" );
+					assertNotNull( entityBinding, "GeneratorSubjectEntity should be bound" );
+					var idValue = (SimpleValue) entityBinding.getIdentifier();
+					assertNotNull( idValue.getCustomIdGeneratorCreator(),
+							"@GenericGenerator from module-info.java should configure the id generator" );
+				}
+		);
+	}
+
+	@Test
+	void testNativeGeneratorOnModuleInfo(@TempDir Path tempDir) throws Exception {
+		assertModuleAnnotation(
+				tempDir,
+				"@org.hibernate.annotations.NativeGenerator",
+				List.of( SUBJECT_PACKAGE ),
+				List.of( "GeneratorSubjectEntity" ),
+				(metadata, loaded) -> {
+					var entityBinding = metadata.getEntityBinding(
+							SUBJECT_PACKAGE + ".GeneratorSubjectEntity" );
+					assertNotNull( entityBinding, "GeneratorSubjectEntity should be bound" );
+					var idValue = (SimpleValue) entityBinding.getIdentifier();
+					assertNotNull( idValue.getCustomIdGeneratorCreator(),
+							"@NativeGenerator from module-info.java should configure the id generator" );
+				}
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/ModuleLevelEntityListenerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/ModuleLevelEntityListenerTest.java
@@ -11,6 +11,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataBuilderImplementor;
 
 import org.hibernate.testing.orm.junit.Jira;
 import org.junit.jupiter.api.AfterAll;
@@ -70,7 +71,14 @@ public class ModuleLevelEntityListenerTest {
 		metadataSources.addAnnotatedClass( excludingEntityClass );
 		metadataSources.addModule( loaded.module() );
 
-		sessionFactory = metadataSources.buildMetadata().buildSessionFactory();
+		// Pre-register the module in the ModuleDetailsRegistry, because
+		// resolveModuleDetails(String) only searches ModuleLayer.boot()
+		// and cannot find modules from custom module layers.
+		final var builder = (MetadataBuilderImplementor) metadataSources.getMetadataBuilder();
+		builder.getBootstrapContext().getModelsContext()
+				.getModuleDetailsRegistry().resolveModuleDetails( loaded.module() );
+
+		sessionFactory = builder.build().buildSessionFactory();
 	}
 
 	@AfterAll

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/ModuleLevelEntityListenerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/ModuleLevelEntityListenerTest.java
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+
+import org.hibernate.testing.orm.junit.Jira;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Jira("https://hibernate.atlassian.net/browse/HHH-20802")
+public class ModuleLevelEntityListenerTest {
+
+	private static final String MODULE_NAME = "test.module.listener";
+	private static final String SUBJECT_PACKAGE = "org.hibernate.orm.test.boot.models.bind.module.subject";
+
+	@TempDir
+	static Path tempDir;
+
+	static SessionFactory sessionFactory;
+	static Class<?> listenerEntityClass;
+	static Class<?> excludingEntityClass;
+	static Class<?> eventsClass;
+
+	@BeforeAll
+	static void setUp() throws Exception {
+		final var moduleInfoSource = """
+				@jakarta.persistence.EntityListeners(%s.ModuleListener.class)
+				module %s {
+					requires static jakarta.persistence;
+					exports %s;
+					opens %s;
+				}
+				""".formatted( SUBJECT_PACKAGE, MODULE_NAME, SUBJECT_PACKAGE, SUBJECT_PACKAGE );
+
+		final var loaded = TestModuleUtil.compileAndLoadModule(
+				tempDir,
+				MODULE_NAME,
+				moduleInfoSource,
+				List.of( SUBJECT_PACKAGE )
+		);
+
+		listenerEntityClass = loaded.classLoader().loadClass( SUBJECT_PACKAGE + ".ListenerEntity" );
+		excludingEntityClass = loaded.classLoader().loadClass( SUBJECT_PACKAGE + ".ExcludingEntity" );
+		eventsClass = loaded.classLoader().loadClass( SUBJECT_PACKAGE + ".EventTracker" );
+
+		final var bootstrapRegistry = new BootstrapServiceRegistryBuilder()
+				.applyClassLoader( loaded.classLoader() )
+				.build();
+		final var serviceRegistry = new StandardServiceRegistryBuilder( bootstrapRegistry )
+				.applySetting( "hibernate.hbm2ddl.auto", "create-drop" )
+				.build();
+
+		final var metadataSources = new MetadataSources( serviceRegistry );
+		metadataSources.addAnnotatedClass( listenerEntityClass );
+		metadataSources.addAnnotatedClass( excludingEntityClass );
+		metadataSources.addModule( loaded.module() );
+
+		sessionFactory = metadataSources.buildMetadata().buildSessionFactory();
+	}
+
+	@AfterAll
+	static void tearDown() {
+		if ( sessionFactory != null ) {
+			sessionFactory.close();
+		}
+	}
+
+	@BeforeEach
+	void resetEvents() throws Exception {
+		eventsClass.getMethod( "reset" ).invoke( null );
+	}
+
+	@AfterEach
+	void dropData() {
+		sessionFactory.getSchemaManager().truncate();
+	}
+
+	@Test
+	void callbackOrderingIsModuleThenPackageThenEntityListenerThenEntityCallback() throws Exception {
+		sessionFactory.inTransaction( session -> {
+			try {
+				session.persist( listenerEntityClass.getConstructor( Long.class ).newInstance( 1L ) );
+			}
+			catch (Exception e) {
+				throw new RuntimeException( e );
+			}
+		} );
+
+		@SuppressWarnings("unchecked")
+		var events = (List<String>) eventsClass.getField( "events" ).get( null );
+		assertThat( events ).containsExactly(
+				"module:ListenerEntity",
+				"package:ListenerEntity",
+				"entity-listener:ListenerEntity",
+				"entity-callback:ListenerEntity"
+		);
+	}
+
+	@Test
+	void excludeDefaultListenersDoesNotExcludeModuleOrPackageLevelEntityListeners() throws Exception {
+		sessionFactory.inTransaction( session -> {
+			try {
+				session.persist( excludingEntityClass.getConstructor( Long.class ).newInstance( 1L ) );
+			}
+			catch (Exception e) {
+				throw new RuntimeException( e );
+			}
+		} );
+
+		@SuppressWarnings("unchecked")
+		var events = (List<String>) eventsClass.getField( "events" ).get( null );
+		assertThat( events ).containsExactly(
+				"module:ExcludingEntity",
+				"package:ExcludingEntity",
+				"entity-callback:ExcludingEntity"
+		);
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/TestModuleUtil.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/TestModuleUtil.java
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module;
+
+import java.io.IOException;
+import java.lang.module.Configuration;
+import java.lang.module.ModuleFinder;
+import java.net.URISyntaxException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Compiles a {@code module-info.java} at runtime and loads it into a new
+ * {@link ModuleLayer}, returning the resulting {@link Module}.
+ * <p>
+ * When {@code classPackages} are specified, pre-compiled {@code .class} files
+ * for those packages are copied into the module output directory so they become
+ * part of the named module.
+ */
+final class TestModuleUtil {
+
+	record LoadedModule(Module module, ClassLoader classLoader) {
+	}
+
+	static LoadedModule compileAndLoadModule(
+			Path tempDir,
+			String moduleName,
+			String moduleInfoSource) throws Exception {
+		return compileAndLoadModule( tempDir, moduleName, moduleInfoSource, List.of() );
+	}
+
+	static LoadedModule compileAndLoadModule(
+			Path tempDir,
+			String moduleName,
+			String moduleInfoSource,
+			List<String> classPackages) throws Exception {
+		final Path srcDir = tempDir.resolve( "src" );
+		final Path outDir = tempDir.resolve( "out" );
+		final Path moduleSourceDir = srcDir.resolve( moduleName );
+		Files.createDirectories( moduleSourceDir );
+
+		Files.writeString( moduleSourceDir.resolve( "module-info.java" ), moduleInfoSource );
+
+		final Path moduleOutDir = outDir.resolve( moduleName );
+		Files.createDirectories( moduleOutDir );
+
+		final Path testClassesDir = testClassesDir();
+
+		// Copy pre-compiled .class files into the module output directory
+		// so the compiler can resolve types referenced from module-info.java
+		for ( String pkg : classPackages ) {
+			final String pkgPath = pkg.replace( '.', '/' );
+			final Path sourceDir = testClassesDir.resolve( pkgPath );
+			final Path targetDir = moduleOutDir.resolve( pkgPath );
+			Files.createDirectories( targetDir );
+			copyDirectory( sourceDir, targetDir );
+		}
+
+		final var compilerArgs = new ArrayList<String>();
+		final var modulePath = jakartaPersistenceJar() + System.getProperty( "path.separator" )
+				+ hibernateCoreJar();
+		compilerArgs.addAll( List.of(
+				"-d", moduleOutDir.toString(),
+				"--module-path", modulePath
+		) );
+		if ( !classPackages.isEmpty() ) {
+			// Pre-compiled .class files were copied into moduleOutDir above,
+			// but javac's -d is output-only: it does not search that directory
+			// to resolve types. --patch-module tells javac to treat the
+			// pre-compiled classes as part of the module being compiled.
+			compilerArgs.addAll( List.of(
+					"--patch-module", moduleName + "=" + moduleOutDir
+			) );
+		}
+		compilerArgs.add( moduleSourceDir.resolve( "module-info.java" ).toString() );
+
+		final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+		assertNotNull( compiler, "No system Java compiler available" );
+		final int result = compiler.run( null, null, null, compilerArgs.toArray( new String[0] ) );
+		if ( result != 0 ) {
+			throw new AssertionError( "Compilation of module-info.java failed (exit code " + result + ")" );
+		}
+
+		final ClassLoader parentLoader = TestModuleUtil.class.getClassLoader();
+		final ModuleFinder finder = ModuleFinder.of( moduleOutDir );
+		final ModuleLayer parentLayer = ModuleLayer.boot();
+		final Configuration cfg = parentLayer.configuration().resolve(
+				finder,
+				ModuleFinder.of(),
+				Set.of( moduleName )
+		);
+		final ModuleLayer.Controller controller = ModuleLayer.defineModulesWithOneLoader(
+				cfg,
+				List.of( parentLayer ),
+				parentLoader
+		);
+		final ModuleLayer moduleLayer = controller.layer();
+		final Module module = moduleLayer.findModule( moduleName ).orElseThrow();
+		// Runtime equivalent of --add-reads: lets the named module
+		// access classes from the test classloader's unnamed module.
+		controller.addReads( module, parentLoader.getUnnamedModule() );
+
+		return new LoadedModule( module, moduleLayer.findLoader( moduleName ) );
+	}
+
+	private static Path jakartaPersistenceJar() throws URISyntaxException {
+		return Path.of(
+				jakarta.persistence.NamedQuery.class.getProtectionDomain()
+						.getCodeSource().getLocation().toURI()
+		);
+	}
+
+	private static Path testClassesDir() throws URISyntaxException {
+		return Path.of(
+				TestModuleUtil.class.getProtectionDomain()
+						.getCodeSource().getLocation().toURI()
+		);
+	}
+
+	private static Path hibernateCoreJar() throws Exception {
+		// In Gradle tests, FilterDef.class is loaded from the exploded
+		// classes directory, not a JAR. Automatic modules require an
+		// actual JAR (with Automatic-Module-Name in the manifest), so
+		// we locate the packaged JAR under target/libs/.
+		final var classesDir = Path.of(
+				org.hibernate.annotations.FilterDef.class.getProtectionDomain()
+						.getCodeSource().getLocation().toURI()
+		);
+		final var targetDir = classesDir.getParent().getParent().getParent();
+		try ( var paths = Files.list( targetDir.resolve( "libs" ) ) ) {
+			return paths
+					.filter( p -> p.getFileName().toString().startsWith( "hibernate-core-" ) )
+					.findFirst()
+					.orElseThrow( () -> new AssertionError( "hibernate-core JAR not found in "
+							+ targetDir.resolve( "libs" ) ) );
+		}
+	}
+
+	private static void copyDirectory(Path source, Path target) throws IOException {
+		Files.walkFileTree( source, new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Files.copy( file, target.resolve( source.relativize( file ) ) );
+				return FileVisitResult.CONTINUE;
+			}
+		} );
+	}
+
+	private TestModuleUtil() {
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/TestModuleUtil.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/TestModuleUtil.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.orm.test.boot.models.bind.module;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
@@ -89,9 +90,11 @@ final class TestModuleUtil {
 
 		final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 		assertNotNull( compiler, "No system Java compiler available" );
-		final int result = compiler.run( null, null, null, compilerArgs.toArray( new String[0] ) );
+		final var errOutput = new ByteArrayOutputStream();
+		final int result = compiler.run( null, null, errOutput, compilerArgs.toArray( new String[0] ) );
 		if ( result != 0 ) {
-			throw new AssertionError( "Compilation of module-info.java failed (exit code " + result + ")" );
+			throw new AssertionError( "Compilation of module-info.java failed (exit code " + result + "):\n"
+					+ errOutput );
 		}
 
 		final ClassLoader parentLoader = TestModuleUtil.class.getClassLoader();
@@ -130,23 +133,12 @@ final class TestModuleUtil {
 		);
 	}
 
-	private static Path hibernateCoreJar() throws Exception {
-		// In Gradle tests, FilterDef.class is loaded from the exploded
-		// classes directory, not a JAR. Automatic modules require an
-		// actual JAR (with Automatic-Module-Name in the manifest), so
-		// we locate the packaged JAR under target/libs/.
-		final var classesDir = Path.of(
-				org.hibernate.annotations.FilterDef.class.getProtectionDomain()
-						.getCodeSource().getLocation().toURI()
-		);
-		final var targetDir = classesDir.getParent().getParent().getParent();
-		try ( var paths = Files.list( targetDir.resolve( "libs" ) ) ) {
-			return paths
-					.filter( p -> p.getFileName().toString().startsWith( "hibernate-core-" ) )
-					.findFirst()
-					.orElseThrow( () -> new AssertionError( "hibernate-core JAR not found in "
-							+ targetDir.resolve( "libs" ) ) );
+	private static Path hibernateCoreJar() {
+		final var jarPath = System.getProperty( "hibernate.core.jar.path" );
+		if ( jarPath == null ) {
+			throw new AssertionError( "System property 'hibernate.core.jar.path' not set" );
 		}
+		return Path.of( jarPath );
 	}
 
 	private static void copyDirectory(Path source, Path target) throws IOException {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/CollectionSubjectEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/CollectionSubjectEntity.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import java.util.Collection;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity(name = "CollectionSubjectEntity")
+public class CollectionSubjectEntity {
+	@Id
+	public Long id;
+
+	@ElementCollection
+	public Collection<String> elements;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/EmbeddableSubjectEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/EmbeddableSubjectEntity.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity(name = "EmbeddableSubjectEntity")
+public class EmbeddableSubjectEntity {
+	@Id
+	public Long id;
+
+	@Embedded
+	public StubEmbeddable embeddable;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/EntityLevelListener.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/EntityLevelListener.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.PrePersist;
+
+public class EntityLevelListener {
+	@PrePersist
+	public void prePersist(Object entity) {
+		EventTracker.events.add( "entity-listener:" + entity.getClass().getSimpleName() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/EventTracker.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/EventTracker.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EventTracker {
+	public static final List<String> events = new ArrayList<>();
+
+	public static void reset() {
+		events.clear();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/ExcludingEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/ExcludingEntity.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.ExcludeDefaultListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+
+@Entity(name = "ExcludingEntity")
+@ExcludeDefaultListeners
+public class ExcludingEntity {
+	@Id
+	public Long id;
+
+	public ExcludingEntity() {
+	}
+
+	public ExcludingEntity(Long id) {
+		this.id = id;
+	}
+
+	@PrePersist
+	void prePersist() {
+		EventTracker.events.add( "entity-callback:" + getClass().getSimpleName() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/GeneratorSubjectEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/GeneratorSubjectEntity.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity(name = "GeneratorSubjectEntity")
+public class GeneratorSubjectEntity {
+	@Id
+	@GeneratedValue
+	public Long id;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/ListenerEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/ListenerEntity.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+
+@Entity(name = "ListenerEntity")
+@EntityListeners(EntityLevelListener.class)
+public class ListenerEntity {
+	@Id
+	public Long id;
+
+	public ListenerEntity() {
+	}
+
+	public ListenerEntity(Long id) {
+		this.id = id;
+	}
+
+	@PrePersist
+	void prePersist() {
+		EventTracker.events.add( "entity-callback:" + getClass().getSimpleName() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/ModuleListener.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/ModuleListener.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.PrePersist;
+
+public class ModuleListener {
+	@PrePersist
+	public void prePersist(Object entity) {
+		EventTracker.events.add( "module:" + entity.getClass().getSimpleName() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/PackageListener.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/PackageListener.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.PrePersist;
+
+public class PackageListener {
+	@PrePersist
+	public void prePersist(Object entity) {
+		EventTracker.events.add( "package:" + entity.getClass().getSimpleName() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubCompositeUserType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubCompositeUserType.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import java.io.Serializable;
+
+import org.hibernate.metamodel.spi.ValueAccess;
+import org.hibernate.usertype.CompositeUserType;
+
+public class StubCompositeUserType implements CompositeUserType<StubDomainType> {
+	@Override
+	public Object getPropertyValue(StubDomainType component, int property) {
+		return component.value;
+	}
+
+	@Override
+	public StubDomainType instantiate(ValueAccess values) {
+		return new StubDomainType( values.getValue( 0, String.class ) );
+	}
+
+	@Override
+	public Class<?> embeddable() {
+		return StubEmbeddable.class;
+	}
+
+	@Override
+	public Class<StubDomainType> returnedClass() {
+		return StubDomainType.class;
+	}
+
+	@Override
+	public boolean equals(StubDomainType x, StubDomainType y) {
+		return x == y || ( x != null && y != null && x.value.equals( y.value ) );
+	}
+
+	@Override
+	public int hashCode(StubDomainType x) {
+		return x == null ? 0 : x.value.hashCode();
+	}
+
+	@Override
+	public StubDomainType deepCopy(StubDomainType value) {
+		return value;
+	}
+
+	@Override
+	public boolean isMutable() {
+		return false;
+	}
+
+	@Override
+	public Serializable disassemble(StubDomainType value) {
+		return value == null ? null : value.value;
+	}
+
+	@Override
+	public StubDomainType assemble(Serializable cached, Object owner) {
+		return cached == null ? null : new StubDomainType( (String) cached );
+	}
+
+	@Override
+	public StubDomainType replace(StubDomainType detached, StubDomainType managed, Object owner) {
+		return detached;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubConverter.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubConverter.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.AttributeConverter;
+
+public class StubConverter implements AttributeConverter<StubDomainType, String> {
+	@Override
+	public String convertToDatabaseColumn(StubDomainType attribute) {
+		return attribute == null ? null : attribute.value;
+	}
+
+	@Override
+	public StubDomainType convertToEntityAttribute(String dbData) {
+		return dbData == null ? null : new StubDomainType( dbData );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubDomainType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubDomainType.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+public class StubDomainType {
+	public final String value;
+
+	public StubDomainType(String value) {
+		this.value = value;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubEmbeddable.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubEmbeddable.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class StubEmbeddable {
+	public String value;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubEmbeddableInstantiator.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubEmbeddableInstantiator.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import org.hibernate.metamodel.spi.EmbeddableInstantiator;
+import org.hibernate.metamodel.spi.ValueAccess;
+
+public class StubEmbeddableInstantiator implements EmbeddableInstantiator {
+	@Override
+	public Object instantiate(ValueAccess valueAccess) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isInstance(Object object) {
+		return object instanceof StubEmbeddable;
+	}
+
+	@Override
+	public boolean isSameClass(Object object) {
+		return StubEmbeddable.class.equals( object.getClass() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubJavaType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubJavaType.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.AbstractClassJavaType;
+
+public class StubJavaType extends AbstractClassJavaType<StubDomainType> {
+	public StubJavaType() {
+		super( StubDomainType.class );
+	}
+
+	@Override
+	public <X> X unwrap(StubDomainType value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+		if ( String.class.isAssignableFrom( type ) ) {
+			return type.cast( value.value );
+		}
+		throw unknownUnwrap( type );
+	}
+
+	@Override
+	public <X> StubDomainType wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+		if ( value instanceof String string ) {
+			return new StubDomainType( string );
+		}
+		throw unknownWrap( value.getClass() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubUserCollectionType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubUserCollectionType.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.metamodel.CollectionClassification;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.usertype.UserCollectionType;
+
+public class StubUserCollectionType implements UserCollectionType {
+	@Override
+	public CollectionClassification getClassification() {
+		return CollectionClassification.BAG;
+	}
+
+	@Override
+	public Class<?> getCollectionClass() {
+		return ArrayList.class;
+	}
+
+	@Override
+	public PersistentCollection<?> instantiate(SharedSessionContractImplementor session, CollectionPersister persister) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public PersistentCollection<?> wrap(SharedSessionContractImplementor session, Object collection) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterator<?> getElementsIterator(Object collection) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean contains(Object collection, Object entity) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object indexOf(Object collection, Object entity) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object replaceElements(
+			Object original,
+			Object target,
+			CollectionPersister persister,
+			Object owner,
+			Map copyCache,
+			SharedSessionContractImplementor session) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object instantiate(int anticipatedSize) {
+		return new ArrayList<>();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubUserType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/StubUserType.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import java.sql.Types;
+
+import org.hibernate.usertype.UserType;
+
+public class StubUserType implements UserType<StubDomainType> {
+	@Override
+	public int getSqlType() {
+		return Types.VARCHAR;
+	}
+
+	@Override
+	public Class<StubDomainType> returnedClass() {
+		return StubDomainType.class;
+	}
+
+	@Override
+	public StubDomainType deepCopy(StubDomainType value) {
+		return value;
+	}
+
+	@Override
+	public boolean isMutable() {
+		return false;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/SubjectEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/SubjectEntity.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity(name = "SubjectEntity")
+public class SubjectEntity {
+	@Id
+	public Long id;
+
+	public StubDomainType domainType;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/package-info.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/bind/module/subject/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+
+@EntityListeners(PackageListener.class)
+package org.hibernate.orm.test.boot.models.bind.module.subject;
+
+import jakarta.persistence.EntityListeners;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/BootstrapTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/BootstrapTest.java
@@ -133,6 +133,11 @@ public class BootstrapTest {
 		// Read package-level metadata.
 		sources.addPackage("hibernate.example");
 
+		// Read module-level metadata from a named module.
+		// Only needed when scanning is not available;
+		// in container environments, modules are auto-discovered.
+		sources.addModule(getClass().getModule());
+
 		// Adds the named JPA orm.xml resource as a source: which performs the
 		// classpath lookup and parses the XML
 		sources.addResource("org/hibernate/example/Product.orm.xml");
@@ -150,6 +155,7 @@ public class BootstrapTest {
 				.addAnnotatedClass(MyEntity.class)
 				.addAnnotatedClassName("org.hibernate.example.Customer")
 				.addPackage("hibernate.example")
+				.addModule(getClass().getModule())
 				.addResource("org/hibernate/example/Product.orm.xml");
 		//end::example-bootstrap-native-MetadataSources-chained[]
 	}
@@ -279,6 +285,11 @@ public class BootstrapTest {
 
 			// Read package-level metadata.
 			sources.addPackage(MyEntity.class.getPackage());
+
+			// Read module-level metadata from a named module.
+			// Only needed when scanning is not available;
+			// in container environments, modules are auto-discovered.
+			sources.addModule(getClass().getModule());
 
 			// Adds the named hbm.xml resource as a source: which performs the
 			// classpath lookup and parses the XML

--- a/hibernate-scan-jandex/src/main/java/org/hibernate/scan/jandex/IndexScanner.java
+++ b/hibernate-scan-jandex/src/main/java/org/hibernate/scan/jandex/IndexScanner.java
@@ -9,7 +9,7 @@ import org.hibernate.boot.scan.internal.ResultCollector;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 
-/// Scans the Jandex Index finding all "managed" classes.
+/// Scans the Jandex Index finding all "managed" classes and modules.
 /// As of JPA 4, this means classes with annotations which are defined with the
 /// [@Discoverable][Discoverable] annotation.
 ///
@@ -32,6 +32,11 @@ public class IndexScanner {
 
 		// Treat Jakarta Data repositories as if they were annotated with an annotation marked `@Discoverable`.
 		addDiscoveredClasses( JAKARTA_DATA_REPOSITORY, jandexIndex, resultCollector );
+
+		// Discover modules whose module-info has annotations
+		for ( var moduleInfo : jandexIndex.getKnownModules() ) {
+			resultCollector.addModule( moduleInfo.name().toString() );
+		}
 	}
 
 	private static void addDiscoveredClasses(

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -18,3 +18,10 @@ IMPORTANT: If migrating from earlier versions, be sure to also check out the lin
 Schema management DDL now uses `CREATE SCHEMA IF NOT EXISTS` and `DROP SCHEMA IF EXISTS` for dialects which support these clauses, avoiding warnings when a schema already exists or has already been dropped.
 
 Supported dialects: PostgreSQL, CockroachDB, H2, HSQLDB, SAP HANA, and SQL Server (DROP only, version 13+).
+
+[[module-level-annotations]]
+== Module-level annotations
+
+Annotations such as `@NamedQuery`, `@FilterDef`, `@FetchProfile`, and type registration annotations can now be placed on `module-info.java`, in addition to `package-info.java` and entity classes.
+
+Modules are registered via `MetadataSources#addModule(Module)`.


### PR DESCRIPTION
Temporary PR to test CI for fixups to the module-level annotations branch.

Changes on top of #13243:
- Fix `ModuleLevelEntityListenerTest` UnknownModuleException (pre-register module via `MetadataBuilderImplementor`)
- Replace fragile `build/libs/` directory traversal in `TestModuleUtil.hibernateCoreJar()` with a Gradle system property
- Capture javac stderr on compilation failure for better diagnostics

This PR will be closed once CI passes — the changes will be squashed into #13243.

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20802 (New Feature):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20802
<!-- Hibernate GitHub Bot issue links end -->