### PR TITLE
HHH-20872 - Classify Interceptor as SPI (8.0)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Interceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/Interceptor.java
@@ -49,19 +49,27 @@ import org.hibernate.type.Type;
  *          value of an updated property in a {@code @PreUpdate} callback, and do not
  *          provide a well-defined way to intercept changes to collections.
  *          <p>
- *          Note that this API exposes the interface {@link Type}, which in modern
- *          versions of Hibernate is considered an SPI. This is unfortunate, and might
- *          change in the future, but is bearable for now.
+ *          Implementations are supplied to Hibernate, which invokes their callbacks.
+ *          Direct invocation of these callbacks is not a supported provider contract.
  *
+ * @see org.hibernate.engine.creation.CommonBuilder#interceptor(Interceptor)
+ * @see org.hibernate.engine.creation.CommonSharedBuilder#interceptor(Interceptor)
+ * @see org.hibernate.engine.creation.CommonSharedBuilder#interceptor()
  * @see SessionBuilder#interceptor(Interceptor)
+ * @see StatelessSessionBuilder#interceptor(Interceptor)
+ * @see SharedSessionBuilder#interceptor(Interceptor)
+ * @see SharedStatelessSessionBuilder#interceptor(Interceptor)
+ * @see SharedStatelessSessionBuilder#interceptor()
  * @see SharedSessionBuilder#interceptor()
  * @see org.hibernate.cfg.Configuration#setInterceptor(Interceptor)
  *
  * @see org.hibernate.boot.SessionFactoryBuilder#applyInterceptor(Interceptor)
  * @see org.hibernate.boot.SessionFactoryBuilder#applyStatelessInterceptor(Class)
+ * @see org.hibernate.boot.SessionFactoryBuilder#applyStatelessInterceptor(java.util.function.Supplier)
  *
  * @author Gavin King
  */
