### PR TITLE
HHH-20853: Fix @Audited.Table incorrectly applied to element collection audit tables

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AuditHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AuditHelper.java
@@ -73,7 +73,7 @@ public final class AuditHelper {
 			RootClass rootClass,
 			ClassDetails classDetails,
 			MetadataBuildingContext context) {
-		bindAuditTable( auditTable, rootClass, context );
+		bindAuditTable( auditTable, null, rootClass, context );
 		bindSecondaryAuditTables( auditTable, rootClass, classDetails, context );
 		bindSubclassAuditTables( auditTable, rootClass, context );
 	}
@@ -82,11 +82,20 @@ public final class AuditHelper {
 			Audited.@Nullable Table auditTable,
 			Collection collection,
 			MetadataBuildingContext context) {
-		bindAuditTable( auditTable, (Stateful) collection, context );
+		bindAuditTable( auditTable, null, collection, context );
+	}
+
+	static void bindAuditTable(
+			Audited.@Nullable Table auditTable,
+			Audited.@Nullable CollectionTable collectionAuditTable,
+			Collection collection,
+			MetadataBuildingContext context) {
+		bindAuditTable( auditTable, collectionAuditTable, (Stateful) collection, context );
 	}
 
 	private static void bindAuditTable(
 			Audited.@Nullable Table auditTable,
+			Audited.@Nullable CollectionTable collectionAuditTable,
 			Stateful auditable,
 			MetadataBuildingContext context) {
 		final var collector = context.getMetadataCollector();
@@ -96,7 +105,17 @@ public final class AuditHelper {
 		final String auditCatalog;
 		final String csIdColumnName;
 		final String modTypeColumnName;
-		if ( auditTable != null ) {
+
+		// For collections, prefer @Audited.CollectionTable if present
+		if ( collectionAuditTable != null && !isBlank( collectionAuditTable.name() ) ) {
+			explicitAuditTableName = collectionAuditTable.name();
+			auditSchema = collectionAuditTable.schema();
+			auditCatalog = collectionAuditTable.catalog();
+			// CollectionTable doesn't have column name customization, use defaults
+			csIdColumnName = DEFAULT_CHANGESET_ID_COLUMN_NAME;
+			modTypeColumnName = DEFAULT_MODIFICATION_TYPE_COLUMN_NAME;
+		}
+		else if ( auditTable != null ) {
 			explicitAuditTableName = auditTable.name();
 			auditSchema = auditTable.schema();
 			auditCatalog = auditTable.catalog();

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -2461,8 +2461,14 @@ public abstract class CollectionBinder {
 		}
 		final var audited = extract( Audited.class, property, buildingContext );
 		if ( audited != null && !property.hasDirectAnnotationUsage( Audited.Excluded.class ) ) {
+			// For collections, only use @Audited.Table if it's directly on the property itself,
+			// not inherited from the owning entity. The entity's @Audited.Table applies only
+			// to the entity's audit table, not to collection audit tables.
+			final var auditTable = property.getDirectAnnotationUsage( Audited.Table.class );
+			final var collectionAuditTable = property.getDirectAnnotationUsage( Audited.CollectionTable.class );
 			AuditHelper.bindAuditTable(
-					extract( Audited.Table.class, property, buildingContext ),
+					auditTable,
+					collectionAuditTable,
 					collection,
 					buildingContext
 			);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/audit/ElementCollectionWithCollectionAuditTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/audit/ElementCollectionWithCollectionAuditTableTest.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.audit;
+
+import java.util.List;
+
+import java.time.Instant;
+
+import org.hibernate.annotations.Audited;
+import org.hibernate.annotations.Changelog;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for HHH-20853: @Audited.CollectionTable should allow customizing element collection audit table names
+ *
+ * @author Chris Cranford
+ */
+@DomainModel(annotatedClasses = {
+		ElementCollectionWithCollectionAuditTableTest.Product.class,
+		ElementCollectionWithCollectionAuditTableTest.RevisionInfo.class
+})
+@SessionFactory
+public class ElementCollectionWithCollectionAuditTableTest {
+
+	@Test
+	public void testElementCollectionWithCustomAuditTableName(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			// Get all table names
+			final List<String> tableNames = session.createNativeQuery(
+					"""
+					select table_name
+					from information_schema.tables
+					where table_schema = 'PUBLIC'
+					order by table_name
+					""",
+					String.class
+			).getResultList();
+
+			// Custom collection audit table should be created
+			assertThat( tableNames )
+					.as( "Custom collection audit table should be created" )
+					.contains( "PRODUCT_TAGS_AUDIT_LOG" )
+					.doesNotContain( "PRODUCT_TAGS_AUD" ); // Default name should not exist
+		} );
+	}
+
+	@Entity(name = "Product")
+	@Audited
+	@Audited.Table(name = "product_log")
+	@Table(name = "product")
+	public static class Product {
+		@Id
+		@Column(name = "id")
+		private Long id;
+
+		@ElementCollection
+		@Audited
+		@Audited.CollectionTable(name = "product_tags_audit_log")
+		@CollectionTable(name = "product_tags")
+		private List<String> tags;
+
+		public Product() {
+		}
+
+		public Product(Long id) {
+			this.id = id;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public List<String> getTags() {
+			return tags;
+		}
+
+		public void setTags(List<String> tags) {
+			this.tags = tags;
+		}
+	}
+
+	@Entity(name = "RevisionInfo")
+	@Table(name = "REVINFO")
+	@Changelog
+	public static class RevisionInfo {
+		@Id
+		@GeneratedValue
+		@Changelog.ChangesetId
+		@Column(name = "REV")
+		Long id;
+
+		@Changelog.Timestamp
+		@Column(name = "REVTSTMP")
+		Instant timestamp;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/audit/ElementCollectionWithCustomAuditTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/audit/ElementCollectionWithCustomAuditTableTest.java
@@ -1,0 +1,131 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.audit;
+
+import java.util.List;
+
+import java.time.Instant;
+
+import org.hibernate.annotations.Audited;
+import org.hibernate.annotations.Changelog;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for HHH-20853: @Audited.Table on entity should not be reused as audit table for @ElementCollection
+ *
+ * @author Chris Cranford
+ */
+@DomainModel(annotatedClasses = {
+		ElementCollectionWithCustomAuditTableTest.Owner.class,
+		ElementCollectionWithCustomAuditTableTest.RevisionInfo.class
+})
+@SessionFactory
+public class ElementCollectionWithCustomAuditTableTest {
+
+	@Test
+	public void testElementCollectionHasSeparateAuditTable(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			// Get all table names
+			final List<String> tableNames = session.createNativeQuery(
+					"""
+					select table_name
+					from information_schema.tables
+					where table_schema = 'PUBLIC'
+					order by table_name
+					""",
+					String.class
+			).getResultList();
+
+			// Get columns in the entity audit table
+			final List<String> ownerLogColumns = session.createNativeQuery(
+					"""
+					select column_name
+					from information_schema.columns
+					where table_schema = 'PUBLIC'
+					and table_name = 'OWNER_LOG'
+					order by ordinal_position
+					""",
+					String.class
+			).getResultList();
+
+			// Element collection should have its own audit table
+			assertThat( tableNames )
+					.as( "Element collection audit table should be created" )
+					.contains( "OWNER_NAMES_AUD" );
+
+			// Entity audit table should NOT contain element collection columns
+			assertThat( ownerLogColumns )
+					.as( "Entity audit table should only have entity columns" )
+					.containsExactlyInAnyOrder( "REVTYPE", "ID", "REV" )
+					.doesNotContain( "OWNER_ID", "NAMES" );
+		} );
+	}
+
+	@Entity(name = "Owner")
+	@Audited
+	@Audited.Table(name = "owner_log")
+	@Table(name = "owner")
+	public static class Owner {
+		@Id
+		@Column(name = "id")
+		private Long id;
+
+		@ElementCollection
+		@Audited
+		@CollectionTable(name = "owner_names")
+		private List<String> names;
+
+		public Owner() {
+		}
+
+		public Owner(Long id) {
+			this.id = id;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public List<String> getNames() {
+			return names;
+		}
+
+		public void setNames(List<String> names) {
+			this.names = names;
+		}
+	}
+
+	@Entity(name = "RevisionInfo")
+	@Table(name = "REVINFO")
+	@Changelog
+	public static class RevisionInfo {
+		@Id
+		@GeneratedValue
+		@Changelog.ChangesetId
+		@Column(name = "REV")
+		Long id;
+
+		@Changelog.Timestamp
+		@Column(name = "REVTSTMP")
+		Instant timestamp;
+	}
+}


### PR DESCRIPTION
## Description

Fixes an issue where `@ElementCollection` audit tables incorrectly inherited the audit table name configured on their owning entity using `@Audited.Table`.

When an audited entity defines a custom audit table with `@Audited.Table`, its element collections were incorrectly mapped to the same audit table instead of having their own audit tables.

## Root Cause

`CollectionBinder.processAudited()` was using `extract()` to resolve `@Audited.Table`. Since `extract()` also checks the owning entity class, the entity-level `@Audited.Table` annotation was incorrectly applied to the collection.

## Changes

* Updated `CollectionBinder.processAudited()` to use `@Audited.Table` only when it is declared directly on the collection property.
* Added support for `@Audited.CollectionTable` to allow custom audit table names for element collections.
* Added an overload of `AuditHelper.bindAuditTable()` that accepts both `@Audited.Table` and `@Audited.CollectionTable`.
* Element collections now correctly use separate audit tables following the default naming pattern:
  `{collection_table_name}_AUD`

## Test Coverage

Added tests covering both scenarios:

* `ElementCollectionWithCustomAuditTableTest`

  * Verifies that element collections use separate audit tables when the owning entity has a custom `@Audited.Table`.

* `ElementCollectionWithCollectionAuditTableTest`

  * Verifies that `@Audited.CollectionTable` can be used to customize the collection audit table name.

## Compatibility / Breaking Change


Previously, element collection audit data could incorrectly be stored in the entity's custom audit table. After this fix, element collection audit data is stored in its own audit table.

Applications that currently query the entity audit table expecting element collection audit data will need to update their queries to use the corresponding collection audit tables.



----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20853 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20853
<!-- Hibernate GitHub Bot issue links end -->