### PR TITLE
HHH-20862 Deprecate reflection optimizer and related property access APIs

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeProvider.java
@@ -45,9 +45,9 @@ public interface BytecodeProvider extends Service {
 	 * @param setterNames Names of all property setters to be accessed via reflection.
 	 * @param types The types of all properties to be accessed.
 	 * @return The reflection optimization delegate.
-	 * @deprecated Use {@link #getReflectionOptimizer(Class, Map)} insstead
+	 * @deprecated no longer used
 	 */
-	@Deprecated(forRemoval = true)
+	@Deprecated(since = "7.4", forRemoval = true)
 	@Nullable
 	ReflectionOptimizer getReflectionOptimizer(@Nonnull Class<?> clazz, @Nonnull String[] getterNames, @Nonnull String[] setterNames, @Nonnull Class<?>[] types);
 
@@ -58,7 +58,10 @@ public interface BytecodeProvider extends Service {
 	 * @param clazz The class to be reflected upon.
 	 * @param propertyAccessMap The ordered property access map
 	 * @return The reflection optimization delegate.
+	 *
+	 * @deprecated no longer used
 	 */
+	@Deprecated(since = "7.4", forRemoval = true)
 	@Nullable
 	ReflectionOptimizer getReflectionOptimizer(@Nonnull Class<?> clazz, @Nonnull Map<String, PropertyAccess> propertyAccessMap);
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ReflectionOptimizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ReflectionOptimizer.java
@@ -4,9 +4,15 @@
  */
 package org.hibernate.bytecode.spi;
 
+import org.hibernate.Remove;
+
 /**
  * Represents reflection optimization for a particular class.
+ *
+ * @deprecated no longer used
  */
+@Deprecated(since = "7.4", forRemoval = true)
+@Remove
 public interface ReflectionOptimizer {
 	/**
 	 * Retrieve the optimizer for calling an entity's constructor via reflection.

--- a/hibernate-core/src/main/java/org/hibernate/id/CompositeNestedGeneratedValueGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/CompositeNestedGeneratedValueGenerator.java
@@ -100,7 +100,10 @@ public class CompositeNestedGeneratedValueGenerator
 		 * Used when the {@link CompositeType} is {@linkplain CompositeType#isMutable() mutable}.
 		 *
 		 * @see #getPropertyIndex()
+		 *
+		 * @deprecated no longer used, it will be replaced by a method that will not return the deprecated {@link Setter} interface
 		 */
+		@Deprecated(since = "7.4", forRemoval = true)
 		Setter getInjector();
 
 		/**

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -765,11 +765,16 @@ public class Component extends SimpleValue implements AttributeContainer, MetaAt
 		}
 	}
 
+	@Internal
 	public static class ValueGenerationPlan implements GenerationPlan {
 		private final BeforeExecutionGenerator generator;
 		private final Setter injector;
 		private final int propertyIndex;
 
+		/**
+		 * @deprecated it will be replaced by a different constructor which will no longer require a {@link Setter}
+		 */
+		@Deprecated(since = "7.4", forRemoval = true)
 		public ValueGenerationPlan(BeforeExecutionGenerator generator, Setter injector, int propertyIndex) {
 			this.generator = generator;
 			this.injector = injector;

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/EmbeddableRepresentationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/EmbeddableRepresentationStrategy.java
@@ -31,6 +31,9 @@ public interface EmbeddableRepresentationStrategy extends ManagedTypeRepresentat
 	 * The reflection optimizer to use for this embeddable.
 	 *
 	 * https://hibernate.atlassian.net/browse/HHH-14952
+	 *
+	 * @deprecated no longer used
 	 */
+	@Deprecated(since = "7.4", forRemoval = true)
 	ReflectionOptimizer getReflectionOptimizer();
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/ManagedTypeRepresentationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/ManagedTypeRepresentationStrategy.java
@@ -27,7 +27,10 @@ public interface ManagedTypeRepresentationStrategy {
 
 	/**
 	 * The reflection optimizer to use for this embeddable.
+	 *
+	 * @deprecated no longer used
 	 */
+	@Deprecated(since = "7.4", forRemoval = true)
 	ReflectionOptimizer getReflectionOptimizer();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/Getter.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/Getter.java
@@ -19,8 +19,11 @@ import jakarta.annotation.Nullable;
  *
  * @author Gavin King
  * @author Steve Ebersole
+ *
+ * @deprecated no longer used
  */
-@Remove // Remove/replace with a different SPI that is based on Hibernate Models
+@Deprecated(since = "7.4", forRemoval = true)
+@Remove // replace with a different SPI
 public interface Getter {
 	/**
 	 * Get the property value from the given owner instance.
@@ -28,7 +31,10 @@ public interface Getter {
 	 * @param owner The instance containing the property value to be retrieved.
 	 *
 	 * @return The extracted value.
+	 *
+	 * @deprecated no longer used
 	 */
+	@Deprecated(since = "7.4", forRemoval = true)
 	@Nullable Object get(Object owner);
 
 	/**
@@ -39,7 +45,10 @@ public interface Getter {
 	 * @param session The session from which this request originated.
 	 *
 	 * @return The extracted value.
+	 *
+	 * @deprecated no longer used
 	 */
+	@Deprecated(since = "7.4", forRemoval = true)
 	@Nullable Object getForInsert(Object owner, Map<Object, Object> mergeMap, SharedSessionContractImplementor session);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/PropertyAccessStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/PropertyAccessStrategy.java
@@ -27,6 +27,8 @@ public interface PropertyAccessStrategy {
 	 * @param setterRequired Whether it is an error if we are unable to find a corresponding setter
 	 *
 	 * @return The appropriate PropertyAccess
+	 * @deprecated no longer used
 	 */
+	@Deprecated(since = "7.4", forRemoval = true)
 	PropertyAccess buildPropertyAccess(Class<?> containerJavaType, String propertyName, boolean setterRequired);
 }

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/Setter.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/Setter.java
@@ -15,9 +15,19 @@ import org.hibernate.Remove;
  * @author Gavin King
  * @author Steve Ebersole
  */
-@Remove // Remove/replace with a different SPI that is based on Hibernate Models
+@Deprecated(since = "7.4", forRemoval = true)
+@Remove // replace with a different SPI
 public interface Setter {
 
+	/**
+	 * Set the property value on the given target instance.
+	 *
+	 * @param target The instance containing the property value to be set.
+	 * @param value The value to be set.
+	 *
+	 * @deprecated no longer used
+	 */
+	@Deprecated(since = "7.4", forRemoval = true)
 	void set(Object target, @Nullable Object value);
 
 	/**

--- a/hibernate-envers/src/main/java/org/hibernate/envers/strategy/spi/AuditStrategyContext.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/strategy/spi/AuditStrategyContext.java
@@ -23,6 +23,9 @@ public interface AuditStrategyContext {
 	/**
 	 * Get the revision info timestamp accessor
 	 * @return the getter for the timestamp attribute on the revision entity
+	 *
+	 * @deprecated no longer used, it will be replaced by a method that will not return the deprecated {@link Getter} interface
 	 */
+	@Deprecated(since = "7.4", forRemoval = true)
 	Getter getRevisionInfoTimestampAccessor();
 }


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/13356 for 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20862 (Deprecation):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20862
<!-- Hibernate GitHub Bot issue links end -->