### PR TITLE
HHH-20870 - Provide a mechanism for an additional URL based maven repository.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,14 @@ dependencyResolutionManagement {
                 dirs "${System.env.ADDITIONAL_REPO}"
             }
         }
+
+        //Allow loading additional dependencies from a URL
+        if (System.env['ADDITIONAL_REPO_URL'] != null) {
+            maven {
+                name = "url-repository"
+                url = "${System.env.ADDITIONAL_REPO_URL}"
+            }
+        }
     }
 
     pluginManagement {


### PR DESCRIPTION
This PR adds a new mechanism to provide an additional URL-based maven repository for the build dependencies. The `ADDITIONAL_REPO_URL` environment variable is used and has to contain a valid URL.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
