### PR TITLE
HHH-20868 - Move SQL AST and translators out of incubation (8.0)

### DIFF
--- a/documentation/src/main/asciidoc/dialect-provider/index.adoc
+++ b/documentation/src/main/asciidoc/dialect-provider/index.adoc
@@ -337,11 +337,19 @@ metadata support objects are stable strategies.
 
 [NOTE]
 ====
-The aggregate-column, locking, row-level-security, temporal-table, and SQL AST
+The aggregate-column, locking, row-level-security, and temporal-table
 extension families are incubating. Their contracts may change within an
 `X.Y` release family and are excluded from the corresponding SPI compatibility
 guarantee. Check the generated Javadoc for `@Incubating` before depending on a
 strategy, request, result, or SQL AST contract.
+
+The central SQL AST and translator contracts, translator factories and requests,
+`JdbcParameterFactory`, and `JdbcOperations` builders are no longer incubating.
+The specialized `SqlAstTranslator.renderNamedSetReturningFunction()` hook and
+`SetReturningFunctionType`, together with the SQM-coupled `QueryTransformer`,
+remain incubating. This does not stabilize the separate execution, mapping-model
+mutation, or result-processing contracts; their individual lifecycle markers
+continue to apply.
 ====
 
 === Type and temporal strategies

--- a/hibernate-core/src/main/java/org/hibernate/dialect/sql/ast/spi/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/sql/ast/spi/package-info.java
@@ -3,12 +3,9 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-/// Incubating Dialect contracts for selecting SQL AST translators and
+/// Dialect contracts for selecting SQL AST translators and
 /// expressing database-specific SQL AST rendering behavior.
 ///
 /// @author Steve Ebersole
 /// @since 8.0
-@Incubating
 package org.hibernate.dialect.sql.ast.spi;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/package-info.java
@@ -9,7 +9,4 @@
  * The SQL AST is an intermediate product of the {@linkplain org.hibernate.query.hql process}
  * of translating a HQL or criteria query to SQL.
  */
-@Incubating
 package org.hibernate.sql.ast;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstWalker.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.sql.ast.spi;
 
-import org.hibernate.Incubating;
 import org.hibernate.SPI;
 import org.hibernate.sql.ast.spi.query.predicate.SqlFragmentPredicate;
 import org.hibernate.query.sqm.tree.spi.expression.Conversion;
@@ -97,7 +96,6 @@ import static org.hibernate.SPI.Role.USE;
 /// @since 8.0
 /// @author Steve Ebersole
 /// @author Andrea Boriero
