### PR TITLE
Backport HHH-20848 to branch 8.0 - Drop meaningless "provided" dependency to ant in hibernate-envers

### DIFF
--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -19,8 +19,6 @@ dependencies {
     implementation libs.jandex
     implementation libs.hibernateModels
 
-    compileOnly libs.ant
-
     annotationProcessor project( ':hibernate-processor' )
     compileOnly libs.jakarta.annotation
 


### PR DESCRIPTION
Backport of #13318 to branch 8.0

https://hibernate.atlassian.net/browse/HHH-20848


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20848 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->