### PR TITLE
HHH-20814 + HHH-20823 HbmXmlTransformer, transform entity and collection loaders 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1052,9 +1052,7 @@ public class HbmXmlTransformer {
 			mappingEntity.getSynchronizeTables().add( synchronizedTable );
 		}
 
-		if ( hbmClass.getLoader() != null ) {
-			handleUnsupported( "<loader/> is not supported in mapping.xsd - use <sql-select/> or <hql-select/> instead" );
-		}
+		transferEntityLoader( hbmClass, mappingEntity );
 
 		if ( !hbmClass.getTuplizer().isEmpty() ) {
 			handleUnsupported( "<tuplizer/> is not supported" );
@@ -3051,6 +3049,31 @@ public class HbmXmlTransformer {
 		}
 
 		transferCollectionLoader( source, target );
+	}
+
+	private void transferEntityLoader(EntityInfo hbmClass, JaxbEntityImpl mappingEntity) {
+		final var loader = hbmClass.getLoader();
+		if ( loader == null || isEmpty( loader.getQueryRef() ) ) {
+			return;
+		}
+		final String queryRef = loader.getQueryRef();
+
+		final var nativeQuery = findNamedNativeQuery( queryRef );
+		if ( nativeQuery != null ) {
+			mappingEntity.setSqlSelect( toSqlSelect( nativeQuery ) );
+			return;
+		}
+
+		final var hqlQuery = findNamedHqlQuery( queryRef );
+		if ( hqlQuery != null ) {
+			mappingEntity.setHqlSelect( extractQueryText( hqlQuery.getContent() ) );
+			return;
+		}
+
+		handleUnsupported(
+				"Entity <loader query-ref=\"%s\"> could not be resolved to a named query",
+				queryRef
+		);
 	}
 
 	private void transferCollectionLoader(PluralAttributeInfo source, JaxbPluralAttribute target) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -165,6 +165,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbSecondaryTableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbSingularAssociationAttribute;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbSingularFetchModeImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbSqlResultSetMappingImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbSqlSelectImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbSynchronizedTableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbTableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbTransientImpl;
