### PR TITLE
HHH-20839 Add SqmFunctionRegistry.retainOnly(Set)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CaseInsensitiveDictionary.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CaseInsensitiveDictionary.java
@@ -5,6 +5,7 @@
 package org.hibernate.internal.util.collections;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -67,6 +68,20 @@ public final class CaseInsensitiveDictionary<V> {
 
 	public void clear() {
 		map.clear();
+	}
+
+	/**
+	 * Retains only the entries whose key (case-insensitive) is in the provided set.
+	 * All other entries are removed.
+	 *
+	 * @param keys the keys to retain (compared case-insensitively)
+	 */
+	public void retainAll(Set<String> keys) {
+		final Set<String> lowercasedKeys = new HashSet<>( keys.size() );
+		for ( String key : keys ) {
+			lowercasedKeys.add( trueKey( key ) );
+		}
+		map.keySet().retainAll( lowercasedKeys );
 	}
 
 	public void forEach(final BiConsumer<? super String, ? super V> action) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SqmFunctionRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SqmFunctionRegistry.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query.sqm.function;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -576,6 +577,30 @@ public class SqmFunctionRegistry {
 		//		 functionMap directly in performing this operation
 		functionMap.forEach( registryToOverly::register );
 		alternateKeyMap.forEach( registryToOverly::registerAlternateKey );
+	}
+
+	/**
+	 * Retains only the functions whose names are in the provided set,
+	 * removing all other registrations. Alternate keys (aliases) are
+	 * retained if their target function is in the retained set.
+	 * <p>
+	 * This allows frameworks to prune unused dialect-specific function
+	 * registrations after {@link org.hibernate.dialect.Dialect#initializeFunctionRegistry}
+	 * has populated the full registry, reducing startup overhead.
+	 *
+	 * @param functionNames the function names to retain (compared case-insensitively)
+	 */
+	public void retainOnly(Set<String> functionNames) {
+		functionMap.retainAll( functionNames );
+		setReturningFunctionMap.retainAll( functionNames );
+		// Retain alternate keys whose target function survived pruning
+		final var keysToRemove = new HashSet<String>();
+		alternateKeyMap.forEach( (alias, target) -> {
+			if ( !functionMap.containsKey( target ) && !setReturningFunctionMap.containsKey( target ) ) {
+				keysToRemove.add( alias );
+			}
+		} );
+		keysToRemove.forEach( alternateKeyMap::remove );
 	}
 
 	public void close() {

--- a/hibernate-core/src/test/java/org/hibernate/internal/util/collections/CaseInsensitiveDictionaryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/internal/util/collections/CaseInsensitiveDictionaryTest.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.internal.util.collections;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CaseInsensitiveDictionaryTest {
+
+	@Test
+	void retainAll_retainsMatchingKeys() {
+		CaseInsensitiveDictionary<String> dict = new CaseInsensitiveDictionary<>();
+		dict.put( "Foo", "fooValue" );
+		dict.put( "Bar", "barValue" );
+		dict.put( "Baz", "bazValue" );
+
+		dict.retainAll( Set.of( "foo", "baz" ) );
+
+		assertNotNull( dict.get( "Foo" ) );
+		assertNull( dict.get( "Bar" ) );
+		assertNotNull( dict.get( "Baz" ) );
+	}
+
+	@Test
+	void retainAll_isCaseInsensitive() {
+		CaseInsensitiveDictionary<String> dict = new CaseInsensitiveDictionary<>();
+		dict.put( "count", "countValue" );
+		dict.put( "SUM", "sumValue" );
+		dict.put( "Avg", "avgValue" );
+
+		dict.retainAll( Set.of( "COUNT", "avg" ) );
+
+		assertNotNull( dict.get( "count" ) );
+		assertNotNull( dict.get( "Avg" ) );
+		assertNull( dict.get( "SUM" ) );
+	}
+
+	@Test
+	void retainAll_withEmptySet_clearsAll() {
+		CaseInsensitiveDictionary<String> dict = new CaseInsensitiveDictionary<>();
+		dict.put( "a", "1" );
+		dict.put( "b", "2" );
+
+		dict.retainAll( Set.of() );
+
+		assertNull( dict.get( "a" ) );
+		assertNull( dict.get( "b" ) );
+		assertTrue( dict.unmodifiableKeySet().isEmpty() );
+	}
+
+	@Test
+	void retainAll_withAllKeys_isNoOp() {
+		CaseInsensitiveDictionary<String> dict = new CaseInsensitiveDictionary<>();
+		dict.put( "a", "1" );
+		dict.put( "b", "2" );
+
+		dict.retainAll( Set.of( "a", "b" ) );
+
+		assertEquals( "1", dict.get( "a" ) );
+		assertEquals( "2", dict.get( "b" ) );
+		assertEquals( 2, dict.unmodifiableKeySet().size() );
+	}
+
+	@Test
+	void retainAll_withNonExistentKeys_removesAll() {
+		CaseInsensitiveDictionary<String> dict = new CaseInsensitiveDictionary<>();
+		dict.put( "a", "1" );
+		dict.put( "b", "2" );
+
+		dict.retainAll( Set.of( "x", "y" ) );
+
+		assertNull( dict.get( "a" ) );
+		assertNull( dict.get( "b" ) );
+		assertTrue( dict.unmodifiableKeySet().isEmpty() );
+	}
+
+	@Test
+	void retainAll_onEmptyDictionary_isNoOp() {
+		CaseInsensitiveDictionary<String> dict = new CaseInsensitiveDictionary<>();
+
+		dict.retainAll( Set.of( "a", "b" ) );
+
+		assertTrue( dict.unmodifiableKeySet().isEmpty() );
+	}
+
+	@Test
+	void retainAll_preservesValues() {
+		CaseInsensitiveDictionary<Integer> dict = new CaseInsensitiveDictionary<>();
+		dict.put( "count", 42 );
+		dict.put( "sum", 100 );
+		dict.put( "avg", 50 );
+
+		dict.retainAll( Set.of( "count", "avg" ) );
+
+		assertEquals( 42, dict.get( "count" ) );
+		assertEquals( 50, dict.get( "avg" ) );
+		assertFalse( dict.containsKey( "sum" ) );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/function/SqmFunctionRegistryRetainOnlyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/function/SqmFunctionRegistryRetainOnlyTest.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.sqm.function;
+
+import java.util.Set;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for {@link SqmFunctionRegistry#retainOnly(Set)}.
+ * Verifies that pruning works with a real SessionFactory and that
+ * retained functions can be used in HQL queries.
+ */
+@DomainModel(annotatedClasses = SqmFunctionRegistryRetainOnlyTest.TestEntity.class)
+@SessionFactory
+@JiraKey("HHH-20839")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SqmFunctionRegistryRetainOnlyTest {
+
+	@Test
+	@Order(1)
+	void retainOnly_reducesFunctionCount(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			SessionFactoryImplementor sfi = session.getSessionFactory();
+			SqmFunctionRegistry registry = sfi.getQueryEngine().getSqmFunctionRegistry();
+
+			int initialSize = registry.getValidFunctionKeys().size();
+			assertTrue( initialSize > 10, "Dialect should register many functions, got: " + initialSize );
+
+			// Retain only core aggregate functions
+			registry.retainOnly( Set.of( "count", "sum", "avg", "min", "max",
+					"coalesce", "nullif", "cast", "lower", "upper", "trim",
+					"substring", "concat", "length", "character_length",
+					"abs", "mod", "sqrt", "floor", "ceiling",
+					"current_date", "current_time", "current_timestamp",
+					"extract", "position" ) );
+
+			int prunedSize = registry.getValidFunctionKeys().size();
+			assertTrue( prunedSize < initialSize,
+					"Registry should be smaller after pruning: " + prunedSize + " >= " + initialSize );
+		} );
+	}
+
+	@Test
+	@Order(2)
+	void retainOnly_retainedFunctionWorksInHql(SessionFactoryScope scope) {
+		// Insert test data
+		scope.inTransaction( session -> {
+			session.persist( new TestEntity( 1L, "alpha" ) );
+			session.persist( new TestEntity( 2L, "beta" ) );
+			session.persist( new TestEntity( 3L, "gamma" ) );
+		} );
+
+		scope.inTransaction( session -> {
+			SessionFactoryImplementor sfi = session.getSessionFactory();
+			SqmFunctionRegistry registry = sfi.getQueryEngine().getSqmFunctionRegistry();
+
+			// Retain count (and other core functions needed by Hibernate internally)
+			registry.retainOnly( Set.of( "count", "sum", "avg", "min", "max",
+					"coalesce", "nullif", "cast", "lower", "upper", "trim",
+					"substring", "concat", "length", "character_length",
+					"abs", "mod", "sqrt", "floor", "ceiling",
+					"current_date", "current_time", "current_timestamp",
+					"extract", "position" ) );
+
+			// count() should still work
+			Long result = session.createQuery(
+					"select count(e) from TestEntity e", Long.class ).getSingleResult();
+			assertEquals( 3L, result );
+		} );
+
+		// Cleanup
+		scope.inTransaction( session -> {
+			session.createMutationQuery( "delete from TestEntity" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	@Order(3)
+	void retainOnly_prunedFunctionNotAvailable(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			SessionFactoryImplementor sfi = session.getSessionFactory();
+			SqmFunctionRegistry registry = sfi.getQueryEngine().getSqmFunctionRegistry();
+
+			// Retain only core aggregate functions
+			registry.retainOnly( Set.of( "count", "sum", "avg", "min", "max",
+					"coalesce", "nullif", "cast" ) );
+
+			// Functions not in the retained set should be gone
+			assertNull( registry.findFunctionDescriptor( "json_object" ),
+					"json_object should be pruned" );
+			assertNull( registry.findFunctionDescriptor( "array_agg" ),
+					"array_agg should be pruned" );
+
+			// Retained functions should still be available
+			assertNotNull( registry.findFunctionDescriptor( "count" ),
+					"count should be retained" );
+		} );
+	}
+
+	@Entity(name = "TestEntity")
+	@Table(name = "sqm_function_test_entity")
+	public static class TestEntity {
+		@Id
+		private Long id;
+		private String name;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/sqm/function/SqmFunctionRegistryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/sqm/function/SqmFunctionRegistryTest.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.query.sqm.function;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SqmFunctionRegistryTest {
+
+	private SqmFunctionRegistry registry;
+	private SqmFunctionDescriptor countFn;
+	private SqmFunctionDescriptor sumFn;
+	private SqmFunctionDescriptor avgFn;
+	private SqmFunctionDescriptor jsonObjectFn;
+	private SqmFunctionDescriptor arrayAggFn;
+
+	@BeforeEach
+	void setUp() {
+		registry = new SqmFunctionRegistry();
+		countFn = Mockito.mock( SqmFunctionDescriptor.class );
+		sumFn = Mockito.mock( SqmFunctionDescriptor.class );
+		avgFn = Mockito.mock( SqmFunctionDescriptor.class );
+		jsonObjectFn = Mockito.mock( SqmFunctionDescriptor.class );
+		arrayAggFn = Mockito.mock( SqmFunctionDescriptor.class );
+
+		registry.register( "count", countFn );
+		registry.register( "sum", sumFn );
+		registry.register( "avg", avgFn );
+		registry.register( "json_object", jsonObjectFn );
+		registry.register( "array_agg", arrayAggFn );
+	}
+
+	@Test
+	void retainOnly_retainsSpecifiedFunctions() {
+		registry.retainOnly( Set.of( "count", "sum" ) );
+
+		assertNotNull( registry.findFunctionDescriptor( "count" ) );
+		assertNotNull( registry.findFunctionDescriptor( "sum" ) );
+		assertNull( registry.findFunctionDescriptor( "avg" ) );
+		assertNull( registry.findFunctionDescriptor( "json_object" ) );
+		assertNull( registry.findFunctionDescriptor( "array_agg" ) );
+	}
+
+	@Test
+	void retainOnly_isCaseInsensitive() {
+		registry.retainOnly( Set.of( "COUNT", "SUM" ) );
+
+		assertNotNull( registry.findFunctionDescriptor( "count" ) );
+		assertNotNull( registry.findFunctionDescriptor( "sum" ) );
+		assertNull( registry.findFunctionDescriptor( "avg" ) );
+	}
+
+	@Test
+	void retainOnly_withEmptySet_removesAll() {
+		registry.retainOnly( Set.of() );
+
+		assertNull( registry.findFunctionDescriptor( "count" ) );
+		assertNull( registry.findFunctionDescriptor( "sum" ) );
+		assertNull( registry.findFunctionDescriptor( "avg" ) );
+		assertTrue( registry.getValidFunctionKeys().isEmpty() );
+	}
+
+	@Test
+	void retainOnly_withAllKeys_isNoOp() {
+		registry.retainOnly( Set.of( "count", "sum", "avg", "json_object", "array_agg" ) );
+
+		assertNotNull( registry.findFunctionDescriptor( "count" ) );
+		assertNotNull( registry.findFunctionDescriptor( "sum" ) );
+		assertNotNull( registry.findFunctionDescriptor( "avg" ) );
+		assertNotNull( registry.findFunctionDescriptor( "json_object" ) );
+		assertNotNull( registry.findFunctionDescriptor( "array_agg" ) );
+		assertEquals( 5, registry.getValidFunctionKeys().size() );
+	}
+
+	@Test
+	void retainOnly_retainsAlternateKeyWhenTargetIsRetained() {
+		// "character_length" is the primary key, "length" is an alias
+		SqmFunctionDescriptor charLengthFn = Mockito.mock( SqmFunctionDescriptor.class );
+		registry.register( "character_length", charLengthFn );
+		registry.registerAlternateKey( "length", "character_length" );
+
+		registry.retainOnly( Set.of( "character_length", "count" ) );
+
+		// Primary key retained
+		assertNotNull( registry.findFunctionDescriptor( "character_length" ) );
+		// Alias should still work because its target is retained
+		assertNotNull( registry.findFunctionDescriptor( "length" ) );
+		// Other functions removed
+		assertNull( registry.findFunctionDescriptor( "sum" ) );
+		assertNull( registry.findFunctionDescriptor( "json_object" ) );
+	}
+
+	@Test
+	void retainOnly_removesAlternateKeyWhenTargetIsPruned() {
+		SqmFunctionDescriptor charLengthFn = Mockito.mock( SqmFunctionDescriptor.class );
+		registry.register( "character_length", charLengthFn );
+		registry.registerAlternateKey( "length", "character_length" );
+
+		// Retain only "count" — neither "character_length" nor "length" are in the set
+		registry.retainOnly( Set.of( "count" ) );
+
+		assertNotNull( registry.findFunctionDescriptor( "count" ) );
+		assertNull( registry.findFunctionDescriptor( "character_length" ) );
+		// Alias should also be removed since its target was pruned
+		assertNull( registry.findFunctionDescriptor( "length" ) );
+	}
+
+	@Test
+	void retainOnly_prunesSetReturningFunctions() {
+		SqmSetReturningFunctionDescriptor unnestFn = Mockito.mock( SqmSetReturningFunctionDescriptor.class );
+		SqmSetReturningFunctionDescriptor generateSeriesFn = Mockito.mock( SqmSetReturningFunctionDescriptor.class );
+		registry.register( "unnest", unnestFn );
+		registry.register( "generate_series", generateSeriesFn );
+
+		registry.retainOnly( Set.of( "count", "unnest" ) );
+
+		assertNotNull( registry.findFunctionDescriptor( "count" ) );
+		assertNotNull( registry.findSetReturningFunctionDescriptor( "unnest" ) );
+		assertNull( registry.findSetReturningFunctionDescriptor( "generate_series" ) );
+	}
+
+	@Test
+	void retainOnly_preservesDescriptorInstances() {
+		registry.retainOnly( Set.of( "count", "sum" ) );
+
+		// Verify the exact same descriptor instances are returned
+		assertEquals( countFn, registry.findFunctionDescriptor( "count" ) );
+		assertEquals( sumFn, registry.findFunctionDescriptor( "sum" ) );
+	}
+
+	@Test
+	void retainOnly_multipleAlternateKeysForSameTarget() {
+		SqmFunctionDescriptor charLengthFn = Mockito.mock( SqmFunctionDescriptor.class );
+		registry.register( "character_length", charLengthFn );
+		registry.registerAlternateKey( "length", "character_length" );
+		registry.registerAlternateKey( "char_length", "character_length" );
+
+		registry.retainOnly( Set.of( "character_length" ) );
+
+		assertNotNull( registry.findFunctionDescriptor( "character_length" ) );
+		assertNotNull( registry.findFunctionDescriptor( "length" ) );
+		assertNotNull( registry.findFunctionDescriptor( "char_length" ) );
+		// Others pruned
+		assertNull( registry.findFunctionDescriptor( "count" ) );
+	}
+
+	@Test
+	void retainOnly_calledTwice_furtherPrunes() {
+		registry.retainOnly( Set.of( "count", "sum", "avg" ) );
+
+		assertEquals( 3, registry.getValidFunctionKeys().size() );
+
+		registry.retainOnly( Set.of( "count" ) );
+
+		assertEquals( 1, registry.getValidFunctionKeys().size() );
+		assertNotNull( registry.findFunctionDescriptor( "count" ) );
+		assertNull( registry.findFunctionDescriptor( "sum" ) );
+		assertNull( registry.findFunctionDescriptor( "avg" ) );
+	}
+}

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -18,3 +18,16 @@ IMPORTANT: If migrating from earlier versions, be sure to also check out the lin
 Schema management DDL now uses `CREATE SCHEMA IF NOT EXISTS` and `DROP SCHEMA IF EXISTS` for dialects which support these clauses, avoiding warnings when a schema already exists or has already been dropped.
 
 Supported dialects: PostgreSQL, CockroachDB, H2, HSQLDB, SAP HANA, and SQL Server (DROP only, version 13+).
+
+[[function-registry-pruning]]
+== Function registry pruning
+
+`SqmFunctionRegistry` now exposes a `retainOnly(Set<String>)` method that removes
+all registered functions not in the provided set. This enables frameworks to prune
+unused dialect-specific function registrations after `initializeFunctionRegistry()`
+completes, reducing startup allocation and class loading overhead.
+
+For `PostgreSQLDialect`, approximately 175 functions are registered during startup.
+Applications that use only a subset of these in HQL queries can benefit from pruning
+the unused entries. Alternate keys (aliases) are retained automatically when their
+target function is in the retained set.


### PR DESCRIPTION
Add retainOnly(Set<String>) to SqmFunctionRegistry that removes all registered functions not in the provided set.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20839 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20839
<!-- Hibernate GitHub Bot issue links end -->