### PR TITLE
HHH-20747 - Reorganize stuff needed for Dialect implementors to make them SPI

### DIFF
--- a/classification-tooling.adoc
+++ b/classification-tooling.adoc
@@ -403,6 +403,22 @@ classification, role, and release horizon.
 `REVIEW`:: A context-dependent Java change which requires human review and must
 not be silently treated as compatible.
 
+The Java analyzer resolves inherited methods before reporting a removed
+declaration. Removing a redundant override does not remove an otherwise
+unchanged inherited callable contract; the inherited declaration must still
+preserve the supported classification and SPI roles. Constructors are never inherited.
+Checked-exception removal or narrowing can break provider overrides and
+callers' catch clauses and is reported as `DECLARED_EXCEPTION_REMOVED`.
+Unchecked-exception declarations do not impose these source requirements.
+If the exception hierarchy is unavailable in the supplied artifacts, removal
+is reported for `REVIEW` rather than assumed to be a definite incompatibility.
+
+When changing the analyzer, exercise both its declaration-level tests and the
+compiled-client/provider fixtures in `CompiledJavaMigrationTests`. The latter
+compile baseline and current artifacts, recompile consumers, and execute old
+client bytecode where binary compatibility is expected. Run the complete
+tooling suite with `./gradlew -p local-build-plugins test`.
+
 === Baseline selection and resolution
 
 Run compatibility validation with:
@@ -459,9 +475,22 @@ https://docs.hibernate.org/orm/X.Y/metadata/classifications.json.gz.sha256
 ----
 
 The resolver verifies the SHA-256 sidecar, family, schema, exact source
-version, and artifact manifest. It uses a family-scoped Gradle cache, honors
+version, and artifact manifest. It uses an origin-and-family-scoped Gradle cache, honors
 offline and refresh-dependencies modes, and resolves the manifest's exact
 artifact coordinates through the repositories configured for the build.
