### PR TITLE
Fix typo in QueryExporter error message (occured -> occurred)

### DIFF
--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/export/query/QueryExporter.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/export/query/QueryExporter.java
@@ -65,7 +65,7 @@ public class QueryExporter extends AbstractExporter {
 			if(transaction!=null) {
 				transaction.rollback();
 			}
-			throw new RuntimeException("Error occured while trying to execute query", he);
+			throw new RuntimeException("Error occurred while trying to execute query", he);
 		}
 		finally {
 			if(session!=null) {


### PR DESCRIPTION
Corrects the spelling of `occurred` in an exception message. No functional change.