+@SPI(value = {SPI.Role.IMPLEMENT, SPI.Role.SUPPLY})
 public interface Interceptor extends EntityManager.CreationOption, EntityAgent.CreationOption {
 	/**
 	 * Called just before an object is initialized. The interceptor may change the {@code state}, which will

--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -56,6 +56,7 @@ public interface SessionBuilder extends CommonBuilder {
 
 	@Override
 	@Nonnull
+	@SPI(SPI.Role.SUPPLY)
 	SessionBuilder interceptor(@Nullable Interceptor interceptor);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
@@ -84,6 +84,7 @@ public interface SharedSessionBuilder extends SessionBuilder, CommonSharedBuilde
 
 	@Override
 	@Nonnull
+	@SPI(SPI.Role.SUPPLY)
 	SharedSessionBuilder interceptor();
 
 	/**
@@ -198,6 +199,7 @@ public interface SharedSessionBuilder extends SessionBuilder, CommonSharedBuilde
 
 	@Override
 	@Nonnull
+	@SPI(SPI.Role.SUPPLY)
 	SharedSessionBuilder interceptor(@Nullable Interceptor interceptor);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/SharedStatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedStatelessSessionBuilder.java
@@ -76,10 +76,12 @@ public interface SharedStatelessSessionBuilder extends StatelessSessionBuilder, 
 
 	@Override
 	@Nonnull
+	@SPI(SPI.Role.SUPPLY)
 	SharedStatelessSessionBuilder interceptor();
 
 	@Override
 	@Nonnull
+	@SPI(SPI.Role.SUPPLY)
 	SharedStatelessSessionBuilder interceptor(@Nullable Interceptor interceptor);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -48,6 +48,7 @@ public interface StatelessSessionBuilder extends CommonBuilder {
 
 	@Override
 	@Nonnull
+	@SPI(SPI.Role.SUPPLY)
 	StatelessSessionBuilder interceptor(@Nullable Interceptor interceptor);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -138,12 +138,16 @@ public interface SessionFactoryBuilder {
 	 * which will be used by all sessions unless an interceptor is explicitly
 	 * specified using {@link org.hibernate.SessionBuilder#interceptor}.
 	 *
+	 * The shared instance must be thread-safe. Hibernate invokes its callbacks
+	 * during the lifecycle of each session using it.
+	 *
 	 * @param interceptor The interceptor
 	 *
 	 * @return {@code this}, for method chaining
 	 *
 	 * @see org.hibernate.cfg.AvailableSettings#INTERCEPTOR
 	 */
+	@SPI(SPI.Role.SUPPLY)
 	SessionFactoryBuilder applyInterceptor(Interceptor interceptor);
 
 	/**
@@ -158,6 +162,7 @@ public interface SessionFactoryBuilder {
 	 *
 	 * @see org.hibernate.cfg.AvailableSettings#SESSION_SCOPED_INTERCEPTOR
 	 */
+	@SPI(SPI.Role.SUPPLY)
 	SessionFactoryBuilder applyStatelessInterceptor(Class<? extends Interceptor> statelessInterceptorClass);
 
 	/**
@@ -172,6 +177,7 @@ public interface SessionFactoryBuilder {
 	 *
 	 * @see org.hibernate.cfg.AvailableSettings#SESSION_SCOPED_INTERCEPTOR
 	 */
+	@SPI(SPI.Role.SUPPLY)
 	SessionFactoryBuilder applyStatelessInterceptor(Supplier<? extends Interceptor> statelessInterceptorSupplier);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
@@ -913,17 +913,21 @@ public class Configuration {
 	 *
 	 * @return The current {@link Interceptor}
 	 */
+	@SPI(SPI.Role.USE)
 	public Interceptor getInterceptor() {
 		return interceptor;
 	}
 
 	/**
-	 * Set the current {@link Interceptor}.
+	 * Supply the {@link Interceptor} shared by sessions opened from the built factory.
+	 * Hibernate invokes its callbacks during each session’s lifecycle. The shared
+	 * instance must be thread-safe. A session-specific interceptor may override it.
 	 *
 	 * @param interceptor The {@link Interceptor} to use
 	 *
 	 * @return {@code this} for method chaining
 	 */
+	@SPI(SPI.Role.SUPPLY)
 	public Configuration setInterceptor(Interceptor interceptor) {
 		this.interceptor = interceptor;
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/engine/creation/CommonBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/creation/CommonBuilder.java
@@ -13,6 +13,7 @@ import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
+import org.hibernate.SPI;
 import org.hibernate.Session;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.StatelessSession;
@@ -55,11 +56,14 @@ public interface CommonBuilder {
 	@Nonnull
 	CommonBuilder connectionHandling(@Nonnull ConnectionAcquisitionMode acquisitionMode, @Nonnull ConnectionReleaseMode releaseMode);
 
-	/// Adds a specific interceptor to the session options.
+	/// Supply an [Interceptor] for the session being built.
+	/// Hibernate invokes its callbacks during that session’s lifecycle.
+	/// If the instance is also supplied to other sessions, it must be thread-safe.
 	///
 	/// @param interceptor The interceptor to use.
 	/// @return `this`, for method chaining
 	@Nonnull
+	@SPI(SPI.Role.SUPPLY)
 	CommonBuilder interceptor(@Nullable Interceptor interceptor);
 
 	/// Specifies that no {@link Interceptor} should be used.  This indicates to

--- a/hibernate-core/src/main/java/org/hibernate/engine/creation/CommonSharedBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/creation/CommonSharedBuilder.java
@@ -13,6 +13,7 @@ import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
+import org.hibernate.SPI;
 
 import java.sql.Connection;
 import java.time.Instant;
@@ -36,10 +37,13 @@ public interface CommonSharedBuilder extends CommonBuilder {
 	@Nonnull
 	CommonSharedBuilder connection();
 
-	/// Signifies the interceptor from the original session should be used to create the new session.
+	/// Supply the original session’s [Interceptor] to the new session.
+	/// Both sessions share the same instance, which must be thread-safe if they run concurrently.
 	///
 	/// @return `this`, for method chaining
+	/// @see Interceptor
 	@Nonnull
+	@SPI(SPI.Role.SUPPLY)
 	CommonSharedBuilder interceptor();
 
 	/// Signifies that the SQL statement inspector from the original session should be used to create the new session.
@@ -52,8 +56,12 @@ public interface CommonSharedBuilder extends CommonBuilder {
 	@Nonnull
 	CommonSharedBuilder noStatementInspector();
 
+	/// {@inheritDoc}
+	///
+	/// @see Interceptor
 	@Override
 	@Nonnull
+	@SPI(SPI.Role.SUPPLY)
 	CommonSharedBuilder interceptor(@Nullable Interceptor interceptor);
 
 	@Override

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -421,6 +421,24 @@ StatelessSessionLazyDelegator` is implemented. Consumers of this class must exte
 and implement the abstract `delegate()` method, thus providing the required Session to
 it.
 
+[[interceptor-spi]]
+=== Interceptor classification
+
+`Interceptor`, previously considered an API simply because it was not yet classified,
+is classified as an SPI with the `IMPLEMENT` and `SUPPLY` roles. Implementing its callbacks
+and supplying an instance to Hibernate remain supported. Hibernate continues to invoke them
+during session operations.
+
+The interceptor registration methods on `SessionBuilder`, `StatelessSessionBuilder`,
+their shared-session variants, `CommonBuilder`, `CommonSharedBuilder`,
+`SessionFactoryBuilder`, and `Configuration` are now SPI supply points instead
+of API.
+
+These classification changes do not change Java signatures or runtime behavior.
+Existing implementations and registration calls require no source changes.
+The affected contracts now carry the SPI compatibility promise within an `X.Y`
+release family, instead of the API promise across a major version.
+
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Changes in Behavior


### PR DESCRIPTION
HHH-20872 - Classify Interceptor as SPI

backport to 8.0

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20872 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20872
<!-- Hibernate GitHub Bot issue links end -->