### PR TITLE
HHH-19485 - Removed assert in SqlExpressionResolver

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/creation/SqlExpressionResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/creation/SqlExpressionResolver.java
@@ -88,8 +88,6 @@ public interface SqlExpressionResolver {
 	 * Convenience form for creating a key from TableReference and SelectableMapping
 	 */
 	static ColumnReferenceKey createColumnReferenceKey(TableReference tableReference, SelectableMapping selectable) {
-		assert tableReference.containsAffectedTableName( selectable.getContainingTableExpression() )
-				: String.format( ROOT, "Expecting tables to match between TableReference (%s) and SelectableMapping (%s)", tableReference.getTableId(), selectable.getContainingTableExpression() );
 		return createColumnReferenceKey( tableReference, selectable.getSelectablePath(), selectable.getJdbcMapping() );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/SubQueryWithCaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/SubQueryWithCaseTest.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.criteria;
+
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Tuple;
+import org.hibernate.query.criteria.JpaCriteriaQuery;
+import org.hibernate.query.criteria.JpaDerivedRoot;
+import org.hibernate.query.criteria.JpaJoin;
+import org.hibernate.query.criteria.JpaRoot;
+import org.hibernate.query.criteria.JpaSimpleCase;
+import org.hibernate.query.criteria.JpaSubQuery;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel (
+		annotatedClasses = {SubQueryWithCaseTest.Book.class, SubQueryWithCaseTest.Isbn.class}
+)
+@SessionFactory
+public class SubQueryWithCaseTest {
+
+	@BeforeAll
+	public void setup(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Isbn isbn1 = new Isbn("123");
+					Isbn isbn2 = new Isbn("none");
+					Book book1 = new Book(1, isbn1);
+					Book book2 = new Book(2, isbn2);
+					session.persist( book1 );
+					session.persist( book2 );
+				}
+		);
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> session.getSessionFactory().getSchemaManager().truncate()
+		);
+	}
+
+	@Test
+	public void testCriteriaSubqueryWithCase(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					var cb = session.getCriteriaBuilder();
+					JpaCriteriaQuery<Tuple> query = cb.createTupleQuery();
+					JpaSubQuery<Tuple> subquery = query.subquery(Tuple.class);
+					JpaRoot<Book> sqRoot = subquery.from(Book.class);
+					JpaJoin<Book, Isbn> isbnJoin = sqRoot.join( SubQueryWithCaseTest_.Book_.isbn);
+					JpaSimpleCase<String, String> isbnExpr = cb.<String, String>selectCase(isbnJoin.get(SubQueryWithCaseTest_.Isbn_.isbn))
+							.when("none", cb.nullLiteral(String.class))
+							.otherwise(isbnJoin.get(SubQueryWithCaseTest_.Isbn_.isbn));
+					subquery.multiselect(
+							sqRoot.get(SubQueryWithCaseTest_.Book_.id).alias("id"),
+							isbnExpr.alias("isbn")
+					);
+					JpaDerivedRoot<Tuple> root = query.from(subquery);
+					query.select(cb.tuple(
+							root.get("id").alias("id"),
+							root.get("isbn").alias("isbn")
+					)).orderBy(
+							cb.asc(root.get("id"))
+					);
+					List<Tuple> list = session.createQuery(query).getResultList();
+					assertThat(list).hasSize(2);
+					Iterator<Tuple> it = list.iterator();
+					Tuple tuple = it.next();
+					assertThat(tuple.get("id")).isEqualTo(1);
+					assertThat(tuple.get("isbn")).isEqualTo("123");
+					tuple = it.next();
+					assertThat(tuple.get("id")).isEqualTo(2);
+					assertThat(tuple.get("isbn")).isEqualTo(null);
+
+				}
+		);
+	}
+
+	@Entity(name = "Book")
+	@Table(name = "t_book")
+	public static class Book {
+		@Id
+		private int id;
+
+		@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+		@JoinColumn(name = "isbn")
+		private Isbn isbn;
+
+		public Book() {
+		}
+
+		public Book(int id, Isbn isbn) {
+			this.id = id;
+			this.isbn = isbn;
+		}
+
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+
+		public Isbn getIsbn() {
+			return isbn;
+		}
+
+		public void setIsbn(Isbn isbn) {
+			this.isbn = isbn;
+		}
+	}
+
+	@Entity(name = "Isbn")
+	@Table(name = "t_isbn")
+	public static class Isbn {
+		@Id
+		private String isbn;
+
+		public Isbn() {
+		}
+
+		public Isbn(String isbn) {
+			this.isbn = isbn;
+		}
+
+		public String getIsbn() {
+			return isbn;
+		}
+
+		public void setIsbn(String isbn) {
+			this.isbn = isbn;
+		}
+	}
+
+}


### PR DESCRIPTION
It causes problems when TableReference.getTableId() is null
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
