### PR TITLE
HHH-20840 @Formula no longer recognizes functions without parens

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -263,6 +263,12 @@ public class OracleDialect extends Dialect {
 		this.driverMajorVersion = serverConfiguration.getDriverMajorVersion();
 	}
 
+	@Override
+	protected void registerDefaultKeywords() {
+		super.registerDefaultKeywords();
+		registerKeyword( "sysdate" );
+	}
+
 	public boolean isAutonomous() {
 		return autonomous;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaFunctionNameCollisionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaFunctionNameCollisionTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.formula;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.Formula;
+import org.hibernate.dialect.H2Dialect;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DomainModel( annotatedClasses = {
+		FormulaFunctionNameCollisionTest.Parent.class,
+		FormulaFunctionNameCollisionTest.Detail.class
+} )
+@SessionFactory
+@RequiresDialect(H2Dialect.class)
+@JiraKey("HHH-20840")
+class FormulaFunctionNameCollisionTest {
+
+	@Test
+	void testColumnNamedSysdateInCorrelatedSubquery(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new Parent( 1, 1 ) );
+			session.persist( new Parent( 2, 2 ) );
+			session.persist( new Detail( 1, 1, 10 ) );
+			session.persist( new Detail( 2, 2, 99 ) );
+		} );
+		scope.inTransaction( session -> {
+			assertEquals( 10, session.find( Parent.class, 1 ).maximumAmount );
+			assertEquals( 99, session.find( Parent.class, 2 ).maximumAmount );
+		} );
+	}
+
+	@Entity(name = "FormulaParent")
+	@Table(name = "formula_parent")
+	static class Parent {
+		@Id
+		private Integer id;
+
+		private int sysdate;
+
+		@Formula("(select max(d.amount) from formula_detail d where d.sysdate = sysdate)")
+		private Integer maximumAmount;
+
+		Parent() {
+		}
+
+		Parent(Integer id, int sysdate) {
+			this.id = id;
+			this.sysdate = sysdate;
+		}
+	}
+
+	@Entity(name = "FormulaDetail")
+	@Table(name = "formula_detail")
+	static class Detail {
+		@Id
+		private Integer id;
+
+		private int sysdate;
+		private int amount;
+
+		Detail() {
+		}
+
+		Detail(Integer id, int sysdate, int amount) {
+			this.id = id;
+			this.sysdate = sysdate;
+			this.amount = amount;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaFunctionWithoutParenthesesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaFunctionWithoutParenthesesTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.formula;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.annotations.Formula;
+import org.hibernate.dialect.OracleDialect;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DomainModel( annotatedClasses = FormulaFunctionWithoutParenthesesTest.TestEntity.class )
+@SessionFactory
+@RequiresDialect(OracleDialect.class)
+@JiraKey("HHH-20840")
+public class FormulaFunctionWithoutParenthesesTest {
+
+	@Test
+	void testFunctionWithoutParentheses(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.persist( new TestEntity( 1L ) ) );
+
+		scope.inTransaction( session -> {
+			final var entity = session.find( TestEntity.class, 1L );
+			assertNotNull( entity.currentTimestamp );
+		} );
+	}
+
+	@Entity(name = "TestEntity")
+	static class TestEntity {
+		@Id
+		private Long id;
+
+		@Formula("sysdate")
+		private Timestamp currentTimestamp;
+
+		TestEntity() {
+		}
+
+		TestEntity(Long id) {
+			this.id = id;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/OracleSysdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/OracleSysdateTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.sql;
+
+import java.sql.SQLException;
+
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
+import org.hibernate.mapping.Formula;
+import org.hibernate.sql.Template;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@JiraKey("HHH-20840")
+class OracleSysdateTest {
+
+	@Test
+	void testSysdateFormulaWithoutJdbcMetadata() {
+		final var dialect = new OracleDialect();
+		final var types = new TypeConfiguration();
+		assertEquals( "sysdate", new Formula( "sysdate" ).getTemplate( dialect, types ) );
+		assertEquals( "SYSDATE", new Formula( "SYSDATE" ).getTemplate( dialect, types ) );
+		assertEquals( "sysdate - {@}.created_at",
+				new Formula( "sysdate - created_at" ).getTemplate( dialect, types ) );
+		assertEquals( "p.created_at < sysdate",
+				Template.renderWhereStringTemplate( "created_at < sysdate", "p", dialect, types ) );
+	}
+
+	@Test
+	void testQuotedAndQualifiedColumns() {
+		final var dialect = new OracleDialect();
+		final var types = new TypeConfiguration();
+		assertEquals( "{@}.\"SYSDATE\"",
+				new Formula( "\"SYSDATE\"" ).getTemplate( dialect, types ) );
+		assertEquals( "{@}.\"SYSDATE\"",
+				new Formula( "`SYSDATE`" ).getTemplate( dialect, types ) );
+		assertEquals( "p.sysdate", new Formula( "p.sysdate" ).getTemplate( dialect, types ) );
+		assertEquals( "upper({@}.name)", new Formula( "upper(name)" ).getTemplate( dialect, types ) );
+	}
+
+	@Test
+	void testSysdateColumnOnH2() {
+		assertEquals( "{@}.sysdate",
+				new Formula( "sysdate" ).getTemplate( new H2Dialect(), new TypeConfiguration() ) );
+	}
+
+	@Test
+	void testKeywordAutoQuoting() throws SQLException {
+		final var builder = IdentifierHelperBuilder.from( null );
+		builder.setAutoQuoteKeywords( true );
+		final var helper = new OracleDialect().buildIdentifierHelper( builder, null );
+		assertTrue( helper.toIdentifier( "sysdate" ).isQuoted() );
+		assertTrue( helper.toIdentifier( "SYSDATE" ).isQuoted() );
+		assertFalse( helper.toIdentifier( "created_at" ).isQuoted() );
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20840 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20840
<!-- Hibernate GitHub Bot issue links end -->