### PR TITLE
Remove explicit strict JAXP testing from nightly CI

### DIFF
--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -222,39 +222,6 @@ stage('Build') {
 				}
 			}
 		})
-		executions.put('Strict JAXP configuration', {
-			runBuildOnNode(NODE_PATTERN_BASE) {
-				// we want to test with JDK 23 where the strict settings were introduced
-				def testJavaHome = tool(name: "OpenJDK 23 Latest", type: 'jdk')
-				def javaHome = tool(name: DEFAULT_JDK_TOOL, type: 'jdk')
-				// Use withEnv instead of setting env directly, as that is global!
-				// See https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md
-				withEnv(["JAVA_HOME=${javaHome}", "PATH+JAVA=${javaHome}/bin"]) {
-					stage('Checkout') {
-						checkout scm
-					}
-					stage('Test') {
-						withGradle {
-							def tempDir = pwd(tmp: true)
-							def jaxpStrictProperties = tempDir + '/jaxp-strict.properties'
-							def jaxpStrictTemplate = testJavaHome + '/conf/jaxp-strict.properties.template'
-
-							echo 'Copy strict JAXP configuration properties.'
-							sh "cp $jaxpStrictTemplate $jaxpStrictProperties"
-
-							// explicitly calling toString here to prevent Jenkins failures like:
-							//  > Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (org.codehaus.groovy.runtime.GStringImpl positive)
-							String args = ("-Ptest.jdk.version=23 -Porg.gradle.java.installations.paths=${javaHome},${testJavaHome}"
-								+ " -Ptest.jdk.launcher.args=\"-Djava.xml.config.file=${jaxpStrictProperties}\"").toString()
-
-							timeout( [time: 60, unit: 'MINUTES'] ) {
-								ciBuild(args)
-							}
-						}
-					}
-				}
-			}
-		})
 	}
 	parallel(executions)
 }


### PR DESCRIPTION
The strict JAXP properties template (jaxp-strict.properties.template) was introduced as opt-in in JDK 23 (JDK-8303531). In JDK 24, all numeric JAXP limits were tightened to match the strict template (JDK-8343006), making them the default for all JDK 24+ environments.

The only remaining difference between the default jaxp.properties and the strict template is jdk.xml.jdkcatalog.resolve (continue vs strict). The OpenJDK team intends to tighten this eventually (JDK-8344801, JDK-8330605) but no target version is committed -- they are expanding the built-in catalog first to reduce breakage.

Since most CI test environments now use JDK 25+, the strict numeric limits are already exercised by default, and the dedicated nightly test (which was stuck on JDK 23) is no longer needed.