### PR TITLE
HHH-20834 HbmXmlTransformer: Map <key on-delete="..."> in <joined-subclass> to <on-delete> inside <entity>

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/transform/HbmXmlTransformer.java
@@ -1214,6 +1214,12 @@ public class HbmXmlTransformer {
 		final var key = hbmSubclass.getKey();
 		if ( key != null ) {
 			transferKeyColumns( key, subclassEntity.getPrimaryKeyJoinColumns() );
+
+			// Transfer on-delete from key to entity level
+			final OnDeleteAction onDeleteAction = interpretOnDeleteAction( key.getOnDelete() );
+			if ( onDeleteAction != null && onDeleteAction != OnDeleteAction.NO_ACTION ) {
+				subclassEntity.setOnDelete( onDeleteAction );
+			}
 		}
 
 		if ( !hbmSubclass.getJoinedSubclass().isEmpty() ) {
@@ -2817,6 +2823,16 @@ public class HbmXmlTransformer {
 		return switch ( hbmNotFound ) {
 			case EXCEPTION -> NotFoundAction.EXCEPTION;
 			case IGNORE -> NotFoundAction.IGNORE;
+		};
+	}
+
+	private OnDeleteAction interpretOnDeleteAction(JaxbHbmOnDeleteEnum hbmOnDelete) {
+		if ( hbmOnDelete == null ) {
+			return null;
+		}
+		return switch ( hbmOnDelete ) {
+			case CASCADE -> OnDeleteAction.CASCADE;
+			case NOACTION -> OnDeleteAction.NO_ACTION;
 		};
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HbmTransformationJaxbTests.java
@@ -12,6 +12,7 @@ import java.util.function.Consumer;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
 
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.jaxb.Origin;
 import org.hibernate.boot.jaxb.SourceType;
@@ -2059,6 +2060,30 @@ public class HbmTransformationJaxbTests {
 			assertThat( elementCollection.getCollectionType().getParameters() )
 					.as( "collection-type should include typedef parameters" )
 					.hasSize( 1 );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-20834" )
+	public void testJoinedSubclassOnDeleteTransformation(ServiceRegistryScope scope) {
+		transformAndVerify( "xml/jaxb/mapping/on-delete-joined-subclass/hbm.xml", scope, transformed -> {
+			assertThat( transformed.getEntities() ).hasSize( 2 );
+
+			final JaxbEntityImpl childEntity = transformed.getEntities().stream()
+					.filter( e -> "Child".equals( e.getClazz() ) )
+					.findFirst()
+					.orElseThrow();
+
+			assertThat( childEntity.getPrimaryKeyJoinColumns() )
+					.as( "Child entity should have primary-key-join-column" )
+					.hasSize( 1 );
+
+			assertThat( childEntity.getPrimaryKeyJoinColumns().get( 0 ).getName() )
+					.isEqualTo( "parent_id" );
+
+			assertThat( childEntity.getOnDelete() )
+					.as( "joined-subclass with key on-delete='cascade' should have on-delete at entity level" )
+					.isEqualTo( OnDeleteAction.CASCADE );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/ondelete/joined/Child.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/ondelete/joined/Child.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.ondelete.joined;
+
+/**
+ * @author Andrea Boriero
+ */
+public class Child extends Parent {
+
+	private String childData;
+
+	public String getChildData() {
+		return childData;
+	}
+
+	public void setChildData(String childData) {
+		this.childData = childData;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/ondelete/joined/Parent.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/ondelete/joined/Parent.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.ondelete.joined;
+
+/**
+ * @author Andrea Boriero
+ */
+public class Parent {
+
+	private Long id;
+
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/on-delete-joined-subclass/hbm.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/on-delete-joined-subclass/hbm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<hibernate-mapping package="org.hibernate.orm.test.ondelete.joined">
+    <class name="Parent">
+        <id name="id" type="long">
+            <generator class="identity"/>
+        </id>
+        <property name="name"/>
+        
+        <joined-subclass name="Child" table="Child">
+            <key column="parent_id" on-delete="cascade"/>
+            <property name="childData"/>
+        </joined-subclass>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20834

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20834 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->