### PR TITLE
HHH-20798 Fix NullPointerException in getReference() for leaf entities with @ConcreteProxy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityConcreteTypeLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityConcreteTypeLoader.java
@@ -4,13 +4,6 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
  */
-
-/*
- * Hibernate, Relational Persistence for Idiomatic Java
- *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later
- * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
- */
 package org.hibernate.loader.ast.internal;
 
 import java.util.List;
@@ -55,22 +48,36 @@ public class EntityConcreteTypeLoader {
 	public EntityConcreteTypeLoader(EntityMappingType entityDescriptor, SessionFactoryImplementor sessionFactory) {
 		this.entityDescriptor = entityDescriptor;
 		final EntityDiscriminatorMapping discriminatorMapping = entityDescriptor.getDiscriminatorMapping();
-		final JdbcParametersList.Builder jdbcParametersBuilder = JdbcParametersList.newBuilder();
-		sqlSelect = LoaderSelectBuilder.createSelect(
-				entityDescriptor,
-				singletonList( discriminatorMapping ),
-				entityDescriptor.getIdentifierMapping(),
-				null,
-				1,
-				new LoadQueryInfluencers( sessionFactory ),
-				LockOptions.NONE,
-				jdbcParametersBuilder::add,
-				sessionFactory
-		);
-		jdbcParameters = jdbcParametersBuilder.build();
+		if ( discriminatorMapping == null ) {
+			// No discriminator mapping means this is a leaf entity with no subclasses,
+			// so we don't need to query for the concrete type
+			sqlSelect = null;
+			jdbcParameters = null;
+		}
+		else {
+			final JdbcParametersList.Builder jdbcParametersBuilder = JdbcParametersList.newBuilder();
+			sqlSelect = LoaderSelectBuilder.createSelect(
+					entityDescriptor,
+					singletonList( discriminatorMapping ),
+					entityDescriptor.getIdentifierMapping(),
+					null,
+					1,
+					new LoadQueryInfluencers( sessionFactory ),
+					LockOptions.NONE,
+					jdbcParametersBuilder::add,
+					sessionFactory
+			);
+			jdbcParameters = jdbcParametersBuilder.build();
+		}
 	}
 
 	public EntityMappingType getConcreteType(Object id, SharedSessionContractImplementor session) {
+		// If there's no SQL select, this is a leaf entity with no subclasses,
+		// so the concrete type is the entity descriptor itself
+		if ( sqlSelect == null ) {
+			return entityDescriptor;
+		}
+
 		final SessionFactoryImplementor sessionFactory = session.getSessionFactory();
 		final SqlAstTranslatorFactory sqlAstTranslatorFactory = sessionFactory.getJdbcServices()
 				.getJdbcEnvironment()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/concrete/AbstractConcreteProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/concrete/AbstractConcreteProxyTest.java
@@ -226,6 +226,20 @@ public abstract class AbstractConcreteProxyTest extends BaseNonConfigCoreFunctio
 			assertThat( Hibernate.isInitialized( proxy2 ), is( false ) );
 			inspector.assertExecutedCount( 1 );
 			inspector.assertNumberOfOccurrenceInQuery( 0, "union", 3 );
+			inspector.clear();
+			// Test getReference on leaf entity (HHH-20798)
+			final UnionChild2 proxy3 = session.getReference( UnionChild2.class, 2L );
+			assertThat( proxy3, instanceOf( UnionChild2.class ) );
+			assertThat( Hibernate.isInitialized( proxy3 ), is( false ) );
+			// No query should be executed for leaf entities as the concrete type is known
+			inspector.assertExecutedCount( 0 );
+			inspector.clear();
+			// Test getReference on another leaf entity (UnionSubChild1)
+			final UnionSubChild1 proxy4 = session.getReference( UnionSubChild1.class, 1L );
+			assertThat( proxy4, instanceOf( UnionSubChild1.class ) );
+			assertThat( Hibernate.isInitialized( proxy4 ), is( false ) );
+			// No query should be executed for leaf entities as the concrete type is known
+			inspector.assertExecutedCount( 0 );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/concrete/ConcreteProxyTablePerClassLeafTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/concrete/ConcreteProxyTablePerClassLeafTest.java
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.proxy.concrete;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.ConcreteProxy;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Test for HHH-20798: getReference() throws NullPointerException when called for
+ * a leaf entity (no subclasses) in a TABLE_PER_CLASS inheritance hierarchy with @ConcreteProxy.
+ *
+ * @author Chikumar Nagappa
+ */
+@DomainModel(
+		annotatedClasses = {
+				ConcreteProxyTablePerClassLeafTest.Parent.class,
+				ConcreteProxyTablePerClassLeafTest.Child.class,
+				ConcreteProxyTablePerClassLeafTest.Holder.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced(runNotEnhancedAsWell = true)
+@Jira("https://hibernate.atlassian.net/browse/HHH-20798")
+public class ConcreteProxyTablePerClassLeafTest {
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Child child = new Child( 1L, "test child" );
+			session.persist( child );
+
+			Holder holder = new Holder( 1L, child );
+			session.persist( holder );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createMutationQuery( "delete from Holder" ).executeUpdate();
+			session.createMutationQuery( "delete from Child" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testGetReferenceOnLeafEntity(SessionFactoryScope scope) {
+		// This should not throw NullPointerException
+		scope.inSession( session -> {
+			// Test getReference on leaf entity (Child has no subclasses)
+			Child proxy = session.getReference( Child.class, 1L );
+			assertThat( proxy, notNullValue() );
+			assertThat( proxy, instanceOf( Child.class ) );
+			assertThat( Hibernate.isInitialized( proxy ), is( false ) );
+
+			// Access a property to force initialization
+			String name = proxy.getName();
+			assertThat( name, is( "test child" ) );
+			assertThat( Hibernate.isInitialized( proxy ), is( true ) );
+		} );
+	}
+
+	@Test
+	public void testGetReferenceOnParentEntity(SessionFactoryScope scope) {
+		// This should work as Parent has a subclass (Child)
+		scope.inSession( session -> {
+			Parent proxy = session.getReference( Parent.class, 1L );
+			assertThat( proxy, notNullValue() );
+			assertThat( proxy, instanceOf( Child.class ) );
+			assertThat( Hibernate.isInitialized( proxy ), is( false ) );
+		} );
+	}
+
+	@Test
+	public void testManyToOneWithLeafEntity(SessionFactoryScope scope) {
+		// Test lazy loading of a many-to-one association to a leaf entity
+		scope.inSession( session -> {
+			Holder holder = session.find( Holder.class, 1L );
+			assertThat( holder, notNullValue() );
+
+			Child child = holder.getChild();
+			assertThat( child, notNullValue() );
+			assertThat( child, instanceOf( Child.class ) );
+			assertThat( Hibernate.isInitialized( child ), is( false ) );
+
+			// Access property to verify proxy works
+			String name = child.getName();
+			assertThat( name, is( "test child" ) );
+		} );
+	}
+
+	@Entity(name = "Parent")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@ConcreteProxy
+	public static class Parent {
+		@Id
+		private Long id;
+
+		private String name;
+
+		public Parent() {
+		}
+
+		public Parent(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Entity(name = "Child")
+	public static class Child extends Parent {
+		private String childProperty;
+
+		public Child() {
+		}
+
+		public Child(Long id, String name) {
+			super( id, name );
+			this.childProperty = "child-" + id;
+		}
+
+		public String getChildProperty() {
+			return childProperty;
+		}
+	}
+
+	@Entity(name = "Holder")
+	public static class Holder {
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Child child;
+
+		public Holder() {
+		}
+
+		public Holder(Long id, Child child) {
+			this.id = id;
+			this.child = child;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public Child getChild() {
+			return child;
+		}
+	}
+}


### PR DESCRIPTION
## Description

Fixes HHH-20798: `NullPointerException` when calling `getReference()` on a leaf entity (an entity with no subclasses) in a `TABLE_PER_CLASS` inheritance hierarchy using `@ConcreteProxy`.

## Problem

Consider the following entity hierarchy:

```java
@Entity
@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
@ConcreteProxy
class Parent {
    @Id
    Long id;
}

@Entity
class Child extends Parent {
} // Leaf entity - no subclasses
```

Calling:

```java
Child proxy = session.getReference(Child.class, 1L);
```

resulted in a `NullPointerException`.

### Root Cause

Leaf entities in a `TABLE_PER_CLASS` hierarchy do not have a discriminator mapping. However, `EntityConcreteTypeLoader` attempted to query the discriminator without first checking whether the discriminator mapping was present.

## Solution

Updated `EntityConcreteTypeLoader` to handle leaf entities explicitly:

* If `discriminatorMapping` is `null`, indicating a leaf entity, skip the discriminator query and return the entity descriptor directly.
* If `discriminatorMapping` is present, execute the discriminator query as before.

This preserves the existing behavior for non-leaf entities while preventing the `NullPointerException` for leaf entities.

## Testing

Added a new test class:

`ConcreteProxyTablePerClassLeafTest`

The test runs in both supported modes.

 `testGetReferenceOnLeafEntity()` — verifies the bug fix.
 `testGetReferenceOnParentEntity()` — verifies that parent entities continue to work correctly.
 `testManyToOneWithLeafEntity()` — verifies lazy `ManyToOne` associations involving a leaf entity.


### Test Execution

```bash
./gradlew :hibernate-core:test --tests "ConcreteProxyTablePerClassLeafTest"

./gradlew :hibernate-core:test --tests "AbstractConcreteProxyTest.testUnion"

./gradlew :hibernate-core:test --tests "*ConcreteProxy*"
```




----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20798 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20798
<!-- Hibernate GitHub Bot issue links end -->