### PR TITLE
[7.4] Don't use --illegal-field-mutation=deny in JDK 28 testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ stage('Configure') {
 		// Make sure to remove that argument as soon as possible
 		// -- generally that requires upgrading bytebuddy after the JDK goes GA.
 		new BuildEnvironment( testJdkVersion: '27', testJdkLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true', additionalOptions: '-PskipJacoco=true' ),
-		new BuildEnvironment( testJdkVersion: '28', testJdkLauncherArgs: '--enable-preview --illegal-final-field-mutation=deny -Dnet.bytebuddy.experimental=true', additionalOptions: '-PskipJacoco=true' )
+		new BuildEnvironment( testJdkVersion: '28', testJdkLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true', additionalOptions: '-PskipJacoco=true' )
 	];
 
 	if ( env.CHANGE_ID ) {


### PR DESCRIPTION
This would require backporting [HHH-20482](https://hibernate.atlassian.net/browse/HHH-20482), which we don't plan to do.

[HHH-20482]: https://hibernate.atlassian.net/browse/HHH-20482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