### PR TITLE
HHH-10815 Make ScrollableResults row numbering consistently 0-based

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/scrollable/FetchingScrollableResultsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/scrollable/FetchingScrollableResultsImpl.java
@@ -48,6 +48,8 @@ public class FetchingScrollableResultsImpl<R> extends AbstractScrollableResults<
 						? null
 						: queryOptions.getEffectiveLimit().getMaxRows();
 		beforeFirst = true;
+		afterLast = false;
+		currentPosition = 0;
 	}
 
 	@Override
@@ -72,6 +74,7 @@ public class FetchingScrollableResultsImpl<R> extends AbstractScrollableResults<
 				// no rows to read
 				currentPosition = 0;
 				beforeFirst = false;
+				afterLast = true;
 				return false;
 			}
 		}
@@ -81,11 +84,8 @@ public class FetchingScrollableResultsImpl<R> extends AbstractScrollableResults<
 		beforeFirst = false;
 		currentPosition++;
 
-		if ( last ) {
-			if ( maxPosition == null ) {
-				// we just hit the last position
-				maxPosition = currentPosition;
-			}
+		if ( last && maxPosition == null ) {
+			maxPosition = currentPosition;
 		}
 
 		afterScrollOperation();
@@ -200,7 +200,38 @@ public class FetchingScrollableResultsImpl<R> extends AbstractScrollableResults<
 
 	@Override
 	public boolean position(int position) {
-		return setRowNumber( position );
+		if ( position == 1 ) {
+			return first();
+		}
+		else if ( position == -1 || maxPosition != null && position == maxPosition ) {
+			return last();
+		}
+		else if ( position < 0 && maxPosition == null ) {
+			/*
+			 * We need to discover the end before resolving a negative
+			 * position such as -2.
+			 */
+			while ( next() ) {
+				// continue until after the last logical row
+			}
+			return scroll( position );
+		}
+		else {
+			final int targetPosition =
+					position < 0
+							? maxPosition + position + 1
+							: position;
+			if ( targetPosition <= 0 ) {
+				afterLast();
+				return false;
+			}
+			if ( maxPosition != null && targetPosition > maxPosition ) {
+				afterLast();
+				return false;
+			}
+
+			return scroll( targetPosition - currentPosition );
+		}
 	}
 
 	@Override
@@ -269,7 +300,9 @@ public class FetchingScrollableResultsImpl<R> extends AbstractScrollableResults<
 
 	@Override
 	public int getRowNumber() {
-		return currentPosition - 1;
+		return currentPosition == 0 || afterLast
+				? -1
+				: currentPosition - 1;
 	}
 
 	@Override
@@ -279,23 +312,7 @@ public class FetchingScrollableResultsImpl<R> extends AbstractScrollableResults<
 
 	@Override
 	public boolean setRowNumber(int rowNumber) {
-		if ( rowNumber == 1 ) {
-			return first();
-		}
-		else if ( rowNumber == -1 || maxPosition != null && rowNumber == maxPosition ) {
-			return last();
-		}
-		else if ( rowNumber < 0 && maxPosition == null ) {
-			while ( next() ) {
-				// skip all the way to the end (inefficiently)
-			}
-			return scroll( rowNumber );
-		}
-		else {
-			// rowNumber -1 is the same as maxPosition
-			final int targetRowNumber = rowNumber < 0 ? maxPosition + rowNumber + 1 : rowNumber;
-			return scroll( targetRowNumber - currentPosition );
-		}
+		return position( rowNumber >= 0 ? rowNumber + 1 : rowNumber );
 	}
 
 	private boolean prepareCurrentRow() {

--- a/hibernate-core/src/main/java/org/hibernate/internal/scrollable/ScrollableResultsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/scrollable/ScrollableResultsImpl.java
@@ -117,7 +117,7 @@ public class ScrollableResultsImpl<R> extends AbstractScrollableResults<R> {
 
 	@Override
 	public boolean setRowNumber(int rowNumber) {
-		return position( rowNumber );
+		return position( rowNumber >= 0 ? rowNumber + 1 : rowNumber );
 	}
 
 	private void prepareCurrentRow(boolean underlyingScrollSuccessful) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hqlfetchscroll/HQLScrollFetchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hqlfetchscroll/HQLScrollFetchTest.java
@@ -338,6 +338,179 @@ public class HQLScrollFetchTest {
 		);
 	}
 
+	@Test
+	@JiraKey("HHH-10815")
+	public void testScrollableResultsGetRowNumber(SessionFactoryScope scope) {
+		createFiveParentsWithNoChild( scope );
+
+		scope.inTransaction(
+				s -> {
+					try (
+							ScrollableResults<Parent> fetchResult = s.createQuery(
+									"from Parent p left join fetch p.children order by p.id",
+									Parent.class
+							).scroll();
+
+							ScrollableResults<Parent> standardResult = s.createQuery(
+									"from Parent p order by p.id",
+									Parent.class
+							).scroll()
+					) {
+						standardResult.first();
+						fetchResult.first();
+
+						assertEquals(
+								0,
+								standardResult.getRowNumber(),
+								"row number must be 0 on first result"
+						);
+						assertEquals(
+								0,
+								fetchResult.getRowNumber(),
+								"row number must be 0 on first result"
+						);
+
+						standardResult.next();
+						fetchResult.next();
+
+						assertEquals(
+								1,
+								standardResult.getRowNumber(),
+								"row number must be 1 on next result"
+						);
+						assertEquals(
+								1,
+								fetchResult.getRowNumber(),
+								"row number must be 1 on next result"
+						);
+
+						standardResult.last();
+						fetchResult.last();
+
+						assertEquals(
+								standardResult.getRowNumber(),
+								fetchResult.getRowNumber(),
+								"Both results should have the same row number"
+						);
+					}
+				}
+		);
+	}
+
+	@Test
+	@JiraKey("HHH-10815")
+	public void testScrollableResultsSetRowNumber(SessionFactoryScope scope) {
+		createFiveParentsWithNoChild( scope );
+
+		scope.inTransaction(
+				s -> {
+					try (
+							ScrollableResults<Parent> fetchResult = s.createQuery(
+									"from Parent p left join fetch p.children order by p.id",
+									Parent.class
+							).scroll();
+
+							ScrollableResults<Parent> standardResult = s.createQuery(
+									"from Parent p order by p.id",
+									Parent.class
+							).scroll()
+					) {
+						for ( int rowNumber = 0; rowNumber < 5; rowNumber++ ) {
+							assertTrue( standardResult.setRowNumber( rowNumber ) );
+							assertTrue( fetchResult.setRowNumber( rowNumber ) );
+
+							assertEquals(
+									standardResult.get(),
+									fetchResult.get(),
+									"Both results should point to the same row"
+							);
+
+							assertEquals(
+									rowNumber,
+									standardResult.getRowNumber()
+							);
+
+							assertEquals(
+									rowNumber,
+									fetchResult.getRowNumber()
+							);
+						}
+					}
+				}
+		);
+	}
+
+	@Test
+	@JiraKey("HHH-10815")
+	public void testScrollableResultsSetNegativeRowNumber(SessionFactoryScope scope) {
+		createFiveParentsWithNoChild( scope );
+
+		scope.inTransaction(
+				s -> {
+					try (
+							ScrollableResults<Parent> fetchResult = s.createQuery(
+									"from Parent p left join fetch p.children order by p.id",
+									Parent.class
+							).scroll();
+
+							ScrollableResults<Parent> standardResult = s.createQuery(
+									"from Parent p order by p.id",
+									Parent.class
+							).scroll()
+					) {
+						assertTrue( standardResult.setRowNumber( -1 ) );
+						assertTrue( fetchResult.setRowNumber( -1 ) );
+
+						assertEquals(
+								standardResult.get(),
+								fetchResult.get()
+						);
+
+						assertEquals(
+								4,
+								standardResult.getRowNumber()
+						);
+
+						assertEquals(
+								4,
+								fetchResult.getRowNumber()
+						);
+
+						assertTrue( standardResult.setRowNumber( -2 ) );
+						assertTrue( fetchResult.setRowNumber( -2 ) );
+
+						assertEquals(
+								standardResult.get(),
+								fetchResult.get()
+						);
+
+						assertEquals(
+								3,
+								standardResult.getRowNumber()
+						);
+
+						assertEquals(
+								3,
+								fetchResult.getRowNumber()
+						);
+					}
+				}
+		);
+	}
+
+	private void createFiveParentsWithNoChild(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+
+		scope.inTransaction(
+				s -> {
+					for ( int i = 0; i < 5; i++ ) {
+						Parent p = new Parent( "parent" + i );
+						s.persist( p );
+					}
+				}
+		);
+	}
+
 	private void assertResultFromOneUser(Parent parent) {
 		assertEquals(
 				3,


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

This resolves the inconsistency reported in HHH-10815 where
FetchingScrollableResultsImpl did not accept setRowNumber(0) and
returned different row numbers than ScrollableResultsImpl for the same
logical position.

https://hibernate.atlassian.net/browse/HHH-10815

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-10815 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->