### PR TITLE
[8.0] Fix errors in the Hibern8 guide

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Advanced.adoc
+++ b/documentation/src/main/asciidoc/introduction/Advanced.adoc
@@ -148,10 +148,11 @@ try (var session = factory.createEntityManager(enabledFilter)) {
 Now, any queries executed within the session will have the filter restriction applied.
 Collections annotated `@Filter` will also have their members correctly filtered.
 
-[CAUTION]
+[NOTE]
 ====
-On the other hand, filters are not applied to `@ManyToOne` associations, nor to `find()`.
-This is completely by design and is not in any way a bug.
+On the other hand, by default, filters are not applied to `@ManyToOne` associations, nor to `find()`.
+This is completely by design and is not in any way a mistake.
+The default behavior may be overridden using `@FilterDef(applyToLoadByKey=true)`.
 ====
 
 More than one filter may be enabled in a given session.
@@ -1306,7 +1307,7 @@ We do this by annotating the entity class.
 | link:{doc-javadoc-url}org/hibernate/annotations/DynamicUpdate.html[`@DynamicUpdate`] | Specifies that an `update` statement should be generated each time an entity is modified
 |===
 
-It's important to realize that, while `@DynamicInsert` has no impact on semantics, the more useful `@DynamicUpdate` annotation _does_ have a subtle side effect.
+It's important to realize that, while `@DynamicInsert` usually has no impact on semantics, the more useful `@DynamicUpdate` annotation _does_ have a subtle side effect.
 
 [CAUTION]
 ====
@@ -1400,20 +1401,14 @@ Interception-based change detection is a nice performance optimization with a sl
 - _Without_ the bytecode enhancer, Hibernate keeps a snapshot of the state of each entity after reading from or writing to the database.
 When the session flushes, the snapshot state is compared to the current state of the entity to determine if the entity has been modified.
 Maintaining these snapshots does have an impact on performance.
-- _With_ bytecode enhancement, we may avoid this cost by intercepting writes to the field and recording these modifications as they happen.
+- _With_ bytecode enhancement, we may avoid most of this cost by intercepting writes to the field and recording these modifications as they happen--however, a snapshot is still maintained for any field whose value is itself mutable, for example, for a field of type `byte[]`.
 
 This optimization isn't _completely_ transparent, however.
 
 [CAUTION]
 ====
 Interception-based change detection is less accurate than snapshot-based dirty checking.
-For example, consider this attribute:
-
-[source,java]
-byte[] image;
-
-Interception is able to detect writes to the `image` field, that is, replacement of the whole array.
-It's not able to detect modifications made directly to the _elements_ of the array, and so such modifications may be lost.
+In particular, writes to a field of an enhanced entity from outside the entity class itself are not detected by the enhanced bytecode and might not be made persistent.
 ====
 
 [IMPORTANT]

--- a/documentation/src/main/asciidoc/introduction/Configuration.adoc
+++ b/documentation/src/main/asciidoc/introduction/Configuration.adoc
@@ -148,9 +148,9 @@ Sticking to the JPA-standard approach, we would provide a file named `persistenc
 
 [source,xml]
 ----
-<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_4_0.xsd"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_4_0.xsd"
              version="4.0">
 
     <persistence-unit name="org.hibernate.example">
@@ -451,7 +451,7 @@ a| * If `drop-and-create`, first drop the schema, then export tables, sequences,
 * If `create`, export tables, sequences, and constraints, without attempting to drop them first, and then populate initial data
 * If `create-drop`, drop the schema and recreate it on factory startup;
 additionally, drop the schema on factory shutdown
-* If `drop`, drop the schema on factory shutdown
+* If `drop`, drop the schema on factory startup
 * If `validate`, validate the database schema without changing it
 * If `update`, only export what's missing in the schema, and alter incorrect column types
 * If `populate`, only populate initial data
@@ -565,7 +565,7 @@ We'll have more to say about them in <<naming-strategies>>.
 
 By default, Hibernate never quotes a SQL table or column name in generated SQL when the name contains only alphanumeric characters.
 This behavior is usually much more convenient, especially when working with a legacy schema, since unquoted identifiers aren't case-sensitive, and so Hibernate doesn't need to know or care whether a column is named `NAME`, `name`, or `Name` on the database side.
-On the other hand, any table or column name containing a punctuation character like `$` is automatically quoted by default.
+On the other hand, any table or column name containing a punctuation character, or with an initial `$` is automatically quoted by default.
 
 The following settings enable additional automatic quoting:
 

--- a/documentation/src/main/asciidoc/introduction/Entities.adoc
+++ b/documentation/src/main/asciidoc/introduction/Entities.adoc
@@ -959,7 +959,7 @@ On the other hand, there are no perfectly natural mappings for `Instant` and `Du
 By default:
 
 - `Duration` is mapped to a column of type `NUMERIC(21)` holding the length of the duration in nanoseconds, and
-- `Instant` is mapped to a column of type `TIMESTAMP` (`DATETIME` on MySQL).
+- `Instant` is mapped to a column of type `TIMESTAMP` (`DATETIME` on MySQL) or TIMESTAMP WITH TIME ZONE, depending on the database.
 
 Fortunately, these mappings can be modified by specifying the `JdbcType`.
 
@@ -1078,9 +1078,6 @@ JPA provides an `@Embedded` annotation to identify an attribute of an entity tha
 This annotation is completely optional, and so we don't usually use it.
 ====
 
-On the other hand a reference to an embeddable type is _never_ polymorphic.
-One `@Embeddable` class `F` may inherit a second `@Embeddable` class `R`, but an attribute of type `R` will always refer to an instance of that concrete class `R`, never to an instance of `F`.
-
 Usually, embeddable types are stored in a "flattened" format.
 Their attributes map columns of the table of their parent entity.
 Later, in <<mapping-embeddables>>, we'll see a couple of different options.
@@ -1089,6 +1086,8 @@ An attribute of embeddable type represents a relationship between a Java object 
 We can think of it as a whole/part relationship.
 The embeddable object belongs to the entity, and can't be shared with other entity instances.
 And it exists for only as long as its parent entity exists.
+
+Since Hibernate 6.6, an embedded attribute whose declared type is an embeddable class with embeddable subclasses is fully polymorphic.
 
 Next we'll discuss a different kind of relationship: a relationship between Java objects which each have their own distinct persistent identity and persistence lifecycle.
 
@@ -1639,12 +1638,9 @@ For example, the Java array types `String[]`, `UUID[]`, `double[]`, `BigDecimal[
 // .Not every database has an `ARRAY` type
 ====
 Now for the gotcha: not every database has a SQL `ARRAY` type, and some that _do_ have an `ARRAY` type don't allow it to be used as a column type.
-
-In particular, neither DB2 nor SQL Server have array-typed columns.
-On these databases, Hibernate falls back to something much worse: it uses Java serialization to encode the array to a binary representation, and stores the binary stream in a `VARBINARY` column.
-Quite clearly, this is terrible.
-You can ask Hibernate to do something _slightly_ less terrible by annotating the attribute `@JdbcTypeCode(SqlTypes.JSON)`, so that the array is serialized to JSON instead of binary format.
-But at this point it's better to just admit defeat and use an `@ElementCollection` instead.
+In particular, neither Db2 nor SQL Server have array-typed columns.
+On these databases, Hibernate falls back to something quite a bit worse:
+the array value is encoded to XML and stored in an XML-typed column.
 ====
 
 Alternatively, we could store this array or list in a separate table.
@@ -1678,6 +1674,7 @@ class Event {
     Long id;
     ...
     @ElementCollection
+    @OrderColumn
     List<DayOfWeek> daysOfWeek;  // stored in a dedicated table
     ...
 }

--- a/documentation/src/main/asciidoc/introduction/Interacting.adoc
+++ b/documentation/src/main/asciidoc/introduction/Interacting.adoc
@@ -22,7 +22,7 @@ Session session = entityManager.unwrap(Session.class);
 Similarly, every `EntityAgent` is `StatelessSession`:
 [source,java]
 ----
-StatelessSession session = entityManager.unwrap(StatelessSession.class);
+StatelessSession session = entityAgent.unwrap(StatelessSession.class);
 ----
 ====
 
@@ -320,7 +320,7 @@ affecting the database
 | Detect changes made to persistent objects association with the session and synchronize the database state with the state of the session by executing SQL `insert`, `update`, and `delete` statements
 |===
 
-Notice that `persist()` and `remove()` have no immediate effect on the database, and instead simply schedule a command for later execution.
+Notice that `persist()` and `remove()` usually have no immediate effect on the database, and instead simply schedule a command for later execution.
 Also notice that there's no `update()` operation for a stateful session.
 Modifications are automatically detected when the session is <<flush,flushed>>.
 
@@ -1076,7 +1076,7 @@ Therefore, Hibernate uses heuristics.
 The two most useful heuristics are:
 
 1. If the entity has a <<generated-identifiers,generated identifier>>, the value of the id field is inspected: if the value currently assigned to the id field is the default value for the type of the field, then the object is transient; otherwise, the object is detached.
-2. If the entity has a <<version-attributes,version>>, the value of the version field is inspected: if the value currently assigned to the version field is the default value, or a negative number, then the object is transient; otherwise, the object is detached.
+2. If the entity has a <<version-attributes,version>>, the value of the version field is inspected: if the value currently assigned to the version field is null or a negative number, then the object is transient; otherwise, the object is detached.
 
 If the entity has neither a generated id, nor a version, Hibernate usually falls back to just doing something reasonable.
 In extreme cases a `SELECT` query will be issued to determine whether a matching row exists in the database.

--- a/documentation/src/main/asciidoc/introduction/Introduction.adoc
+++ b/documentation/src/main/asciidoc/introduction/Introduction.adoc
@@ -230,7 +230,7 @@ import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 
 @Entity
-class Book {
+public class Book {
     @Id
     String isbn;
 
@@ -239,7 +239,7 @@ class Book {
 
     Book() {}
 
-    Book(String isbn, String title) {
+    public Book(String isbn, String title) {
         this.isbn = isbn;
         this.title = title;
     }

--- a/documentation/src/main/asciidoc/introduction/Mapping.adoc
+++ b/documentation/src/main/asciidoc/introduction/Mapping.adoc
@@ -887,11 +887,6 @@ A second option that's available is to map the embeddable type to a `JSON` (or `
 Now, this isn't something we would exactly _recommend_ if you're defining a data model from scratch, but it's at least useful for mapping pre-existing tables with JSON-typed columns.
 Since embeddable types are nestable, we can map some JSON formats this way, and even query JSON properties using HQL.
 
-[NOTE]
-====
-At this time, JSON arrays are not supported!
-====
-
 To map an attribute of embeddable type to JSON, we must annotate the attribute `@JdbcTypeCode(SqlTypes.JSON)`, instead of annotating the embeddable type.
 But the embeddable type `Name` should still be annotated `@Embeddable` if we want to query its attributes using HQL.
 

--- a/documentation/src/main/asciidoc/introduction/Processor.adoc
+++ b/documentation/src/main/asciidoc/introduction/Processor.adoc
@@ -83,27 +83,27 @@ public abstract class Book_ {
 	/**
 	 * Static metamodel for attribute {@link org.example.Book#isbn}
 	 **/
-    public static volatile SingularAttribute<Book, String> isbn;
+    public static volatile TextAttribute<Book> isbn;
 
     /**
      * Static metamodel for attribute {@link org.example.Book#text}
      **/
-    public static volatile SingularAttribute<Book, String> text;
+    public static volatile TextAttribute<Book> text;
 
     /**
      * Static metamodel for attribute {@link org.example.Book#title}
      **/
-    public static volatile SingularAttribute<Book, String> title;
+    public static volatile TextAttribute<Book> title;
 
     /**
      * Static metamodel for attribute {@link org.example.Book#type}
      **/
-    public static volatile SingularAttribute<Book, Type> type;
+    public static volatile ComparableAttribute<Book, Type> type;
 
     /**
      * Static metamodel for attribute {@link org.example.Book#publicationDate}
      **/
-    public static volatile SingularAttribute<Book, LocalDate> publicationDate;
+    public static volatile TemporalAttribute<Book, LocalDate> publicationDate;
 
     /**
      * Static metamodel for attribute {@link org.example.Book#publisher}

--- a/documentation/src/main/asciidoc/introduction/Querying.adoc
+++ b/documentation/src/main/asciidoc/introduction/Querying.adoc
@@ -714,7 +714,7 @@ List<Book> books = query.setMaxResults(MAX_RESULTS).getResultList();
 | `setMaxResults()` | Set a limit on the number of results returned by a query | &#10004;
 | `setFirstResult()` | Set an offset on the results returned by a query | &#10004;
 | `setPage()` | Set the limit and offset by specifying a `Page` object | &#10006;
-| `getResultCount()` | Determine how many results the query would return in the absence of any limit or offset | &#10006;
+| `getResultCount()` | Determine how many results the query would return in the absence of any limit or offset | &#10004;
 |===
 
 // It's quite common for pagination to be combined with the need to order query results by a field that's determined at runtime.
@@ -817,7 +817,7 @@ This works just as well with queries written in SQL:
 record BookInfo(String isbn, String title, int pages) {}
 
 List<BookInfo> resultList =
-        entityAgent.createNativeQuery("select title, isbn, pages from Book", BookInfo.class)
+        entityAgent.createNativeQuery("select isbn, title, pages from Book", BookInfo.class)
                    .getResultList();
 ----
 

--- a/documentation/src/main/asciidoc/introduction/Tuning.adoc
+++ b/documentation/src/main/asciidoc/introduction/Tuning.adoc
@@ -204,7 +204,7 @@ Consider the following code:
 [source,java]
 ----
 List<Book> books =
-        entityAgent.createQuery("from Book order by isbn")
+        entityManager.createQuery("from Book order by isbn")
             .ofType(Book.class)
             .getResultList();
 books.forEach(book -> book.getAuthors().forEach(author -> out.println(book.title + " by " + author.name)));
@@ -412,7 +412,7 @@ Here's how we can ask for join fetching in HQL:
 [source,java]
 ----
 List<Book> booksWithJoinFetchedAuthors =
-        entityAgent.createQuery("from Book join fetch authors order by isbn")
+        entityAgent.createQuery("from Book left join fetch authors order by isbn")
             .ofType(Book.class)
             .getResultList();
 ----
@@ -424,7 +424,7 @@ And this is the same query, written using the criteria API:
 var builder = sessionFactory.getCriteriaBuilder();
 var query = builder.createQuery(Book.class);
 var book = query.from(Book.class);
-book.fetch(Book_.authors);
+book.fetch(Book_.authors, JoinType.LEFT);
 query.select(book);
 query.orderBy(builder.asc(book.get(Book_.isbn)));
 List<Book> booksWithJoinFetchedAuthors =
@@ -895,7 +895,7 @@ A Hibernate link:{doc-javadoc-url}/org/hibernate/CacheMode.html[`CacheMode`] pac
 | `IGNORE` | `CacheRetrieveMode.BYPASS`, `CacheStoreMode.BYPASS`
 | `GET` | `CacheRetrieveMode.USE`, `CacheStoreMode.BYPASS`
 | `PUT` | `CacheRetrieveMode.BYPASS`, `CacheStoreMode.USE`
-| `REFRESH` | `CacheRetrieveMode.REFRESH`, `CacheStoreMode.BYPASS`
+| `REFRESH` | `CacheRetrieveMode.BYPASS`, `CacheStoreMode.REFRESH`
 | `REFRESH_SESSION` | none
 |===
 
@@ -1013,7 +1013,7 @@ To insert many entities at once, use `insert ... select`:
 entityAgent.createStatement(
         """
         insert into OrderQueue (id, isbn, quantity, customerId)
-            select o.id, i.quantity, i.book.isbn, o.customer.id
+            select o.id, i.book.isbn, i.quantity, o.customer.id
             from Order o join o.items i
             where o.status = PENDING
         """


### PR DESCRIPTION
Corrects inaccurate examples and outdated behavior descriptions in the Hibern8 guide, including schema-action timing, query projection order, dirty tracking, and Jakarta Persistence 4 examples.

Backport of 59fc83387bee306af869c9d46eb30634716bdbb7 to `8.0`, applied cleanly with `git cherry-pick -x`. The backport has the same patch ID as the original commit.

Validation:

- `./gradlew --console=plain :documentation:renderIntroductionHtml` passed.
- The persistence XML example validates against the branch's `persistence_4_0.xsd`.
- `git diff --check origin/8.0...HEAD` passed.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
