### PR TITLE
Remove redundant this qualifiers

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/AbstractEntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/AbstractEntityInsertAction.java
@@ -57,8 +57,8 @@ public abstract class AbstractEntityInsertAction extends EntityAction {
 		assert state != null;
 		assert instance != null;
 		this.state = state;
-		this.isExecuted = false;
-		this.areTransientReferencesNullified = false;
+		isExecuted = false;
+		areTransientReferencesNullified = false;
 
 		if ( id != null ) {
 			handleNaturalIdPreSaveNotifications();
@@ -262,7 +262,7 @@ public abstract class AbstractEntityInsertAction extends EntityAction {
 	 * Indicate that the action has executed.
 	 */
 	public void markExecuted() {
-		this.isExecuted = true;
+		isExecuted = true;
 	}
 
 	/**
@@ -285,7 +285,7 @@ public abstract class AbstractEntityInsertAction extends EntityAction {
 		// guard against NullPointerException
 		if ( session != null ) {
 			final var entityEntry = session.getPersistenceContextInternal().getEntry( getInstance() );
-			this.state = entityEntry.getLoadedState();
+			state = entityEntry.getLoadedState();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/BulkOperationCleanupAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/BulkOperationCleanupAction.java
@@ -275,7 +275,7 @@ public class BulkOperationCleanupAction implements Executable, Serializable {
 				@Nonnull EntityDataAccess cacheAccess,
 				@Nonnull SharedSessionContractImplementor session) {
 			this.cacheAccess = cacheAccess;
-			this.cacheLock = cacheAccess.lockRegion();
+			cacheLock = cacheAccess.lockRegion();
 			cacheAccess.removeAll( session );
 		}
 
@@ -292,7 +292,7 @@ public class BulkOperationCleanupAction implements Executable, Serializable {
 				@Nonnull CollectionDataAccess cacheAccess,
 				@Nonnull SharedSessionContractImplementor session) {
 			this.cacheAccess = cacheAccess;
-			this.cacheLock = cacheAccess.lockRegion();
+			cacheLock = cacheAccess.lockRegion();
 			cacheAccess.removeAll( session );
 		}
 
@@ -309,7 +309,7 @@ public class BulkOperationCleanupAction implements Executable, Serializable {
 				@Nonnull NaturalIdDataAccess naturalIdCacheAccessStrategy,
 				@Nonnull SharedSessionContractImplementor session) {
 			this.naturalIdCacheAccessStrategy = naturalIdCacheAccessStrategy;
-			this.cacheLock = naturalIdCacheAccessStrategy.lockRegion();
+			cacheLock = naturalIdCacheAccessStrategy.lockRegion();
 			naturalIdCacheAccessStrategy.removeAll( session );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
@@ -74,7 +74,7 @@ public abstract class CollectionAction implements ComparableExecutable {
 		this.persister = persister;
 		this.session = session;
 		this.key = key;
-		this.collectionRole = persister.getRole();
+		collectionRole = persister.getRole();
 		this.collection = collection;
 		this.lifecyclePrepared = lifecyclePrepared;
 		this.interpretation = interpretation;
@@ -145,7 +145,7 @@ public abstract class CollectionAction implements ComparableExecutable {
 		// guard against NullPointerException
 		if ( session != null ) {
 			this.session = session;
-			this.persister = session.getFactory().getMappingMetamodel().getCollectionDescriptor( collectionRole );
+			persister = session.getFactory().getMappingMetamodel().getCollectionDescriptor( collectionRole );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRecreateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRecreateAction.java
@@ -42,10 +42,10 @@ public final class CollectionRecreateAction extends CollectionAction {
 		assert collection != null;
 		// Capture the owner at action creation time so it's available when the post-event
 		// fires (which may be after the collection owner reference has been cleared)
-		this.affectedOwner = collection.getOwner();
+		affectedOwner = collection.getOwner();
 		// Also capture the owner ID from the entity entry at action creation time
 		final var ownerEntry = session.getPersistenceContextInternal().getEntry( affectedOwner );
-		this.affectedOwnerId = ownerEntry != null ? ownerEntry.getId() : null;
+		affectedOwnerId = ownerEntry != null ? ownerEntry.getId() : null;
 	}
 
 	/// Creates the legacy lowering of an already-prepared semantic mutation.

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRemoveAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRemoveAction.java
@@ -102,7 +102,7 @@ public final class CollectionRemoveAction extends CollectionAction {
 		this.affectedOwner = affectedOwner;
 		// Get the owner ID from the entity entry at action creation time
 		final var ownerEntry = session.getPersistenceContextInternal().getEntry( affectedOwner );
-		this.affectedOwnerId = ownerEntry != null ? ownerEntry.getId() : null;
+		affectedOwnerId = ownerEntry != null ? ownerEntry.getId() : null;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/DelayedPostInsertIdentifier.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/DelayedPostInsertIdentifier.java
@@ -73,6 +73,6 @@ public class DelayedPostInsertIdentifier
 
 	@Override
 	public int compareTo(@Nonnull DelayedPostInsertIdentifier that) {
-		return Long.compare( this.identifier, that.identifier );
+		return Long.compare( identifier, that.identifier );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
@@ -55,7 +55,7 @@ public abstract class EntityAction
 			@Nonnull EntityPersister persister) {
 		assert session != null;
 		assert persister != null;
-		this.entityName = persister.getEntityName();
+		entityName = persister.getEntityName();
 		this.id = id;
 		this.instance = instance;
 		this.session = session;
@@ -195,7 +195,7 @@ public abstract class EntityAction
 	 */
 	@Override
 	public void afterDeserialize(@Nullable EventSource session) {
-		if ( this.session != null || this.persister != null ) {
+		if ( this.session != null || persister != null ) {
 			throw new IllegalStateException( "already attached to a session." );
 		}
 		// IMPL NOTE: non-flushed changes code calls this method with session == null...
@@ -205,9 +205,9 @@ public abstract class EntityAction
 			final var resolvedPersister =
 					session.getFactory().getMappingMetamodel()
 							.getEntityDescriptor( entityName );
-			this.persister = resolvedPersister;
+			persister = resolvedPersister;
 			assert id != null;
-			this.instance =
+			instance =
 					session.getPersistenceContext()
 							.getEntity( session.generateEntityKey( id, resolvedPersister ) );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
@@ -69,7 +69,7 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 				session
 		);
 		this.isDelayed = isDelayed;
-		this.delayedEntityKey = useDelayedIdentifier ? generateDelayedEntityKey() : null;
+		delayedEntityKey = useDelayedIdentifier ? generateDelayedEntityKey() : null;
 	}
 
 	@Nonnull

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -99,12 +99,12 @@ public class EntityUpdateAction extends EntityAction {
 		this.previousState = previousState;
 		this.previousVersion = previousVersion;
 		this.nextVersion = nextVersion;
-		this.dirtyFields = dirtyProperties;
+		dirtyFields = dirtyProperties;
 		this.hasDirtyCollection = hasDirtyCollection;
 		this.rowId = rowId;
 
 		final var naturalIdMapping = persister.getNaturalIdMapping();
-		this.previousNaturalIdValues =
+		previousNaturalIdValues =
 				naturalIdMapping == null
 						? null
 						: determinePreviousNaturalIdValues( persister, naturalIdMapping, id, previousState, session );


### PR DESCRIPTION
This PR removes redundant `this` qualifiers identified by a new Checkstyle validation, [`RedundantThisCheck`](https://github.com/checkstyle/checkstyle/pull/20944).

The changes are limited to cases where removing `this` does not change name resolution or program behavior.

This validation is currently being evaluated against real-world projects, so feedback on whether these changes are considered desirable in this project would be particularly useful.

No functional behavior is intended to change.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
