### PR TITLE
Follow up on HHH-17990 More advanced "proxy" classes (and tests) for session/statelessSession for use in other libraries

### DIFF
--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -105,16 +105,6 @@ initialized collection has no queued commands while its snapshot still represent
 the persisted comparison baseline.  Wrappers derived from
 `AbstractPersistentCollection` inherit this sequencing automatically.
 
-[[session-lazy-delegator-spi]]
-=== `SessionLazyDelegator` initialization
-
-The `SessionLazyDelegator` class has been made abstract, and its constructor that
-accepted a `Supplier<Session>` removed, in order to align it with how the new
-StatelessSessionLazyDelegator` is implemented. Consumers of this class must extend it
-and implement the abstract `delegate()` method, thus providing the required Session to
-it.
-
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Changes in Behavior
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17990

Because this is being backported to 8.0, so that's where migration will happen.

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-17990 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->