### PR TITLE
Fix ignored tags regexps in Hibernate GitHub Bot config

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -63,7 +63,7 @@ develocity:
       - column: "DB"
         pattern: "((?:h2|postgres(?:ql)?|postgis|pgsql|mysql|mariadb|mssql|tidb|cockroach(?:db)?|oracle|db2|hsqldb|edb|sybase|spanner.*)(?:.*(?=)|.*))(?:)?"
         replacement: "$1"
-      - pattern: "main|HEAD|\\d+.\\d+|PR-\\d+|\\d+/merge"
+      - pattern: "main|HEAD|\\d+\.\\d+|PR-\\d+|\\d+/merge"
         replacement: "" # Just remove these tags
     testSummary:
       historyQuery: "tag:CI"


### PR DESCRIPTION
`\\d+.\\d+` was matching `12345/merge` for the bot's `.replaceAll` calls, leading to `\\d+/merge` being ignored.