+Online resolution checks the remote checksum on every invocation, even when
+Gradle's local inputs have not changed. Unchanged bytes are reused from the
+validated cache; `--refresh-dependencies` forces a download and disallows stale
+cache fallback. An explicitly configured local metadata file remains eligible
+for Gradle's normal up-to-date checking.
+
+The repository resolver and published provider plugin share their transport
+and cache implementation. Cache entries from different metadata origins are
+never interchangeable, including offline. The earlier family-only cache layout
+is not reused: after upgrading the tooling, resolve once online (or configure a
+local metadata file) before working offline. Concurrent cache writers are
+serialized, and downloaded metadata is validated before replacing a good entry.
+
 Modules which did not exist in the selected baseline are naturally absent.
 Mixed ORM versions, missing artifacts, duplicate coordinates, and manifest
 mismatches are configuration failures.

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/StructHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/StructHelper.java
@@ -60,18 +60,29 @@ public class StructHelper {
 			RawJdbcValueTransformer rawJdbcValueTransformer) throws SQLException {
 		final int numberOfAttributeMappings = embeddableMappingType.getNumberOfAttributeMappings();
 		final int size = numberOfAttributeMappings + ( embeddableMappingType.isPolymorphic() ? 1 : 0 );
+		// Ordering describes JDBC slots, not attributes: a flattened embeddable
+		// contributes several slots to a single attribute.
+		final Object[] logicalJdbcValues;
+		if ( orderMapping == null ) {
+			logicalJdbcValues = rawJdbcValues;
+		}
+		else {
+			logicalJdbcValues = new Object[rawJdbcValues.length];
+			for ( int physicalIndex = 0; physicalIndex < orderMapping.length; physicalIndex++ ) {
+				logicalJdbcValues[orderMapping[physicalIndex]] = rawJdbcValues[physicalIndex];
+			}
+		}
 		final var attributeValues = new StructAttributeValues(
 				numberOfAttributeMappings,
-				orderMapping == null ? rawJdbcValues : null
+				null
 		);
 		int jdbcIndex = 0;
 		for ( int i = 0; i < size; i++ ) {
-			final int attributeIndex = orderMapping == null ? i : orderMapping[i];
 			jdbcIndex += injectAttributeValue(
-					getSubPart( embeddableMappingType, attributeIndex ),
+					getSubPart( embeddableMappingType, i ),
 					attributeValues,
-					attributeIndex,
-					rawJdbcValues,
+					i,
+					logicalJdbcValues,
 					jdbcIndex,
 					options,
 					rawJdbcValueTransformer

--- a/hibernate-core/src/test/java/org/hibernate/type/descriptor/jdbc/spi/AggregateJdbcValuesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/type/descriptor/jdbc/spi/AggregateJdbcValuesTest.java
@@ -5,17 +5,24 @@
 package org.hibernate.type.descriptor.jdbc.spi;
 
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
+import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
 import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.spi.EmbeddableInstantiator;
 import org.hibernate.metamodel.spi.EmbeddableRepresentationStrategy;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.IntegerJdbcType;
+import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
+import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
+import org.hibernate.type.BasicPluralType;
+import org.hibernate.type.BasicType;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -26,6 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 /// @author Steve Ebersole
 class AggregateJdbcValuesTest {
@@ -76,6 +84,94 @@ class AggregateJdbcValuesTest {
 	}
 
 	@Test
+	void roundTripsFlattenedEmbeddableWithInterleavedPhysicalSlots() throws SQLException {
+		final EmbeddableMappingType nested = mappingType( 2 );
+		final EmbeddableMappingType mapping = mappingType( 2 );
+		when( mapping.getJdbcValueCount() ).thenReturn( 3 );
+		final AttributeMapping embedded = mock(
+				AttributeMapping.class, withSettings().extraInterfaces( EmbeddableValuedModelPart.class )
+		);
+		when( embedded.getMappedType() ).thenReturn( nested );
+		when( mapping.getAttributeMapping( 0 ) ).thenReturn( embedded );
+		final Object[] domain = { new Object[] { "A", null }, "C" };
+		final AggregateJdbcValueOrder order = AggregateJdbcValueOrder.physicalOrder( 2, 0, 1 );
+		final Object[] physical = AggregateJdbcValues.fromDomainValue( mapping, domain, order, options );
+		assertArrayEquals( new Object[] { "C", "A", null }, physical );
+		assertArrayEquals( new Object[] { "A", null, "C" },
+				AggregateJdbcValues.toLogicalJdbcValues( mapping, physical, order, options ) );
+		assertEquals( Arrays.asList( Arrays.asList( "A", null ), "C" ),
+				AggregateJdbcValues.toDomainValue( mapping, physical, order, options ) );
+		assertArrayEquals( new Object[] { "C", "A", null }, physical );
+	}
+
+	@Test
+	void roundTripsNestedNativeAggregateWithoutDecodingItTwice() throws SQLException {
+		final EmbeddableMappingType nested = mappingType( 2 );
+		final EmbeddableMappingType mapping = mappingType( 2 );
+		final AttributeMapping embedded = mock(
+				AttributeMapping.class, withSettings().extraInterfaces( EmbeddableValuedModelPart.class )
+		);
+		when( embedded.getMappedType() ).thenReturn( nested );
+		when( mapping.getAttributeMapping( 0 ) ).thenReturn( embedded );
+		final SelectableMapping selectable = mock( SelectableMapping.class );
+		when( nested.getAggregateMapping() ).thenReturn( selectable );
+		final JdbcMapping jdbcMapping = mock( JdbcMapping.class );
+		when( selectable.getJdbcMapping() ).thenReturn( jdbcMapping );
+		final AggregateJdbcType aggregate = mock( AggregateJdbcType.class );
+		when( jdbcMapping.getJdbcType() ).thenReturn( aggregate );
+		final ValueBinder<Object> binder = mock( ValueBinder.class );
+		when( jdbcMapping.getJdbcValueBinder() ).thenReturn( binder );
+		when( binder.getBindValue( any(), any() ) ).thenReturn( "native-container" );
+		when( aggregate.extractJdbcValues( "native-container", options ) ).thenReturn( new Object[] { "A", null } );
+		final AggregateJdbcValueOrder order = AggregateJdbcValueOrder.physicalOrder( 1, 0 );
+		final Object[] physical = AggregateJdbcValues.fromDomainValue( mapping,
+				new Object[] { new Object[] { "A", null }, "B" }, order, options );
+		assertArrayEquals( new Object[] { "B", "native-container" }, physical );
+		assertEquals( Arrays.asList( Arrays.asList( "A", null ), "B" ),
+				AggregateJdbcValues.toDomainValue( mapping, physical, order, options ) );
+		assertArrayEquals( new Object[] { "B", "native-container" }, physical );
+		assertEquals( Arrays.asList( null, "B" ), AggregateJdbcValues.toDomainValue(
+				mapping, new Object[] { "B", null }, order, options ) );
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void convertsArrayComponentsWithoutMutatingTheDecodedContainer() throws SQLException {
+		final EmbeddableMappingType mapping = mappingType( 2 );
+		final BasicPluralType<Object[], Object> arrayType = mock( BasicPluralType.class );
+		final BasicType<Object> elementType = mock( BasicType.class );
+		when( arrayType.getElementType() ).thenReturn( elementType );
+		when( elementType.getJdbcType() ).thenReturn( IntegerJdbcType.INSTANCE );
+		when( arrayType.getJdbcType() ).thenReturn( new ArrayJdbcType( IntegerJdbcType.INSTANCE ) );
+		final JavaType<Object[]> javaType = mock( JavaType.class );
+		doReturn( javaType ).when( arrayType ).getJdbcJavaType();
+		when( javaType.wrap( any(), any() ) ).thenAnswer( invocation ->
+				( (java.sql.Array) invocation.getArgument( 0 ) ).getArray() );
+		when( arrayType.convertToDomainValue( any() ) ).thenAnswer( invocation -> invocation.getArgument( 0 ) );
+		when( mapping.getAttributeMapping( 0 ).getSingleJdbcMapping() ).thenReturn( arrayType );
+		final java.sql.Array nativeArray = mock( java.sql.Array.class );
+		final Object[] elements = { 1, null, 3 };
+		when( nativeArray.getArray() ).thenReturn( elements );
+		final Object[] physical = { "B", nativeArray };
+		final AggregateJdbcValueOrder order = AggregateJdbcValueOrder.physicalOrder( 1, 0 );
+		assertArrayEquals( new Object[] { elements, "B" },
+				AggregateJdbcValues.toLogicalJdbcValues( mapping, physical, order, options ) );
+		assertEquals( Arrays.asList( elements, "B" ), AggregateJdbcValues.toDomainValue( mapping, physical, order, options ) );
+		assertArrayEquals( new Object[] { "B", nativeArray }, physical );
+		assertArrayEquals( new Object[] { 1, null, 3 }, elements );
+	}
+
+	@Test
+	void domainConversionDoesNotMutateInputOrApplyConvertersTwice() throws SQLException {
+		final EmbeddableMappingType mapping = mappingType( 1 );
+		final JdbcMapping jdbcMapping = mapping.getAttributeMapping( 0 ).getSingleJdbcMapping();
+		when( jdbcMapping.convertToDomainValue( any() ) ).thenAnswer( invocation -> "domain:" + invocation.getArgument( 0 ) );
+		final Object[] physical = { "value" };
+		assertEquals( List.of( "domain:value" ), AggregateJdbcValues.toDomainValue( mapping, physical, options ) );
+		assertArrayEquals( new Object[] { "value" }, physical );
+	}
+
+	@Test
 	void rejectsComponentCountMismatchesBeforeConversion() throws SQLException {
 		assertThrows(
 				IllegalArgumentException.class,
@@ -87,14 +183,18 @@ class AggregateJdbcValuesTest {
 		);
 	}
 
-	@SuppressWarnings("unchecked")
 	private EmbeddableMappingType mappingType() throws SQLException {
+		return mappingType( 3 );
+	}
+
+	@SuppressWarnings("unchecked")
+	private EmbeddableMappingType mappingType(int attributeCount) throws SQLException {
 		final EmbeddableMappingType mappingType = mock( EmbeddableMappingType.class );
-		when( mappingType.getJdbcValueCount() ).thenReturn( 3 );
-		when( mappingType.getNumberOfAttributeMappings() ).thenReturn( 3 );
+		when( mappingType.getJdbcValueCount() ).thenReturn( attributeCount );
+		when( mappingType.getNumberOfAttributeMappings() ).thenReturn( attributeCount );
 		when( mappingType.getValues( any() ) ).thenAnswer( invocation -> invocation.getArgument( 0 ) );
 
-		for ( int i = 0; i < 3; i++ ) {
+		for ( int i = 0; i < attributeCount; i++ ) {
 			final AttributeMapping modelPart = mock( AttributeMapping.class );
 			final JdbcMapping jdbcMapping = mock( JdbcMapping.class );
 			final JavaType<Object> jdbcJavaType = mock( JavaType.class );
@@ -118,7 +218,7 @@ class AggregateJdbcValuesTest {
 		when( mappingType.getRepresentationStrategy() ).thenReturn( representationStrategy );
 		when( representationStrategy.getInstantiator() ).thenReturn( instantiator );
 		when( instantiator.instantiate( any() ) )
-				.thenAnswer( invocation -> List.of( invocation.getArgument( 0, org.hibernate.metamodel.spi.ValueAccess.class ).getValues() ) );
+				.thenAnswer( invocation -> Arrays.asList( invocation.getArgument( 0, org.hibernate.metamodel.spi.ValueAccess.class ).getValues() ) );
 		return mappingType;
 	}
 }

--- a/local-build-plugins/build.gradle
+++ b/local-build-plugins/build.gradle
@@ -16,6 +16,9 @@ group = 'org.hibernate.build'
 version = '1.0.0-SNAPSHOT'
 layout.buildDirectory.set(file("target"))
 
+// Shared with the published provider plugin without a build-bootstrap dependency.
+sourceSets.main.java.srcDir("../shared/classification/src/main/java")
+
 dependencies {
 	implementation gradleApi()
 
@@ -104,6 +107,7 @@ spotless {
 	//Don't fail during the check: rather than enforcing guidelines, we use this plugin to fix mistakes automatically.
 	enforceCheck = false
 	java {
+		target "src/**/*.java"
 		targetExclude( "**/target/**/*.java" )
 		licenseHeaderFile project.file("../shared/config/spotless/license.java")
 		removeUnusedImports()

--- a/local-build-plugins/src/main/java/org/hibernate/orm/post/ClassificationMigrationValidator.java
+++ b/local-build-plugins/src/main/java/org/hibernate/orm/post/ClassificationMigrationValidator.java
@@ -50,7 +50,7 @@ public final class ClassificationMigrationValidator {
 		final boolean apiEnforced = baselineFamily.major == currentFamily.major;
 		final boolean spiEnforced = baselineFamily.equals( currentFamily );
 		final List<Diagnostic> diagnostics = new ArrayList<>();
-		validateClassificationChanges( baseline, current, apiEnforced, spiEnforced, diagnostics );
+		validateClassificationChanges( baseline, current, javaAnalysis, apiEnforced, spiEnforced, diagnostics );
 		for ( JavaMigrationCompatibilityAnalyzer.Change change : javaAnalysis.getChanges() ) {
 			validateJavaChange( baseline, current, change, apiEnforced, spiEnforced, diagnostics );
 		}
@@ -77,6 +77,7 @@ public final class ClassificationMigrationValidator {
 	private static void validateClassificationChanges(
 			ClassificationMetadata baseline,
 			ClassificationMetadata current,
+			JavaMigrationCompatibilityAnalyzer.Analysis javaAnalysis,
 			boolean apiEnforced,
 			boolean spiEnforced,
 			Collection<Diagnostic> diagnostics) {
@@ -86,7 +87,8 @@ public final class ClassificationMigrationValidator {
 					|| oldElement.getLifecycle().isIncubating() ) {
 				continue;
 			}
-			final ClassificationModel.Element newElement = current.getModel().getElement( oldElement.getId() );
+			final String currentId = javaAnalysis.getInheritedDeclarations().getOrDefault( oldElement.getId(), oldElement.getId() );
+			final ClassificationModel.Element newElement = current.getModel().getElement( currentId );
 			if ( newElement == null ) {
 				continue;
 			}
@@ -234,6 +236,7 @@ public final class ClassificationMigrationValidator {
 			case OVERLOAD_ADDED:
 			case VARARGS_CHANGED:
 			case DECLARED_EXCEPTION_ADDED:
+			case DECLARED_EXCEPTION_REMOVED:
 			case ANNOTATION_DEFAULT_CHANGED:
 				return true;
 			default:
@@ -256,6 +259,7 @@ public final class ClassificationMigrationValidator {
 			case DEFAULT_METHOD_ADDED:
 			case VARARGS_CHANGED:
 			case DECLARED_EXCEPTION_ADDED:
+			case DECLARED_EXCEPTION_REMOVED:
 				return true;
 			default:
 				return false;
@@ -267,6 +271,7 @@ public final class ClassificationMigrationValidator {
 			case RECORD_COMPONENTS_CHANGED:
 			case VARARGS_CHANGED:
 			case DECLARED_EXCEPTION_ADDED:
+			case DECLARED_EXCEPTION_REMOVED:
 			case ANNOTATION_DEFAULT_CHANGED:
 				return true;
 			default:

--- a/local-build-plugins/src/main/java/org/hibernate/orm/post/JavaMigrationCompatibilityAnalyzer.java
+++ b/local-build-plugins/src/main/java/org/hibernate/orm/post/JavaMigrationCompatibilityAnalyzer.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,10 +58,16 @@ public final class JavaMigrationCompatibilityAnalyzer {
 		final Set<String> includedTypes = includedTypeElementIds == null
 				? null
 				: new TreeSet<>( includedTypeElementIds );
-		final Map<String, TypeShape> baseline = scan( baselineArtifacts, includedTypes );
-		final Map<String, TypeShape> current = scan( currentArtifacts, includedTypes );
+		// Retain dependency shapes for hierarchy resolution, even when only a
+		// subset of declarations belongs to the compatibility surface.
+		final Map<String, TypeShape> baseline = scan( baselineArtifacts, null );
+		final Map<String, TypeShape> current = scan( currentArtifacts, null );
 		final List<Change> changes = new ArrayList<>();
-		for ( TypeShape oldType : baseline.values() ) {
+		final Map<String, String> inheritedDeclarations = new TreeMap<>();
+		for ( TypeShape oldType : new ArrayList<>( baseline.values() ) ) {
+			if ( includedTypes != null && !includedTypes.contains( oldType.elementId ) ) {
+				continue;
+			}
 			final TypeShape newType = current.get( oldType.elementId );
 			if ( newType == null ) {
 				changes.add( change( Cause.TYPE_REMOVED, oldType.elementId, oldType.elementId, oldType.kind, null ) );
@@ -68,10 +75,10 @@ public final class JavaMigrationCompatibilityAnalyzer {
 			}
 			compareType( oldType, newType, changes );
 			compareFields( oldType, newType, changes );
-			compareMethods( oldType, newType, changes );
+			compareMethods( oldType, newType, baseline, current, changes, inheritedDeclarations );
 		}
 		Collections.sort( changes );
-		return new Analysis( changes );
+		return new Analysis( changes, inheritedDeclarations );
 	}
 
 	private static void compareType(TypeShape oldType, TypeShape newType, Collection<Change> changes) {
@@ -159,12 +166,18 @@ public final class JavaMigrationCompatibilityAnalyzer {
 		}
 	}
 
-	private static void compareMethods(TypeShape oldType, TypeShape newType, Collection<Change> changes) {
+	private static void compareMethods(
+			TypeShape oldType, TypeShape newType,
+			Map<String, TypeShape> baseline, Map<String, TypeShape> current,
+			Collection<Change> changes, Map<String, String> inheritedDeclarations) {
 		for ( MethodShape oldMethod : oldType.methods.values() ) {
-			final MethodShape newMethod = newType.methods.get( oldMethod.elementId );
+			final MethodShape newMethod = resolveMethod( newType, oldMethod, current, new HashSet<>() );
 			if ( newMethod == null ) {
 				changes.add( change( oldMethod.constructor ? Cause.CONSTRUCTOR_REMOVED : Cause.METHOD_REMOVED, oldMethod.elementId, oldType.elementId, oldMethod.descriptor, null ) );
 				continue;
+			}
+			if ( !newMethod.elementId.equals( oldMethod.elementId ) ) {
+				inheritedDeclarations.put( oldMethod.elementId, newMethod.elementId );
 			}
 			compareAccess(
 					oldMethod.elementId,
@@ -193,8 +206,20 @@ public final class JavaMigrationCompatibilityAnalyzer {
 				changes.add( change( Cause.VARARGS_CHANGED, oldMethod.elementId, oldType.elementId, Boolean.toString( isVarargs( oldMethod.access ) ), Boolean.toString( isVarargs( newMethod.access ) ) ) );
 			}
 			for ( String exception : newMethod.exceptions ) {
-				if ( !oldMethod.exceptions.contains( exception ) ) {
+				if ( !uncheckedException( exception, current )
+						&& !coveredException( exception, oldMethod.exceptions, current ) ) {
 					changes.add( change( Cause.DECLARED_EXCEPTION_ADDED, oldMethod.elementId, oldType.elementId, null, exception ) );
+				}
+			}
+			for ( String exception : oldMethod.exceptions ) {
+				if ( !uncheckedException( exception, baseline )
+						&& !coveredException( exception, newMethod.exceptions, baseline ) ) {
+					// An unavailable dependency might be an unchecked exception.
+					// Report it for review instead of asserting a definite break.
+					final Certainty certainty = subtype( exception, "java/lang/Throwable", baseline, new HashSet<>() )
+							? Certainty.DEFINITE : Certainty.POTENTIAL;
+					changes.add( new Change( Cause.DECLARED_EXCEPTION_REMOVED, oldMethod.elementId,
+							oldType.elementId, exception, null, certainty ) );
 				}
 			}
 			if ( !Objects.equals( oldMethod.annotationDefault, newMethod.annotationDefault ) ) {
@@ -203,7 +228,7 @@ public final class JavaMigrationCompatibilityAnalyzer {
 		}
 
 		for ( MethodShape newMethod : newType.methods.values() ) {
-			if ( oldType.methods.containsKey( newMethod.elementId ) || newMethod.constructor ) {
+			if ( oldType.methods.containsKey( newMethod.elementId ) || isPrivate( newMethod.access ) ) {
 				continue;
 			}
 			if ( isAbstract( newMethod.access ) ) {
@@ -216,6 +241,83 @@ public final class JavaMigrationCompatibilityAnalyzer {
 				changes.add( change( Cause.OVERLOAD_ADDED, newMethod.elementId, oldType.elementId, null, newMethod.descriptor ) );
 			}
 		}
+	}
+
+	private static MethodShape resolveMethod(
+			TypeShape type, MethodShape original, Map<String, TypeShape> types, Set<String> visited) {
+		if ( type == null || !visited.add( type.elementId ) ) {
+			return null;
+		}
+		final boolean declaringType = type.elementId.equals( "type:" + owner( original.elementId ) );
+		final MethodShape declared = type.methods.get( methodId( className( type.elementId ), original.name, original.descriptor ) );
+		if ( declared != null && (declaringType || !isPrivate( declared.access )
+				&& (visibility( declared.access ) >= 2
+						|| packageName( className( type.elementId ) ).equals( packageName( owner( original.elementId ) ) ))
+				&& !(type.isInterface() && isStatic( declared.access ))) ) {
+			return declared;
+		}
+		if ( original.constructor ) {
+			return null;
+		}
+		final MethodShape superclassMethod = resolveMethod( shape( type.superName, types ), original, types, visited );
+		if ( superclassMethod != null ) {
+			return superclassMethod;
+		}
+		for ( String contract : type.interfaces ) {
+			final MethodShape method = resolveMethod( shape( contract, types ), original, types, visited );
+			if ( method != null ) {
+				return method;
+			}
+		}
+		return null;
+	}
+
+	private static String owner(String elementId) {
+		return elementId.substring( elementId.indexOf( ':' ) + 1, elementId.indexOf( '#' ) );
+	}
+
+	private static String packageName(String className) {
+		return className.substring( 0, Math.max( 0, className.lastIndexOf( '.' ) ) );
+	}
+
+	private static boolean uncheckedException(String exception, Map<String, TypeShape> types) {
+		return subtype( exception, "java/lang/RuntimeException", types, new HashSet<>() )
+				|| subtype( exception, "java/lang/Error", types, new HashSet<>() );
+	}
+
+	private static boolean coveredException(String exception, Set<String> declarations, Map<String, TypeShape> types) {
+		return declarations.stream().anyMatch( declared -> subtype( exception, declared, types, new HashSet<>() ) );
+	}
+
+	private static boolean subtype(String name, String target, Map<String, TypeShape> types, Set<String> visited) {
+		if ( name == null || !visited.add( name ) ) {
+			return false;
+		}
+		if ( name.replace( '/', '.' ).equals( target.replace( '/', '.' ) ) ) {
+			return true;
+		}
+		final TypeShape type = shape( name, types );
+		return type != null && (subtype( type.superName, target, types, visited )
+				|| type.interfaces.stream().anyMatch( contract -> subtype( contract, target, types, visited ) ));
+	}
+
+	private static TypeShape shape(String name, Map<String, TypeShape> types) {
+		if ( name == null ) {
+			return null;
+		}
+		final String id = "type:" + name.replace( '/', '.' );
+		if ( !types.containsKey( id ) && name.startsWith( "java" ) ) {
+			// Read platform declarations without loading or initializing provider classes.
+			try ( InputStream input = ClassLoader.getPlatformClassLoader().getResourceAsStream( name.replace( '.', '/' ) + ".class" ) ) {
+				if ( input != null ) {
+					types.put( id, read( input ) );
+				}
+			}
+			catch (IOException e) {
+				throw new AnalysisException( "Unable to analyze platform type " + name, e );
+			}
+		}
+		return types.get( id );
 	}
 
 	private static void compareAccess(
@@ -387,13 +489,21 @@ public final class JavaMigrationCompatibilityAnalyzer {
 	/// One deterministic comparison result.
 	public static final class Analysis {
 		private final List<Change> changes;
+		private final Map<String, String> inheritedDeclarations;
 
-		private Analysis(Collection<Change> changes) {
+		private Analysis(Collection<Change> changes, Map<String, String> inheritedDeclarations) {
 			this.changes = Collections.unmodifiableList( new ArrayList<>( changes ) );
+			this.inheritedDeclarations = Collections.unmodifiableMap( new TreeMap<>( inheritedDeclarations ) );
 		}
 
 		public List<Change> getChanges() {
 			return changes;
+		}
+
+		/// Current inherited declarations replacing baseline overrides. Policy
+		/// validation must still check their classification and supported roles.
+		public Map<String, String> getInheritedDeclarations() {
+			return inheritedDeclarations;
 		}
 	}
 
@@ -404,13 +514,19 @@ public final class JavaMigrationCompatibilityAnalyzer {
 		private final String ownerId;
 		private final String baselineValue;
 		private final String currentValue;
+		private final Certainty certainty;
 
 		private Change(Cause cause, String elementId, String ownerId, String baselineValue, String currentValue) {
+			this( cause, elementId, ownerId, baselineValue, currentValue, cause.certainty );
+		}
+
+		private Change(Cause cause, String elementId, String ownerId, String baselineValue, String currentValue, Certainty certainty) {
 			this.cause = cause;
 			this.elementId = elementId;
 			this.ownerId = ownerId;
 			this.baselineValue = baselineValue;
 			this.currentValue = currentValue;
+			this.certainty = certainty;
 		}
 
 		public Cause getCause() {
@@ -438,7 +554,7 @@ public final class JavaMigrationCompatibilityAnalyzer {
 		}
 
 		public Certainty getCertainty() {
-			return cause.certainty;
+			return certainty;
 		}
 
 		@Override
@@ -506,6 +622,7 @@ public final class JavaMigrationCompatibilityAnalyzer {
 		OVERLOAD_ADDED( Certainty.POTENTIAL, Impact.SOURCE ),
 		VARARGS_CHANGED( Impact.SOURCE ),
 		DECLARED_EXCEPTION_ADDED( Certainty.POTENTIAL, Impact.SOURCE ),
+		DECLARED_EXCEPTION_REMOVED( Impact.SOURCE ),
 		ANNOTATION_DEFAULT_CHANGED( Certainty.POTENTIAL, Impact.SOURCE, Impact.BEHAVIORAL );
 
 		private final Set<Impact> impacts;

--- a/local-build-plugins/src/main/java/org/hibernate/orm/post/ResolveClassificationMetadataTask.java
+++ b/local-build-plugins/src/main/java/org/hibernate/orm/post/ResolveClassificationMetadataTask.java
@@ -5,17 +5,11 @@
 package org.hibernate.orm.post;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
-import java.util.Locale;
+
+import org.hibernate.orm.tooling.classification.internal.ClassificationMetadataResolver;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -38,6 +32,12 @@ import org.gradle.work.DisableCachingByDefault;
 /// @since 8.0
 @DisableCachingByDefault(because = "Resolves remote metadata into a shared conditional cache")
 public abstract class ResolveClassificationMetadataTask extends DefaultTask {
+	public ResolveClassificationMetadataTask() {
+		// Remote family documents are mutable. Always check their checksum;
+		// a configured local file still benefits from Gradle input tracking.
+		getOutputs().upToDateWhen( task -> getClassificationMetadataFile().isPresent() );
+	}
+
 	@Input
 	public abstract Property<String> getFamily();
 
@@ -88,73 +88,21 @@ public abstract class ResolveClassificationMetadataTask extends DefaultTask {
 	}
 
 	private void resolveRemote(String family, Path output) throws IOException {
-		final Path familyCache = getSharedCacheDirectory().get().getAsFile().toPath().resolve( family );
-		final Path cachedMetadata = familyCache.resolve( "classifications.json.gz" );
-		final Path cachedChecksum = familyCache.resolve( "classifications.json.gz.sha256" );
-		if ( getOffline().get() ) {
-			if ( !validCache( cachedMetadata, cachedChecksum, family ) ) {
-				throw new GradleException(
-						"No validated classification metadata is cached for Hibernate ORM " + family
-								+ "; run online or configure a local metadata file"
-				);
-			}
-			Files.copy( cachedMetadata, output, StandardCopyOption.REPLACE_EXISTING );
-			return;
-		}
-
-		final String base = trimSlash( getClassificationMetadataBaseUrl().get() ) + '/' + family + "/metadata/";
 		try {
-			final byte[] checksumBytes = download( URI.create( base + "classifications.json.gz.sha256" ) );
-			final String expected = parseChecksum( new String( checksumBytes, StandardCharsets.UTF_8 ) );
-			if ( !getRefreshDependencies().get()
-					&& Files.isRegularFile( cachedMetadata )
-					&& expected.equals( digest( Files.readAllBytes( cachedMetadata ) ) ) ) {
-				validate( cachedMetadata, family );
-				Files.copy( cachedMetadata, output, StandardCopyOption.REPLACE_EXISTING );
-				return;
-			}
-
-			final byte[] metadataBytes = download( URI.create( base + "classifications.json.gz" ) );
-			final String actual = digest( metadataBytes );
-			if ( !expected.equals( actual ) ) {
-				throw new GradleException(
-						"Classification metadata checksum mismatch for Hibernate ORM " + family
-								+ ": expected " + expected + " but received " + actual
-				);
-			}
-			Files.createDirectories( familyCache );
-			writeAtomically( cachedMetadata, metadataBytes );
-			writeAtomically( cachedChecksum, checksumBytes );
-			validate( cachedMetadata, family );
-			Files.copy( cachedMetadata, output, StandardCopyOption.REPLACE_EXISTING );
-		}
-		catch (MissingMetadataException e) {
-			if ( validCache( cachedMetadata, cachedChecksum, family ) ) {
-				Files.copy( cachedMetadata, output, StandardCopyOption.REPLACE_EXISTING );
-				return;
-			}
-			if ( getAllowMissing().get() ) {
-				if ( remoteExists( URI.create( base + "classifications.json.gz" ) ) ) {
-					throw new GradleException(
-							"Classification metadata already exists for Hibernate ORM " + family
-									+ " but its authenticated checksum is unavailable"
-					);
-				}
+			final boolean resolved = new ClassificationMetadataResolver(
+					getSharedCacheDirectory().get().getAsFile().toPath(),
+					getClassificationMetadataBaseUrl().get(),
+					family
+			).resolve(
+					output, getOffline().get(), getRefreshDependencies().get(), getAllowMissing().get(),
+					file -> validate( file, family ), message -> getLogger().warn( message )
+			);
+			if ( !resolved ) {
 				getLogger().lifecycle( "No published classification baseline exists for Hibernate ORM {}", family );
-				return;
 			}
-			throw e;
 		}
-		catch (IOException e) {
-			if ( !getRefreshDependencies().get() && validCache( cachedMetadata, cachedChecksum, family ) ) {
-				getLogger().warn(
-						"Unable to refresh Hibernate ORM {} classification metadata; using the validated cached copy",
-						family
-				);
-				Files.copy( cachedMetadata, output, StandardCopyOption.REPLACE_EXISTING );
-				return;
-			}
-			throw e;
+		catch (IllegalArgumentException e) {
+			throw new GradleException( e.getMessage(), e );
 		}
 	}
 
@@ -168,112 +116,6 @@ public abstract class ResolveClassificationMetadataTask extends DefaultTask {
 		}
 		if ( metadata.getSourceVersion() == null || metadata.getSourceVersion().isBlank() ) {
 			throw new GradleException( "Classification metadata does not identify its exact source version" );
-		}
-	}
-
-	private static boolean validCache(Path metadata, Path checksum, String family) {
-		if ( !Files.isRegularFile( metadata ) || !Files.isRegularFile( checksum ) ) {
-			return false;
-		}
-		try {
-			final String expected = parseChecksum( Files.readString( checksum, StandardCharsets.UTF_8 ) );
-			if ( !expected.equals( digest( Files.readAllBytes( metadata ) ) ) ) {
-				return false;
-			}
-			validate( metadata, family );
-			return true;
-		}
-		catch (RuntimeException | IOException e) {
-			return false;
-		}
-	}
-
-	private static byte[] download(URI uri) throws IOException {
-		final HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
-		connection.setConnectTimeout( 10_000 );
-		connection.setReadTimeout( 30_000 );
-		connection.setRequestProperty( "Accept-Encoding", "identity" );
-		final int status = connection.getResponseCode();
-		if ( status == HttpURLConnection.HTTP_NOT_FOUND ) {
-			connection.disconnect();
-			throw new MissingMetadataException( uri );
-		}
-		if ( status < 200 || status >= 300 ) {
-			connection.disconnect();
-			throw new IOException( "HTTP " + status + " resolving " + uri );
-		}
-		try ( InputStream input = connection.getInputStream() ) {
-			return input.readAllBytes();
-		}
-		finally {
-			connection.disconnect();
-		}
-	}
-
-	private static boolean remoteExists(URI uri) throws IOException {
-		final HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
-		connection.setRequestMethod( "HEAD" );
-		connection.setConnectTimeout( 10_000 );
-		connection.setReadTimeout( 30_000 );
-		try {
-			final int status = connection.getResponseCode();
-			if ( status == HttpURLConnection.HTTP_NOT_FOUND ) {
-				return false;
-			}
-			if ( status < 200 || status >= 300 ) {
-				throw new IOException( "HTTP " + status + " checking " + uri );
-			}
-			return true;
-		}
-		finally {
-			connection.disconnect();
-		}
-	}
-
-	private static String parseChecksum(String contents) {
-		final String trimmed = contents.trim();
-		final int separator = trimmed.indexOf( ' ' );
-		final String checksum = (separator < 0 ? trimmed : trimmed.substring( 0, separator )).toLowerCase( Locale.ROOT );
-		if ( checksum.length() != 64 || !checksum.matches( "[0-9a-f]{64}" ) ) {
-			throw new GradleException( "Malformed SHA-256 classification metadata checksum" );
-		}
-		if ( separator >= 0 && !trimmed.substring( separator ).trim().endsWith( "classifications.json.gz" ) ) {
-			throw new GradleException( "Classification metadata checksum names an unexpected file" );
-		}
-		return checksum;
-	}
-
-	private static String digest(byte[] bytes) {
-		try {
-			return HexFormat.of().formatHex( MessageDigest.getInstance( "SHA-256" ).digest( bytes ) );
-		}
-		catch (NoSuchAlgorithmException e) {
-			throw new IllegalStateException( "SHA-256 is not available", e );
-		}
-	}
-
-	private static void writeAtomically(Path target, byte[] contents) throws IOException {
-		final Path temporary = target.resolveSibling( target.getFileName() + ".tmp" );
-		Files.write( temporary, contents );
-		try {
-			Files.move( temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING );
-		}
-		catch (java.nio.file.AtomicMoveNotSupportedException e) {
-			Files.move( temporary, target, StandardCopyOption.REPLACE_EXISTING );
-		}
-	}
-
-	private static String trimSlash(String value) {
-		int end = value.length();
-		while ( end > 0 && value.charAt( end - 1 ) == '/' ) {
-			end--;
-		}
-		return value.substring( 0, end );
-	}
-
-	private static final class MissingMetadataException extends IOException {
-		private MissingMetadataException(URI uri) {
-			super( "HTTP 404 resolving " + uri );
 		}
 	}
 }

--- a/local-build-plugins/src/test/java/org/hibernate/orm/post/ClassificationMigrationResolutionTests.java
+++ b/local-build-plugins/src/test/java/org/hibernate/orm/post/ClassificationMigrationResolutionTests.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.HexFormat;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.JarOutputStream;
 
 import com.sun.net.httpserver.HttpServer;
@@ -37,6 +38,53 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 public class ClassificationMigrationResolutionTests {
 	@TempDir
 	Path temporaryDirectory;
+
+	@Test
+	public void remoteBaselineIsRecheckedOnConsecutiveBuilds() throws Exception {
+		final AtomicReference<byte[]> metadata = new AtomicReference<>(
+				compressedMetadata( "8.0", "8.0.7.Final", Collections.emptyList() ) );
+		final HttpServer server = HttpServer.create( new InetSocketAddress( "127.0.0.1", 0 ), 0 );
+		server.createContext( "/8.0/metadata/classifications.json.gz", exchange -> {
+			final byte[] bytes = metadata.get();
+			exchange.sendResponseHeaders( 200, bytes.length );
+			exchange.getResponseBody().write( bytes );
+			exchange.close();
+		} );
+		server.createContext( "/8.0/metadata/classifications.json.gz.sha256", exchange -> {
+			try {
+				final byte[] checksum = HexFormat.of().formatHex( MessageDigest.getInstance( "SHA-256" ).digest( metadata.get() ) )
+						.getBytes( StandardCharsets.UTF_8 );
+				exchange.sendResponseHeaders( 200, checksum.length );
+				exchange.getResponseBody().write( checksum );
+			}
+			catch (java.security.NoSuchAlgorithmException e) {
+				throw new AssertionError( e );
+			}
+			finally {
+				exchange.close();
+			}
+		} );
+		server.start();
+		try {
+			Files.writeString( temporaryDirectory.resolve( "settings.gradle" ), "" );
+			Files.writeString( temporaryDirectory.resolve( "build.gradle" ),
+					"plugins { id 'org.hibernate.orm.build.reports' }\n"
+							+ "migrationCompatibility { baselineFamily = '8.0'; classificationMetadataBaseUrl = 'http://127.0.0.1:"
+							+ server.getAddress().getPort() + "' }\n"
+							+ "tasks.named('resolveMigrationCompatibilityBaselineMetadata') { sharedCacheDirectory = layout.projectDirectory.dir('cache') }\n" );
+			final String task = "resolveMigrationCompatibilityBaselineMetadata";
+			final GradleRunner runner = GradleRunner.create().withProjectDir( temporaryDirectory.toFile() )
+					.withPluginClasspath().withArguments( task );
+			assertEquals( SUCCESS, runner.build().task( ":" + task ).getOutcome() );
+			metadata.set( compressedMetadata( "8.0", "8.0.8.Final", Collections.emptyList() ) );
+			assertEquals( SUCCESS, runner.build().task( ":" + task ).getOutcome() );
+			assertArrayEquals( metadata.get(), Files.readAllBytes( temporaryDirectory.resolve(
+					"build/orm/migration-compatibility/baseline/classifications.json.gz" ) ) );
+		}
+		finally {
+			server.stop( 0 );
+		}
+	}
 
 	@Test
 	public void resolvesAuthenticatedRemoteMetadata() throws Exception {

--- a/local-build-plugins/src/test/java/org/hibernate/orm/post/ClassificationMigrationValidatorTests.java
+++ b/local-build-plugins/src/test/java/org/hibernate/orm/post/ClassificationMigrationValidatorTests.java
@@ -30,6 +30,7 @@ import static org.hibernate.orm.post.ClassificationModel.Role.IMPLEMENT;
 import static org.hibernate.orm.post.ClassificationModel.Role.USE;
 import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.ABSTRACT_METHOD_ADDED;
 import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.DEFAULT_METHOD_ADDED;
+import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.DECLARED_EXCEPTION_REMOVED;
 import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.METHOD_REMOVED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -113,6 +114,62 @@ public class ClassificationMigrationValidatorTests {
 				analysis
 		);
 		assertFalse( useResult.hasFailures() );
+	}
+
+	@Test
+	public void inheritedMethodMustRetainTheOverridesSupportedRoles() throws IOException {
+		final Path baseline = temporaryDirectory.resolve( "inherited-baseline" );
+		final Path current = temporaryDirectory.resolve( "inherited-current" );
+		writeInheritedContract( baseline, true );
+		writeInheritedContract( current, false );
+		final var oldModel = categoryModel( org.hibernate.orm.post.ClassificationModel.Category.SPI, List.of( IMPLEMENT ), true );
+		final var newModel = categoryBuilder( org.hibernate.orm.post.ClassificationModel.Category.SPI, List.of( IMPLEMENT ), false );
+		newModel.declaration( "type:fixture.Parent", TYPE, null,
+				new ClassificationModel.Structure( Modifier.PUBLIC | Modifier.ABSTRACT, true, false ), "fixture" );
+		newModel.declaration( "method:fixture.Parent#operation()", METHOD, "type:fixture.Parent",
+				new ClassificationModel.Structure( Modifier.PUBLIC | Modifier.ABSTRACT, true, false ), "fixture" );
+		classify( newModel, "type:fixture.Parent", org.hibernate.orm.post.ClassificationModel.Category.SPI, List.of( USE ) );
+		classify( newModel, "method:fixture.Parent#operation()", org.hibernate.orm.post.ClassificationModel.Category.SPI, List.of( USE ) );
+		final var analysis = analyze( baseline, current );
+		assertTrue( analysis.getChanges().isEmpty() );
+		final var result = validator.validate( metadata( "8.1", "8.1.0", oldModel ),
+				metadata( "8.1", "8.1.1", newModel.build() ), analysis );
+		assertTrue( result.hasFailures() );
+		assertEquals( SPI_ROLE_REMOVED, result.getDiagnostics().get( 0 ).getFindingCause() );
+	}
+
+	private static void writeInheritedContract(Path root, boolean override) throws IOException {
+		for ( String name : List.of( "Parent", "Contract" ) ) {
+			final ClassWriter writer = new ClassWriter( 0 );
+			writer.visit( Opcodes.V17, Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE,
+					"fixture/" + name, null, "java/lang/Object", name.equals( "Contract" ) ? new String[] { "fixture/Parent" } : null );
+			if ( name.equals( "Parent" ) || override ) {
+				writer.visitMethod( Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT, "operation", "()V", null, null ).visitEnd();
+			}
+			writer.visitEnd();
+			final Path file = root.resolve( "fixture/" + name + ".class" );
+			Files.createDirectories( file.getParent() );
+			Files.write( file, writer.toByteArray() );
+		}
+	}
+
+	@Test
+	public void removedCheckedExceptionIsEnforcedForApiAndSpiWithinTheirHorizons() throws IOException {
+		final Path baseline = temporaryDirectory.resolve( "throws-baseline" );
+		final Path current = temporaryDirectory.resolve( "throws-current" );
+		writeContract( baseline, true, false, false, new String[] { "java/io/IOException" } );
+		writeContract( current, true, false );
+		final var analysis = analyze( baseline, current );
+		for ( var role : ClassificationModel.Role.values() ) {
+			final var model = categoryModel( org.hibernate.orm.post.ClassificationModel.Category.SPI, List.of( role ), true );
+			final var result = validator.validate( metadata( "8.1", "8.1.0", model ), metadata( "8.1", "8.1.1", model ), analysis );
+			assertDiagnostic( result, SPI, DECLARED_EXCEPTION_REMOVED );
+			assertTrue( result.hasFailures() );
+			assertFalse( validator.validate( metadata( "8.1", "8.1.0", model ), metadata( "8.2", "8.2.0", model ), analysis ).hasFailures() );
+		}
+		final var model = categoryModel( org.hibernate.orm.post.ClassificationModel.Category.API, List.of(), true );
+		assertTrue( validator.validate( metadata( "8.1", "8.1.0", model ), metadata( "8.2", "8.2.0", model ), analysis ).hasFailures() );
+		assertFalse( validator.validate( metadata( "8.1", "8.1.0", model ), metadata( "9.0", "9.0.0", model ), analysis ).hasFailures() );
 	}
 
 	@Test
@@ -343,6 +400,11 @@ public class ClassificationMigrationValidatorTests {
 			boolean operation,
 			boolean required,
 			boolean defaultMethod) throws IOException {
+		writeContract( root, operation, required, defaultMethod, null );
+	}
+
+	private static void writeContract(
+			Path root, boolean operation, boolean required, boolean defaultMethod, String[] exceptions) throws IOException {
 		final ClassWriter writer = new ClassWriter( 0 );
 		writer.visit(
 				Opcodes.V17,
@@ -353,7 +415,7 @@ public class ClassificationMigrationValidatorTests {
 				null
 		);
 		if ( operation ) {
-			writer.visitMethod( Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT, "operation", "()V", null, null ).visitEnd();
+			writer.visitMethod( Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT, "operation", "()V", null, exceptions ).visitEnd();
 		}
 		if ( required ) {
 			writer.visitMethod( Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT, "required", "()V", null, null ).visitEnd();

--- a/local-build-plugins/src/test/java/org/hibernate/orm/post/CompiledJavaMigrationTests.java
+++ b/local-build-plugins/src/test/java/org/hibernate/orm/post/CompiledJavaMigrationTests.java
@@ -1,0 +1,222 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.post;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.tools.ToolProvider;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.CONSTRUCTOR_REMOVED;
+import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.DECLARED_EXCEPTION_ADDED;
+import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.DECLARED_EXCEPTION_REMOVED;
+import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.GENERIC_SIGNATURE_CHANGED;
+import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.METHOD_REMOVED;
+import static org.hibernate.orm.post.JavaMigrationCompatibilityAnalyzer.Cause.OVERLOAD_ADDED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Compare analyzer findings with actual source compilation and binary linkage.
+/// These tests intentionally complement the declaration-shape and policy tests.
+///
+/// @author Steve Ebersole
+class CompiledJavaMigrationTests {
+	@TempDir
+	Path directory;
+
+	@Test
+	void inheritedMethodRemainsSourceAndBinaryCompatible() throws Exception {
+		final String parent = "package fixture; public class Parent { public String value() { return \"ok\"; } }";
+		final Path old = compile( "old", null, Map.of(
+				"Parent", parent,
+				"Child", "package fixture; public class Child extends Parent { public String value() { return \"ok\"; } }"
+		) );
+		final Path current = compile( "current", null, Map.of(
+				"Parent", parent, "Child", "package fixture; public class Child extends Parent {}"
+		) );
+		final Map<String, String> client = Map.of( "Client",
+				"package fixture; public class Client { public static String run() { return new Child().value(); } }" );
+		final Path oldClient = compile( "client", old, client );
+		compile( "recompiled", current, client );
+		try ( URLClassLoader loader = new URLClassLoader(
+				new java.net.URL[] { oldClient.toUri().toURL(), current.toUri().toURL() }, null ) ) {
+			assertEquals( "ok", loader.loadClass( "fixture.Client" ).getMethod( "run" ).invoke( null ) );
+		}
+		assertTrue( new JavaMigrationCompatibilityAnalyzer().analyze(
+				List.of( old.toFile() ), List.of( current.toFile() ), List.of( "type:fixture.Child" )
+		).getChanges().isEmpty() );
+	}
+
+	@Test
+	void inheritedCovariantBridgePreservesExistingBinaryClients() throws Exception {
+		final String root = "package fixture; public interface Root<T> { T value(); }";
+		final String parent = "package fixture; public class Parent implements Root<String> { public String value() { return \"ok\"; } }";
+		final Path old = compile( "old", null, Map.of( "Root", root, "Parent", parent, "Child",
+				"package fixture; public class Child extends Parent { public String value() { return \"ok\"; } }" ) );
+		final Path current = compile( "current", null, Map.of( "Root", root, "Parent", parent, "Child",
+				"package fixture; public class Child extends Parent {}" ) );
+		final Map<String, String> client = Map.of( "Client",
+				"package fixture; public class Client { public static String run() { Child child = new Child(); Root<?> root = child; return child.value() + root.value(); } }" );
+		final Path oldClient = compile( "client", old, client );
+		compile( "recompiled", current, client );
+		try ( URLClassLoader loader = new URLClassLoader(
+				new java.net.URL[] { oldClient.toUri().toURL(), current.toUri().toURL() }, null ) ) {
+			assertEquals( "okok", loader.loadClass( "fixture.Client" ).getMethod( "run" ).invoke( null ) );
+		}
+		assertTrue( causes( old, current ).isEmpty() );
+	}
+
+	@Test
+	void inheritedDefaultMethodRemainsAvailable() throws Exception {
+		final String parent = "package fixture; public interface Parent { default String value() { return \"ok\"; } }";
+		final Path old = compile( "old", null, Map.of( "Parent", parent, "Child",
+				"package fixture; public interface Child extends Parent { default String value() { return \"ok\"; } }" ) );
+		final Path current = compile( "current", null, Map.of( "Parent", parent, "Child",
+				"package fixture; public interface Child extends Parent {}" ) );
+		final Map<String, String> client = Map.of( "Client",
+				"package fixture; public class Client { public static String run() { return new Child() {}.value(); } }" );
+		final Path oldClient = compile( "client", old, client );
+		compile( "recompiled", current, client );
+		try ( URLClassLoader loader = new URLClassLoader(
+				new java.net.URL[] { oldClient.toUri().toURL(), current.toUri().toURL() }, null ) ) {
+			assertEquals( "ok", loader.loadClass( "fixture.Client" ).getMethod( "run" ).invoke( null ) );
+		}
+		assertTrue( causes( old, current ).isEmpty() );
+	}
+
+	@Test
+	void constructorsAreNeverResolvedFromSuperclasses() throws Exception {
+		final String parent = "package fixture; public class Parent { public Parent(String s) {} }";
+		final Path old = compile( "old", null, Map.of( "Parent", parent, "Child",
+				"package fixture; public class Child extends Parent { public Child(String s) { super(s); } }" ) );
+		final Path current = compile( "current", null, Map.of( "Parent", parent, "Child",
+				"package fixture; public class Child extends Parent { public Child() { super(null); } }" ) );
+		assertTrue( causes( old, current ).contains( CONSTRUCTOR_REMOVED ) );
+	}
+
+	@Test
+	void genericReturnChangeBreaksSourceEvenWithIdenticalErasure() throws Exception {
+		final Path old = compile( "old", null, Map.of( "Contract",
+				"package fixture; public interface Contract { java.util.List<String> values(); }" ) );
+		final Path current = compile( "current", null, Map.of( "Contract",
+				"package fixture; public interface Contract { java.util.List<Integer> values(); }" ) );
+		final Map<String, String> client = Map.of( "Client",
+				"package fixture; class Client { String value(Contract c) { return c.values().get(0); } }" );
+		compile( "client", old, client );
+		assertFalse( compileResult( "recompiled", current, client ) );
+		assertEquals( List.of( GENERIC_SIGNATURE_CHANGED ), causes( old, current ) );
+	}
+
+	@Test
+	void removedCheckedExceptionBreaksProviderRecompilation() throws Exception {
+		final Path old = contract( "old", "throws java.io.IOException" );
+		final Path current = contract( "current", "" );
+		final Map<String, String> provider = Map.of( "Provider",
+				"package fixture; public class Provider implements Contract { public void operation() throws java.io.IOException {} }" );
+		compile( "provider", old, provider );
+		assertFalse( compileResult( "recompiled", current, provider ) );
+		assertEquals( List.of( DECLARED_EXCEPTION_REMOVED ), causes( old, current ) );
+	}
+
+	@Test
+	void narrowedCheckedExceptionBreaksOverridesButWideningDoesNot() throws Exception {
+		final Path old = contract( "old", "throws java.io.IOException" );
+		final Path narrowed = contract( "narrowed", "throws java.io.FileNotFoundException" );
+		final Path widened = contract( "widened", "throws Exception" );
+		assertEquals( List.of( DECLARED_EXCEPTION_REMOVED ), causes( old, narrowed ) );
+		assertEquals( List.of( DECLARED_EXCEPTION_ADDED ), causes( old, widened ) );
+	}
+
+	@Test
+	void unavailableExceptionDependencyRequiresReviewInsteadOfAnAssumedBreak() throws Exception {
+		final Path dependency = compile( "dependency", null, Map.of( "CustomException",
+				"package fixture; public class CustomException extends RuntimeException {}" ) );
+		final Path old = compile( "old", dependency, Map.of( "Contract",
+				"package fixture; public interface Contract { void operation() throws CustomException; }" ) );
+		final Path current = contract( "current", "" );
+		final var change = new JavaMigrationCompatibilityAnalyzer().analyze(
+				List.of( old.toFile() ), List.of( current.toFile() ) ).getChanges().get( 0 );
+		assertEquals( DECLARED_EXCEPTION_REMOVED, change.getCause() );
+		assertEquals( JavaMigrationCompatibilityAnalyzer.Certainty.POTENTIAL, change.getCertainty() );
+		assertTrue( new JavaMigrationCompatibilityAnalyzer().analyze(
+				List.of( old.toFile(), dependency.toFile() ), List.of( current.toFile(), dependency.toFile() ),
+				List.of( "type:fixture.Contract" ) ).getChanges().isEmpty() );
+	}
+
+	@Test
+	void uncheckedExceptionDeclarationsDoNotChangeCompatibility() throws Exception {
+		final Path old = contract( "old", "throws IllegalArgumentException, Error" );
+		final Path current = contract( "current", "throws IllegalStateException" );
+		assertTrue( causes( old, current ).isEmpty() );
+	}
+
+	@Test
+	void privateAncestorMethodDoesNotReplaceRemovedPublicMethod() throws Exception {
+		final String parent = "package fixture; public class Parent { private void value() {} }";
+		final Path old = compile( "old", null, Map.of( "Parent", parent, "Child",
+				"package fixture; public class Child extends Parent { public void value() {} }" ) );
+		final Path current = compile( "current", null, Map.of( "Parent", parent, "Child",
+				"package fixture; public class Child extends Parent {}" ) );
+		assertEquals( List.of( METHOD_REMOVED ), causes( old, current ) );
+	}
+
+	@Test
+	void constructorOverloadCanMakeExistingSourceAmbiguous() throws Exception {
+		final Path old = compile( "old", null, Map.of( "Choice",
+				"package fixture; public class Choice { public Choice(String s) {} }" ) );
+		final Path current = compile( "current", null, Map.of( "Choice",
+				"package fixture; public class Choice { public Choice(String s) {} public Choice(Integer i) {} }" ) );
+		final Map<String, String> client = Map.of( "Client",
+				"package fixture; class Client { Object value = new Choice(null); }" );
+		compile( "client", old, client );
+		assertFalse( compileResult( "recompiled", current, client ) );
+		assertEquals( List.of( OVERLOAD_ADDED ), causes( old, current ) );
+	}
+
+	private Path contract(String name, String exceptions) throws IOException {
+		return compile( name, null, Map.of( "Contract",
+				"package fixture; public interface Contract { void operation() " + exceptions + "; }" ) );
+	}
+
+	private List<JavaMigrationCompatibilityAnalyzer.Cause> causes(Path old, Path current) {
+		return new JavaMigrationCompatibilityAnalyzer().analyze( List.of( old.toFile() ), List.of( current.toFile() ) )
+				.getChanges().stream().map( JavaMigrationCompatibilityAnalyzer.Change::getCause ).toList();
+	}
+
+	private Path compile(String name, Path classpath, Map<String, String> sources) throws IOException {
+		assertTrue( compileResult( name, classpath, sources ) );
+		return directory.resolve( name + "/classes" );
+	}
+
+	private boolean compileResult(String name, Path classpath, Map<String, String> sources) throws IOException {
+		final Path root = directory.resolve( name );
+		Files.createDirectories( root.resolve( "classes" ) );
+		final List<Path> files = new ArrayList<>();
+		for ( Map.Entry<String, String> source : sources.entrySet() ) {
+			final Path file = root.resolve( source.getKey() + ".java" );
+			Files.writeString( file, source.getValue() );
+			files.add( file );
+		}
+		final var compiler = ToolProvider.getSystemJavaCompiler();
+		try ( var manager = compiler.getStandardFileManager( null, null, null ) ) {
+			final List<String> options = new ArrayList<>( List.of( "-proc:none", "-d", root.resolve( "classes" ).toString() ) );
+			if ( classpath != null ) {
+				options.addAll( List.of( "-classpath", classpath.toString() ) );
+			}
+			return compiler.getTask( new StringWriter(), manager, null, options, null,
+					manager.getJavaFileObjectsFromPaths( files ) ).call();
+		}
+	}
+}

--- a/shared/classification/src/main/java/org/hibernate/orm/tooling/classification/internal/ClassificationMetadataResolver.java
+++ b/shared/classification/src/main/java/org/hibernate/orm/tooling/classification/internal/ClassificationMetadataResolver.java
@@ -1,0 +1,249 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.tooling.classification.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+/// Shared transport and cache for family classification metadata. Both Gradle
+/// builds compile this source so build bootstrapping needs no published tooling
+/// dependency. Callers retain version selection and metadata-schema validation.
+///
+/// Cache entries are scoped by metadata origin and family. A file lock protects
+/// the metadata/checksum pair across tasks and processes, and unique temporary
+/// files ensure readers never observe a partially written output.
+///
+/// @author Steve Ebersole
+public final class ClassificationMetadataResolver {
+	private static final String METADATA = "classifications.json.gz";
+	private static final String CHECKSUM = METADATA + ".sha256";
+	private final String family;
+	private final String base;
+	private final Path cache;
+
+	public ClassificationMetadataResolver(Path cacheRoot, String baseUrl, String family) {
+		this.family = family;
+		this.base = trimSlash( baseUrl ) + '/' + family + "/metadata/";
+		this.cache = cacheDirectory( cacheRoot, baseUrl, family );
+	}
+
+	public static Path cacheDirectory(Path root, String baseUrl, String family) {
+		return root.resolve( digest( trimSlash( baseUrl ).getBytes( StandardCharsets.UTF_8 ) ) ).resolve( family );
+	}
+
+	/// Resolve a validated document, returning false only for an explicitly
+	/// allowed absent baseline. Refresh requests never fall back to cached data.
+	public boolean resolve(
+			Path output, boolean offline, boolean refresh, boolean allowMissing,
+			Consumer<Path> validate, Consumer<String> warning) throws IOException {
+		Files.createDirectories( cache );
+		Files.createDirectories( output.getParent() );
+		try ( FileChannel channel = FileChannel.open( cache.resolve( "metadata.lock" ),
+				StandardOpenOption.CREATE, StandardOpenOption.WRITE );
+				FileLock ignored = lock( channel ) ) {
+			final Path metadata = cache.resolve( METADATA );
+			final Path checksum = cache.resolve( CHECKSUM );
+			if ( offline ) {
+				if ( !validCache( metadata, checksum, validate ) ) {
+					throw new IOException( "No validated classification metadata is cached for Hibernate ORM " + family
+							+ "; run online or configure classificationMetadataFile" );
+				}
+				writeAtomically( output, Files.readAllBytes( metadata ) );
+				return true;
+			}
+			try {
+				final byte[] checksumBytes = download( URI.create( base + CHECKSUM ) );
+				final String expected = parseChecksum( new String( checksumBytes, StandardCharsets.UTF_8 ) );
+				if ( !refresh && Files.isRegularFile( metadata ) && expected.equals( digest( Files.readAllBytes( metadata ) ) ) ) {
+					validate.accept( metadata );
+					writeAtomically( checksum, checksumBytes );
+					writeAtomically( output, Files.readAllBytes( metadata ) );
+					return true;
+				}
+				final byte[] bytes = download( URI.create( base + METADATA ) );
+				if ( !expected.equals( digest( bytes ) ) ) {
+					throw new IllegalArgumentException( "Classification metadata checksum mismatch for Hibernate ORM " + family );
+				}
+				final Path candidate = Files.createTempFile( cache, "candidate-", ".json.gz" );
+				try {
+					Files.write( candidate, bytes );
+					validate.accept( candidate );
+					writeAtomically( metadata, bytes );
+					writeAtomically( checksum, checksumBytes );
+					writeAtomically( output, bytes );
+				}
+				finally {
+					Files.deleteIfExists( candidate );
+				}
+				return true;
+			}
+			catch (IOException e) {
+				if ( !refresh && validCache( metadata, checksum, validate ) ) {
+					warning.accept( "Unable to refresh Hibernate ORM " + family
+							+ " classification metadata; using the validated cached copy" );
+					writeAtomically( output, Files.readAllBytes( metadata ) );
+					return true;
+				}
+				if ( e instanceof MissingMetadataException && allowMissing
+						&& ((MissingMetadataException) e).uri.equals( URI.create( base + CHECKSUM ) ) ) {
+					if ( remoteExists( URI.create( base + METADATA ) ) ) {
+						throw new IllegalArgumentException( "Classification metadata already exists for Hibernate ORM " + family
+								+ " but its authenticated checksum is unavailable" );
+					}
+					Files.deleteIfExists( output );
+					return false;
+				}
+				throw e;
+			}
+		}
+	}
+
+	private static FileLock lock(FileChannel channel) throws IOException {
+		// Blocking FileChannel.lock() throws for overlapping locks in the same
+		// JVM. Retry covers both separate Gradle daemons and plugin classloaders.
+		while ( true ) {
+			try {
+				final FileLock lock = channel.tryLock();
+				if ( lock != null ) {
+					return lock;
+				}
+			}
+			catch (OverlappingFileLockException ignored) {
+			}
+			try {
+				Thread.sleep( 25 );
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IOException( "Interrupted waiting for classification metadata cache", e );
+			}
+		}
+	}
+
+	private static boolean validCache(Path metadata, Path checksum, Consumer<Path> validate) {
+		try {
+			if ( !Files.isRegularFile( metadata ) || !Files.isRegularFile( checksum )
+					|| !parseChecksum( Files.readString( checksum ) ).equals( digest( Files.readAllBytes( metadata ) ) ) ) {
+				return false;
+			}
+			validate.accept( metadata );
+			return true;
+		}
+		catch (RuntimeException | IOException e) {
+			return false;
+		}
+	}
+
+	private static byte[] download(URI uri) throws IOException {
+		final HttpURLConnection connection = connection( uri );
+		try {
+			checkStatus( connection, uri );
+			try ( InputStream input = connection.getInputStream() ) {
+				return input.readAllBytes();
+			}
+		}
+		finally {
+			connection.disconnect();
+		}
+	}
+
+	private static boolean remoteExists(URI uri) throws IOException {
+		final HttpURLConnection connection = connection( uri );
+		connection.setRequestMethod( "HEAD" );
+		try {
+			checkStatus( connection, uri );
+			return true;
+		}
+		catch (MissingMetadataException e) {
+			return false;
+		}
+		finally {
+			connection.disconnect();
+		}
+	}
+
+	private static HttpURLConnection connection(URI uri) throws IOException {
+		final HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
+		connection.setConnectTimeout( 10_000 );
+		connection.setReadTimeout( 30_000 );
+		connection.setRequestProperty( "Accept-Encoding", "identity" );
+		return connection;
+	}
+
+	private static void checkStatus(HttpURLConnection connection, URI uri) throws IOException {
+		final int status = connection.getResponseCode();
+		if ( status == HttpURLConnection.HTTP_NOT_FOUND ) {
+			throw new MissingMetadataException( uri );
+		}
+		if ( status < 200 || status >= 300 ) {
+			throw new IOException( "HTTP " + status + " resolving " + uri );
+		}
+	}
+
+	private static String parseChecksum(String contents) {
+		final String[] parts = contents.trim().split( "\\s+", 2 );
+		final String checksum = parts[0].toLowerCase( Locale.ROOT );
+		if ( !checksum.matches( "[0-9a-f]{64}" ) ) {
+			throw new IllegalArgumentException( "Malformed SHA-256 classification metadata checksum" );
+		}
+		if ( parts.length > 1 && !parts[1].equals( METADATA ) && !parts[1].equals( '*' + METADATA ) ) {
+			throw new IllegalArgumentException( "Classification metadata checksum names an unexpected file" );
+		}
+		return checksum;
+	}
+
+	private static String digest(byte[] bytes) {
+		try {
+			return HexFormat.of().formatHex( MessageDigest.getInstance( "SHA-256" ).digest( bytes ) );
+		}
+		catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException( "SHA-256 is not available", e );
+		}
+	}
+
+	private static void writeAtomically(Path target, byte[] bytes) throws IOException {
+		final Path temporary = Files.createTempFile( target.getParent(), target.getFileName() + "-", ".tmp" );
+		try {
+			Files.write( temporary, bytes );
+			try {
+				Files.move( temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING );
+			}
+			catch (java.nio.file.AtomicMoveNotSupportedException e) {
+				Files.move( temporary, target, StandardCopyOption.REPLACE_EXISTING );
+			}
+		}
+		finally {
+			Files.deleteIfExists( temporary );
+		}
+	}
+
+	private static String trimSlash(String value) {
+		return value.replaceAll( "/+$", "" );
+	}
+
+	private static final class MissingMetadataException extends IOException {
+		private final URI uri;
+
+		private MissingMetadataException(URI uri) {
+			super( "HTTP 404 resolving " + uri );
+			this.uri = uri;
+		}
+	}
+}

--- a/tooling/hibernate-dialect-provider/hibernate-dialect-provider-tooling.gradle
+++ b/tooling/hibernate-dialect-provider/hibernate-dialect-provider-tooling.gradle
@@ -16,6 +16,7 @@ plugins {
 description = "Gradle tooling and compatibility fixture for external Hibernate ORM Dialect providers"
 
 sourceSets {
+	main.java.srcDir rootProject.file("shared/classification/src/main/java")
 	providerFixture
 	providerFixtureTest
 }
@@ -167,6 +168,8 @@ tasks.withType(JavaCompile).configureEach {
 spotless {
 	enforceCheck = false
 	java {
+		// The shared source directory is outside this subproject's formatting scope.
+		target "src/**/*.java"
 		licenseHeaderFile rootProject.file("shared/config/spotless/license.java")
 		removeUnusedImports()
 		leadingSpacesToTabs(4)

--- a/tooling/hibernate-dialect-provider/src/main/java/org/hibernate/orm/tooling/dialectprovider/ResolveDialectProviderClassificationMetadata.java
+++ b/tooling/hibernate-dialect-provider/src/main/java/org/hibernate/orm/tooling/dialectprovider/ResolveDialectProviderClassificationMetadata.java
@@ -5,17 +5,12 @@
 package org.hibernate.orm.tooling.dialectprovider;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
 import java.util.Locale;
+
+import org.hibernate.orm.tooling.classification.internal.ClassificationMetadataResolver;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -43,6 +38,12 @@ import org.hibernate.orm.tooling.dialectprovider.internal.HibernateVersions;
 /// @since 8.0
 @DisableCachingByDefault(because = "Resolves authenticated remote metadata into a shared conditional cache")
 public abstract class ResolveDialectProviderClassificationMetadata extends DefaultTask {
+	public ResolveDialectProviderClassificationMetadata() {
+		// Remote family documents are mutable. Always check their checksum;
+		// a configured local file still benefits from Gradle input tracking.
+		getOutputs().upToDateWhen( task -> getClassificationMetadataFile().isPresent() );
+	}
+
 	@Input
 	public abstract Property<String> getHibernateVersion();
 
@@ -114,73 +115,18 @@ public abstract class ResolveDialectProviderClassificationMetadata extends Defau
 	}
 
 	private void resolveRemote(String family, Path output) throws IOException {
-		final Path familyCache = getSharedCacheDirectory().get().getAsFile().toPath().resolve( family );
-		final Path cachedMetadata = familyCache.resolve( "classifications.json.gz" );
-		final Path cachedChecksum = familyCache.resolve( "classifications.json.gz.sha256" );
-		if ( getOffline().get() ) {
-			if ( !validCache( cachedMetadata, cachedChecksum, family ) ) {
-				throw new GradleException(
-						"No validated classification metadata is cached for Hibernate ORM " + family
-								+ "; run online or configure classificationMetadataFile"
-				);
-			}
-			Files.copy( cachedMetadata, output, StandardCopyOption.REPLACE_EXISTING );
-			return;
-		}
-
-		final String base = trimSlash( getClassificationMetadataBaseUrl().get() ) + "/" + family + "/metadata/";
 		try {
-			final byte[] checksumBytes = download( URI.create( base + "classifications.json.gz.sha256" ) );
-			final String expected = parseChecksum( new String( checksumBytes, StandardCharsets.UTF_8 ) );
-			if ( !getRefreshDependencies().get()
-					&& Files.isRegularFile( cachedMetadata )
-					&& expected.equals( digest( Files.readAllBytes( cachedMetadata ) ) ) ) {
-				validate( cachedMetadata, family );
-				Files.copy( cachedMetadata, output, StandardCopyOption.REPLACE_EXISTING );
-				return;
-			}
-
-			final byte[] metadataBytes = download( URI.create( base + "classifications.json.gz" ) );
-			final String actual = digest( metadataBytes );
-			if ( !expected.equals( actual ) ) {
-				throw new GradleException(
-						"Classification metadata checksum mismatch for Hibernate ORM " + family
-								+ ": expected " + expected + " but received " + actual
-				);
-			}
-			Files.createDirectories( familyCache );
-			writeAtomically( cachedMetadata, metadataBytes );
-			writeAtomically( cachedChecksum, checksumBytes );
-			validate( cachedMetadata, family );
-			Files.copy( cachedMetadata, output, StandardCopyOption.REPLACE_EXISTING );
+			new ClassificationMetadataResolver(
+					getSharedCacheDirectory().get().getAsFile().toPath(),
+					getClassificationMetadataBaseUrl().get(),
+					family
+			).resolve(
+					output, getOffline().get(), getRefreshDependencies().get(), false,
+					file -> validate( file, family ), message -> getLogger().warn( message )
+			);
 		}
-		catch (IOException e) {
-			if ( !getRefreshDependencies().get() && validCache( cachedMetadata, cachedChecksum, family ) ) {
-				getLogger().warn(
-						"Unable to refresh Hibernate ORM {} classification metadata; using the validated cached copy",
-						family
-				);
-				Files.copy( cachedMetadata, output, StandardCopyOption.REPLACE_EXISTING );
-				return;
-			}
-			throw e;
-		}
-	}
-
-	private static boolean validCache(Path metadata, Path checksum, String family) {
-		if ( !Files.isRegularFile( metadata ) || !Files.isRegularFile( checksum ) ) {
-			return false;
-		}
-		try {
-			final String expected = parseChecksum( Files.readString( checksum, StandardCharsets.UTF_8 ) );
-			if ( !expected.equals( digest( Files.readAllBytes( metadata ) ) ) ) {
-				return false;
-			}
-			validate( metadata, family );
-			return true;
-		}
-		catch (RuntimeException | IOException e) {
-			return false;
+		catch (IllegalArgumentException e) {
+			throw new GradleException( e.getMessage(), e );
 		}
 	}
 
@@ -196,62 +142,8 @@ public abstract class ResolveDialectProviderClassificationMetadata extends Defau
 			throw new GradleException( "Classification metadata does not identify its exact source version" );
 		}
 	}
-
-	private static byte[] download(URI uri) throws IOException {
-		final HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
-		connection.setConnectTimeout( 10_000 );
-		connection.setReadTimeout( 30_000 );
-		connection.setRequestProperty( "Accept-Encoding", "identity" );
-		final int status = connection.getResponseCode();
-		if ( status < 200 || status >= 300 ) {
-			throw new IOException( "HTTP " + status + " resolving " + uri );
-		}
-		try ( InputStream input = connection.getInputStream() ) {
-			return input.readAllBytes();
-		}
-		finally {
-			connection.disconnect();
-		}
-	}
-
-	private static String parseChecksum(String contents) {
-		final String trimmed = contents.trim();
-		final int separator = trimmed.indexOf( ' ' );
-		final String digest = ( separator < 0 ? trimmed : trimmed.substring( 0, separator ) ).toLowerCase( Locale.ROOT );
-		if ( digest.length() != 64 || !digest.matches( "[0-9a-f]{64}" ) ) {
-			throw new GradleException( "Malformed SHA-256 classification metadata checksum" );
-		}
-		if ( separator >= 0 && !trimmed.substring( separator ).trim().endsWith( "classifications.json.gz" ) ) {
-			throw new GradleException( "Classification metadata checksum names an unexpected file" );
-		}
-		return digest;
-	}
-
-	private static String digest(byte[] bytes) {
-		try {
-			return HexFormat.of().formatHex( MessageDigest.getInstance( "SHA-256" ).digest( bytes ) );
-		}
-		catch (NoSuchAlgorithmException e) {
-			throw new IllegalStateException( "SHA-256 is not available", e );
-		}
-	}
-
-	private static void writeAtomically(Path target, byte[] contents) throws IOException {
-		final Path temporary = target.resolveSibling( target.getFileName() + ".tmp" );
-		Files.write( temporary, contents );
-		try {
-			Files.move( temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING );
-		}
-		catch (java.nio.file.AtomicMoveNotSupportedException e) {
-			Files.move( temporary, target, StandardCopyOption.REPLACE_EXISTING );
-		}
-	}
-
 	private static String trimSlash(String value) {
-		int end = value.length();
-		while ( end > 0 && value.charAt( end - 1 ) == '/' ) {
-			end--;
-		}
-		return value.substring( 0, end );
+		return value.replaceAll( "/+$", "" );
 	}
+
 }

--- a/tooling/hibernate-dialect-provider/src/test/java/org/hibernate/orm/tooling/dialectprovider/ClassificationMetadataResolutionTest.java
+++ b/tooling/hibernate-dialect-provider/src/test/java/org/hibernate/orm/tooling/dialectprovider/ClassificationMetadataResolutionTest.java
@@ -16,6 +16,7 @@ import com.sun.net.httpserver.HttpServer;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
+import org.hibernate.orm.tooling.classification.internal.ClassificationMetadataResolver;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -169,10 +170,10 @@ public class ClassificationMetadataResolutionTest {
 
 	@Test
 	void transientFailureFallsBackToValidatedCacheUnlessRefreshWasExplicit() throws Exception {
-		final byte[] metadata = seedCache();
 		final HttpServer server = failingServer();
 		try {
 			final String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+			final byte[] metadata = seedCache( baseUrl );
 			final ResolveDialectProviderClassificationMetadata ordinary = task( "8.1.2" );
 			ordinary.getClassificationMetadataBaseUrl().set( baseUrl );
 			ordinary.resolve();
@@ -194,6 +195,7 @@ public class ClassificationMetadataResolutionTest {
 		final AtomicInteger metadataRequests = new AtomicInteger();
 		final HttpServer server = server( metadata, checksum( metadata ), metadataRequests );
 		try {
+			seedCache( "http://127.0.0.1:" + server.getAddress().getPort() );
 			final ResolveDialectProviderClassificationMetadata task = task( "8.1.2" );
 			task.getClassificationMetadataBaseUrl().set( "http://127.0.0.1:" + server.getAddress().getPort() );
 			task.resolve();
@@ -211,6 +213,7 @@ public class ClassificationMetadataResolutionTest {
 		final AtomicInteger metadataRequests = new AtomicInteger();
 		final HttpServer server = server( metadata, checksum( metadata ), metadataRequests );
 		try {
+			seedCache( "http://127.0.0.1:" + server.getAddress().getPort() );
 			final ResolveDialectProviderClassificationMetadata task = task( "8.1.2" );
 			task.getClassificationMetadataBaseUrl().set( "http://127.0.0.1:" + server.getAddress().getPort() );
 			task.getRefreshDependencies().set( true );
@@ -293,8 +296,12 @@ public class ClassificationMetadataResolutionTest {
 	}
 
 	private byte[] seedCache() throws Exception {
+		return seedCache( "https://docs.hibernate.org/orm" );
+	}
+
+	private byte[] seedCache(String baseUrl) throws Exception {
 		final byte[] metadata = metadata( "8.1", "8.1.4" ).getBytes( StandardCharsets.UTF_8 );
-		final Path familyCache = temporaryDirectory.resolve( "cache/8.1" );
+		final Path familyCache = ClassificationMetadataResolver.cacheDirectory( temporaryDirectory.resolve( "cache" ), baseUrl, "8.1" );
 		Files.createDirectories( familyCache );
 		Files.write( familyCache.resolve( "classifications.json.gz" ), metadata );
 		Files.writeString(

--- a/tooling/hibernate-dialect-provider/src/test/java/org/hibernate/orm/tooling/dialectprovider/DialectProviderPluginFunctionalTest.java
+++ b/tooling/hibernate-dialect-provider/src/test/java/org/hibernate/orm/tooling/dialectprovider/DialectProviderPluginFunctionalTest.java
@@ -5,14 +5,21 @@
 package org.hibernate.orm.tooling.dialectprovider;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.JarOutputStream;
 
 import javax.tools.ToolProvider;
+
+import com.sun.net.httpserver.HttpServer;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
@@ -52,6 +59,65 @@ public class DialectProviderPluginFunctionalTest {
 
 		final BuildResult second = runner( "check", "--configuration-cache" ).build();
 		assertTrue( second.getOutput().contains( "Reusing configuration cache" ) );
+		assertEquals( TaskOutcome.UP_TO_DATE, second.task( ":resolveDialectProviderClassificationMetadata" ).getOutcome() );
+	}
+
+	@Test
+	void remoteMetadataIsRecheckedOnConsecutiveBuilds() throws Exception {
+		final String version = PluginVersions.hibernateOrm();
+		seedCoreModule( version );
+		writeProviderBuild( version );
+		final AtomicReference<byte[]> document = new AtomicReference<>(
+				Files.readAllBytes( temporaryDirectory.resolve( "classifications.json" ) )
+		);
+		final AtomicInteger downloads = new AtomicInteger();
+		final HttpServer server = HttpServer.create( new InetSocketAddress( "127.0.0.1", 0 ), 0 );
+		final String path = "/" + HibernateVersions.family( version ) + "/metadata/classifications.json.gz";
+		server.createContext( path, exchange -> {
+			downloads.incrementAndGet();
+			final byte[] bytes = document.get();
+			exchange.sendResponseHeaders( 200, bytes.length );
+			exchange.getResponseBody().write( bytes );
+			exchange.close();
+		} );
+		server.createContext( path + ".sha256", exchange -> {
+			try {
+				final byte[] checksum = HexFormat.of().formatHex( MessageDigest.getInstance( "SHA-256" ).digest( document.get() ) )
+						.getBytes( StandardCharsets.UTF_8 );
+				exchange.sendResponseHeaders( 200, checksum.length );
+				exchange.getResponseBody().write( checksum );
+			}
+			catch (java.security.NoSuchAlgorithmException e) {
+				throw new AssertionError( e );
+			}
+			finally {
+				exchange.close();
+			}
+		} );
+		server.start();
+		try {
+			appendBuild( "hibernateDialectProvider { classificationMetadataFile.unset(); classificationMetadataBaseUrl = 'http://127.0.0.1:"
+					+ server.getAddress().getPort() + "' }\n"
+					+ "tasks.named('resolveDialectProviderClassificationMetadata') { sharedCacheDirectory = layout.projectDirectory.dir('cache') }\n" );
+			final String task = "resolveDialectProviderClassificationMetadata";
+			assertEquals( TaskOutcome.SUCCESS, runner( task, "--configuration-cache" ).build().task( ":" + task ).getOutcome() );
+			// Whitespace changes the authenticated bytes without changing their schema.
+			document.set( (new String( document.get(), StandardCharsets.UTF_8 ) + "\n").getBytes( StandardCharsets.UTF_8 ) );
+			final BuildResult second = runner( task, "--configuration-cache" ).build();
+			assertEquals( TaskOutcome.SUCCESS, second.task( ":" + task ).getOutcome() );
+			assertTrue( second.getOutput().contains( "Reusing configuration cache" ) );
+			assertEquals( new String( document.get(), StandardCharsets.UTF_8 ), Files.readString(
+					temporaryDirectory.resolve( "build/hibernate-dialect-provider/metadata/classifications.json.gz" ) ) );
+			assertEquals( 2, downloads.get() );
+			runner( task ).build();
+			assertEquals( 2, downloads.get() );
+			runner( task, "--refresh-dependencies" ).build();
+			runner( task, "--refresh-dependencies" ).build();
+			assertEquals( 4, downloads.get() );
+		}
+		finally {
+			server.stop( 0 );
+		}
 	}
 
 	@Test

--- a/tooling/hibernate-dialect-provider/src/test/java/org/hibernate/orm/tooling/dialectprovider/internal/ClassificationMetadataResolverTest.java
+++ b/tooling/hibernate-dialect-provider/src/test/java/org/hibernate/orm/tooling/dialectprovider/internal/ClassificationMetadataResolverTest.java
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.tooling.dialectprovider.internal;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sun.net.httpserver.HttpServer;
+import org.hibernate.orm.tooling.classification.internal.ClassificationMetadataResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Exercises the shared resolver's cache isolation, concurrent writers, and
+/// validation-before-publication guarantees independently of Gradle tasks.
+///
+/// @author Steve Ebersole
+class ClassificationMetadataResolverTest {
+	@TempDir
+	Path directory;
+
+	@Test
+	void cachesAreIsolatedByOriginAndFamily() throws Exception {
+		final Path first = ClassificationMetadataResolver.cacheDirectory( directory, "https://first.example/orm", "8.0" );
+		assertEquals( first, ClassificationMetadataResolver.cacheDirectory( directory, "https://first.example/orm/", "8.0" ) );
+		assertTrue( !first.equals( ClassificationMetadataResolver.cacheDirectory( directory, "https://second.example/orm", "8.0" ) ) );
+		assertTrue( !first.equals( ClassificationMetadataResolver.cacheDirectory( directory, "https://first.example/orm", "8.1" ) ) );
+		final AtomicReference<String> document = new AtomicReference<>( "valid" );
+		final HttpServer server = server( document );
+		try {
+			resolver( server ).resolve( directory.resolve( "first.json" ), false, false, false, this::validate, this::unexpectedWarning );
+			assertThrows( java.io.IOException.class, () -> new ClassificationMetadataResolver( directory, "https://second.example", "8.0" )
+					.resolve( directory.resolve( "second.json" ), true, false, false, this::validate, this::unexpectedWarning ) );
+		}
+		finally {
+			server.stop( 0 );
+		}
+	}
+
+	@Test
+	void bootstrapDoesNotTreatAPartiallyPublishedBaselineAsAbsent() throws Exception {
+		for ( boolean checksumPresent : new boolean[] { true, false } ) {
+			final HttpServer server = HttpServer.create( new InetSocketAddress( "127.0.0.1", 0 ), 0 );
+			server.createContext( "/8.0/metadata/classifications.json.gz", exchange -> {
+				exchange.sendResponseHeaders( checksumPresent ? 404 : 200, -1 );
+				exchange.close();
+			} );
+			server.createContext( "/8.0/metadata/classifications.json.gz.sha256", exchange -> {
+				if ( checksumPresent ) {
+					final byte[] bytes = "0".repeat( 64 ).getBytes( StandardCharsets.UTF_8 );
+					exchange.sendResponseHeaders( 200, bytes.length );
+					exchange.getResponseBody().write( bytes );
+				}
+				else {
+					exchange.sendResponseHeaders( 404, -1 );
+				}
+				exchange.close();
+			} );
+			server.start();
+			try {
+				final Class<? extends Exception> expected = checksumPresent ? java.io.IOException.class : IllegalArgumentException.class;
+				assertThrows( expected,
+						() -> resolver( server ).resolve( directory.resolve( "bootstrap.json" ),
+								false, true, true, this::validate, this::unexpectedWarning ) );
+			}
+			finally {
+				server.stop( 0 );
+			}
+		}
+	}
+
+	@Test
+	void concurrentResolversPublishConsistentOutputs() throws Exception {
+		final HttpServer server = server( new AtomicReference<>( "valid" ) );
+		final var executor = Executors.newFixedThreadPool( 4 );
+		try {
+			final var jobs = new ArrayList<Callable<Boolean>>();
+			for ( int i = 0; i < 12; i++ ) {
+				final Path output = directory.resolve( "output-" + i + ".json" );
+				jobs.add( () -> {
+					resolver( server ).resolve( output, false, true, false, this::validate, this::unexpectedWarning );
+					return "valid".equals( Files.readString( output ) );
+				} );
+			}
+			for ( var result : executor.invokeAll( jobs ) ) {
+				assertTrue( result.get() );
+			}
+			resolver( server ).resolve( directory.resolve( "offline.json" ), true, false, false, this::validate, this::unexpectedWarning );
+			assertEquals( "valid", Files.readString( directory.resolve( "offline.json" ) ) );
+			try ( var files = Files.walk( directory ) ) {
+				assertTrue( files.noneMatch( file -> file.getFileName().toString().endsWith( ".tmp" )
+						|| file.getFileName().toString().startsWith( "candidate-" ) ) );
+			}
+		}
+		finally {
+			executor.shutdownNow();
+			server.stop( 0 );
+		}
+	}
+
+	@Test
+	void invalidDownloadedSchemaDoesNotReplaceValidatedCache() throws Exception {
+		final AtomicReference<String> document = new AtomicReference<>( "valid" );
+		final HttpServer server = server( document );
+		try {
+			final Path output = directory.resolve( "metadata.json" );
+			resolver( server ).resolve( output, false, false, false, this::validate, this::unexpectedWarning );
+			document.set( "invalid" );
+			assertThrows( IllegalArgumentException.class,
+					() -> resolver( server ).resolve( output, false, false, false, this::validate, this::unexpectedWarning ) );
+			resolver( server ).resolve( output, true, false, false, this::validate, this::unexpectedWarning );
+			assertEquals( "valid", Files.readString( output ) );
+		}
+		finally {
+			server.stop( 0 );
+		}
+	}
+
+	private ClassificationMetadataResolver resolver(HttpServer server) {
+		return new ClassificationMetadataResolver( directory, "http://127.0.0.1:" + server.getAddress().getPort(), "8.0" );
+	}
+
+	private void validate(Path path) {
+		try {
+			if ( !"valid".equals( Files.readString( path ) ) ) {
+				throw new IllegalArgumentException( "Invalid schema" );
+			}
+		}
+		catch (java.io.IOException e) {
+			throw new IllegalArgumentException( e );
+		}
+	}
+
+	private void unexpectedWarning(String message) {
+		throw new AssertionError( message );
+	}
+
+	private static HttpServer server(AtomicReference<String> document) throws Exception {
+		final HttpServer server = HttpServer.create( new InetSocketAddress( "127.0.0.1", 0 ), 0 );
+		server.createContext( "/8.0/metadata/classifications.json.gz", exchange -> {
+			final byte[] bytes = document.get().getBytes( StandardCharsets.UTF_8 );
+			exchange.sendResponseHeaders( 200, bytes.length );
+			exchange.getResponseBody().write( bytes );
+			exchange.close();
+		} );
+		server.createContext( "/8.0/metadata/classifications.json.gz.sha256", exchange -> {
+			try {
+				final byte[] checksum = HexFormat.of().formatHex( MessageDigest.getInstance( "SHA-256" )
+						.digest( document.get().getBytes( StandardCharsets.UTF_8 ) ) ).getBytes( StandardCharsets.UTF_8 );
+				exchange.sendResponseHeaders( 200, checksum.length );
+				exchange.getResponseBody().write( checksum );
+			}
+			catch (java.security.NoSuchAlgorithmException e) {
+				throw new AssertionError( e );
+			}
+			finally {
+				exchange.close();
+			}
+		} );
+		server.start();
+		return server;
+	}
+}


### PR DESCRIPTION
HHH-20747 - Reorganize stuff needed for Dialect implementors to make them SPI
HHH-20748 - New @SPI annotation to clarify expectations around SPI providers

Some fixes for aggregate value handling
Some improvement to classification tooling

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20747 (Task):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20747
<!-- Hibernate GitHub Bot issue links end -->