### PR TITLE
HHH-20744 Skip inverse to-one attributes in follow-on locking

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/lock/FollowOnLockingAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/lock/FollowOnLockingAction.java
@@ -16,8 +16,10 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.TableDetails;
+import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.persister.entity.UnionSubclassEntityPersister;
 import org.hibernate.query.internal.QueryOptionsImpl;
 import org.hibernate.query.spi.QueryOptions;
@@ -154,8 +156,10 @@ public class FollowOnLockingAction implements PostAction {
 		effectiveEntityGraph.applyGraph( graph, GraphSemantic.FETCH );
 
 		entityMappingType.forEachAttributeMapping( (index, attributeMapping) -> {
-			// we need to handle collections specially (which we do below, so skip them here)
-			if ( !(attributeMapping instanceof PluralAttributeMapping) ) {
+			// we need to handle collections specially (which we do below, so skip them here),
+			// and inverse to-one attributes have no columns here to select at all
+			if ( !(attributeMapping instanceof PluralAttributeMapping)
+					&& !isInverseToOne( attributeMapping ) ) {
 				final var tableLock = resolveTableLock( attributeMapping, tableLocks, entityMappingType );
 				if ( tableLock == null ) {
 					throw new AssertionFailure( String.format(
@@ -203,6 +207,15 @@ public class FollowOnLockingAction implements PostAction {
 
 		// at this point, we have all the individual locking selects ready to go - execute them
 		return buildLockingOptions( executionContext );
+	}
+
+	/**
+	 * An inverse ({@code mappedBy}) to-one is mapped to the foreign-key columns of the
+	 * <em>associated</em> table rather than to any column of the table being locked.
+	 */
+	private static boolean isInverseToOne(AttributeMapping attributeMapping) {
+		return attributeMapping instanceof ToOneAttributeMapping toOne
+			&& toOne.getSideNature() == ForeignKeyDescriptor.Nature.TARGET;
 	}
 
 	private TableLock resolveTableLock(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/Article.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/Article.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.locking.options;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+/**
+ * Holds an inverse one-to-one, which contributes no column to {@code articles}: the join
+ * column belongs to {@code article_reviews}.
+ *
+ * @author Ivo Raisr
+ */
+@Entity
+@Table(name = "articles")
+public class Article {
+	@Id
+	private Integer id;
+	private String title;
+
+	@OneToOne(mappedBy = "article")
+	private ArticleReview review;
+
+	public Article() {
+	}
+
+	public Article(Integer id, String title) {
+		this.id = id;
+		this.title = title;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/ArticleReview.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/ArticleReview.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.locking.options;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+/**
+ * Owning side of {@linkplain Article#review}, joined on a foreign-key column.
+ *
+ * @author Ivo Raisr
+ */
+@Entity
+@Table(name = "article_reviews")
+public class ArticleReview {
+	@Id
+	private Integer id;
+	private String assessment;
+
+	@OneToOne
+	@JoinColumn(name = "article_fk")
+	private Article article;
+
+	public ArticleReview() {
+	}
+
+	public ArticleReview(Integer id, String assessment, Article article) {
+		this.id = id;
+		this.assessment = assessment;
+		this.article = article;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/InverseToOneFollowOnLockingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/InverseToOneFollowOnLockingTests.java
@@ -1,0 +1,165 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.locking.options;
+
+import jakarta.persistence.LockModeType;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
+import org.hibernate.Locking;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.lock.PessimisticLockStyle;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Follow-on locking builds its locking select from the attributes of the entity being locked.
+ * An inverse one-to-one is mapped to a column of the associated table, so attempting to select
+ * it raised an {@code UnknownTableReferenceException} against a table that select never joins.
+ *
+ * @author Ivo Raisr
+ */
+@SuppressWarnings("JUnitMalformedDeclaration")
+@DomainModel(annotatedClasses = {Article.class, ArticleReview.class})
+@SessionFactory(useCollectingStatementInspector = true)
+@Jira( "https://hibernate.atlassian.net/browse/HHH-20744" )
+@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsSelectLocking.class )
+@Tag("db-locking")
+public class InverseToOneFollowOnLockingTests {
+	private static final Helper.TableInformation ARTICLES = new TableInfo( "articles", "a1_0", "id" );
+	private static final Helper.TableInformation ARTICLE_REVIEWS = new TableInfo( "article_reviews", "r1_0", "id" );
+
+	@BeforeEach
+	void createTestData(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			final Article article = new Article( 1, "Follow-on locking" );
+			session.persist( article );
+			session.persist( new ArticleReview( 1, "Accepted", article ) );
+		} );
+	}
+
+	@AfterEach
+	void dropTestData(SessionFactoryScope factoryScope) {
+		factoryScope.dropData();
+	}
+
+	@Test
+	void testFind(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			session.find( Article.class, 1, LockModeType.PESSIMISTIC_WRITE, Locking.FollowOn.FORCE );
+
+			assertLockedArticlesOnly( sqlCollector, session.getDialect() );
+		} );
+	}
+
+	@Test
+	void testQueryWithJoinFetch(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			session.createSelectionQuery( "from Article a left join fetch a.review where a.id = 1", Article.class )
+					.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+					.setFollowOnStrategy( Locking.FollowOn.FORCE )
+					.getResultList();
+
+			assertLockedArticlesOnly( sqlCollector, session.getDialect() );
+		} );
+	}
+
+	@Test
+	void testFetchedScopeStillLocksTheAssociatedTable(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			session.createSelectionQuery( "from Article a left join fetch a.review where a.id = 1", Article.class )
+					.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+					.setLockScope( Locking.Scope.INCLUDE_FETCHES )
+					.setFollowOnStrategy( Locking.FollowOn.FORCE )
+					.getResultList();
+
+			if ( usesTableHints( session.getDialect() ) ) {
+				assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+				Helper.checkSql( sqlCollector.getSqlQueries().get( 0 ), false, session.getDialect(),
+						ARTICLES, ARTICLE_REVIEWS );
+			}
+			else {
+				// skipping the inverse one-to-one must not cost the fetched entity its lock; it is
+				// locked as an entity in its own right rather than as an attribute of the article
+				final List<String> followOnStatements = followOnStatements( sqlCollector );
+				assertThat( followOnStatements ).hasSize( 2 );
+				assertThat( followOnStatements ).anySatisfy( sql -> assertThat( sql ).contains( "articles" ) );
+				assertThat( followOnStatements ).anySatisfy( sql -> assertThat( sql ).contains( "article_reviews" ) );
+			}
+		} );
+	}
+
+	private void assertLockedArticlesOnly(SQLStatementInspector sqlCollector, Dialect dialect) {
+		if ( usesTableHints( dialect ) ) {
+			// t-sql applies the lock to the initial select as a table hint
+			assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+
+			final String initialSelect = sqlCollector.getSqlQueries().get( 0 );
+			Helper.checkSql( initialSelect, false, dialect, ARTICLES );
+			assertThat( initialSelect ).doesNotContain( lockHintFor( dialect, ARTICLE_REVIEWS ) );
+		}
+		else {
+			final List<String> followOnStatements = followOnStatements( sqlCollector );
+			assertThat( followOnStatements ).hasSize( 1 );
+
+			final String lockingSelect = followOnStatements.get( 0 );
+			Helper.checkSql( lockingSelect, true, dialect, ARTICLES );
+			assertThat( lockingSelect ).doesNotContain( "article_reviews" );
+		}
+	}
+
+	private String lockHintFor(Dialect dialect, Helper.TableInformation table) {
+		return dialect.appendLockHint( new LockOptions( LockMode.PESSIMISTIC_WRITE ), table.getTableAlias() );
+	}
+
+	private List<String> followOnStatements(SQLStatementInspector sqlCollector) {
+		final List<String> queries = sqlCollector.getSqlQueries();
+		assertThat( queries ).hasSizeGreaterThan( 1 );
+		return queries.subList( 1, queries.size() );
+	}
+
+	private boolean usesTableHints(Dialect dialect) {
+		return dialect.getLockingSupport().getMetadata().getPessimisticLockStyle() == PessimisticLockStyle.TABLE_HINT;
+	}
+
+	private record TableInfo(String tableName, String tableAlias, String keyColumnName)
+			implements Helper.TableInformation {
+		@Override
+		public String getTableName() {
+			return tableName;
+		}
+
+		@Override
+		public String getTableAlias() {
+			return tableAlias;
+		}
+
+		@Override
+		public String getKeyColumnName() {
+			return keyColumnName;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/13285

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20744 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20744
<!-- Hibernate GitHub Bot issue links end -->