@@ -1627,6 +1628,11 @@ public class HbmXmlTransformer {
 		final var hbmNativeQueries = hbmXmlBinding.getRoot().getSqlQuery();
 		if ( !hbmNativeQueries.isEmpty() ) {
 			for ( var hbmQuery : hbmNativeQueries ) {
+				// A <sql-query> containing <load-collection> is a collection loader, not a standalone
+				// named query - it is inlined as <sql-select> on the collection that references it.
+				if ( isCollectionLoaderQuery( hbmQuery ) ) {
+					continue;
+				}
 				// A callable <sql-query> maps to a <named-stored-procedure-query>, everything else
 				// maps to a <named-native-query>.
 				if ( hbmQuery.isCallable() ) {
@@ -1639,6 +1645,16 @@ public class HbmXmlTransformer {
 				}
 			}
 		}
+	}
+
+	private static boolean isCollectionLoaderQuery(JaxbHbmNamedNativeQueryType hbmQuery) {
+		for ( Object content : hbmQuery.getContent() ) {
+			if ( content instanceof JAXBElement<?> contentElement
+					&& contentElement.getValue() instanceof JaxbHbmNativeQueryCollectionLoadReturnType ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private JaxbNamedNativeQueryImpl transformNamedNativeQuery(JaxbHbmNamedNativeQueryType hbmQuery, String queryName) {
@@ -3033,6 +3049,82 @@ public class HbmXmlTransformer {
 			);
 			target.setClassification( LimitedCollectionClassification.LIST );
 		}
+
+		transferCollectionLoader( source, target );
+	}
+
+	private void transferCollectionLoader(PluralAttributeInfo source, JaxbPluralAttribute target) {
+		final var loader = source.getLoader();
+		if ( loader == null || isEmpty( loader.getQueryRef() ) ) {
+			return;
+		}
+		final String queryRef = loader.getQueryRef();
+
+		final var nativeQuery = findNamedNativeQuery( queryRef );
+		if ( nativeQuery != null ) {
+			target.setSqlSelect( toSqlSelect( nativeQuery ) );
+			return;
+		}
+
+		final var hqlQuery = findNamedHqlQuery( queryRef );
+		if ( hqlQuery != null ) {
+			target.setHqlSelect( extractQueryText( hqlQuery.getContent() ) );
+			return;
+		}
+
+		handleUnsupported(
+				"Collection <loader query-ref=\"%s\"> could not be resolved to a named query",
+				queryRef
+		);
+	}
+
+	private JaxbHbmNamedNativeQueryType findNamedNativeQuery(String queryName) {
+		for ( var hbmQuery : hbmXmlBinding.getRoot().getSqlQuery() ) {
+			if ( queryName.equals( hbmQuery.getName() ) ) {
+				return hbmQuery;
+			}
+		}
+		return null;
+	}
+
+	private JaxbHbmNamedQueryType findNamedHqlQuery(String queryName) {
+		for ( var hbmQuery : hbmXmlBinding.getRoot().getQuery() ) {
+			if ( queryName.equals( hbmQuery.getName() ) ) {
+				return hbmQuery;
+			}
+		}
+		return null;
+	}
+
+	private static JaxbSqlSelectImpl toSqlSelect(JaxbHbmNamedNativeQueryType nativeQuery) {
+		final var sqlSelect = new JaxbSqlSelectImpl();
+		for ( Object content : nativeQuery.getContent() ) {
+			if ( content instanceof String sql ) {
+				final String trimmed = sql.trim();
+				if ( !trimmed.isEmpty() ) {
+					sqlSelect.setSql( trimmed );
+				}
+			}
+			else if ( content instanceof JAXBElement<?> element
+					&& element.getValue() instanceof JaxbHbmSynchronizeType hbmSynchronize ) {
+				final var synchronize = new JaxbSynchronizedTableImpl();
+				synchronize.setTable( hbmSynchronize.getTable() );
+				sqlSelect.getSynchronize().add( synchronize );
+			}
+		}
+		return sqlSelect;
+	}
+
+	private static String extractQueryText(List<?> content) {
+		for ( Object element : content ) {
+			if ( element instanceof String queryText ) {
+				final String trimmed = queryText.trim();
+				if ( !trimmed.isEmpty() ) {
+					return trimmed;
+				}
+			}
+		}
+		return null;
 	}
 
 	private void transferCollectionId(JaxbHbmIdBagCollectionType idBag, JaxbPluralAttribute target) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -2042,6 +2042,33 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20814" )
+	public void testCollectionLoaderTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/collection-loader/hbm.xml", scope, transformed -> {
+			final JaxbEntityImpl ownerEntity = transformed.getEntities().stream()
+					.filter( e -> "Owner".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( ownerEntity.getAttributes().getOneToManyAttributes() ).hasSize( 1 );
+
+			final JaxbOneToManyImpl employments = ownerEntity.getAttributes().getOneToManyAttributes().get( 0 );
+			assertThat( employments.getName() ).isEqualTo( "employments" );
+
+			assertThat( employments.getSqlSelect() )
+					.as( "collection <loader query-ref> to a <load-collection> query should become <sql-select>" )
+					.isNotNull();
+			assertThat( employments.getSqlSelect().getSql() )
+					.as( "sql-select should carry the referenced native query SQL" )
+					.contains( "FROM Employment" );
+
+			assertThat( transformed.getNamedNativeQueries() )
+					.as( "a <load-collection> query is consumed as a collection loader and must not be emitted as a named native query" )
+					.noneMatch( q -> "ownerEmployments".equals( q.getName() ) );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20703" )
 	public void testCollectionTypeTypedefResolution(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/collection-type-typedef/hbm.xml", scope, transformed -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -2069,6 +2069,24 @@ public class HbmTransformationJaxbTests {
 	}
 
 	@Test
+	@JiraKey( "HHH-20823" )
+	public void testEntityLoaderTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/entity-loader/hbm.xml", scope, transformed -> {
+			final JaxbEntityImpl productEntity = transformed.getEntities().stream()
+					.filter( e -> "Product".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( productEntity.getSqlSelect() )
+					.as( "entity <loader query-ref> to a native query should become <sql-select>" )
+					.isNotNull();
+			assertThat( productEntity.getSqlSelect().getSql() )
+					.as( "sql-select should carry the referenced native query SQL" )
+					.contains( "FROM products" );
+		} );
+	}
+
+	@Test
 	@JiraKey( "HHH-20703" )
 	public void testCollectionTypeTypedefResolution(ServiceRegistryScope scope) {
 		transformAndVerify( "xml/jaxb/mapping/collection-type-typedef/hbm.xml", scope, transformed -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionloader/Employment.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionloader/Employment.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.collectionloader;
+
+public class Employment {
+	private Long id;
+	private Owner owner;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public Owner getOwner() {
+		return owner;
+	}
+
+	public void setOwner(Owner owner) {
+		this.owner = owner;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionloader/Owner.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/collectionloader/Owner.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.collectionloader;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class Owner {
+	private Long id;
+	private String name;
+	private Set<Employment> employments = new HashSet<>();
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Set<Employment> getEmployments() {
+		return employments;
+	}
+
+	public void setEmployments(Set<Employment> employments) {
+		this.employments = employments;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/entityloader/Product.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/entityloader/Product.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.jaxb.mapping.entityloader;
+
+public class Product {
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-loader/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/collection-loader/hbm.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.collectionloader" default-access="field">
+	<class name="Owner">
+		<id name="id" type="long">
+			<generator class="native"/>
+		</id>
+		<property name="name"/>
+		<set name="employments" inverse="true">
+			<key column="owner_id"/>
+			<one-to-many class="Employment"/>
+			<loader query-ref="ownerEmployments"/>
+		</set>
+	</class>
+
+	<class name="Employment">
+		<id name="id" type="long">
+			<generator class="native"/>
+		</id>
+		<many-to-one name="owner" column="owner_id"/>
+	</class>
+
+	<sql-query name="ownerEmployments">
+		<load-collection alias="e" role="Owner.employments"/>
+		SELECT *
+		FROM Employment e
+		WHERE e.owner_id = :id
+		ORDER BY e.id ASC
+	</sql-query>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/entity-loader/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/entity-loader/hbm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.hibernate.orm.test.boot.jaxb.mapping.entityloader" default-access="field">
+	<class name="Product">
+		<id name="id" type="long">
+			<generator class="native"/>
+		</id>
+		<property name="name"/>
+		<loader query-ref="loadProduct"/>
+	</class>
+
+	<sql-query name="loadProduct">
+		<return alias="p" class="Product"/>
+		SELECT *
+		FROM products p
+		WHERE p.id = ?
+	</sql-query>
+</hibernate-mapping>


### PR DESCRIPTION
- [HHH-20814](https://hibernate.atlassian.net/browse/HHH-20814) HbmXmlTransformer does not transform hbm collection loaders
- [HHH-20823](https://hibernate.atlassian.net/browse/HHH-20823) HbmXmlTransformer does not transform hbm entity loaders



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20823 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-20814 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

[HHH-20814]: https://hibernate.atlassian.net/browse/HHH-20814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-20823]: https://hibernate.atlassian.net/browse/HHH-20823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