-@Incubating
 @SPI({ USE, IMPLEMENT })
 public interface SqlAstWalker {
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/analysis/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/analysis/package-info.java
@@ -3,11 +3,8 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-/// Incubating contracts for analyzing a SQL AST.
+/// Contracts for analyzing a SQL AST.
 ///
 /// @author Steve Ebersole
 /// @since 8.0
-@Incubating
 package org.hibernate.sql.ast.spi.analysis;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/creation/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/creation/package-info.java
@@ -3,11 +3,8 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-/// Incubating contracts for creating a SQL AST.
+/// Contracts for creating a SQL AST.
 ///
 /// @author Steve Ebersole
 /// @since 8.0
-@Incubating
 package org.hibernate.sql.ast.spi.creation;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/package-info.java
@@ -6,7 +6,4 @@
 /**
  * Package defining support for creating and consuming a SQL AST.
  */
-@Incubating
 package org.hibernate.sql.ast.spi;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/SetReturningFunctionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/SetReturningFunctionType.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.ast.spi.query;
 
+import org.hibernate.Incubating;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.SelectableConsumer;
 
@@ -13,6 +14,7 @@ import jakarta.annotation.Nullable;
 /// function.
 ///
 /// @author Steve Ebersole
+@Incubating
 public interface SetReturningFunctionType {
 	/// Find a named part of the function result.
 	///

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/cte/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/cte/package-info.java
@@ -36,7 +36,4 @@
 /**
  * Support for common table expressions (CTE) in a SQL tree.
  */
-@Incubating
 package org.hibernate.sql.ast.spi.query.cte;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/delete/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/delete/package-info.java
@@ -6,7 +6,4 @@
 /**
  * AST nodes representing {@code delete} statements in a SQL tree.
  */
-@Incubating
 package org.hibernate.sql.ast.spi.query.delete;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/expression/JdbcParameterFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/expression/JdbcParameterFactory.java
@@ -8,7 +8,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import jakarta.annotation.Nonnull;
-import org.hibernate.Incubating;
 import org.hibernate.SPI;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.sql.exec.internal.AbstractJdbcParameter;
@@ -38,7 +37,6 @@ import static org.hibernate.SPI.Role.USE;
 ///
 /// @since 8.0
 /// @author Steve Ebersole
-@Incubating
 @SPI(USE)
 public final class JdbcParameterFactory {
 	private JdbcParameterFactory() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/expression/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/expression/package-info.java
@@ -6,7 +6,4 @@
 /**
  * AST nodes representing expressions in a SQL tree.
  */
-@Incubating
 package org.hibernate.sql.ast.spi.query.expression;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/from/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/from/package-info.java
@@ -6,7 +6,4 @@
 /**
  * AST nodes representing root tables and joins in a SQL tree.
  */
-@Incubating
 package org.hibernate.sql.ast.spi.query.from;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/insert/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/insert/package-info.java
@@ -6,7 +6,4 @@
 /**
  * AST nodes representing {@code insert} statements in a SQL tree.
  */
-@Incubating
 package org.hibernate.sql.ast.spi.query.insert;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/package-info.java
@@ -7,10 +7,5 @@
  * Package defining the SQL AST.
  * <p>
  * The package {@link org.hibernate.sql.ast.spi} defines support for creating and consuming the AST.
- * <p>
- * This package and all subpackages are currently incubating and subject to change.
  */
-@Incubating
 package org.hibernate.sql.ast.spi.query;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/predicate/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/predicate/package-info.java
@@ -6,7 +6,4 @@
 /**
  * AST nodes representing logical predicates in a SQL tree.
  */
-@Incubating
 package org.hibernate.sql.ast.spi.query.predicate;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/select/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/select/package-info.java
@@ -6,7 +6,4 @@
 /**
  * AST nodes representing {@code select} statements in a SQL tree.
  */
-@Incubating
 package org.hibernate.sql.ast.spi.query.select;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/update/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/query/update/package-info.java
@@ -6,7 +6,4 @@
 /**
  * AST nodes representing {@code update} statements in a SQL tree.
  */
-@Incubating
 package org.hibernate.sql.ast.spi.query.update;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/transform/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/transform/package-info.java
@@ -3,11 +3,8 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-/// Incubating contracts for transforming a SQL AST.
+/// Contracts for transforming a SQL AST.
 ///
 /// @author Steve Ebersole
 /// @since 8.0
-@Incubating
 package org.hibernate.sql.ast.spi.transform;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/translation/Clause.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/translation/Clause.java
@@ -4,14 +4,11 @@
  */
 package org.hibernate.sql.ast.spi.translation;
 
-import org.hibernate.Incubating;
-
 /**
  * Used to indicate which query clause we are currently processing
  *
  * @author Steve Ebersole
  */
-@Incubating
 public enum Clause {
 	/**
 	 * The insert clause

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/translation/SqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/translation/SqlAstTranslator.java
@@ -45,7 +45,6 @@ import static org.hibernate.SPI.Role.USE;
 /// @author Steve Ebersole
 /// @see org.hibernate.dialect.sql.ast.spi.SqlAstTranslatorFactory#buildTranslator
 /// @see org.hibernate.dialect.sql.ast.spi.StandardSqlAstTranslatorFactory#createTranslator
-@Incubating
 @SPI({ USE, IMPLEMENT, SUPPLY })
 public interface SqlAstTranslator<T extends JdbcOperation> extends SqlAstWalker {
 	/// Perform this translator's one translation.
@@ -58,7 +57,6 @@ public interface SqlAstTranslator<T extends JdbcOperation> extends SqlAstWalker 
 	T translate(JdbcParameterBindings jdbcParameterBindings, QueryOptions queryOptions);
 
 	/// The SQL AST assigned to this translator.
-	@Incubating
 	Statement getSqlAst();
 
 	/// The SessionFactory whose services are used during translation.

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/translation/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/translation/package-info.java
@@ -3,11 +3,8 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-/// Incubating contracts for translating a SQL AST to executable SQL.
+/// Contracts for translating a SQL AST to executable SQL.
 ///
 /// @author Steve Ebersole
 /// @since 8.0
-@Incubating
 package org.hibernate.sql.ast.spi.translation;
-
-import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/CacheableJdbcOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/CacheableJdbcOperation.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.query.spi.QueryOptions;
 
 /**
@@ -12,6 +13,7 @@ import org.hibernate.query.spi.QueryOptions;
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface CacheableJdbcOperation {
 	/**
 	 * Signals that the SQL depends on the parameter bindings - e.g., due to the need for inlining

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/Callback.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/Callback.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.ast.spi.AfterLoadAction;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -15,6 +16,7 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface Callback {
 	/**
 	 * Register a callback action

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/ExecutionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/ExecutionContext.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.spi.CollectionKey;
 import org.hibernate.engine.spi.EntityHolder;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
@@ -17,6 +18,7 @@ import org.hibernate.resource.jdbc.spi.LogicalConnectionImplementor;
  * A context for execution of SQL statements expressed via
  * SQL AST and JdbcOperation
  */
+@Incubating
 public interface ExecutionContext {
 
 	default boolean isScrollResult(){

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallFunctionReturn.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallFunctionReturn.java
@@ -4,11 +4,14 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
+
 /**
  * Models the function return when the JdbcOperationQueryCall represents a call to a database
  * function.
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcCallFunctionReturn extends JdbcCallParameterRegistration {
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallParameterExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallParameterExtractor.java
@@ -6,6 +6,7 @@ package org.hibernate.sql.exec.spi;
 
 import java.sql.CallableStatement;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.sql.exec.internal.JdbcCallRefCursorExtractorImpl;
 
@@ -16,6 +17,7 @@ import org.hibernate.sql.exec.internal.JdbcCallRefCursorExtractorImpl;
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcCallParameterExtractor<T> {
 	String getParameterName();
 	int getParameterPosition();

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallParameterRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallParameterRegistration.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.exec.spi;
 import java.sql.CallableStatement;
 import jakarta.persistence.ParameterMode;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.OutputableType;
 import org.hibernate.sql.exec.internal.JdbcCallRefCursorExtractorImpl;
@@ -14,6 +15,7 @@ import org.hibernate.sql.exec.internal.JdbcCallRefCursorExtractorImpl;
 /**
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcCallParameterRegistration {
 
 	String getName();

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallRefCursorExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallRefCursorExtractor.java
@@ -7,11 +7,13 @@ package org.hibernate.sql.exec.spi;
 import java.sql.CallableStatement;
 import java.sql.ResultSet;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcCallRefCursorExtractor {
 	ResultSet extractResultSet(CallableStatement callableStatement, SharedSessionContractImplementor session);
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcLockingApplication.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcLockingApplication.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.SPI;
 
 /// Records which stage owns pessimistic locking for a JDBC select plan.
@@ -15,6 +16,7 @@ import org.hibernate.SPI;
 /// @since 8.0
 /// @author Steve Ebersole
 @SPI
+@Incubating
 public enum JdbcLockingApplication {
 	/// The select does not request pessimistic locking.
 	NONE,

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcMutation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcMutation.java
@@ -4,10 +4,13 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
+
 /**
  * Primary operation, which is an ({@code INSERT}, {@code UPDATE} or {@code DELETE}) performed via JDBC.
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcMutation extends PrimaryOperation {
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcMutationExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcMutationExecutor.java
@@ -8,11 +8,14 @@ import java.sql.PreparedStatement;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import org.hibernate.Incubating;
+
 /**
  * Executor for model-mutation operations
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcMutationExecutor {
 	/**
 	 * Perform the execution

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperation.java
@@ -7,6 +7,7 @@ package org.hibernate.sql.exec.spi;
 import java.util.List;
 import java.util.Set;
 
+import org.hibernate.Incubating;
 import org.hibernate.SPI;
 
 import static org.hibernate.SPI.Role.SUPPLY;
@@ -29,6 +30,7 @@ import static org.hibernate.SPI.Role.USE;
 /// @see org.hibernate.sql.ast.spi.translation.SqlAstTranslator#translate
 /// @see org.hibernate.sql.ast.spi.model.TableMutation#createMutationOperation(String, List)
 @SPI({ USE, SUPPLY })
+@Incubating
 public interface JdbcOperation {
 	/// The command text to execute through JDBC. This is ordinarily SQL, but may
 	/// use another language understood by the configured JDBC driver.

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQuery.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.query.Query;
 import org.hibernate.sql.ast.spi.query.expression.JdbcParameter;
 
@@ -14,6 +15,7 @@ import java.util.Map;
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcOperationQuery extends JdbcOperation, CacheableJdbcOperation {
 	/**
 	 * The parameters which were inlined into the query as literals.

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryAnonBlock.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryAnonBlock.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducer;
 
 /**
@@ -13,6 +14,7 @@ import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducer;
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcOperationQueryAnonBlock extends JdbcOperationQuery {
 	/**
 	 * Retrieve the "result set mappings" for processing any ResultSets returned from

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryCall.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryCall.java
@@ -6,9 +6,12 @@ package org.hibernate.sql.exec.spi;
 
 import java.util.List;
 
+import org.hibernate.Incubating;
+
 /**
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcOperationQueryCall extends JdbcOperationQueryAnonBlock {
 	/**
 	 * If the call is a function, returns the function return descriptor

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryInsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryInsert.java
@@ -4,11 +4,14 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
+
 /**
  * Basic contract for an insert operation
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcOperationQueryInsert extends JdbcOperationQueryMutation {
 	String getUniqueConstraintNameThatMayFail();
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryMutation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryMutation.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.SPI;
 
 import static org.hibernate.SPI.Role.SUPPLY;
@@ -20,6 +21,7 @@ import static org.hibernate.SPI.Role.USE;
 /// @author Steve Ebersole
 /// @see org.hibernate.sql.ast.spi.translation.SqlAstTranslator#translate
 @SPI({ USE, SUPPLY })
+@Incubating
 public interface JdbcOperationQueryMutation extends JdbcOperationQuery, JdbcMutation {
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperations.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperations.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.hibernate.Incubating;
 import org.hibernate.SPI;
 import org.hibernate.dialect.sql.ast.spi.SqlAstTranslationRequest;
 import org.hibernate.sql.ast.spi.query.delete.DeleteStatement;
@@ -41,7 +40,6 @@ import static org.hibernate.SPI.Role.USE;
 ///
 /// @since 8.0
 /// @author Steve Ebersole
-@Incubating
 @SPI(USE)
 public final class JdbcOperations {
 	private JdbcOperations() {
@@ -80,7 +78,6 @@ public final class JdbcOperations {
 	///
 	/// @since 8.0
 	/// @author Steve Ebersole
-	@Incubating
 	@SPI(USE)
 	public static final class SelectBuilder {
 		private final SqlAstTranslationRequest.Select request;
@@ -229,7 +226,6 @@ public final class JdbcOperations {
 	///
 	/// @since 8.0
 	/// @author Steve Ebersole
-	@Incubating
 	@SPI(USE)
 	public static final class QueryMutationBuilder {
 		private final SqlAstTranslationRequest.QueryMutation request;

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcPaginationApplication.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcPaginationApplication.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.SPI;
 
 /// Records which stage owns pagination for a JDBC select plan.
@@ -16,6 +17,7 @@ import org.hibernate.SPI;
 /// @since 8.0
 /// @author Steve Ebersole
 @SPI
+@Incubating
 public enum JdbcPaginationApplication {
 	/// The plan has no effective limit or offset.
 	NONE,

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParameterBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParameterBinder.java
@@ -7,12 +7,15 @@ package org.hibernate.sql.exec.spi;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import org.hibernate.Incubating;
+
 /**
  * Performs parameter value binding to a JDBC PreparedStatement.
  *
  * @author Steve Ebersole
  * @author John O'Hara
  */
+@Incubating
 public interface JdbcParameterBinder {
 
 	JdbcParameterBinder NOOP = (statement, startPosition, jdbcParameterBindings, executionContext) -> {};

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParameterBinding.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParameterBinding.java
@@ -4,11 +4,13 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 
 /**
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcParameterBinding {
 	JdbcMapping getBindType();
 	Object getBindValue();

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParameterBindings.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParameterBindings.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.BiConsumer;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.Bindable;
@@ -31,6 +32,7 @@ import static org.hibernate.type.internal.BindingTypeHelper.resolveBindType;
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcParameterBindings {
 	void addBinding(JdbcParameter parameter, JdbcParameterBinding binding);
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParameters.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParameters.java
@@ -8,12 +8,14 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import org.hibernate.Incubating;
 import org.hibernate.sql.ast.spi.query.expression.JdbcParameter;
 
 /**
  * The collection
  * @author Steve Ebersole
  */
+@Incubating
 public interface JdbcParameters {
 	void addParameter(JdbcParameter parameter);
 	void addParameters(Collection<JdbcParameter> parameters);

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParametersList.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcParametersList.java
@@ -6,6 +6,7 @@ package org.hibernate.sql.exec.spi;
 
 import java.util.List;
 
+import org.hibernate.Incubating;
 import org.hibernate.sql.ast.spi.query.expression.JdbcParameter;
 
 /**
@@ -14,6 +15,7 @@ import org.hibernate.sql.ast.spi.query.expression.JdbcParameter;
  * Also as nice side effect, avoid any potential type pollution
  * problems during access.
  */
+@Incubating
 public interface JdbcParametersList {
 
 	JdbcParametersList EMPTY = new JdbcParametersListMulti( new JdbcParameter[]{} );

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/LoadedValuesCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/LoadedValuesCollector.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.spi.CollectionKey;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -20,6 +21,7 @@ import java.util.List;
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface LoadedValuesCollector {
 	/**
 	 * Register a loading entity.

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/PrimaryOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/PrimaryOperation.java
@@ -6,6 +6,8 @@ package org.hibernate.sql.exec.spi;
 
 import java.util.Set;
 
+import org.hibernate.Incubating;
+
 /**
  * A primary operation to be executed using JDBC.
  *
@@ -13,6 +15,7 @@ import java.util.Set;
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface PrimaryOperation extends JdbcOperation {
 	/**
 	 * The names of tables this operation refers to

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/StatementAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/StatementAccess.java
@@ -6,6 +6,8 @@ package org.hibernate.sql.exec.spi;
 
 import java.sql.Statement;
 
+import org.hibernate.Incubating;
+
 /**
  * Access to a JDBC {@linkplain Statement}.
  *
@@ -14,6 +16,7 @@ import java.sql.Statement;
  *
  * @author Steve Ebersole
  */
+@Incubating
 public interface StatementAccess {
 	/**
 	 * Access the JDBC {@linkplain Statement}.

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/package-info.java
@@ -12,6 +12,8 @@
  * Provider-owned SQL AST translators create query operations through
  * {@link org.hibernate.sql.exec.spi.JdbcOperations}, which keeps the concrete
  * operation implementations internal to Hibernate.
+ * The operation builders are stable SPI contracts; other execution contracts
+ * retain their individual {@link org.hibernate.Incubating} status.
  * <p>
  * For operations that return {@link java.sql.ResultSet}s, be sure to see
  * {@link org.hibernate.sql.results} which provides support for processing results
@@ -24,7 +26,4 @@
  * {@linkplain org.hibernate.sql.exec.internal.lock.FollowOnLockingAction}
  * and friends.
  */
-@Incubating
 package org.hibernate.sql.exec.spi;
-
-import org.hibernate.Incubating;

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -275,6 +275,19 @@ The annotation processor now propagates security annotations from the `jakarta.a
 
 This section describes changes to contracts (classes, interfaces, methods, etc.) which are considered https://hibernate.org/community/compatibility-policy/#spi[SPI].
 
+[[sql-ast-translator-stability]]
+=== SQL AST and translator changes
+
+The central SQL AST and translator SPIs are no longer incubating, including
+the translator factories and typed requests, `JdbcParameterFactory`, and the
+`JdbcOperations` builders. Their supported SPI roles now carry the normal
+compatibility expectations within an `X.Y` release family. No signatures or
+provider implementation requirements change as part of this stabilization.
+
+`QueryTransformer`, `SqlAstTranslator.renderNamedSetReturningFunction()`, and
+`SetReturningFunctionType` remain incubating. Separate execution, mapping-model
+mutation, and result-processing contracts retain their existing lifecycle status.
+
 
 [[graph-flushing-spi]]
 === Graph-based Flushing


### PR DESCRIPTION
HHH-20868 - Move SQL AST and translators out of incubation
(cherry picked from commit 415ebf93b425e1b689c7f874ff6d700d6297f3f5)

backport to 8.0
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
