### PR TITLE
HHH-20864 MariaDB 13.0.1 added single-table UPDATE ... RETURNING.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -339,17 +339,22 @@ public class MariaDBDialect extends MySQLDialect {
 	}
 
 	/**
-	 * @return {@code true} for 10.6 and above because Maria supports
-	 *         {@code insert ... returning} even though MySQL does not
+	 * MariaDB supports {@code insert ... returning} since 10.5, and so for
+	 * every version supported by this dialect, even though MySQL does not.
+	 * Single-table {@code update ... returning} was added in 13.0 and is
+	 * enabled for 13.0 and above.
 	 */
 	@Override
 	public GeneratedValuesSupport getGeneratedValuesSupport() {
-		return GeneratedValuesSupport.builder( super.getGeneratedValuesSupport() )
+		final var builder = GeneratedValuesSupport.builder( super.getGeneratedValuesSupport() )
 				.enable(
 						GeneratedValuesSupport.Capability.INSERT_RETURNING,
 						GeneratedValuesSupport.Capability.INSERT_RETURNING_ROW_ID
-				)
-				.build();
+				);
+		if ( getVersion().isSameOrAfter( 13 ) ) {
+			builder.enable( GeneratedValuesSupport.Capability.UPDATE_RETURNING );
+		}
+		return builder.build();
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/IdentityAndGeneratedValuesSupportTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/IdentityAndGeneratedValuesSupportTests.java
@@ -170,6 +170,17 @@ public class IdentityAndGeneratedValuesSupportTests {
 				INSERT_RETURNING,
 				INSERT_RETURNING_ROW_ID
 		);
+		assertProfile(
+				new MariaDBDialect( DatabaseVersion.make( 12, 3 ) ).getGeneratedValuesSupport(),
+				INSERT_RETURNING,
+				INSERT_RETURNING_ROW_ID
+		);
+		assertProfile(
+				new MariaDBDialect( DatabaseVersion.make( 13, 0 ) ).getGeneratedValuesSupport(),
+				INSERT_RETURNING,
+				UPDATE_RETURNING,
+				INSERT_RETURNING_ROW_ID
+		);
 		assertProfile( new OracleDialect().getGeneratedValuesSupport(), ARBITRARY_GENERATED_KEYS );
 
 		final var h2 = new H2Dialect().getGeneratedValuesSupport();


### PR DESCRIPTION
MariaDB 13.0.1 added single-table UPDATE ... RETURNING. 

This PR enables the UPDATE_RETURNING capability on MariaDBDialect for version 13 and above, so update-time generated values are read back from the update statement instead of a separate select. Older servers keep the existing fallback.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

please note that tests have been run with mariadb docker 13.0-RC version, since 13.0.1 is still in RC, 13.0.2 will be the GA version.
