### PR TITLE
HHH-20792 - Flip the default for hibernate.type.java_time_use_direct_jdbc (8.0)

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Configuration.adoc
+++ b/documentation/src/main/asciidoc/introduction/Configuration.adoc
@@ -613,27 +613,21 @@ Alternatively, you can configure SQL Server to use the UTF-8 enabled collation `
 [[datetime-jdbc]]
 === Date and time types and JDBC
 
-By default, Hibernate handles date and time types defined by `java.time` by:
+Hibernate highly recommends that applications use `java.time` types to represent temporal-related values.
+When `java.time` types are used, Hibernate will by default use those types directly at the JDBC boundary.
+JDBC drivers are required to directly support `java.time` types since Java 8 (JDBC 4.2).
 
-- converting `java.time` types to JDBC date/time types defined in `java.sql` when sending data to the database, and
-- reading `java.sql` types from JDBC and then converting them to `java.time` types when retrieving data from the database.
+[NOTE]
+====
+This is a change since version 8.0.  Previous versions, by default, would perform a conversion between
+`java.time` and `java.sql` date/time types and use the `java.sql` types at the JDBC boundary.
 
-This works best when the database server time zone agrees with JVM system time zone.
+This change in behavior can have subtle impacts on legacy applications migrating to 8.0.
+Set `hibernate.type.java_time_use_direct_jdbc` to `false` to retain the legacy behavior.
+====
 
-TIP: We therefore recommend setting things up so that the database server and the JVM agree on the same time zone. **Hint:** when in doubt, UTC is quite a nice time zone.
+When `java.sql` date/time types are used (either in the model or by disabling
+`hibernate.type.java_time_use_direct_jdbc`) it is important to make sure that
+database server time zone agrees with JVM system time zone.  This is achieved using
+the `hibernate.jdbc.time_zone` setting.
 
-There are two system configuration properties which influence this behavior:
-
-.Settings for JDBC date/time handling
-[%breakable,cols="35,~"]
-|===
-| Configuration property name           | Purpose
-
-| link:{doc-javadoc-url}org/hibernate/cfg/JdbcSettings.html#JDBC_TIME_ZONE[`hibernate.jdbc.time_zone`]          | Use an explicit time zone when interacting with JDBC
-| link:{doc-javadoc-url}org/hibernate/cfg/MappingSettings.html#JAVA_TIME_USE_DIRECT_JDBC[`hibernate.type.java_time_use_direct_jdbc`] | Read and write `java.time` types directly to and from JDBC
-|===
-
-You may set `hibernate.jdbc.time_zone` to the time zone of the database server if for some reason the JVM needs to operate in a different time zone.
-We do not recommend this approach.
-
-On the other hand, we would love to recommend the use of `hibernate.type.java_time_use_direct_jdbc`, but this option is still experimental for now, and does result in some subtle differences in behavior which might affect legacy programs using Hibernate.

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
@@ -17,6 +17,7 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
+import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.jpa.internal.MutableJpaComplianceImpl;
@@ -100,7 +101,9 @@ public class BootstrapContextImpl implements BootstrapContext {
 
 		representationStrategySelector = ManagedTypeRepresentationResolverStandard.INSTANCE;
 
-		typeConfiguration = new TypeConfiguration();
+		typeConfiguration = new TypeConfiguration(
+				MetadataBuildingContext.isPreferJavaTimeJdbcTypesEnabled( configService )
+		);
 		beanInstanceProducer = new TypeBeanInstanceProducer( configService, serviceRegistry );
 		sqmFunctionRegistry = new SqmFunctionRegistry();
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
@@ -110,7 +110,7 @@ public class VersionResolution<E> implements BasicValue.Resolution<E> {
 		final var basicTypeRegistry = typeConfiguration.getBasicTypeRegistry();
 		final var basicType = basicTypeRegistry.resolve( basicJavaType, recommendedJdbcType );
 		final var legacyType = basicTypeRegistry.getRegisteredType( basicJavaType.getJavaTypeClass() );
-		assert legacyType.getJdbcType().getDefaultSqlTypeCode() == recommendedJdbcType.getDefaultSqlTypeCode();
+		assert legacyType.getJdbcType().getDdlTypeCode() == recommendedJdbcType.getDdlTypeCode();
 
 		return new VersionResolution<>( basicJavaType, recommendedJdbcType, basicType, legacyType );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingContext.java
@@ -16,6 +16,7 @@ import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.service.ServiceRegistry;
 
 import static org.hibernate.cfg.MappingSettings.JAVA_TIME_USE_DIRECT_JDBC;
+import static org.hibernate.cfg.MappingSettings.JAVA_TIME_USE_DIRECT_JDBC_DEFAULT;
 import static org.hibernate.cfg.MappingSettings.PREFER_LOCALE_LANGUAGE_TAG;
 import static org.hibernate.cfg.MappingSettings.PREFER_NATIVE_ENUM_TYPES;
 import static org.hibernate.audit.AuditStrategy.DEFAULT;
@@ -135,7 +136,11 @@ public interface MetadataBuildingContext {
 
 	@Remove
 	static boolean isPreferJavaTimeJdbcTypesEnabled(ConfigurationService configurationService) {
-		return getBoolean( JAVA_TIME_USE_DIRECT_JDBC, configurationService.getSettings() );
+		return getBoolean(
+				JAVA_TIME_USE_DIRECT_JDBC,
+				configurationService.getSettings(),
+				JAVA_TIME_USE_DIRECT_JDBC_DEFAULT
+		);
 	}
 
 	@Remove

--- a/hibernate-core/src/main/java/org/hibernate/cfg/MappingSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/MappingSettings.java
@@ -248,12 +248,19 @@ public interface MappingSettings {
 	 * See {@linkplain #PREFERRED_INSTANT_JDBC_TYPE}, {@linkplain org.hibernate.type.SqlTypes#INSTANT} and
 	 * {@linkplain org.hibernate.type.descriptor.jdbc.InstantJdbcType}.
 	 *
-	 * @settingDefault false
+	 * @settingDefault {@value #JAVA_TIME_USE_DIRECT_JDBC_DEFAULT}
 	 *
 	 * @since 6.5
 	 */
 	@Incubating
 	String JAVA_TIME_USE_DIRECT_JDBC = "hibernate.type.java_time_use_direct_jdbc";
+
+	/**
+	 * The default value for {@link #JAVA_TIME_USE_DIRECT_JDBC}.
+	 *
+	 * @since 8.0
+	 */
+	boolean JAVA_TIME_USE_DIRECT_JDBC_DEFAULT = true;
 
 	/**
 	 * Indicates that named SQL {@code enum} types should be used by default instead

--- a/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
@@ -31,6 +31,8 @@ import java.util.UUID;
 import jakarta.persistence.TemporalType;
 import org.hibernate.type.spi.TypeConfiguration;
 
+import static org.hibernate.cfg.MappingSettings.JAVA_TIME_USE_DIRECT_JDBC_DEFAULT;
+
 /**
  * References to common instances of {@link BasicTypeReference}.
  *
@@ -844,6 +846,10 @@ public final class StandardBasicTypes {
 
 
 	public static void prime(TypeConfiguration typeConfiguration) {
+		prime( typeConfiguration, JAVA_TIME_USE_DIRECT_JDBC_DEFAULT );
+	}
+
+	public static void prime(TypeConfiguration typeConfiguration, boolean javaTimeUseDirectJdbc) {
 		BasicTypeRegistry basicTypeRegistry = typeConfiguration.getBasicTypeRegistry();
 
 		if ( basicTypeRegistry.isPrimed() ) {
@@ -1108,6 +1114,24 @@ public final class StandardBasicTypes {
 
 		//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		// date / time data
+		final BasicTypeReference<LocalDateTime> localDateTimeType = javaTimeUseDirectJdbc
+				? javaTimeType( LOCAL_DATE_TIME, SqlTypes.LOCAL_DATE_TIME )
+				: LOCAL_DATE_TIME;
+		final BasicTypeReference<LocalDate> localDateType = javaTimeUseDirectJdbc
+				? javaTimeType( LOCAL_DATE, SqlTypes.LOCAL_DATE )
+				: LOCAL_DATE;
+		final BasicTypeReference<LocalTime> localTimeType = javaTimeUseDirectJdbc
+				? javaTimeType( LOCAL_TIME, SqlTypes.LOCAL_TIME )
+				: LOCAL_TIME;
+		final BasicTypeReference<OffsetDateTime> offsetDateTimeType = javaTimeUseDirectJdbc
+				? javaTimeType( OFFSET_DATE_TIME, SqlTypes.OFFSET_DATE_TIME )
+				: OFFSET_DATE_TIME;
+		final BasicTypeReference<OffsetTime> offsetTimeType = javaTimeUseDirectJdbc
+				? javaTimeType( OFFSET_TIME, SqlTypes.OFFSET_TIME )
+				: OFFSET_TIME;
+		final BasicTypeReference<ZonedDateTime> zonedDateTimeType = javaTimeUseDirectJdbc
+				? javaTimeType( ZONED_DATE_TIME, SqlTypes.ZONED_DATE_TIME )
+				: ZONED_DATE_TIME;
 
 		handle(
 				DURATION,
@@ -1117,28 +1141,28 @@ public final class StandardBasicTypes {
 		);
 
 		handle(
-				LOCAL_DATE_TIME,
+				localDateTimeType,
 				"org.hibernate.type.LocalDateTimeType",
 				basicTypeRegistry,
 				LocalDateTime.class.getSimpleName(), LocalDateTime.class.getName()
 		);
 
 		handle(
-				LOCAL_DATE,
+				localDateType,
 				"org.hibernate.type.LocalDateType",
 				basicTypeRegistry,
 				LocalDate.class.getSimpleName(), LocalDate.class.getName()
 		);
 
 		handle(
-				LOCAL_TIME,
+				localTimeType,
 				"org.hibernate.type.LocalTimeType",
 				basicTypeRegistry,
 				LocalTime.class.getSimpleName(), LocalTime.class.getName()
 		);
 
 		handle(
-				OFFSET_DATE_TIME,
+				offsetDateTimeType,
 				"org.hibernate.type.OffsetDateTimeType",
 				basicTypeRegistry,
 				OffsetDateTime.class.getSimpleName(), OffsetDateTime.class.getName()
@@ -1159,7 +1183,7 @@ public final class StandardBasicTypes {
 		);
 
 		handle(
-				OFFSET_TIME,
+				offsetTimeType,
 				"org.hibernate.type.OffsetTimeType",
 				basicTypeRegistry,
 				OffsetTime.class.getSimpleName(), OffsetTime.class.getName()
@@ -1187,7 +1211,7 @@ public final class StandardBasicTypes {
 		);
 
 		handle(
-				ZONED_DATE_TIME,
+				zonedDateTimeType,
 				"org.hibernate.type.ZonedDateTimeType",
 				basicTypeRegistry,
 				ZonedDateTime.class.getSimpleName(), ZonedDateTime.class.getName()
@@ -1461,6 +1485,16 @@ public final class StandardBasicTypes {
 		handle( serializableImmutableType, null, basicTypeRegistry, serializableImmutableType.getName() );
 
 		basicTypeRegistry.primed();
+	}
+
+	private static <T> BasicTypeReference<T> javaTimeType(
+			BasicTypeReference<T> standardType,
+			int directJdbcTypeCode) {
+		return new BasicTypeReference<>(
+				standardType.getName(),
+				standardType.getJavaType(),
+				directJdbcTypeCode
+		);
 	}
 
 	private static void handle(

--- a/hibernate-core/src/main/java/org/hibernate/type/format/OsonDocumentWriter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/format/OsonDocumentWriter.java
@@ -196,6 +196,14 @@ public class OsonDocumentWriter implements JsonDocumentWriter {
 			case SqlTypes.NAMED_ENUM:
 				generator.write( javaType.toString( (T)value ) );
 				break;
+			case SqlTypes.LOCAL_DATE:
+			case SqlTypes.LOCAL_TIME:
+			case SqlTypes.LOCAL_DATE_TIME:
+			case SqlTypes.OFFSET_TIME:
+			case SqlTypes.OFFSET_DATE_TIME:
+			case SqlTypes.ZONED_DATE_TIME:
+				generator.write( javaType.toString( (T)value ) );
+				break;
 			case SqlTypes.DATE:
 				DATE dd = new DATE(javaType.unwrap( (T)value,java.sql.Date.class,options ));
 				OracleJsonDate jsonDate = new OracleJsonDateImpl(dd.shareBytes());

--- a/hibernate-core/src/main/java/org/hibernate/type/format/StringJsonDocumentWriter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/format/StringJsonDocumentWriter.java
@@ -313,6 +313,16 @@ public class StringJsonDocumentWriter extends StringJsonDocument implements Json
 				appender.endEscaping();
 				appender.append( StringJsonDocumentMarker.QUOTE.getMarkerCharacter() );
 				break;
+			case SqlTypes.LOCAL_DATE:
+			case SqlTypes.LOCAL_TIME:
+			case SqlTypes.LOCAL_DATE_TIME:
+			case SqlTypes.OFFSET_TIME:
+			case SqlTypes.OFFSET_DATE_TIME:
+			case SqlTypes.ZONED_DATE_TIME:
+				appender.append( StringJsonDocumentMarker.QUOTE.getMarkerCharacter() );
+				javaType.appendEncodedString( appender, (T) value );
+				appender.append( StringJsonDocumentMarker.QUOTE.getMarkerCharacter() );
+				break;
 			case SqlTypes.DATE:
 				appender.append( StringJsonDocumentMarker.QUOTE.getMarkerCharacter() );
 				JdbcDateJavaType.INSTANCE.appendEncodedString(

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -83,6 +83,7 @@ import org.hibernate.type.internal.ParameterizedTypeImpl;
 
 import jakarta.persistence.TemporalType;
 
+import static org.hibernate.cfg.MappingSettings.JAVA_TIME_USE_DIRECT_JDBC_DEFAULT;
 import static org.hibernate.id.uuid.LocalObjectUuidHelper.generateLocalObjectUuid;
 import static org.hibernate.internal.util.NullnessUtil.castNonNull;
 import static org.hibernate.internal.util.type.PrimitiveWrappers.canonicalize;
@@ -134,12 +135,16 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 	private final transient Map<Integer, Set<String>> jdbcToHibernateTypeContributionMap = new HashMap<>();
 
 	public TypeConfiguration() {
+		this( JAVA_TIME_USE_DIRECT_JDBC_DEFAULT );
+	}
+
+	public TypeConfiguration(boolean javaTimeUseDirectJdbc) {
 		scope = new Scope( this );
 		javaTypeRegistry = new JavaTypeRegistry( this );
 		jdbcTypeRegistry = new JdbcTypeRegistry( this );
 		ddlTypeRegistry = new DdlTypeRegistry( this );
 		basicTypeRegistry = new BasicTypeRegistry( this );
-		StandardBasicTypes.prime( this );
+		StandardBasicTypes.prime( this, javaTimeUseDirectJdbc );
 	}
 
 	public String getUuid() {

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -930,11 +930,13 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 	@SuppressWarnings("deprecation")
 	protected static @Nullable TemporalType getSqlTemporalType(int jdbcTypeCode) {
 		return switch ( jdbcTypeCode ) {
-			case SqlTypes.TIMESTAMP, SqlTypes.TIMESTAMP_WITH_TIMEZONE, SqlTypes.TIMESTAMP_UTC
+			case SqlTypes.TIMESTAMP, SqlTypes.TIMESTAMP_WITH_TIMEZONE, SqlTypes.TIMESTAMP_UTC,
+					SqlTypes.LOCAL_DATE_TIME, SqlTypes.OFFSET_DATE_TIME, SqlTypes.ZONED_DATE_TIME
 					-> TemporalType.TIMESTAMP;
-			case SqlTypes.TIME, SqlTypes.TIME_WITH_TIMEZONE, SqlTypes.TIME_UTC
+			case SqlTypes.TIME, SqlTypes.TIME_WITH_TIMEZONE, SqlTypes.TIME_UTC,
+					SqlTypes.LOCAL_TIME, SqlTypes.OFFSET_TIME
 					-> TemporalType.TIME;
-			case SqlTypes.DATE
+			case SqlTypes.DATE, SqlTypes.LOCAL_DATE
 					-> TemporalType.DATE;
 			default -> null;
 		};

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/LocalDateMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/LocalDateMappingTests.java
@@ -4,16 +4,17 @@
  */
 package org.hibernate.orm.test.mapping.basic;
 
-import java.sql.Types;
 import java.time.LocalDate;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -32,15 +33,19 @@ public class LocalDateMappingTests {
 
 	@Test
 	public void verifyMappings(SessionFactoryScope scope) {
-		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
-				.getRuntimeMetamodels()
-				.getMappingMetamodel();
+		final SessionFactoryImplementor sf = scope.getSessionFactory();
+
+		final MappingMetamodelImplementor mappingMetamodel = sf.getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor(EntityWithLocalDate.class);
 
 		final BasicAttributeMapping duration = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("localDate");
 		final JdbcMapping jdbcMapping = duration.getJdbcMapping();
 		assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(LocalDate.class));
-		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), equalTo( Types.DATE));
+
+		final int expectedJdbcType  = sf.getSessionFactoryOptions().isPreferJavaTimeJdbcTypesEnabled()
+				? SqlTypes.LOCAL_DATE
+				: SqlTypes.DATE;
+		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), equalTo( expectedJdbcType ));
 
 		scope.inTransaction(
 				(session) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/LocalDateTimeMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/LocalDateTimeMappingTests.java
@@ -4,16 +4,17 @@
  */
 package org.hibernate.orm.test.mapping.basic;
 
-import java.sql.Types;
 import java.time.LocalDateTime;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -32,15 +33,19 @@ public class LocalDateTimeMappingTests {
 
 	@Test
 	public void verifyMappings(SessionFactoryScope scope) {
-		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
-				.getRuntimeMetamodels()
-				.getMappingMetamodel();
+		final SessionFactoryImplementor sf = scope.getSessionFactory();
+
+		final MappingMetamodelImplementor mappingMetamodel = sf.getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor(EntityWithLocalDateTime.class);
 
 		final BasicAttributeMapping duration = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("localDateTime");
 		final JdbcMapping jdbcMapping = duration.getJdbcMapping();
 		assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(LocalDateTime.class));
-		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), equalTo( Types.TIMESTAMP));
+
+		final int expectedJdbcType = sf.getSessionFactoryOptions().isPreferJavaTimeJdbcTypesEnabled()
+				? SqlTypes.LOCAL_DATE_TIME
+				: SqlTypes.TIMESTAMP;
+		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), equalTo( expectedJdbcType ) );
 
 		scope.inTransaction(
 				(session) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/LocalTimeMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/LocalTimeMappingTests.java
@@ -4,17 +4,18 @@
  */
 package org.hibernate.orm.test.mapping.basic;
 
-import java.sql.Types;
 import java.time.LocalTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -33,15 +34,19 @@ public class LocalTimeMappingTests {
 
 	@Test
 	public void verifyMappings(SessionFactoryScope scope) {
-		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
-				.getRuntimeMetamodels()
-				.getMappingMetamodel();
+		final SessionFactoryImplementor sf = scope.getSessionFactory();
+
+		final MappingMetamodelImplementor mappingMetamodel = sf.getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor(EntityWithLocalTime.class);
 
 		final BasicAttributeMapping duration = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("localTime");
 		final JdbcMapping jdbcMapping = duration.getJdbcMapping();
 		assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(LocalTime.class));
-		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), equalTo( Types.TIME));
+
+		final int expectedJdbcType = sf.getSessionFactoryOptions().isPreferJavaTimeJdbcTypesEnabled()
+				? SqlTypes.LOCAL_TIME
+				: SqlTypes.TIME;
+		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), equalTo( expectedJdbcType ) );
 
 		scope.inTransaction(
 				(session) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/OffsetDateTimeMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/OffsetDateTimeMappingTests.java
@@ -4,21 +4,24 @@
  */
 package org.hibernate.orm.test.mapping.basic;
 
-import java.sql.Types;
 import java.time.OffsetDateTime;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
+
+import org.hamcrest.Matcher;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -33,15 +36,19 @@ public class OffsetDateTimeMappingTests {
 
 	@Test
 	public void verifyMappings(SessionFactoryScope scope) {
-		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
-				.getRuntimeMetamodels()
-				.getMappingMetamodel();
+		final SessionFactoryImplementor sf = scope.getSessionFactory();
+
+		final MappingMetamodelImplementor mappingMetamodel = sf.getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor(EntityWithOffsetDateTime.class);
 
 		final BasicAttributeMapping attributeMapping = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("offsetDateTime");
 		final JdbcMapping jdbcMapping = attributeMapping.getJdbcMapping();
 		assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(OffsetDateTime.class));
-		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), isOneOf( Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE));
+
+		final Matcher<Integer> expectedJdbcType = sf.getSessionFactoryOptions().isPreferJavaTimeJdbcTypesEnabled()
+				? equalTo( SqlTypes.OFFSET_DATE_TIME )
+				: isOneOf( SqlTypes.TIMESTAMP, SqlTypes.TIMESTAMP_WITH_TIMEZONE );
+		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), expectedJdbcType );
 
 		scope.inTransaction(
 				(session) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/OffsetTimeMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/OffsetTimeMappingTests.java
@@ -4,21 +4,24 @@
  */
 package org.hibernate.orm.test.mapping.basic;
 
-import java.sql.Types;
 import java.time.OffsetTime;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
+
+import org.hamcrest.Matcher;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -33,18 +36,19 @@ public class OffsetTimeMappingTests {
 
 	@Test
 	public void verifyMappings(SessionFactoryScope scope) {
-		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
-				.getRuntimeMetamodels()
-				.getMappingMetamodel();
+		final SessionFactoryImplementor sf = scope.getSessionFactory();
+
+		final MappingMetamodelImplementor mappingMetamodel = sf.getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor(EntityWithOffsetTime.class);
 
 		final BasicAttributeMapping attributeMapping = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("offsetTime");
 		final JdbcMapping jdbcMapping = attributeMapping.getJdbcMapping();
 		assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(OffsetTime.class));
-		assertThat(
-				jdbcMapping.getJdbcType().getJdbcTypeCode(),
-				isOneOf( Types.TIME, Types.TIMESTAMP_WITH_TIMEZONE, Types.TIME_WITH_TIMEZONE )
-		);
+
+		final Matcher<Integer> expectedJdbcType = sf.getSessionFactoryOptions().isPreferJavaTimeJdbcTypesEnabled()
+				? equalTo( SqlTypes.OFFSET_TIME )
+				: isOneOf( SqlTypes.TIME, SqlTypes.TIMESTAMP_WITH_TIMEZONE, SqlTypes.TIME_WITH_TIMEZONE );
+		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), expectedJdbcType );
 
 		scope.inTransaction(
 				(session) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/TimeZoneStorageMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/TimeZoneStorageMappingTests.java
@@ -47,7 +47,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 @DomainModel(annotatedClasses = TimeZoneStorageMappingTests.TimeZoneStorageEntity.class)
 @SessionFactory
-@ServiceRegistry(settings = @Setting( name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "AUTO"))
+@ServiceRegistry(settings = {
+		@Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "AUTO"),
+		@Setting(name = AvailableSettings.JAVA_TIME_USE_DIRECT_JDBC, value = "false")
+})
 public class TimeZoneStorageMappingTests {
 
 	private static final ZoneOffset JVM_TIMEZONE_OFFSET = OffsetDateTime.now().getOffset();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/ZonedDateTimeMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/ZonedDateTimeMappingTests.java
@@ -4,21 +4,24 @@
  */
 package org.hibernate.orm.test.mapping.basic;
 
-import java.sql.Types;
 import java.time.ZonedDateTime;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
+
+import org.hamcrest.Matcher;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -33,15 +36,19 @@ public class ZonedDateTimeMappingTests {
 
 	@Test
 	public void verifyMappings(SessionFactoryScope scope) {
-		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
-				.getRuntimeMetamodels()
-				.getMappingMetamodel();
+		final SessionFactoryImplementor sf = scope.getSessionFactory();
+
+		final MappingMetamodelImplementor mappingMetamodel = sf.getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor(EntityWithZonedDateTime.class);
 
 		final BasicAttributeMapping attributeMapping = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("zonedDateTime");
 		final JdbcMapping jdbcMapping = attributeMapping.getJdbcMapping();
 		assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(ZonedDateTime.class));
-		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), isOneOf( Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE));
+
+		final Matcher<Integer> expectedJdbcType = sf.getSessionFactoryOptions().isPreferJavaTimeJdbcTypesEnabled()
+				? equalTo( SqlTypes.ZONED_DATE_TIME )
+				: isOneOf( SqlTypes.TIMESTAMP, SqlTypes.TIMESTAMP_WITH_TIMEZONE );
+		assertThat( jdbcMapping.getJdbcType().getJdbcTypeCode(), expectedJdbcType );
 
 		scope.inTransaction(
 				(session) -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/GlobalJavaTimeJdbcTypeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/GlobalJavaTimeJdbcTypeTests.java
@@ -25,6 +25,7 @@ import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
+import org.hibernate.testing.orm.junit.Setting;
 import org.hibernate.type.descriptor.jdbc.JavaTimeJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.LocalDateJdbcType;
@@ -37,7 +38,6 @@ import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.Setting;
 import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ import static org.hibernate.type.descriptor.DateTimeUtils.adjustToDefaultPrecisi
 import static org.hibernate.type.descriptor.DateTimeUtils.adjustToPrecision;
 
 /**
- * Tests for "direct" JDBC handling of {@linkplain java.time Java Time} types.
+ * Tests the default, direct JDBC handling of {@linkplain java.time Java Time} types.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/GlobalJavaTimeJdbcTypeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/GlobalJavaTimeJdbcTypeTests.java
@@ -68,20 +68,22 @@ public class GlobalJavaTimeJdbcTypeTests {
 	void testMappings(DomainModelScope scope) {
 		final PersistentClass entityBinding = scope.getEntityBinding( EntityWithJavaTimeValues.class );
 
-		checkAttribute( entityBinding, "theLocalDate", LocalDateJdbcType.class );
-		checkAttribute( entityBinding, "theLocalDateTime", LocalDateTimeJdbcType.class );
-		checkAttribute( entityBinding, "theLocalTime", LocalTimeJdbcType.class );
+		checkAttribute( entityBinding, "theLocalDate", LocalDateJdbcType.class, "LocalDate" );
+		checkAttribute( entityBinding, "theLocalDateTime", LocalDateTimeJdbcType.class, "LocalDateTime" );
+		checkAttribute( entityBinding, "theLocalTime", LocalTimeJdbcType.class, "LocalTime" );
 	}
 
 	private void checkAttribute(
 			PersistentClass entityBinding,
 			String attributeName,
-			Class<? extends JavaTimeJdbcType> expectedJdbcTypeDescriptorType) {
+			Class<? extends JavaTimeJdbcType> expectedJdbcTypeDescriptorType,
+			String expectedTypeName) {
 		final Property property = entityBinding.getProperty( attributeName );
 		final BasicValue value = (BasicValue) property.getValue();
 		final BasicValue.Resolution<?> resolution = value.resolve();
 		final JdbcType jdbcType = resolution.getJdbcType();
 		assertThat( jdbcType ).isInstanceOf( expectedJdbcTypeDescriptorType );
+		assertThat( resolution.getLegacyResolvedBasicType().getName() ).isEqualTo( expectedTypeName );
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/JavaTimeJdbcTypeBaselineTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/JavaTimeJdbcTypeBaselineTests.java
@@ -48,20 +48,22 @@ public class JavaTimeJdbcTypeBaselineTests {
 	void testMappings(DomainModelScope scope) {
 		final PersistentClass entityBinding = scope.getEntityBinding( EntityWithJavaTimeValues.class );
 
-		checkAttribute( entityBinding, "theLocalDate", DateJdbcType.class );
-		checkAttribute( entityBinding, "theLocalDateTime", TimestampJdbcType.class );
-		checkAttribute( entityBinding, "theLocalTime", TimeJdbcType.class );
+		checkAttribute( entityBinding, "theLocalDate", DateJdbcType.class, "LocalDate" );
+		checkAttribute( entityBinding, "theLocalDateTime", TimestampJdbcType.class, "LocalDateTime" );
+		checkAttribute( entityBinding, "theLocalTime", TimeJdbcType.class, "LocalTime" );
 	}
 
 	private void checkAttribute(
 			PersistentClass entityBinding,
 			String attributeName,
-			Class<?> expectedJdbcTypeDescriptorType) {
+			Class<?> expectedJdbcTypeDescriptorType,
+			String expectedTypeName) {
 		final Property property = entityBinding.getProperty( attributeName );
 		final BasicValue value = (BasicValue) property.getValue();
 		final BasicValue.Resolution<?> resolution = value.resolve();
 		final JdbcType jdbcType = resolution.getJdbcType();
 		assertThat( jdbcType ).isInstanceOf( expectedJdbcTypeDescriptorType );
+		assertThat( resolution.getLegacyResolvedBasicType().getName() ).isEqualTo( expectedTypeName );
 	}
 
 	@Entity(name="EntityWithJavaTimeValues")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/JavaTimeJdbcTypeBaselineTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/JavaTimeJdbcTypeBaselineTests.java
@@ -32,7 +32,8 @@ import jakarta.persistence.Table;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for "direct" JDBC handling of {@linkplain java.time Java Time} types.
+ * Tests the legacy JDBC handling of {@linkplain java.time Java Time} types when
+ * {@value MappingSettings#JAVA_TIME_USE_DIRECT_JDBC} is explicitly disabled.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/DatabaseTimeZoneMultiTenancyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/DatabaseTimeZoneMultiTenancyTest.java
@@ -76,6 +76,7 @@ public class DatabaseTimeZoneMultiTenancyTest {
 		//end::multitenacy-hibernate-timezone-configuration-registerConnectionProvider-call-example[]
 
 		Map<String, Object> settings = new HashMap<>();
+		settings.put( AvailableSettings.JAVA_TIME_USE_DIRECT_JDBC, false );
 
 		settings.put(
 				AvailableSettings.MULTI_TENANT_CONNECTION_PROVIDER,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/JDBCTimeZoneZonedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/JDBCTimeZoneZonedTest.java
@@ -33,8 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DomainModel(annotatedClasses = JDBCTimeZoneZonedTest.Zoned.class)
 @SessionFactory
-@ServiceRegistry(settings = {@Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "NORMALIZE"),
-							@Setting(name = AvailableSettings.JDBC_TIME_ZONE, value = "GMT+5")})
+@ServiceRegistry(settings = {
+		@Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "NORMALIZE"),
+		@Setting(name = AvailableSettings.JDBC_TIME_ZONE, value = "GMT+5"),
+		@Setting(name = AvailableSettings.JAVA_TIME_USE_DIRECT_JDBC, value = "false")
+})
 public class JDBCTimeZoneZonedTest {
 
 	@Test void test(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/PassThruZonedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/PassThruZonedTest.java
@@ -32,7 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DomainModel(annotatedClasses = PassThruZonedTest.Zoned.class)
 @SessionFactory
-@ServiceRegistry(settings = @Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "NORMALIZE"))
+@ServiceRegistry(settings = {
+		@Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "NORMALIZE"),
+		@Setting(name = AvailableSettings.JAVA_TIME_USE_DIRECT_JDBC, value = "false")
+})
 public class PassThruZonedTest {
 
 	@Test void test(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/UTCNormalizedZonedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/UTCNormalizedZonedTest.java
@@ -32,7 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DomainModel(annotatedClasses = UTCNormalizedZonedTest.Zoned.class)
 @SessionFactory
-@ServiceRegistry(settings = @Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "NORMALIZE_UTC"))
+@ServiceRegistry(settings = {
+		@Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "NORMALIZE_UTC"),
+		@Setting(name = AvailableSettings.JAVA_TIME_USE_DIRECT_JDBC, value = "false")
+})
 public class UTCNormalizedZonedTest {
 
 	@Test void test(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/BasicTypeRegistryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/BasicTypeRegistryTest.java
@@ -9,6 +9,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import org.hibernate.HibernateException;
@@ -17,6 +23,7 @@ import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.CustomType;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.StringJavaType;
 import org.hibernate.type.descriptor.java.UUIDJavaType;
@@ -42,6 +49,42 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  */
 @BaseUnitTest
 public class BasicTypeRegistryTest {
+	@Test
+	public void testLegacyJavaTimeTypePriming() {
+		final BasicTypeRegistry registry = new TypeConfiguration( false ).getBasicTypeRegistry();
+
+		assertJavaTimeType( registry, LocalDate.class, "LocalDate", SqlTypes.DATE );
+		assertJavaTimeType( registry, LocalDateTime.class, "LocalDateTime", SqlTypes.TIMESTAMP );
+		assertJavaTimeType( registry, LocalTime.class, "LocalTime", SqlTypes.TIME );
+		assertJavaTimeType( registry, OffsetDateTime.class, "OffsetDateTime", SqlTypes.TIMESTAMP_WITH_TIMEZONE );
+		assertJavaTimeType( registry, OffsetTime.class, "OffsetTime", SqlTypes.TIME_WITH_TIMEZONE );
+		assertJavaTimeType( registry, ZonedDateTime.class, "ZonedDateTime", SqlTypes.TIMESTAMP_WITH_TIMEZONE );
+	}
+
+	@Test
+	public void testDirectJavaTimeTypePriming() {
+		final BasicTypeRegistry registry = new TypeConfiguration( true ).getBasicTypeRegistry();
+
+		assertJavaTimeType( registry, LocalDate.class, "LocalDate", SqlTypes.LOCAL_DATE );
+		assertJavaTimeType( registry, LocalDateTime.class, "LocalDateTime", SqlTypes.LOCAL_DATE_TIME );
+		assertJavaTimeType( registry, LocalTime.class, "LocalTime", SqlTypes.LOCAL_TIME );
+		assertJavaTimeType( registry, OffsetDateTime.class, "OffsetDateTime", SqlTypes.OFFSET_DATE_TIME );
+		assertJavaTimeType( registry, OffsetTime.class, "OffsetTime", SqlTypes.OFFSET_TIME );
+		assertJavaTimeType( registry, ZonedDateTime.class, "ZonedDateTime", SqlTypes.ZONED_DATE_TIME );
+	}
+
+	private <T> void assertJavaTimeType(
+			BasicTypeRegistry registry,
+			Class<T> javaType,
+			String typeName,
+			int jdbcTypeCode) {
+		final BasicType<T> registeredType = registry.getRegisteredType( javaType );
+		assertNotNull( registeredType );
+		assertEquals( typeName, registeredType.getName() );
+		assertEquals( jdbcTypeCode, registeredType.getJdbcType().getJdbcTypeCode() );
+		assertSame( registeredType, registry.getRegisteredType( typeName ) );
+	}
+
 	@Test
 	public void testOverriding() {
 		TypeConfiguration typeConfiguration = new TypeConfiguration();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/AbstractJavaTimeTypeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/temporal/AbstractJavaTimeTypeTests.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 
 import static org.hibernate.cfg.JdbcSettings.DIALECT;
 import static org.hibernate.cfg.JdbcSettings.JDBC_TIME_ZONE;
+import static org.hibernate.cfg.MappingSettings.JAVA_TIME_USE_DIRECT_JDBC;
 
 /**
  * Test support for handling of temporal values.
@@ -44,6 +45,7 @@ public abstract class AbstractJavaTimeTypeTests<T, E>
 
 	@Override
 	public StandardServiceRegistry produceServiceRegistry(StandardServiceRegistryBuilder builder) {
+		builder.applySetting( JAVA_TIME_USE_DIRECT_JDBC, false );
 		if ( env.hibernateJdbcTimeZone() != null ) {
 			builder.applySetting( JDBC_TIME_ZONE, env.hibernateJdbcTimeZone().getId() );
 		}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/RevisionInfoConfiguration.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/RevisionInfoConfiguration.java
@@ -261,6 +261,7 @@ public class RevisionInfoConfiguration {
 			Class<?> revisionInfoClass,
 			PropertyData revisionInfoTimestampData,
 			String typeName,
+			Class<?> javaType,
 			ServiceRegistry serviceRegistry) {
 		return new RevisionTimestampValueResolver(
 				revisionInfoClass,
@@ -268,7 +269,8 @@ public class RevisionInfoConfiguration {
 						revisionInfoTimestampData.getName(),
 						revisionInfoTimestampData.getBeanName(),
 						revisionInfoTimestampData.getAccessType(),
-						typeName
+						typeName,
+						javaType
 				),
 				serviceRegistry
 		);
@@ -355,12 +357,14 @@ public class RevisionInfoConfiguration {
 				revisionListenerClass = getRevisionListenerClass( revisionEntity.value() );
 
 				final Property timestampProperty = persistentClass.getProperty( revisionInfoTimestampData.getName() );
-				revisionInfoTimestampTypeName = timestampProperty.getType().getName();
+				final var timestampType = timestampProperty.getType();
+				revisionInfoTimestampTypeName = timestampType.getName();
 
 				timestampValueResolver = createRevisionTimestampResolver(
 						revisionInfoClass,
 						revisionInfoTimestampData,
 						revisionInfoTimestampTypeName,
+						timestampType.getReturnedClass(),
 						metadata.getMetadataBuildingOptions().getServiceRegistry()
 				);
 
@@ -410,6 +414,7 @@ public class RevisionInfoConfiguration {
 						revisionInfoClass,
 						revisionInfoTimestampData,
 						revisionInfoTimestampTypeName,
+						Long.TYPE,
 						metadata.getMetadataBuildingOptions().getServiceRegistry()
 				);
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/RevisionTimestampData.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/RevisionTimestampData.java
@@ -4,6 +4,9 @@
  */
 package org.hibernate.envers.internal.entities;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -13,14 +16,21 @@ import java.util.Objects;
 public class RevisionTimestampData extends PropertyData {
 
 	private final String typeName;
+	private final Class<?> javaType;
 
-	public RevisionTimestampData(String name, String beanName, String accessType, String typeName) {
+	public RevisionTimestampData(
+			String name,
+			String beanName,
+			String accessType,
+			String typeName,
+			Class<?> javaType) {
 		super( name, beanName, accessType );
 		this.typeName = typeName;
+		this.javaType = javaType;
 	}
 
-	public RevisionTimestampData(RevisionTimestampData old, String typeName) {
-		this( old.getName(), old.getBeanName(), old.getAccessType(), typeName );
+	public RevisionTimestampData(RevisionTimestampData old, String typeName, Class<?> javaType) {
+		this( old.getName(), old.getBeanName(), old.getAccessType(), typeName, javaType );
 	}
 
 	public String getTypeName() {
@@ -28,24 +38,22 @@ public class RevisionTimestampData extends PropertyData {
 	}
 
 	public boolean isTimestampDate() {
-		return "date".equals( typeName )
-				|| "time".equals( typeName )
-				|| "timestamp".equals( typeName )
-				|| typeName.contains( "java.util.Date" );
+		return Date.class.isAssignableFrom( javaType );
 	}
 
 	public boolean isTimestampLocalDateTime() {
-		return "LocalDateTime".equals( typeName );
+		return LocalDateTime.class.equals( javaType );
 	}
 
 	public boolean isInstant() {
-		return "instant".equals( typeName );
+		return Instant.class.equals( javaType );
 	}
 
 	@Override
 	public int hashCode() {
 		int result = super.hashCode();
 		result = 31 * result + ( typeName != null ? typeName.hashCode() : 0 );
+		result = 31 * result + ( javaType != null ? javaType.hashCode() : 0 );
 		return result;
 	}
 
@@ -61,6 +69,7 @@ public class RevisionTimestampData extends PropertyData {
 			return false;
 		}
 		RevisionTimestampData that = (RevisionTimestampData) o;
-		return Objects.equals( typeName, that.typeName );
+		return Objects.equals( typeName, that.typeName )
+				&& Objects.equals( javaType, that.javaType );
 	}
 }

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/LocalDateTimeTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/LocalDateTimeTest.java
@@ -16,12 +16,14 @@ import java.util.Date;
 
 import org.hibernate.envers.AuditReaderFactory;
 import org.hibernate.envers.test.entities.reventity.CustomLocalDateTimeRevEntity;
+import org.hibernate.cfg.MappingSettings;
 import org.hibernate.orm.test.envers.entities.StrTestEntity;
 import org.hibernate.testing.envers.junit.EnversTest;
 import org.hibernate.testing.orm.junit.BeforeClassTemplate;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,7 +38,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 // TableGenerator uses a separate transaction to allocate identifiers, requiring concurrent transactions.
 @RequiresDialectFeature(feature = DialectFeatureChecks.SupportsConcurrentTransactions.class)
 @EnversTest
-@Jpa(annotatedClasses = {StrTestEntity.class, CustomLocalDateTimeRevEntity.class})
+@Jpa(
+		annotatedClasses = {StrTestEntity.class, CustomLocalDateTimeRevEntity.class},
+		integrationSettings = @Setting(name = MappingSettings.JAVA_TIME_USE_DIRECT_JDBC, value = "true")
+)
 public class LocalDateTimeTest {
 	private Instant timestampStart;
 	private Instant timestampEnd;

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -414,6 +414,21 @@ it.
 
 This section describes changes in behavior that applications should be aware of.
 
+[[java-time-direct-jdbc-default]]
+=== Direct JDBC handling of `java.time` values
+
+Hibernate now directly uses `java.time` types by default at the JDBC boundary when
+`java.time` types are used in the domain model.  Historically, Hibernate would convert the
+`java.time` values to/from `java.sql` values and use those `java.sql` types at the JDBC boundary.
+
+Direct support for  `java.time` values has been required by the JDBC specification since version
+4.2 (Java 8).
+
+Applications which require the previous behavior may set
+`hibernate.type.java_time_use_direct_jdbc` to `false`.
+
+
+
 [[collection-remove-create-callback-order]]
 === Collection remove/create callback order
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

HHH-20792 - Flip the default for hibernate.type.java_time_use_direct_jdbc

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20792 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20792
<!-- Hibernate GitHub Bot issue links end -->